### PR TITLE
Dynamic Slow MPU

### DIFF
--- a/common/app/slices/Container.scala
+++ b/common/app/slices/Container.scala
@@ -10,6 +10,7 @@ object Container extends Logging {
     ("dynamic/fast", Dynamic(DynamicFast)),
     ("dynamic/slow", Dynamic(DynamicSlow)),
     ("dynamic/package", Dynamic(DynamicPackage)),
+    ("dynamic/slow-mpu", Dynamic(DynamicSlowMPU)),
     ("nav/list", NavList),
     ("nav/media-list", NavMediaList),
     ("news/most-popular", MostPopular)

--- a/common/app/slices/DynamicSlowMPU.scala
+++ b/common/app/slices/DynamicSlowMPU.scala
@@ -1,0 +1,26 @@
+package slices
+
+object DynamicSlowMPU extends DynamicContainer {
+  override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
+    val BigsAndStandards(bigs, _) = bigsAndStandards(stories)
+    val isFirstBoosted = stories.headOption.exists(_.isBoosted)
+
+    if (bigs.length == 3) {
+      Some((HalfQQ, stories.drop(3)))
+    } else if (bigs.length == 2) {
+      Some((if (isFirstBoosted) ThreeQuarterQuarter else HalfHalf, stories.drop(2)))
+    } else if (bigs.length == 1) {
+      Some(if (isFirstBoosted) ThreeQuarterQuarter else HalfHalf, stories.drop(2))
+    } else if (bigs.isEmpty) {
+      None
+    } else {
+      Some(QuarterQuarterQuarterQuarter, stories.drop(4))
+    }
+  }
+
+  override protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] =
+    firstSlice match {
+      case Some(_) => Seq(Hl3Mpu)
+      case None    => Seq(TTlMpu)
+    }
+}

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -103,7 +103,8 @@ object DynamicContainers {
   val all: Map[String, DynamicContainer] = Map(
     ("dynamic/fast", DynamicFast),
     ("dynamic/slow", DynamicSlow),
-    ("dynamic/package", DynamicPackage)
+    ("dynamic/package", DynamicPackage),
+    ("dynamic/slow-mpu", DynamicSlowMPU)
   )
 
   def apply(collectionType: Option[String], items: Seq[Content]): Option[ContainerDefinition] = {

--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -431,6 +431,36 @@ case object Hl4Half extends Slice {
   )
 }
 
+
+/* ._________________._________________.
+ * |_###_____________|                 |
+ * |_###_____________|     MPU         |
+ * |_###_____________|_________________|
+ */
+/*
+* The order of this sequence is important.
+* We use flex-direction(row-reverse) to maintain DOM hierarchy whilst having correct visual ordering.
+* */
+case object Hl3Mpu extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "hl3-mpu",
+    columns = Seq(
+      Rows(
+        colSpan = 1,
+        columns = 1,
+        rows = 3,
+        ItemClasses(
+          mobile = MediaList,
+          tablet = MediaList
+        )
+      ),
+      MPU(
+        colSpan = 1
+        )
+    )
+  )
+}
+
 /** This is not actually used but is a reflection of Hl4Half, for the thumbnail display in the tool */
 object HalfHl4 extends Slice {
   val layout = Hl4Half.layout.copy(

--- a/facia-tool/app/controllers/FrontendDependentController.scala
+++ b/facia-tool/app/controllers/FrontendDependentController.scala
@@ -43,6 +43,11 @@ object FrontendDependentController extends Controller with PanDomainAuthActions 
     "snap"
   )
 
+  private val DynamicMpu = Seq(
+    "standard",
+    "big"
+  )
+
   def configuration = APIAuthAction { request =>
     Cached(60) {
       Ok(Json.toJson(Defaults(
@@ -60,6 +65,8 @@ object FrontendDependentController extends Controller with PanDomainAuthActions 
         DynamicContainers.all.keys.toSeq.map(id =>
           if (id == "dynamic/package") {
             ContainerJsonConfig(id, Some(DynamicPackage))
+          } else if (id == "dynamic/slow-mpu") {
+            ContainerJsonConfig(id, Some(DynamicMpu))
           } else {
             ContainerJsonConfig(id, Some(DynamicGroups))
           }


### PR DESCRIPTION
This is a port of the changes introduced in https://github.com/guardian/frontend/pull/10367.

It creates a new `dynamic` container that can be used, `DynamicSlowMpu`.