### PR TITLE
Close without saving

### DIFF
--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1025,6 +1025,7 @@ collection-widget:first-child .collection {
 
 .supporting .trailText,
 .supporting .tool--done,
+.supporting .tool--cancel,
 .supporting .image__overrides,
 .supporting .supporting-message {
     display: none !important;
@@ -1480,6 +1481,10 @@ button {
     color: #ddd;
 }
 
+.article-edit {
+  max-width: 55%;
+}
+
 .article__tools {
     display: none;
     position: absolute;
@@ -1518,6 +1523,12 @@ button {
 }
 
 .tool--done {
+    float: right;
+    line-height: 30px;
+    text-align: center;
+}
+
+.tool--cancel {
     float: right;
     line-height: 30px;
     text-align: center;

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -920,6 +920,14 @@ define([
             return false;
         };
 
+        Article.prototype.closeWithoutSaving = function() {
+            this.close();
+            if ( this.group && this.group.parentType === 'Collection' ) {
+                this.group.parent.replaceArticle(this.id());
+            }
+            return false;
+        };
+
         Article.prototype.omitItem = function () {
             this.group.omitItem(this);
         };

--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -319,6 +319,26 @@ define([
         return this.front.mode() !== 'treats' && this.history().length;
     };
 
+    Collection.prototype.replaceArticle = function(articleId) {
+        var self = this;
+        var collectionList = this.front.getCollectionList(this.raw);
+
+        _.find(collectionList, function(item, index) {
+            if (item.id === articleId) {
+                var group = _.find(self.groups, function(g) {
+                    return (parseInt((item.meta || {}).group, 10) || 0) === g.index;
+                });
+                var article = new Article(_.extend(item, {
+                    group: group,
+                    slimEditor: self.front.slimEditor()
+                }));
+
+                group.items.splice(index, 1, article);
+                return true;
+            }
+        });
+        this.decorate();
+    };
 
     Collection.prototype.populate = function(rawCollection, callback) {
         callback = callback || function () {};

--- a/facia-tool/public/js/widgets/trail.html
+++ b/facia-tool/public/js/widgets/trail.html
@@ -46,13 +46,17 @@
                         </div>
                 </div>
             </div>
-            <span class="supporting-message">Drop content above, hold Ctrl key to replace item</span>
+            <span class="article-edit supporting-message">Drop content above, hold Ctrl key to replace item</span>
         </div>
 
         <div class="tools article-tools">
             <a class="tool tool--done" data-bind="
                 clickBubble: false,
                 click: closeAndSave">Save edits</a>
+            <a class="tool tool--cancel" data-bind="
+                visible: front,
+                clickBubble: false,
+                click: closeWithoutSaving">Close</a>
         </div>
     </div>
 

--- a/facia-tool/test/public/mocks/search.js
+++ b/facia-tool/test/public/mocks/search.js
@@ -12,7 +12,7 @@ function parse (string) {
 
 class Search extends Mock {
     constructor() {
-        super(/\/api\/live\/search\?(.+)/, ['queryString']);
+        super(/\/api\/(live|preview)\/search\?(.+)/, ['queryString']);
 
         this.latestArticles = {
             response: {

--- a/facia-tool/test/public/spec/collections.spec.js
+++ b/facia-tool/test/public/spec/collections.spec.js
@@ -410,6 +410,26 @@ describe('Collections', function () {
         .catch(done.fail);
     });
 
+    it('closes without saving', function (done) {
+
+        this.testInstance.load()
+        .then(() => {
+            $('.element__headline', dom.collection(0)).click();
+        })
+        .then(() => {
+            $('.element__headline', dom.collection(0)).val('different').change();
+        })
+        .then(() => {
+            $('.tool--cancel', dom.collection(0)).click();
+        })
+        .then(() => {
+            expect(textInside('.collection .element__headline')).toBe('I won the elections');
+            expect($('.editor', dom.collection(0)).is(':visible')).toBe(false);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
     it('copy paste above an article', function (done) {
         var mockCollection = this.testInstance.mockCollections;
 


### PR DESCRIPTION
When editing an article, there is now an option to close article editing without saving the changes made to it. 
<img width="617" alt="close button" src="https://cloud.githubusercontent.com/assets/3066534/10171638/fbb4096c-66d2-11e5-99dc-debfb82f4391.png">
