### PR TITLE
move log initialisation to global settings

### DIFF
--- a/common/app/conf/GlobalSettings.scala
+++ b/common/app/conf/GlobalSettings.scala
@@ -55,7 +55,7 @@ trait SwitchboardLifecycle extends GlobalSettings with ExecutionContexts with Lo
   }
 
   def refresh() {
-    log.info("Refreshing switches")
+    Logger.info("Refreshing switches")
     services.S3.get(Configuration.switches.key) map { response =>
 
       val nextState = Properties(response)
@@ -64,7 +64,7 @@ trait SwitchboardLifecycle extends GlobalSettings with ExecutionContexts with Lo
         nextState.get(switch.name) foreach {
           case "on" => switch.switchOn()
           case "off" => switch.switchOff()
-          case other => log.warn(s"Badly configured switch ${switch.name} -> $other")
+          case other => Logger.warn(s"Badly configured switch ${switch.name} -> $other")
         }
       }
     }

--- a/common/app/conf/GlobalSettings.scala
+++ b/common/app/conf/GlobalSettings.scala
@@ -2,10 +2,11 @@ package conf
 
 import common._
 import model.Cors
-import play.api.{Application, GlobalSettings}
+import play.api.{Logger, Application, GlobalSettings}
 import play.api.mvc.{Result, RequestHeader, Results}
 
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 trait CorsErrorHandler extends GlobalSettings with Results with common.ExecutionContexts {
 
@@ -68,4 +69,18 @@ trait SwitchboardLifecycle extends GlobalSettings with ExecutionContexts with Lo
       }
     }
   }
+}
+
+trait LogStashConfig extends GlobalSettings with Logging {
+
+
+  override def onStart(app: Application) {
+    super.onStart(app)
+    Logger.info("configuring log stash")
+    try LogStash.init()
+    catch {
+      case NonFatal(e) => Logger.error(s"could not configure log stream ${e}")
+    }
+  }
+
 }

--- a/common/app/conf/LogStash.scala
+++ b/common/app/conf/LogStash.scala
@@ -1,19 +1,15 @@
-import ch.qos.logback.classic.spi.ILoggingEvent
+package conf
+
 import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
-import ch.qos.logback.core.FileAppender
-import ch.qos.logback.core.util.Duration
 import com.gu.logback.appender.kinesis.KinesisAppender
-import conf.Configuration
-import net.logstash.logback.appender.LogstashTcpSocketAppender
 import net.logstash.logback.encoder.LogstashEncoder
 import net.logstash.logback.layout.LogstashLayout
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.LoggerFactory
 import play.api.{Logger => PlayLogger, LoggerLike}
 
 object LogStash {
 
   lazy val loggingContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-  import play.api.Play.current
 
   case class KinesisAppenderConfig(stream: String, region: String, roleArn: String, bufferSize: Int)
 

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -1,7 +1,7 @@
 import java.io.File
 
 import common._
-import conf.{Configuration => GuardianConfiguration, SwitchboardLifecycle, Gzipper}
+import conf.{Configuration => GuardianConfiguration, LogStashConfig, SwitchboardLifecycle, Gzipper}
 import metrics.FrontendMetric
 import play.api._
 import play.api.mvc.WithFilters
@@ -13,7 +13,8 @@ object Global extends WithFilters(Gzipper)
   with GlobalSettings
   with CloudWatchApplicationMetrics
   with ConfigAgentLifecycle
-  with SwitchboardLifecycle {
+  with SwitchboardLifecycle
+  with LogStashConfig {
 
   override lazy val applicationName = "frontend-facia-tool"
 
@@ -30,12 +31,5 @@ object Global extends WithFilters(Gzipper)
     S3Metrics.S3ClientExceptionsMetric
   )
 
-  override def onStart(app: Application) = {
-    Logger.info("configuring log stash")
-    try LogStash.init()
-    catch {
-      case NonFatal(e) => Logger.error(s"could not configure log stream ${e}")
-    }
-  }
 
 }

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -33,7 +33,9 @@ object Frontend extends Build with Prototypes {
       jacksonCore,
       jacksonMapper,
       jSoup,
+      kinesisLogBack,
       liftJson,
+      logStash,
       playGoogleAuth,
       panDomainAuth,
       quartzScheduler,
@@ -65,9 +67,7 @@ object Frontend extends Build with Prototypes {
   val faciaTool = application("facia-tool").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(
       playJsonVariants,
-      awsKinesis,
-      logStash,
-      kinesisLogBack
+      awsKinesis
     )
   )
 


### PR DESCRIPTION
Having the onStart method in global overrode the onStart methods defined in other areas of the code base. This moves the logging initialisation to a separate trait so that all the onStart methods defined here will run. 

https://fronts.code.dev-gutools.co.uk/switches 

cc @piuccio 