### PR TITLE
Viewer link

### DIFF
--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -102,6 +102,7 @@ export default {
     imageCdnDomain:        '.guim.co.uk',
     imgIXBasePath:         '/img/static/',
     previewBase:           'http://preview.gutools.co.uk',
+    viewerHost:            'viewer.gutools.co.uk',
 
     latestSnapPrefix:      'Latest from ',
 

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -6,7 +6,7 @@ import * as cache from 'modules/cache';
 import modalDialog from 'modules/modal-dialog';
 import internalPageCode from 'utils/internal-page-code';
 import internalContentCode from 'utils/internal-content-code';
-import urlAbsPath from 'utils/url-abs-path';
+import articlePath from 'utils/article-path';
 import identity from 'utils/identity';
 import isGuardianUrl from 'utils/is-guardian-url';
 import * as snap from 'utils/snap';
@@ -55,7 +55,7 @@ function fetchContent(apiUrl) {
 function validateItem (item) {
     return new Promise(function (resolve, reject) {
         var snapId = snap.validateId(item.id()),
-            capiId = urlAbsPath(item.id()),
+            capiId = articlePath(item.id()),
             data = cache.get('contentApi', capiId);
 
         if (snapId) {

--- a/facia-tool/public/js/utils/article-path.js
+++ b/facia-tool/public/js/utils/article-path.js
@@ -1,0 +1,15 @@
+import urlHost from './url-host';
+import urlAbsPath from './url-abs-path';
+import CONST from 'constants/defaults';
+
+export default function(url) {
+
+    var host = urlHost(url);
+
+    if (host === CONST.viewerHost) {
+      return url.match(/(preview|live)\/(.*)/)[2];
+    }
+
+    return urlAbsPath(url);
+};
+

--- a/facia-tool/test/public/spec/article.path.spec.js
+++ b/facia-tool/test/public/spec/article.path.spec.js
@@ -1,0 +1,23 @@
+import articlePath from 'utils/article-path';
+
+describe('Article Path', function () {
+
+    it('returns correct path if url is from  guardian website', function () {
+        var url = 'http://www.theguardian.com/business/2015/example';
+
+        expect(articlePath(url)).toEqual('business/2015/example');
+    });
+
+    it('returns correct path if url is from viewer preview', function () {
+        var url = 'http://viewer.gutools.co.uk/preview/business/2015/example';
+
+        expect(articlePath(url)).toEqual('business/2015/example');
+    });
+
+    it('returns correct path if url is from viewer live', function () {
+        var url = 'http://viewer.gutools.co.uk/live/business/2015/example';
+
+        expect(articlePath(url)).toEqual('business/2015/example');
+    });
+});
+


### PR DESCRIPTION
Articles that are pasted on the clipboard from viewer should be recognised as guardian content on the clipboard rather than snap links. 