### PR TITLE
make the user check case insensitive

### DIFF
--- a/facia-tool/app/permissions/Store.scala
+++ b/facia-tool/app/permissions/Store.scala
@@ -157,7 +157,7 @@ object PermissionsReader  {
   }
 
   def getOverridesForPerm(p: PermissionCacheEntry, user: User): PermissionAuth = {
-    p.overrides.find(_.userId==user.email).fold(
+    p.overrides.find(_.userId.toLowerCase==user.email.toLowerCase).fold(
       PermissionAuth(p.permission.defaultValue, InfoLevel(s"no override set for permission ${p.permission.name}, using default from service"))
     )(user => PermissionAuth(user.active, InfoLevel(s"user override set to ${user.active} for permission ${p.permission.name}")))
   }


### PR DESCRIPTION
Does a case insensitive check on the userId to mitigate against the case where a user is in the permissions system with a different case check than the users' panda token.

Intend to port this logic to the https://github.com/guardian/editorial-permissions-client when this is up and running