### PR TITLE
Search fronts

### DIFF
--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1709,13 +1709,13 @@ ol.search_list > li::before {
     display: none;
 }
 
-.cnf-collection .placements a {
+.cnf-collection__also-on {
     color: #666666;
     border-left: 1px solid #dbd8c9;
     padding-left: 5px;
 }
 
-.cnf-collection .placements a:first-child {
+.cnf-collection__also-on:first-child {
     border-left: inherit;
     padding-left: inherit;
 }

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1635,6 +1635,18 @@ button {
     color: #000000;
 }
 
+ol.search_list {
+    list-style-type: none;
+    counter-reset: ol-counter;
+}
+ol.search_list > li::before {
+    content: counter(ol-counter);
+    counter-increment: ol-counter;
+    color: #666666;
+    font-size: 12px;
+    padding-right: 4px;
+}
+
 .cnf-front__inner {
     padding: 5px 10px 0 10px;
 }

--- a/facia-tool/public/js/models/available-columns.js
+++ b/facia-tool/public/js/models/available-columns.js
@@ -27,5 +27,10 @@ export default {
         title: 'Fronts',
         layoutType: 'config',
         widget: 'fronts-config-widget'
+    },
+    'searchFronts': {
+        title: 'Search',
+        layoutType: 'search',
+        widget: 'fronts-search-widget'
     }
 };

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -10,6 +10,7 @@ import asObservableProps from 'utils/as-observable-props';
 import cloneWithKey from 'utils/clone-with-key';
 import frontCount from 'utils/front-count';
 import populateObservables from 'utils/populate-observables';
+import generateCollections from 'utils/generate-collections';
 import validateImageSrc from 'utils/validate-image-src';
 
 export default class ConfigFront extends BaseClass {
@@ -244,19 +245,6 @@ export default class ConfigFront extends BaseClass {
         this.collections.dispose();
         this.dom = null;
     }
-}
-
-function generateCollections (collections) {
-    var collectionDefinition = vars.model.state().config.collections;
-
-    return _.chain(collections)
-        .map(id => {
-            if (collectionDefinition[id]) {
-                return new Collection(cloneWithKey(collectionDefinition[id], id));
-            }
-        })
-        .filter(collection => !!collection)
-        .value();
 }
 
 function updateCollections (collections) {

--- a/facia-tool/public/js/models/widgets.js
+++ b/facia-tool/public/js/models/widgets.js
@@ -93,6 +93,10 @@ var register = _.once(() => {
         viewModel: { jspm: 'widgets/autocomplete' },
         template: { text: 'widgets/autocomplete.html' }
     });
+    ko.components.register('fronts-search-widget', {
+        viewModel: { jspm: 'widgets/columns/fronts-search' },
+        template: { text: 'widgets/columns/fronts-search.html' }
+    });
     ko.components.register('fronts-config-widget', {
         viewModel: { jspm: 'widgets/columns/fronts-config' },
         template: { text: 'widgets/columns/fronts-config.html' }

--- a/facia-tool/public/js/modules/route-handlers.js
+++ b/facia-tool/public/js/modules/route-handlers.js
@@ -24,7 +24,8 @@ export default {
         extensions.sparklinesTrails
     ]),
     'config': getLoader([
-        columns.frontsConfig
+        columns.frontsConfig,
+        columns.searchFronts
     ], [
         extensions.cardTypes,
         extensions.navSections

--- a/facia-tool/public/js/utils/generate-collections.js
+++ b/facia-tool/public/js/utils/generate-collections.js
@@ -1,0 +1,18 @@
+import _ from 'underscore';
+import * as vars from 'modules/vars';
+import Collection from 'models/config/collection';
+import cloneWithKey from './clone-with-key';
+
+export default function generateCollections (collections) {
+    var collectionDefinition = vars.model.state().config.collections;
+
+    return _.chain(collections)
+        .map(id => {
+            if (collectionDefinition[id]) {
+                return new Collection(cloneWithKey(collectionDefinition[id], id));
+            }
+        })
+        .filter(collection => !!collection)
+        .value();
+}
+

--- a/facia-tool/public/js/widgets/columns/fronts-search.html
+++ b/facia-tool/public/js/widgets/columns/fronts-search.html
@@ -18,9 +18,8 @@
                     text: id
                 "></span>
             </div>
-            <div class="cnf-front__inner" data-bind="foreach: collections">
+            <div class="cnf-front__inner" data-bind="foreach: collections, makeDraggable: true">
                 <div class="cnf-collection open">
-                    <div data-bind="makeDroppable: true">
                         <span class="cnf-collection__index" data-bind="text: $index() + 1"></span>
                         <a class="cnf-collection__name" data-bind="
                             attr: {href: '/' + id, title: id},

--- a/facia-tool/public/js/widgets/columns/fronts-search.html
+++ b/facia-tool/public/js/widgets/columns/fronts-search.html
@@ -23,6 +23,16 @@
                         attr: {href: '/' + id, title: id},
                         click: function() { return false;},
                         text: meta.displayName() || '(no title)'"></a>
+                    <span class="placements" data-bind="if: parents().length > 1">
+                        also on
+                        <span data-bind="foreach: parents">
+                            <!-- ko if: $parents[1].id !== id -->
+                                <span class="cnf-collection__also-on" data-bind="
+                                    text: id"
+                                ></span>
+                            <!-- /ko -->
+                        </span>
+                    </span>
                 </li>
             </ol>
         </div>

--- a/facia-tool/public/js/widgets/columns/fronts-search.html
+++ b/facia-tool/public/js/widgets/columns/fronts-search.html
@@ -6,10 +6,9 @@
         <input
           type="text"
           placeholder="search for collections"
-          data-bind='
-            value: searchTerm,
-            valueUpdate: ["afterkeydown", "afterpaste"]
-        '/>
+          data-bind="
+            textInput: searchTerm
+        "/>
     </div>
     <div class="cnf-fronts open" data-bind="foreach: searchedFronts">
         <div class="cnf-front open">

--- a/facia-tool/public/js/widgets/columns/fronts-search.html
+++ b/facia-tool/public/js/widgets/columns/fronts-search.html
@@ -1,0 +1,34 @@
+<div class="col__inner scrollable">
+    <div class="title">
+        Search
+    </div>
+    <div class="search-form">
+        <input
+          type="text"
+          placeholder="search for fronts"
+          data-bind='
+            value: searchTerm,
+            valueUpdate: ["afterkeydown", "afterpaste"]
+        '/>
+    </div>
+    <div class="cnf-fronts open" data-bind="foreach: searchedFronts">
+        <div class="cnf-front open">
+            <div class="title" data-bind="visible: id">
+                <span class="title--text" data-bind="
+                    text: id
+                "></span>
+            </div>
+            <div class="cnf-front__inner" data-bind="foreach: collections">
+                <div class="cnf-collection open">
+                    <div data-bind="makeDroppable: true">
+                        <span class="cnf-collection__index" data-bind="text: $index() + 1"></span>
+                        <a class="cnf-collection__name" data-bind="
+                            attr: {href: '/' + id, title: id},
+                            click: function() { return false;},
+                            text: meta.displayName() || '(no title)'"></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/facia-tool/public/js/widgets/columns/fronts-search.html
+++ b/facia-tool/public/js/widgets/columns/fronts-search.html
@@ -18,16 +18,14 @@
                     text: id
                 "></span>
             </div>
-            <div class="cnf-front__inner" data-bind="foreach: collections, makeDraggable: true">
-                <div class="cnf-collection open">
-                        <span class="cnf-collection__index" data-bind="text: $index() + 1"></span>
-                        <a class="cnf-collection__name" data-bind="
-                            attr: {href: '/' + id, title: id},
-                            click: function() { return false;},
-                            text: meta.displayName() || '(no title)'"></a>
-                    </div>
-                </div>
-            </div>
+            <ol class="cnf-front__inner search_list" data-bind="foreach: collections, makeDraggable: true">
+                <li class="cnf-collection open">
+                    <a class="cnf-collection__name" data-bind="
+                        attr: {href: '/' + id, title: id},
+                        click: function() { return false;},
+                        text: meta.displayName() || '(no title)'"></a>
+                </li>
+            </ol>
         </div>
     </div>
 </div>

--- a/facia-tool/public/js/widgets/columns/fronts-search.html
+++ b/facia-tool/public/js/widgets/columns/fronts-search.html
@@ -5,7 +5,7 @@
     <div class="search-form">
         <input
           type="text"
-          placeholder="search for fronts"
+          placeholder="search for collections"
           data-bind='
             value: searchTerm,
             valueUpdate: ["afterkeydown", "afterpaste"]

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -2,6 +2,7 @@ import ko from 'knockout';
 import _ from 'underscore';
 import ColumnWidget from 'widgets/column-widget';
 import * as vars from 'modules/vars';
+import CONST from 'constants/defaults';
 import Collection from 'models/config/collection';
 import cloneWithKey from 'utils/clone-with-key';
 
@@ -11,19 +12,25 @@ export default class SearchConfig extends ColumnWidget {
         this.searchTerm = ko.observable('');
         this.searchedFronts = ko.observableArray([]);
         var collectionDefinition = vars.model.state().config.collections;
-        var originalFronts = _.map(this.baseModel.frontsList(), function (front) {
+        var originalFronts = _.reduce(this.baseModel.frontsList(), function (frontList, front) {
 
-            front.groups = ko.observableArray(vars.CONST.frontGroups);
-            front.collections = _.chain(front.collections)
-            .map(id => {
-                if (collectionDefinition[id]) {
-                    return new Collection(cloneWithKey(collectionDefinition[id], id));
-                }
-            })
-            .filter(collection => !!collection)
-            .value();
-            return front;
-        });
+            if (_.every(CONST.askForConfirmation, function (element) {
+                return front.id !== element;
+            }) ) {
+
+                front.groups = ko.observableArray(vars.CONST.frontGroups);
+                front.collections = _.chain(front.collections)
+                .map(id => {
+                    if (collectionDefinition[id]) {
+                        return new Collection(cloneWithKey(collectionDefinition[id], id));
+                    }
+                })
+                .filter(collection => !!collection)
+                .value();
+                frontList.push(front);
+            }
+            return frontList;
+        }, []);
 
         var self = this;
         this.searchTerm.subscribe(function (newTerms) {

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -9,14 +9,16 @@ export default class SearchConfig extends ColumnWidget {
         super(params, element);
         this.searchTerm = ko.observable('');
         this.searchedFronts = ko.observableArray([]);
-        var originalFronts = _.reduce(JSON.parse(JSON.stringify(this.baseModel.frontsList())), function (frontList, front) {
+        var originalFronts = _.reduce(this.baseModel.frontsList(), function (frontList, front) {
 
             if (_.every(CONST.askForConfirmation, function (element) {
                 return front.id !== element;
             }) ) {
 
-                front.collections = generateCollections(front.collections);
-                frontList.push(front);
+                let frontToSearch = { id: front.id.toLowerCase() };
+
+                frontToSearch.collections = generateCollections(front.collections);
+                frontList.push(frontToSearch);
             }
             return frontList;
         }, []);
@@ -34,14 +36,14 @@ export default class SearchConfig extends ColumnWidget {
 
                 if (allSearchTerms.length === 1) {
                     self.searchedFronts(_.filter(originalFronts, function(front) {
-                        return front.id.toLowerCase().indexOf(allSearchTerms[0]) !== -1 ||
+                        return front.id.indexOf(allSearchTerms[0]) !== -1 ||
                             isTermInCollections(front.collections, allSearchTerms[0]);
                     }) );
 
                 } else {
                     let firstTerm = allSearchTerms[ 0 ];
                     let matchedFronts = _.filter(originalFronts, function(front) {
-                        return front.id.toLowerCase().indexOf(firstTerm) !== -1;
+                        return front.id.indexOf(firstTerm) !== -1;
                     });
 
                     if (matchedFronts.length > 0 ) {

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -53,20 +53,20 @@ export default class SearchConfig extends ColumnWidget {
                 }
             }
         });
-
-        function searchForTermsInsideFrontCollections(searchTerms, fronts) {
-            return _.filter(fronts, function(front) {
-                return _.every(searchTerms, function(term) {
-                    return isTermInCollections(front.collections, term);
-                });
-            });
-        }
-
-        function isTermInCollections(collections, term) {
-            return _.some(collections, function(collection) {
-                return collection.meta.displayName().toLowerCase().indexOf(term) !== -1;
-            });
-        }
     }
+}
+
+function searchForTermsInsideFrontCollections(searchTerms, fronts) {
+    return _.filter(fronts, function(front) {
+        return _.every(searchTerms, function(term) {
+            return isTermInCollections(front.collections, term);
+        });
+    });
+}
+
+function isTermInCollections(collections, term) {
+    return _.some(collections, function(collection) {
+        return collection.meta.displayName().toLowerCase().indexOf(term) !== -1;
+    });
 }
 

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -1,32 +1,21 @@
 import ko from 'knockout';
 import _ from 'underscore';
 import ColumnWidget from 'widgets/column-widget';
-import * as vars from 'modules/vars';
 import CONST from 'constants/defaults';
-import Collection from 'models/config/collection';
-import cloneWithKey from 'utils/clone-with-key';
+import generateCollections from 'utils/generate-collections';
 
 export default class SearchConfig extends ColumnWidget {
     constructor(params, element) {
         super(params, element);
         this.searchTerm = ko.observable('');
         this.searchedFronts = ko.observableArray([]);
-        var collectionDefinition = vars.model.state().config.collections;
         var originalFronts = _.reduce(this.baseModel.frontsList(), function (frontList, front) {
 
             if (_.every(CONST.askForConfirmation, function (element) {
                 return front.id !== element;
             }) ) {
 
-                front.groups = ko.observableArray(vars.CONST.frontGroups);
-                front.collections = _.chain(front.collections)
-                .map(id => {
-                    if (collectionDefinition[id]) {
-                        return new Collection(cloneWithKey(collectionDefinition[id], id));
-                    }
-                })
-                .filter(collection => !!collection)
-                .value();
+                front.collections = generateCollections(front.collections);
                 frontList.push(front);
             }
             return frontList;

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -21,11 +21,10 @@ export default class SearchConfig extends ColumnWidget {
                 if (_.every(CONST.askForConfirmation, function (element) {
                     return front.id !== element;
                 }) ) {
-
-                    let frontToSearch = { id: front.id.toLowerCase() };
-
-                    frontToSearch.collections = generateCollections(front.collections);
-                    frontList.push(frontToSearch);
+                    frontList.push({
+                        id: front.id.toLowerCase(),
+                        collections: generateCollections(front.collections)
+                    });
                 }
                 return frontList;
             }, []);

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -1,0 +1,76 @@
+import ko from 'knockout';
+import _ from 'underscore';
+import ColumnWidget from 'widgets/column-widget';
+import * as vars from 'modules/vars';
+import Collection from 'models/config/collection';
+import cloneWithKey from 'utils/clone-with-key';
+
+export default class SearchConfig extends ColumnWidget {
+    constructor(params, element) {
+        super(params, element);
+        this.searchTerm = ko.observable('');
+        this.searchedFronts = ko.observableArray([]);
+        var collectionDefinition = vars.model.state().config.collections;
+        var originalFronts = _.map(this.baseModel.frontsList(), function (front) {
+
+            front.groups = ko.observableArray(vars.CONST.frontGroups);
+            front.collections = _.chain(front.collections)
+            .map(id => {
+                if (collectionDefinition[id]) {
+                    return new Collection(cloneWithKey(collectionDefinition[id], id));
+                }
+            })
+            .filter(collection => !!collection)
+            .value();
+            return front;
+        });
+
+        var self = this;
+        this.searchTerm.subscribe(function (newTerms) {
+
+            if (newTerms.length < 2) {
+                self.searchedFronts([]);
+
+            } else {
+
+                newTerms = newTerms.toLowerCase();
+                var allSearchTerms = newTerms.match(/\S+/g);;
+
+                if (allSearchTerms.length === 1) {
+                    self.searchedFronts(_.filter(originalFronts, function(front) {
+                        return front.id.toLowerCase().indexOf(allSearchTerms[0]) !== -1 ||
+                            isTermInCollections(front.collections, allSearchTerms[0]);
+                    }) );
+
+                } else {
+                    let firstTerm = allSearchTerms[ 0 ];
+                    let matchedFronts = _.filter(originalFronts, function(front) {
+                        return front.id.toLowerCase().indexOf(firstTerm) !== -1;
+                    });
+
+                    if (matchedFronts.length > 0 ) {
+                        allSearchTerms.splice(0, 1);
+                        self.searchedFronts(searchForTermsInsideFrontCollections(allSearchTerms, matchedFronts));
+                    } else {
+                        self.searchedFronts(searchForTermsInsideFrontCollections(allSearchTerms, originalFronts));
+                    }
+                }
+            }
+        });
+
+        function searchForTermsInsideFrontCollections(searchTerms, fronts) {
+            return _.filter(fronts, function(front) {
+                return _.every(searchTerms, function(term) {
+                    return isTermInCollections(front.collections, term);
+                });
+            });
+        }
+
+        function isTermInCollections(collections, term) {
+            return _.some(collections, function(collection) {
+                return collection.meta.displayName().toLowerCase().indexOf(term) !== -1;
+            });
+        }
+    }
+}
+

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -11,25 +11,25 @@ export default class SearchConfig extends ColumnWidget {
         this.searchedFronts = ko.observableArray([]);
         this.originalFronts;
 
-        var self = this;
-        populateOriginalFrontList();
-        this.subscribeOn(this.baseModel.state, populateOriginalFrontList);
+        this.populateOriginalFrontList();
+        this.subscribeOn(this.baseModel.state, this.populateOriginalFrontList);
         this.subscribeOn(this.searchTerm, this.search);
 
-        function populateOriginalFrontList() {
-            self.originalFronts =  _.reduce(self.baseModel.frontsList(), function (frontList, front) {
+    }
 
-                if (_.every(CONST.askForConfirmation, function (element) {
-                    return front.id !== element;
-                }) ) {
-                    frontList.push({
-                        id: front.id.toLowerCase(),
-                        collections: generateCollections(front.collections)
-                    });
-                }
-                return frontList;
-            }, []);
-        }
+    populateOriginalFrontList() {
+        this.originalFronts =  _.reduce(this.baseModel.frontsList(), function (frontList, front) {
+
+            if (_.every(CONST.askForConfirmation, function (element) {
+                return front.id !== element;
+            }) ) {
+                frontList.push({
+                    id: front.id.toLowerCase(),
+                    collections: generateCollections(front.collections)
+                });
+            }
+            return frontList;
+        }, []);
     }
 
     search() {

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -9,7 +9,7 @@ export default class SearchConfig extends ColumnWidget {
         super(params, element);
         this.searchTerm = ko.observable('');
         this.searchedFronts = ko.observableArray([]);
-        var originalFronts = _.reduce(this.baseModel.frontsList(), function (frontList, front) {
+        var originalFronts = _.reduce(JSON.parse(JSON.stringify(this.baseModel.frontsList())), function (frontList, front) {
 
             if (_.every(CONST.askForConfirmation, function (element) {
                 return front.id !== element;

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -73,7 +73,7 @@ function searchForTermsInsideFrontCollections(searchTerms, fronts) {
 
 function isTermInCollections(collections, term) {
     return _.some(collections, function(collection) {
-        return collection.meta.displayName().toLowerCase().indexOf(term) !== -1;
+        return collection.meta.displayName() && collection.meta.displayName().toLowerCase().indexOf(term) !== -1;
     });
 }
 

--- a/facia-tool/public/js/widgets/columns/fronts-search.js
+++ b/facia-tool/public/js/widgets/columns/fronts-search.js
@@ -9,21 +9,28 @@ export default class SearchConfig extends ColumnWidget {
         super(params, element);
         this.searchTerm = ko.observable('');
         this.searchedFronts = ko.observableArray([]);
-        var originalFronts = _.reduce(this.baseModel.frontsList(), function (frontList, front) {
-
-            if (_.every(CONST.askForConfirmation, function (element) {
-                return front.id !== element;
-            }) ) {
-
-                let frontToSearch = { id: front.id.toLowerCase() };
-
-                frontToSearch.collections = generateCollections(front.collections);
-                frontList.push(frontToSearch);
-            }
-            return frontList;
-        }, []);
 
         var self = this;
+        var originalFronts;
+        populateOriginalFrontList();
+        this.subscribeOn(this.baseModel.state, populateOriginalFrontList);
+
+        function populateOriginalFrontList() {
+            originalFronts =  _.reduce(self.baseModel.frontsList(), function (frontList, front) {
+
+                if (_.every(CONST.askForConfirmation, function (element) {
+                    return front.id !== element;
+                }) ) {
+
+                    let frontToSearch = { id: front.id.toLowerCase() };
+
+                    frontToSearch.collections = generateCollections(front.collections);
+                    frontList.push(frontToSearch);
+                }
+                return frontList;
+            }, []);
+        }
+
         this.searchTerm.subscribe(function (newTerms) {
 
             if (newTerms.length < 2) {
@@ -32,7 +39,7 @@ export default class SearchConfig extends ColumnWidget {
             } else {
 
                 newTerms = newTerms.toLowerCase();
-                var allSearchTerms = newTerms.match(/\S+/g);;
+                var allSearchTerms = newTerms.match(/\S+/g);
 
                 if (allSearchTerms.length === 1) {
                     self.searchedFronts(_.filter(originalFronts, function(front) {

--- a/facia-tool/test/public/config.js
+++ b/facia-tool/test/public/config.js
@@ -13,6 +13,12 @@ export default {
                 description: 'Broken news',
                 title: 'UK',
                 priority: 'test'
+            },
+            world: {
+              collections: ['environment'],
+              description: 'World news',
+              title: 'World',
+              priority: 'test'
             }
         },
         collections: {
@@ -23,6 +29,10 @@ export default {
             'sport': {
                 displayName: 'Sport',
                 groups: ['short', 'tall', 'grande', 'venti'],
+                type: 'slow/slower/slowest'
+            },
+            'environment': {
+                displayName: 'Environment',
                 type: 'slow/slower/slowest'
             }
         }

--- a/facia-tool/test/public/utils/config-loader.js
+++ b/facia-tool/test/public/utils/config-loader.js
@@ -12,7 +12,7 @@ import fakePushState from 'test/utils/push-state';
 import inject from 'test/utils/inject';
 
 export default class Loader {
-    constructor() {
+    constructor(searchString) {
         var mockConfig, mockSwitches, mockCollection, mockDefaults;
 
         mockConfig = new MockConfig();
@@ -34,7 +34,7 @@ export default class Loader {
         `);
         this.router = new Router(handlers, {
             pathname: '/test/config',
-            search: ''
+            search: searchString ? searchString : ''
         }, {
             pushState: (...args) => fakePushState.call(this.router.location, ...args)
         });


### PR DESCRIPTION
Adds a search column to config front. The search column allows for searching fronts by front and collection names and dragging collections to the fronts config column. 
<img width="925" alt="screen shot 2015-10-15 at 11 50 02" src="https://cloud.githubusercontent.com/assets/3066534/10511699/056dc170-7333-11e5-9bc0-e29b55c65141.png">
