### PR TITLE
Move article editors in their own class

### DIFF
--- a/facia-tool/public/js/constants/article-meta-fields.js
+++ b/facia-tool/public/js/constants/article-meta-fields.js
@@ -1,0 +1,259 @@
+import CONST from 'constants/defaults';
+
+export default Object.freeze([
+    {
+        key: 'headline',
+        editable: true,
+        slimEditable: true,
+        ifState: 'enableContentOverrides',
+        label: 'headline',
+        type: 'text',
+        maxLength: 120
+    },
+    {
+        key: 'trailText',
+        editable: true,
+        ifState: 'enableContentOverrides',
+        omitForSupporting: true,
+        label: 'trail text',
+        type: 'text'
+    },
+    {
+        key: 'byline',
+        editable: true,
+        ifState: 'enableContentOverrides',
+        visibleWhen: 'showByline',
+        omitForSupporting: true,
+        label: 'byline',
+        type: 'text'
+    },
+    {
+        key: 'customKicker',
+        editable: true,
+        visibleWhen: 'showKickerCustom',
+        label: 'custom kicker',
+        type: 'text'
+    },
+    {
+        key: 'href',
+        label: 'special link URL',
+        type: 'text'
+    },
+    {
+        key: 'imageSrc',
+        editable: true,
+        dropImage: true,
+        omitForSupporting: true,
+        visibleWhen: 'imageReplace',
+        label: 'replacement image URL',
+        validator: {
+            fn: 'validateImage',
+            params: {
+                src: 'imageSrc',
+                width: 'imageSrcWidth',
+                height: 'imageSrcHeight',
+                options: {
+                    maxWidth: 1000,
+                    minWidth: 400,
+                    widthAspectRatio: 5,
+                    heightAspectRatio: 3
+                }
+            }
+        },
+        type: 'text'
+    },
+    {
+        key: 'imageSrcWidth',
+        visibleWhen: 'imageReplace',
+        label: 'replacement image width',
+        type: 'text'
+    },
+    {
+        key: 'imageSrcHeight',
+        visibleWhen: 'imageReplace',
+        label: 'replacement image height',
+        type: 'text'
+    },
+    {
+        key: 'imageCutoutSrc',
+        editable: true,
+        dropImage: true,
+        omitForSupporting: true,
+        visibleWhen: 'imageCutoutReplace',
+        label: 'replacement cutout image URL',
+        validator: {
+            fn: 'validateImage',
+            params: {
+                src: 'imageCutoutSrc',
+                width: 'imageCutoutSrcWidth',
+                height: 'imageCutoutSrcHeight',
+                options: {
+                    maxWidth: 1000,
+                    minWidth: 400
+                }
+            }
+        },
+        type: 'text'
+    },
+    {
+        key: 'imageCutoutSrcWidth',
+        visibleWhen: 'imageCutoutReplace',
+        label: 'replacement cutout image width',
+        type: 'text'
+    },
+    {
+        key: 'imageCutoutSrcHeight',
+        visibleWhen: 'imageCutoutReplace',
+        label: 'replacement cutout image height',
+        type: 'text'
+    },
+    {
+        key: 'isBreaking',
+        editable: true,
+        singleton: 'kicker',
+        label: 'breaking news',
+        type: 'boolean'
+    },
+    {
+        key: 'isBoosted',
+        editable: true,
+        omitForSupporting: true,
+        ifState: 'inDynamicCollection',
+        label: 'boost',
+        type: 'boolean'
+    },
+    {
+        key: 'showLivePlayable',
+        editable: true,
+        omitForSupporting: true,
+        ifState: 'isLiveBlog',
+        label: 'show updates',
+        type: 'boolean'
+    },
+    {
+        key: 'showMainVideo',
+        editable: true,
+        omitForSupporting: true,
+        ifState: 'hasMainVideo',
+        singleton: 'images',
+        label: 'show video',
+        type: 'boolean'
+    },
+    {
+        key: 'showBoostedHeadline',
+        editable: true,
+        omitForSupporting: true,
+        label: 'large headline',
+        type: 'boolean'
+    },
+    {
+        key: 'showQuotedHeadline',
+        editable: true,
+        omitForSupporting: true,
+        label: 'quote headline',
+        type: 'boolean'
+    },
+    {
+        key: 'showByline',
+        editable: true,
+        omitForSupporting: true,
+        label: 'byline',
+        type: 'boolean'
+    },
+    {
+        key: 'imageCutoutReplace',
+        editable: true,
+        omitForSupporting: true,
+        singleton: 'images',
+        label: 'cutout image',
+        type: 'boolean'
+    },
+    {
+        key: 'imageReplace',
+        editable: true,
+        omitForSupporting: true,
+        singleton: 'images',
+        label: 'replace image',
+        omitIfNo: 'imageSrc',
+        type: 'boolean'
+    },
+    {
+        key: 'imageHide',
+        editable: true,
+        omitForSupporting: true,
+        singleton: 'images',
+        label: 'hide image',
+        type: 'boolean'
+    },
+    {
+        key: 'showKickerTag',
+        editable: true,
+        singleton: 'kicker',
+        label: 'kicker',
+        labelState: 'primaryTag',
+        type: 'boolean'
+    },
+    {
+        key: 'showKickerSection',
+        editable: true,
+        singleton: 'kicker',
+        label: 'kicker',
+        labelState: 'sectionName',
+        type: 'boolean'
+    },
+    {
+        key: 'showKickerCustom',
+        editable: true,
+        singleton: 'kicker',
+        label: 'custom kicker',
+        labelMeta: 'customKicker',
+        type: 'boolean'
+    },
+    {
+        key: 'snapUri',
+        label: 'snap target',
+        type: 'text'
+    },
+    {
+        key: 'snapType',
+        label: 'snap type',
+        type: 'text'
+    },
+    {
+        key: 'snapCss',
+        label: 'snap class',
+        type: 'text'
+    },
+    {
+        key: 'imageSlideshowReplace',
+        omitForSupporting: true,
+        editable: true,
+        label: 'slideshow',
+        singleton: 'images',
+        type: 'boolean'
+    },
+    {
+        key: 'slideshow',
+        editable: true,
+        omitForSupporting: true,
+        visibleWhen: 'imageSlideshowReplace',
+        type: 'list',
+        length: CONST.maxSlideshowImages,
+        item: {
+            type: 'image',
+            editable: true,
+            dropImage: true,
+            validator: {
+                fn: 'validateListImage',
+                params: {
+                    options: {
+                        maxWidth: 1000,
+                        minWidth: 400,
+                        widthAspectRatio: 5,
+                        heightAspectRatio: 3
+                    }
+                }
+            }
+        }
+    }
+]);

--- a/facia-tool/public/js/models/collections/editor.js
+++ b/facia-tool/public/js/models/collections/editor.js
@@ -1,0 +1,190 @@
+import ko from 'knockout';
+import _ from 'underscore';
+import BaseClass from 'models/base-class';
+import alert from 'utils/alert';
+import * as draggableElement from 'utils/draggable-element';
+import mediator from 'utils/mediator';
+import validateImageSrc from 'utils/validate-image-src';
+
+const rxScriptStriper = new RegExp(/<script.*/gi);
+
+export default class Editor extends BaseClass {
+    static create(opts, article, all, defaults = {}) {
+        if (opts.editable && (!article.slimEditor || opts.slimEditable)) {
+            return new Editor(opts, article, all, defaults);
+        }
+    }
+
+    constructor(opts, article, all, defaults) {
+        super();
+        var {key, type, validator} = opts;
+        var meta = article.meta[key] || ko.observable(defaults.meta);
+        var field = article.fields[key] || ko.observable(defaults.field);
+
+        this.all = all;
+        this.article = article;
+        this.field = field;
+        this.items = [];
+        this.key = key;
+        this.meta = meta;
+        this.opts = opts;
+        this.type = type;
+        this.label = opts.label + (opts.labelState ? ': ' + _.result(article.state, opts.labelState) : '');
+        this.dropImage = ko.observable(!!opts.dropImage);
+        this.underDrag = ko.observable(false);
+
+        if (type === 'list') {
+            this.items = _.chain(opts.length)
+                .times(i => Editor.create(opts.item, this.article, all, {
+                    meta: (this.article.meta[key]() || [])[i]
+                }))
+                .filter(Boolean)
+                .each(editor => this.subscribeOn(editor.meta, () => {
+                    meta(this.items.map(item => item.meta()));
+                }))
+                .value();
+        } else if (type === 'text') {
+            this.listenOn(mediator, 'ui:open', this.onUIOpen);
+        }
+
+        this.hasFocus = ko.observable(false);
+        this.length = ko.pureComputed(() => {
+            return opts.maxLength ? opts.maxLength - this.value().length : undefined;
+        });
+        this.lengthAlert = ko.pureComputed(() => {
+            return opts.maxLength && this.value().length > opts.maxLength;
+        });
+        this.displayEditor = ko.pureComputed(this.isVisible, this);
+        this.updateText = ko.pureComputed({
+            read: this.value,
+            write: this.writeText,
+            owner: this
+        });
+
+        if (validator && _.isFunction(this[validator.fn])) {
+            this.subscribeOn(meta, () => {
+                this[validator.fn](validator.params, meta);
+            });
+        }
+    }
+
+    value() {
+        return this.meta() || this.field() || '';
+    }
+
+    clear() {
+        this.meta(undefined);
+    }
+
+    open() {
+        this.notifiyUIOpen(this.meta);
+    }
+
+    notifiyUIOpen(meta) {
+        mediator.emit('ui:open', meta, this.article, this.article.front);
+    }
+
+    onUIOpen(meta) {
+        this.hasFocus(meta === this.meta);
+    }
+
+    isVisible() {
+        var key = this.opts.visibleWhen;
+        var display = key ? _.some(this.all, editor => editor.key === key && this.article.meta[editor.key]()) : true;
+
+        display = display && (this.article.state.enableContentOverrides() || key === 'customKicker');
+        display = display && (this.opts.ifState ? this.article.state[this.opts.ifState]() : true);
+        display = display && (this.opts.omitForSupporting ? this.article.group.parentType !== 'Article' : true);
+
+        return display;
+    }
+
+    toggle() {
+        if (this.opts.singleton) {
+           _.chain(this.all)
+            .filter(editor => editor.singleton === this.opts.singleton && editor.key !== this.key)
+            .pluck('key')
+            .each(key => this.article.meta[key](false));
+        }
+
+        this.meta(!this.meta());
+
+       _.chain(this.all)
+        .filter(editor => editor.visibleWhen === this.key)
+        .first(1)
+        .each(editor => this.notifiyUIOpen(this.article.meta[editor.key]));
+    }
+
+    dropInEditor(element) {
+        var sourceMeta = element.getData('sourceMeta');
+        if (sourceMeta) {
+            try {
+                sourceMeta = JSON.parse(sourceMeta);
+                this.meta(sourceMeta);
+                return;
+            } catch (ex) {/**/}
+        }
+
+        try {
+            this.meta({
+                media: draggableElement.getMediaItem(element),
+                origin: element.getData('Url')
+            });
+        } catch (ex) {
+            alert(ex.message);
+        }
+    }
+
+    writeText(value) {
+        this.meta(value === this.field() ? undefined : value.replace(rxScriptStriper, ''));
+    }
+
+    validateImage(params) {
+        var imageSrc = this.article.meta[params.src],
+            imageSrcWidth = this.article.meta[params.width],
+            imageSrcHeight = this.article.meta[params.height],
+            image = imageSrc(),
+            src,
+            opts = params.options;
+
+
+        if (image) {
+            src = typeof image === 'string' ? image : (image.media ? image.media.file || image.origin : image.origin);
+            return validateImageSrc(src, opts)
+                .then(function(img) {
+                    imageSrc(img.src);
+                    imageSrcWidth(img.width);
+                    imageSrcHeight(img.height);
+                }, function(err) {
+                    [imageSrc, imageSrcWidth, imageSrcHeight].forEach(m => m(undefined));
+                    alert(err.message);
+                });
+        } else {
+            [imageSrc, imageSrcWidth, imageSrcHeight].forEach(m => m(undefined));
+        }
+    }
+
+    validateListImage(params = {}, meta) {
+        var image = meta();
+
+        if (image && image.src) {
+            // This image is already validated
+            return;
+        } else if (image) {
+            var originUrl = image.origin,
+                src = image.media ? image.media.file || originUrl : originUrl,
+                origin = image.media ? image.media.origin || originUrl : originUrl;
+            return validateImageSrc(src, params.options)
+                .then(function(img) {
+                    meta(_.extend({
+                        origin: origin
+                    }, img));
+                }, function(err) {
+                    meta(undefined);
+                    alert(err);
+                });
+        } else {
+            meta(undefined);
+        }
+    }
+}

--- a/facia-tool/public/js/models/common-handlers.js
+++ b/facia-tool/public/js/models/common-handlers.js
@@ -1,5 +1,7 @@
 import ko from 'knockout';
 import $ from 'jquery';
+import _ from 'underscore';
+import mediator from 'utils/mediator';
 
 ko.bindingHandlers.toggleClick = {
     init: function (element, valueAccessor) {
@@ -30,5 +32,44 @@ ko.bindingHandlers.fadeVisible = {
     update: function(element, valueAccessor) {
         var value = valueAccessor();
         if (ko.unwrap(value)) { $(element).fadeIn(); } else { $(element).fadeOut(); }
+    }
+};
+
+function mod(n, m) {
+    return ((n % m) + m) % m;
+}
+
+function resize(el) {
+    setTimeout(function() {
+        el.style.height = (el.scrollHeight) + 'px';
+    });
+}
+
+ko.bindingHandlers.autoResize = {
+    init: function(el) {
+        var resizeCallback = function () { resize(el); };
+        resizeCallback();
+        $(el).keydown(resizeCallback).on('paste', resizeCallback);
+    }
+};
+
+ko.bindingHandlers.tabbableFormField = {
+    init: function(el, valueAccessor, allBindings, viewModel, bindingContext) {
+        var article = bindingContext.$parent.article;
+
+        $(el).keydown(function(e) {
+            var keyCode = e.keyCode || e.which,
+                formField,
+                formFields,
+                nextIndex;
+
+            if (keyCode === 9) {
+                e.preventDefault();
+                formField = bindingContext.$rawData;
+                formFields = _.filter(article.editors(), ed => ed.type === 'text' && ed.displayEditor());
+                nextIndex = mod(formFields.indexOf(formField) + (e.shiftKey ? -1 : 1), formFields.length);
+                mediator.emit('ui:open', formFields[nextIndex].meta, article, article.front);
+            }
+        });
     }
 };

--- a/facia-tool/public/js/models/group.js
+++ b/facia-tool/public/js/models/group.js
@@ -19,8 +19,6 @@ export default class Group extends DropTarget {
         this.keepCopy = opts.keepCopy;
         this.front = opts.front;
         this.opts = opts;
-
-        this.elementHasFocus = opts.elementHasFocus || (opts.front ? opts.front.elementHasFocus.bind(opts.front) : null);
     }
 
     pasteItem() {

--- a/facia-tool/public/js/models/widgets.js
+++ b/facia-tool/public/js/models/widgets.js
@@ -57,6 +57,13 @@ var register = _.once(() => {
         synchronous: true,
         template: { text: 'widgets/trail.html' }
     });
+    ko.components.register('trail-editor-widget', {
+        viewModel: {
+            createViewModel: (params) => params.context.$data
+        },
+        synchronous: true,
+        template: { text: 'widgets/trail-editor.html' }
+    });
     ko.components.register('clipboard-widget', {
         viewModel: { jspm: 'widgets/clipboard' },
         template: { text: 'widgets/clipboard.html' }

--- a/facia-tool/public/js/widgets/clipboard.js
+++ b/facia-tool/public/js/widgets/clipboard.js
@@ -35,13 +35,11 @@ class Clipboard extends BaseWidget {
         this.storage = storage.bind('gu.front-tools.clipboard.' +
             (classCount ? classCount + '.' : '') + vars.model.identity.email);
         classCount += 1;
-        this.uiOpenElement = ko.observable();
         this.column = params.column;
         this.group = new Group({
             parentType: 'Clipboard',
             keepCopy:  true,
-            front: null,
-            elementHasFocus: this.elementHasFocus.bind(this)
+            front: null
         });
         this.group.items(this.getItemsFromStorage());
 
@@ -63,14 +61,7 @@ class Clipboard extends BaseWidget {
         return inMemory ? inMemory.displayName : null;
     }
 
-    elementHasFocus(meta) {
-        return meta === this.uiOpenElement();
-    }
-
-    onUIOpen(element, article, front) {
-        if (!front) {
-            this.uiOpenElement(element);
-        }
+    onUIOpen(element, article) {
         updateClipboardScrollable(article ? {
             targetGroup: article.group
         } : null);

--- a/facia-tool/public/js/widgets/columns/fronts.js
+++ b/facia-tool/public/js/widgets/columns/fronts.js
@@ -56,7 +56,6 @@ export default class Front extends ColumnWidget {
         });
 
         this.alertFrontIsStale = ko.observable();
-        this.uiOpenElement = ko.observable();
         this.uiOpenArticle = ko.observable();
 
         this.allExpanded = ko.observable(true);
@@ -87,7 +86,6 @@ export default class Front extends ColumnWidget {
                 openArticle.close();
             }
             this.uiOpenArticle(article);
-            this.uiOpenElement(element);
         });
 
         this.listenOn(mediator, 'presser:live', this.pressLiveFront);
@@ -236,10 +234,6 @@ export default class Front extends ColumnWidget {
         if (this.mode() === 'draft') {
             this.pressDraftFront();
         }
-    }
-
-    elementHasFocus(meta) {
-        return meta === this.uiOpenElement();
     }
 
     getCollectionList(list) {

--- a/facia-tool/public/js/widgets/trail-editor.html
+++ b/facia-tool/public/js/widgets/trail-editor.html
@@ -1,0 +1,75 @@
+<!-- ko if: displayEditor -->
+    <!-- ko if: type === 'text' -->
+        <div class="editor" data-bind="css: {'length--alert': lengthAlert}">
+            <textarea data-bind="
+                click: open,
+                clickBubble: false,
+                hasFocus: hasFocus,
+                attr: {
+                    class: 'element__' + key + (hasFocus() ? ' active' : ''),
+                    placeholder: field() || (label + '...'),
+                    title: label
+                },
+                css: {
+                    'underDrag': underDrag
+                },
+                autoResize: true,
+                dropImage: dropImage,
+                tabbableFormField: true,
+                textInput: updateText"></textarea>
+
+            <!-- ko if: hasFocus -->
+                <span class="editor__length" data-bind="text: length"></span>
+                <a class="editor__revert" data-bind="
+                    visible: meta() && field(),
+                    click: clear"><i class="fa fa-fast-backward"></i></a>
+                <span class="editor__alert__message">Text is too long.</span>
+            <!-- /ko -->
+        </div>
+    <!-- /ko -->
+
+    <!-- ko if: type === 'boolean' -->
+        <span data-bind="
+            click: toggle,
+            clickBubble: false,
+            attr: {class: 'editor--boolean editor--boolean--' + key},
+            css: {selected: meta}">
+            <a class="editor--boolean__label" data-bind="
+                text: label"></a>
+            <span class="editor--boolean__state"><span data-bind="visible: meta">&#10004;</span></span>
+        </span>
+    <!-- /ko -->
+
+    <!-- ko if: type === 'list' -->
+        <div class="editor--list">
+            <!-- ko foreach: items -->
+                <trail-editor-widget params="context: $context"></trail-editor-widget>
+            <!-- /ko -->
+        </div>
+    <!-- /ko -->
+
+    <!-- ko if: type === 'image' -->
+        <a class="editor--image" data-bind="
+            attr: {
+                'href': meta() ? meta().origin || meta().src : ''
+            },
+            css: {
+                'underDrag': underDrag,
+                'allow-default-click': meta() && meta().src
+            },
+            dropImage: dropImage,
+            style: {
+                backgroundImage: meta() && meta().src ? 'url(' + meta().src + ')' : ''
+            }
+        " target="_blank">
+            <!-- ko if: meta -->
+                <span class="editor--image__remove" data-bind="click: clear">
+                    <i class="fa fa-remove"></i>
+                </span>
+            <!-- /ko -->
+            <!-- ko ifnot: meta -->
+                <p>drag an image</p>
+            <!-- /ko -->
+        </a>
+    <!-- /ko -->
+<!-- /ko -->

--- a/facia-tool/public/js/widgets/trail.html
+++ b/facia-tool/public/js/widgets/trail.html
@@ -27,8 +27,11 @@
     <!-- /ko -->
 
     <div data-bind="if: state.isOpen">
-        <div class="article__overrides"
-            data-bind="template: {name: 'template_editor', foreach: editors}"></div>
+        <div class="article__overrides">
+            <!-- ko foreach: editors -->
+                <trail-editor-widget params="context: $context"></trail-editor-widget>
+            <!-- /ko -->
+        </div>
 
         <div data-bind="if: state.enableContentOverrides() && group.parentType !== 'Article'">
             <div class="supporting" data-bind="with: meta.supporting">
@@ -165,80 +168,6 @@
 
     </div>
 </div>
-
-<script type="text/html" id="template_editor">
-    <!-- ko if: displayEditor -->
-        <!-- ko if: type === 'text' -->
-            <div class="editor" data-bind="css: {'length--alert': lengthAlert}">
-                <textarea data-bind="
-                    click: open,
-                    clickBubble: false,
-                    hasFocus: hasFocus,
-                    attr: {
-                        class: 'element__' + key + (hasFocus() ? ' active' : ''),
-                        placeholder: field() || (label + '...'),
-                        title: label
-                    },
-                    css: {
-                        'underDrag': underDrag
-                    },
-                    autoResize: true,
-                    dropImage: dropImage,
-                    tabbableFormField: true,
-                    textInput: overrideOrVal"></textarea>
-
-                <!-- ko if: hasFocus -->
-                    <span class="editor__length" data-bind="text: length"></span>
-                    <a class="editor__revert" data-bind="
-                        visible: meta() && field(),
-                        click: revert"><i class="fa fa-fast-backward"></i></a>
-                    <span class="editor__alert__message">Text is too long.</span>
-                <!-- /ko -->
-            </div>
-        <!-- /ko -->
-
-        <!-- ko if: type === 'boolean' -->
-            <span data-bind="
-                click: toggle,
-                clickBubble: false,
-                attr: {class: 'editor--boolean editor--boolean--' + key},
-                css: {selected: meta}">
-                <a class="editor--boolean__label" data-bind="
-                    text: label"></a>
-                <span class="editor--boolean__state"><span data-bind="visible: meta">&#10004;</span></span>
-            </span>
-        <!-- /ko -->
-
-        <!-- ko if: type === 'list' -->
-            <div class="editor--list" data-bind="template: {name: 'template_editor', foreach: items}"></div>
-        <!-- /ko -->
-
-        <!-- ko if: type === 'image' -->
-            <a class="editor--image" data-bind="
-                attr: {
-                    'href': meta() ? meta().origin || meta().src : ''
-                },
-                css: {
-                    'underDrag': underDrag,
-                    'allow-default-click': meta() && meta().src
-                },
-                dropImage: dropImage,
-                style: {
-                    backgroundImage: meta() && meta().src ? 'url(' + meta().src + ')' : ''
-                }
-            " target="_blank">
-                <!-- ko if: meta -->
-                    <span class="editor--image__remove" data-bind="click: clear">
-                        <i class="fa fa-remove"></i>
-                    </span>
-                <!-- /ko -->
-                <!-- ko ifnot: meta -->
-                    <p>drag an image</p>
-                <!-- /ko -->
-            </a>
-        <!-- /ko -->
-    <!-- /ko -->
-</script>
 
 <script type="text/html" id="template_editor_boolean_states">
     <span class="editor--boolean--display">

--- a/facia-tool/test/public/fixtures/all-editors.js
+++ b/facia-tool/test/public/fixtures/all-editors.js
@@ -1,0 +1,63 @@
+export default Object.freeze([{
+    key: 'one',
+    label: 'one',
+    type: 'boolean',
+    singleton: 'common',
+    editable: true
+}, {
+    key: 'two',
+    label: 'two',
+    type: 'boolean',
+    singleton: 'common',
+    editable: true
+}, {
+    key: 'three',
+    label: 'three',
+    type: 'boolean',
+    singleton: 'common',
+    editable: true
+}, {
+    key: 'field',
+    label: 'field',
+    type: 'text',
+    visibleWhen: 'one',
+    editable: true,
+    maxLength: 5
+}, {
+    key: 'image',
+    label: 'image',
+    type: 'text',
+    editable: true,
+    dropImage: true,
+    validator: {
+        fn: 'validateImage',
+        params: {
+            src: 'image',
+            width: 'imageWidth',
+            height: 'imageHeight'
+        }
+    }
+}, {
+    key: 'imageWidth',
+    type: 'text',
+    editable: false,
+    visibleWhen: 'image'
+}, {
+    key: 'imageHeight',
+    type: 'text',
+    editable: false,
+    visibleWhen: 'image'
+}, {
+    key: 'list',
+    type: 'list',
+    editable: true,
+    length: 3,
+    item: {
+        type: 'image',
+        editable: true,
+        dropImage: true,
+        validator: {
+            fn: 'validateListImage'
+        }
+    }
+}]);

--- a/facia-tool/test/public/spec/editors.spec.js
+++ b/facia-tool/test/public/spec/editors.spec.js
@@ -1,0 +1,137 @@
+import $ from 'jquery';
+import ko from 'knockout';
+import _ from 'underscore';
+import Editor from 'models/collections/editor';
+import {CONST} from 'modules/vars';
+import all from 'test/fixtures/all-editors';
+import drag from 'test/utils/drag';
+import inject from 'test/utils/inject';
+import textInside from 'test/utils/text-inside';
+import 'widgets/trail-editor.html!text';
+
+describe('Editors', function () {
+    beforeEach(function (done) {
+        this.originalCDNDomain = CONST.imageCdnDomain;
+        CONST.imageCdnDomain = window.location.host;
+        this.article = {
+            meta: {},
+            fields: {},
+            state: { enableContentOverrides: ko.observable(true) }
+        };
+        all.forEach(field => this.article.meta[field.key] = ko.observable());
+        this.editors = all.map(field => Editor.create(field, this.article, all)).filter(Boolean);
+
+        this.ko = inject(`
+            <!-- ko foreach: editors -->
+                <trail-editor-widget params="context: $context"></trail-editor-widget>
+            <!-- /ko -->
+        `);
+        this.ko.apply({ editors: this.editors }).then(done);
+    });
+    afterEach(function () {
+        CONST.imageCdnDomain = this.originalCDNDomain;
+        this.ko.dispose();
+    });
+
+    it('toggles boolean values', function () {
+        $('.editor--boolean--one').click();
+        expect($('.editor--boolean--one').hasClass('selected')).toBe(true);
+        expect($('.element__field').is(':visible')).toBe(true);
+        expect($('.editor__length').length).toBe(1);
+
+        // Select another singleton
+        $('.editor--boolean--two').click();
+        expect($('.editor--boolean--one').hasClass('selected')).toBe(false);
+        expect($('.element__field').is(':visible')).toBe(false);
+        expect($('.editor--boolean--two').hasClass('selected')).toBe(true);
+
+        $('.editor--boolean--three').click();
+        expect($('.editor--boolean--one').hasClass('selected')).toBe(false);
+        expect($('.element__field').is(':visible')).toBe(false);
+        expect($('.editor--boolean--two').hasClass('selected')).toBe(false);
+        expect($('.editor--boolean--three').hasClass('selected')).toBe(true);
+
+        $('.editor--boolean--one').click();
+        expect($('.editor--boolean--one').hasClass('selected')).toBe(true);
+        expect($('.element__field').is(':visible')).toBe(true);
+        expect($('.editor__length').length).toBe(1);
+        $('.element__field').val('more than 5 letters').change();
+        expect(textInside('.editor__length')).toBe('-' + ('more than 5 letters'.length - 5));
+
+        $('.editor__revert').click();
+        expect($('.element__field').val()).toBe('');
+
+        // Toggle off
+        $('.editor--boolean--one').click();
+        expect($('.editor--boolean--one').hasClass('selected')).toBe(false);
+        expect($('.element__field').is(':visible')).toBe(false);
+    });
+
+    it('validates inputs', function (done) {
+        var imageEditor = _.find(this.editors, editor => editor.key === 'image');
+        spyOn(imageEditor, 'validateImage').and.callThrough();
+
+        $('.element__image').val('http://' + window.location.host + '/base/test/public/fixtures/square.png').change();
+        expect(imageEditor.validateImage).toHaveBeenCalled();
+        Promise.resolve(imageEditor.validateImage.calls.first().returnValue).then(() => {
+            expect(this.article.meta.image()).toMatch(/square\.png/);
+            expect(this.article.meta.imageWidth()).toBe(140);
+            expect(this.article.meta.imageHeight()).toBe(140);
+
+            imageEditor.validateImage.calls.reset();
+
+            // invalid input
+            $('.element__image').val('http://' + window.location.host + '/this_image_doesnt_exists__promised.png').change();
+            return imageEditor.validateImage.calls.first().returnValue;
+        })
+        .then(() => {
+            expect(this.article.meta.image()).toBeUndefined();
+            expect(this.article.meta.imageWidth()).toBeUndefined();
+            expect(this.article.meta.imageHeight()).toBeUndefined();
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('list editor with drop in editor', function (done) {
+        var listEditor = _.find(this.editors, editor => editor.key === 'list').items[0];
+        spyOn(listEditor, 'validateListImage').and.callThrough();
+
+        var target = $('.editor--image')[0];
+        var sourceImage = new drag.Media([{
+            file: 'http://' + window.location.host + '/base/test/public/fixtures/squarefour.png',
+            dimensions: { width: 400, height: 400 }
+        }], 'imageOrigin');
+        drag.droppable(target).dropInEditor(target, sourceImage);
+
+        expect(listEditor.validateListImage).toHaveBeenCalled();
+        listEditor.validateListImage.calls.first().returnValue.then(() => {
+            var images = this.article.meta.list();
+            expect(images.length).toBe(3);
+            expect(images[0].origin).toEqual('imageOrigin');
+            expect(images[0].src).toMatch(/squarefour\.png/);
+            expect(images[0].width).toBe(400);
+            expect(images[0].height).toBe(400);
+            expect(images[1]).toBeUndefined();
+            expect(images[2]).toBeUndefined();
+
+            listEditor.validateListImage.calls.reset();
+
+            // invalid input
+            sourceImage = new drag.Media([{
+                file: 'http://' + window.location.host + '/this_image_doesnt_exists__promised.png',
+                dimensions: { width: 400, height: 400 }
+            }], 'fakeOrigin');
+        drag.droppable(target).dropInEditor(target, sourceImage);
+            return listEditor.validateListImage.calls.first().returnValue;
+        })
+        .then(() => {
+            var images = this.article.meta.list();
+            expect(images[0]).toBeUndefined();
+            expect(images[1]).toBeUndefined();
+            expect(images[2]).toBeUndefined();
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+});


### PR DESCRIPTION
`article.js` is huge and hard to change. This moves some of the code away adding a bunch of tests. It should make it easier to finally convert `Article` to ES6