### PR TITLE
add eslint plugin for jasmine

### DIFF
--- a/facia-tool/test/.eslintrc
+++ b/facia-tool/test/.eslintrc
@@ -28,11 +28,15 @@
         "jsx": true,
         "restParams": true
     },
+    "plugins": [
+        "jasmine"
+    ],
     "rules": {
         // Overrides old
         "camelcase": 2,
         "no-shadow": 2,
         "strict": 2,
-        "no-unused-vars": 1
+        "no-unused-vars": 1,
+        "jasmine/no-disabled-tests": 2
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Guardian front pages editor",
   "dependencies": {
     "babel": "5.8.23",
+    "eslint-plugin-jasmine": "^1.5.0",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
     "grunt-eslint": "17.2.0",


### PR DESCRIPTION
Add eslint plugin for jasmine and display errors if there are focused or disabled tests. 