### PR TITLE
Better validation for images coming from the Grid

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -362,6 +362,12 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val host = configuration.getStringProperty("memcached.host")
   }
 
+  object media {
+    lazy val baseUrl = playConfiguration.getStringFromStage("media.base.url");
+    lazy val apiUrl = playConfiguration.getStringFromStage("media.api.url");
+    lazy val key = playConfiguration.getStringFromStage("media.key");
+  }
+
   object aws {
 
     lazy val region = playConfiguration.getMandatoryStringFromStage("aws.region")

--- a/facia-tool/app/controllers/FrontendDependentController.scala
+++ b/facia-tool/app/controllers/FrontendDependentController.scala
@@ -25,7 +25,9 @@ case class Defaults(
   lowFrequency: Int,
   highFrequency: Int,
   standardFrequency: Int,
-  sentryPublicDSN: Option[String],
+  sentryPublicDSN: String,
+  mediaBaseUrl: String,
+  apiBaseUrl: String,
   fixedContainers: Seq[ContainerJsonConfig],
   dynamicContainers: Seq[ContainerJsonConfig]
 )
@@ -60,7 +62,9 @@ object FrontendDependentController extends Controller with PanDomainAuthActions 
         Configuration.faciatool.adminPressJobLowPushRateInMinutes,
         Configuration.faciatool.adminPressJobHighPushRateInMinutes,
         Configuration.faciatool.adminPressJobStandardPushRateInMinutes,
-        Configuration.faciatool.sentryPublicDSN,
+        Configuration.faciatool.sentryPublicDSN.get,
+        Configuration.media.baseUrl.get,
+        Configuration.media.apiUrl.get,
         FixedContainers.all.keys.toSeq.map(id => ContainerJsonConfig(id, None)),
         DynamicContainers.all.keys.toSeq.map(id =>
           if (id == "dynamic/package") {

--- a/facia-tool/public/js/constants/article-meta-fields.js
+++ b/facia-tool/public/js/constants/article-meta-fields.js
@@ -52,6 +52,7 @@ export default Object.freeze([
                 src: 'imageSrc',
                 width: 'imageSrcWidth',
                 height: 'imageSrcHeight',
+                origin: 'imageSrcOrigin',
                 options: {
                     maxWidth: 1000,
                     minWidth: 400,
@@ -75,6 +76,12 @@ export default Object.freeze([
         type: 'text'
     },
     {
+        key: 'imageSrcOrigin',
+        visibleWhen: 'imageReplace',
+        label: 'replacement image origin',
+        type: 'text'
+    },
+    {
         key: 'imageCutoutSrc',
         editable: true,
         dropImage: true,
@@ -87,6 +94,7 @@ export default Object.freeze([
                 src: 'imageCutoutSrc',
                 width: 'imageCutoutSrcWidth',
                 height: 'imageCutoutSrcHeight',
+                origin: 'imageCutoutSrcOrigin',
                 options: {
                     maxWidth: 1000,
                     minWidth: 400
@@ -105,6 +113,12 @@ export default Object.freeze([
         key: 'imageCutoutSrcHeight',
         visibleWhen: 'imageCutoutReplace',
         label: 'replacement cutout image height',
+        type: 'text'
+    },
+    {
+        key: 'imageCutoutSrcOrigin',
+        visibleWhen: 'imageCutoutReplace',
+        label: 'replacement cutout image origin',
         type: 'text'
     },
     {

--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -113,7 +113,9 @@ export default {
     reauthTimeout:         60000,
 
     imageCdnDomain:        '.guim.co.uk',
-    imgIXBasePath:         '/img/static/',
+    imageCdnDomainExpr:    /^https?:\/\/(.*)\.guim\.co\.uk\//,
+    imgIXDomainExpr:       /^https?:\/\/i\.guim\.co\.uk\/img\/static\//,
+    staticImageCdnDomain:  'https://static.guim.co.uk/',
     previewBase:           'http://preview.gutools.co.uk',
     viewerHost:            'viewer.gutools.co.uk',
 

--- a/facia-tool/public/js/jspm-config.js
+++ b/facia-tool/public/js/jspm-config.js
@@ -23,6 +23,7 @@ System.config({
     "css": "github:systemjs/plugin-css@0.1.18",
     "es5-shim": "github:es-shims/es5-shim@4.1.14",
     "font-awesome": "npm:font-awesome@4.4.0",
+    "grid-util-js": "npm:grid-util-js@1.0.5",
     "highcharts": "facia-tool/components/highcharts/highcharts-custom",
     "jquery": "npm:jquery@2.1.4",
     "jquery-mockjax": "npm:jquery-mockjax@2.0.1",

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -1,7 +1,8 @@
-import _ from 'underscore';
 import Promise from 'Promise';
-import {CONST} from 'modules/vars';
-import absPath from 'utils/url-abs-path';
+import _ from 'underscore';
+import GridUtil from 'grid-util-js';
+import * as vars from 'modules/vars';
+import deepGet from 'utils/deep-get';
 
 /**
  * Asserts if the given image URL is on The Guardian domain, is proper size and aspect ratio.
@@ -9,67 +10,141 @@ import absPath from 'utils/url-abs-path';
  * @param criteria. validation criteria object. defines: maxWidth, minWidth, widthAspectRatio, heightAspectRatio
  * @returns Promise object: rejects with (error) OR resolves with (width, height, src)
  */
-function validateImageSrc(src, criteria) {
-    return new Promise(function (resolve, reject) {
-        var img,
-            defaultCriteria = {
-                maxWidth: undefined,
-                minWidth: undefined,
-                widthAspectRatio: undefined,
-                heightAspectRatio: undefined
+function validateImageSrc(src, criteria = {}) {
+    if (!src) {
+        return Promise.reject(new Error('Missing image'));
+    }
+
+    return stripImplementationDetails(src, criteria)
+        .then(fetchImage)
+        .then(validateActualImage)
+        .then(({path, origin, thumb, width, height}) => {
+            return {
+                src: path,
+                origin: origin || path,
+                thumb: thumb || path,
+                width, height
             };
-        criteria = _.extend(defaultCriteria, criteria);
+        });
+}
 
-        if (!src) {
-            reject(new Error('Missing image'));
+function grid() {
+    if (!validateImageSrc.gridInstance) {
+        validateImageSrc.gridInstance = new GridUtil({
+            apiBaseUrl: vars.model.state().defaults.apiBaseUrl,
+            fetchInit: {
+                credentials: 'include',
+                mode: 'cors'
+            }
+        });
+    }
+    return validateImageSrc.gridInstance;
+}
 
-        } else if (!src.match(new RegExp('^http://.*' + CONST.imageCdnDomain.replace('.', '\\.') + '/'))) {
-            reject(new Error('Images must come from *' + CONST.imageCdnDomain));
+function stripImplementationDetails (src, criteria) {
+    return new Promise((resolve, reject) => {
+        var maybeFromGrid = grid().excractMediaId(src);
 
+        if (src && vars.CONST.imgIXDomainExpr.test(src)) {
+            src = src.substring(0, src.indexOf('?')).replace(vars.CONST.imgIXDomainExpr, vars.CONST.staticImageCdnDomain);
+            resolve({
+                path: src,
+                criteria
+            });
+        } else if (maybeFromGrid) {
+            grid().getImage(maybeFromGrid.id)
+                .catch(() => reject(new Error('Unable to locate the image on the Grid')))
+                .then(gridImageJson => filterGripdCrops(gridImageJson, maybeFromGrid, criteria))
+                .then(crops => getSuitableAsset(crops, maybeFromGrid.id, criteria))
+                .then(asset => resolve(_.extend(asset, {criteria})))
+                .catch(reject);
+        } else if (!vars.CONST.imageCdnDomainExpr.test(src)) {
+            reject(new Error('Images must come from ' + vars.CONST.imageCdnDomain + ' or the Grid'));
         } else {
-            src = stripImgIXDetails(src);
-
-            img = new Image();
-            img.onerror = function() {
-                reject(new Error('That image could not be found'));
-            };
-            img.onload = function() {
-                var width = this.width || 1,
-                    height = this.height || 1,
-                    err = (criteria.maxWidth !== undefined && width > criteria.maxWidth) ?
-                            'Images cannot be more than ' + criteria.maxWidth + ' pixels wide' :
-                        (criteria.minWidth !== undefined && width < criteria.minWidth) ?
-                            'Images cannot be less than ' + criteria.minWidth + ' pixels wide' :
-                        (criteria.widthAspectRatio !== undefined && criteria.heightAspectRatio !== undefined
-                          && Math.abs((height * criteria.widthAspectRatio) / (width * criteria.heightAspectRatio) - 1) > 0.01) ?
-                            'Images must have a ' + criteria.widthAspectRatio + 'x' + criteria.heightAspectRatio + ' aspect ratio'
-                            : false;
-
-                if (err) {
-                    reject(new Error(err));
-                } else {
-                    // Get the src again from the img, this makes sure that the URL is encoded properly
-                    resolve({
-                        width: width,
-                        height: height,
-                        src: img.src
-                    });
-                }
-            };
-            img.src = src;
+            resolve({
+                path: src,
+                criteria
+            });
         }
     });
 }
 
-function stripImgIXDetails (src) {
-    var pathname = '/' + absPath(src),
-        base = src.substring(0, src.indexOf(pathname));
+function fetchImage (description) {
+    return new Promise((resolve, reject) => {
+        var img = new Image();
+        img.onerror = function() {
+            reject(new Error('That image could not be found'));
+        };
+        img.onload = function() {
+            let size = {
+                width: this.width,
+                height: this.height,
+                ratio: this.width / this.height
+            };
+            resolve(_.extend(description, size));
+        };
+        img.src = description.path;
+    });
+}
 
-    if (pathname.indexOf(CONST.imgIXBasePath) === 0) {
-        return base + '/' + pathname.substring(CONST.imgIXBasePath.length);
+function filterGripdCrops (json, desired, {minWidth, maxWidth, widthAspectRatio, heightAspectRatio}) {
+    return grid().filterCrops(json, function (crop) {
+        if (desired.crop && crop.id !== desired.crop) {
+            return false;
+        }
+
+        let ratio = widthAspectRatio && heightAspectRatio ? widthAspectRatio / heightAspectRatio : NaN;
+        return !!_.find(crop.assets, function (asset) {
+            let {width, height} = asset.dimensions;
+            let actualRatio = width / height;
+            if (maxWidth && maxWidth < width) {
+                return false;
+            } else if (minWidth && minWidth > width) {
+                return false;
+            } else if (ratio && Math.abs(ratio - actualRatio) > 0.01) {
+                return false;
+            }
+            return true;
+        });
+    });
+}
+
+function getSuitableAsset (crops, id, desired) {
+    if (crops.length === 0) {
+        return Promise.reject(new Error('The image does not have a valid crop on the Grid'));
     } else {
-        return src;
+        let maxWidth = desired.maxWidth || 1000;
+        let assets = _.chain(crops[0].assets)
+            .filter(asset => deepGet(asset, '.dimensions.width') <= maxWidth)
+            .sortBy(asset => deepGet(asset, '.dimensions.width') * -1);
+        let path = assets.first().value().file;
+
+        return {
+            path: path,
+            thumb: assets.last().value().file,
+            origin: vars.model.state().defaults.mediaBaseUrl + '/image/' + id
+        };
     }
+}
+
+function validateActualImage (image) {
+    return new Promise((resolve, reject) => {
+        let {width, height, ratio, criteria, path, origin, thumb} = image;
+        let {maxWidth, minWidth, widthAspectRatio, heightAspectRatio} = criteria;
+        let criteriaRatio = widthAspectRatio && heightAspectRatio ? widthAspectRatio / heightAspectRatio : NaN;
+
+        if (maxWidth && maxWidth < width) {
+            reject(new Error('Images cannot be more than ' + maxWidth + ' pixels wide'));
+        } else if (minWidth && minWidth > width) {
+            reject(new Error('Images cannot be less than ' + minWidth + ' pixels wide'));
+        } else if (criteriaRatio && criteriaRatio - ratio > 0.01) {
+            reject(new Error('Images must have a ' + widthAspectRatio + ':' + heightAspectRatio + ' aspect ratio'));
+        } else {
+            resolve({
+                path, origin, thumb, width, height
+            });
+        }
+    });
 }
 
 export default validateImageSrc;

--- a/facia-tool/test/public/fixtures/all-editors.js
+++ b/facia-tool/test/public/fixtures/all-editors.js
@@ -34,7 +34,8 @@ export default Object.freeze([{
         params: {
             src: 'image',
             width: 'imageWidth',
-            height: 'imageHeight'
+            height: 'imageHeight',
+            origin: 'imageOrigin'
         }
     }
 }, {
@@ -44,6 +45,11 @@ export default Object.freeze([{
     visibleWhen: 'image'
 }, {
     key: 'imageHeight',
+    type: 'text',
+    editable: false,
+    visibleWhen: 'image'
+}, {
+    key: 'imageOrigin',
     type: 'text',
     editable: false,
     visibleWhen: 'image'

--- a/facia-tool/test/public/spec/config.front.spec.js
+++ b/facia-tool/test/public/spec/config.front.spec.js
@@ -8,13 +8,12 @@ import * as dom from 'test/utils/dom-nodes';
 import inject from 'test/utils/inject';
 import textInside from 'test/utils/text-inside';
 import * as wait from 'test/utils/wait';
+import images from 'test/utils/images';
 
 describe('Config Front', function () {
     beforeEach(function () {
         this.ko = inject('<fronts-config-widget params="column: $data.testColumn"></fronts-config-widget>');
-        this.loadFront = model => {
-            // TODO Phantom Babel bug
-            if (!model) { model = {}; }
+        this.loadFront = (model = {}) => {
             return this.ko.apply(_.defaults(model, {
                 state: ko.observable({
                     config: {
@@ -32,8 +31,7 @@ describe('Config Front', function () {
                 }
             }), true);
         };
-        this.originalImageCdnDomain = vars.CONST.imageCdnDomain;
-        vars.CONST.imageCdnDomain = window.location.host;
+        images.setup();
         this.originalsearchDebounceMs = vars.CONST.searchDebounceMs;
         vars.CONST.searchDebounceMs = 50;
         spyOn(persistence.front, 'update');
@@ -65,8 +63,8 @@ describe('Config Front', function () {
         });
     });
     afterEach(function () {
-        vars.CONST.imageCdnDomain = this.originalImageCdnDomain;
         vars.CONST.searchDebounceMs = this.originalsearchDebounceMs;
+        images.dispose();
         this.ko.dispose();
     });
 
@@ -205,7 +203,7 @@ describe('Config Front', function () {
 
         function changeImageUrl () {
             $('.linky.tool--metadata').click();
-            var imageUrl = 'http://' + vars.CONST.imageCdnDomain + '/base/test/public/fixtures/square.png';
+            var imageUrl = images.path('square.png');
             dom.type('.metadata--provisionalImage', imageUrl);
 
             return wait.ms(100).then(() => {

--- a/facia-tool/test/public/spec/editors.spec.js
+++ b/facia-tool/test/public/spec/editors.spec.js
@@ -2,17 +2,16 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'underscore';
 import Editor from 'models/collections/editor';
-import {CONST} from 'modules/vars';
 import all from 'test/fixtures/all-editors';
 import drag from 'test/utils/drag';
+import images from 'test/utils/images';
 import inject from 'test/utils/inject';
 import textInside from 'test/utils/text-inside';
 import 'widgets/trail-editor.html!text';
 
 describe('Editors', function () {
     beforeEach(function (done) {
-        this.originalCDNDomain = CONST.imageCdnDomain;
-        CONST.imageCdnDomain = window.location.host;
+        images.setup();
         this.article = {
             meta: {},
             fields: {},
@@ -29,7 +28,7 @@ describe('Editors', function () {
         this.ko.apply({ editors: this.editors }).then(done);
     });
     afterEach(function () {
-        CONST.imageCdnDomain = this.originalCDNDomain;
+        images.dispose();
         this.ko.dispose();
     });
 
@@ -71,7 +70,7 @@ describe('Editors', function () {
         var imageEditor = _.find(this.editors, editor => editor.key === 'image');
         spyOn(imageEditor, 'validateImage').and.callThrough();
 
-        $('.element__image').val('http://' + window.location.host + '/base/test/public/fixtures/square.png').change();
+        $('.element__image').val(images.path('square.png')).change();
         expect(imageEditor.validateImage).toHaveBeenCalled();
         Promise.resolve(imageEditor.validateImage.calls.first().returnValue).then(() => {
             expect(this.article.meta.image()).toMatch(/square\.png/);
@@ -81,7 +80,7 @@ describe('Editors', function () {
             imageEditor.validateImage.calls.reset();
 
             // invalid input
-            $('.element__image').val('http://' + window.location.host + '/this_image_doesnt_exists__promised.png').change();
+            $('.element__image').val(images.path('this_image_doesnt_exists__promised.png')).change();
             return imageEditor.validateImage.calls.first().returnValue;
         })
         .then(() => {
@@ -99,37 +98,37 @@ describe('Editors', function () {
 
         var target = $('.editor--image')[0];
         var sourceImage = new drag.Media([{
-            file: 'http://' + window.location.host + '/base/test/public/fixtures/squarefour.png',
+            file: images.path('squarefour.png'),
             dimensions: { width: 400, height: 400 }
         }], 'imageOrigin');
         drag.droppable(target).dropInEditor(target, sourceImage);
 
         expect(listEditor.validateListImage).toHaveBeenCalled();
         listEditor.validateListImage.calls.first().returnValue.then(() => {
-            var images = this.article.meta.list();
-            expect(images.length).toBe(3);
-            expect(images[0].origin).toEqual('imageOrigin');
-            expect(images[0].src).toMatch(/squarefour\.png/);
-            expect(images[0].width).toBe(400);
-            expect(images[0].height).toBe(400);
-            expect(images[1]).toBeUndefined();
-            expect(images[2]).toBeUndefined();
+            var listImages = this.article.meta.list();
+            expect(listImages.length).toBe(3);
+            expect(listImages[0].origin).toEqual('imageOrigin');
+            expect(listImages[0].src).toMatch(/squarefour\.png/);
+            expect(listImages[0].width).toBe(400);
+            expect(listImages[0].height).toBe(400);
+            expect(listImages[1]).toBeUndefined();
+            expect(listImages[2]).toBeUndefined();
 
             listEditor.validateListImage.calls.reset();
 
             // invalid input
             sourceImage = new drag.Media([{
-                file: 'http://' + window.location.host + '/this_image_doesnt_exists__promised.png',
+                file: images.path('this_image_doesnt_exists__promised.png'),
                 dimensions: { width: 400, height: 400 }
             }], 'fakeOrigin');
         drag.droppable(target).dropInEditor(target, sourceImage);
             return listEditor.validateListImage.calls.first().returnValue;
         })
         .then(() => {
-            var images = this.article.meta.list();
-            expect(images[0]).toBeUndefined();
-            expect(images[1]).toBeUndefined();
-            expect(images[2]).toBeUndefined();
+            var listImages = this.article.meta.list();
+            expect(listImages[0]).toBeUndefined();
+            expect(listImages[1]).toBeUndefined();
+            expect(listImages[2]).toBeUndefined();
         })
         .then(done)
         .catch(done.fail);

--- a/facia-tool/test/public/spec/media.service.spec.js
+++ b/facia-tool/test/public/spec/media.service.spec.js
@@ -1,23 +1,22 @@
 import $ from 'jquery';
 import Promise from 'Promise';
-import {CONST} from 'modules/vars';
 import MockVisible from 'mock/stories-visible';
 import CollectionsLoader from 'test/utils/collections-loader';
 import drag from 'test/utils/drag';
 import editAction from 'test/utils/edit-actions';
+import images from 'test/utils/images';
 import textInside from 'test/utils/text-inside';
 import * as wait from 'test/utils/wait';
 
 describe('Media Service', function () {
     beforeEach(function (done) {
-        this.originalCDNDomain = CONST.imageCdnDomain;
-        CONST.imageCdnDomain = window.location.host;
+        images.setup();
         this.testInstance = new CollectionsLoader();
         this.mockVisible = new MockVisible();
         this.testInstance.load().then(done);
     });
     afterEach(function () {
-        CONST.imageCdnDomain = this.originalCDNDomain;
+        images.dispose();
         this.testInstance.dispose();
         this.mockVisible.dispose();
     });
@@ -52,7 +51,7 @@ describe('Media Service', function () {
             var droppableRegionInsideArticle = $('collection-widget trail-widget .droppable')[0];
             var dropTarget = drag.droppable(droppableRegionInsideArticle);
             var sourceImage = new drag.Media([{
-                file: 'http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/fivethree.png',
+                file: images.path('fivethree.png'),
                 dimensions: { width: 500, height: 200 }
             }], 'testImageOrigin');
             dropTarget.dragover(droppableRegionInsideArticle, sourceImage);
@@ -72,7 +71,7 @@ describe('Media Service', function () {
             var droppableEditor = $('collection-widget trail-widget .element__imageCutoutSrc')[0];
             var dropTarget = drag.droppable(droppableEditor);
             var sourceImage = new drag.Media([{
-                file: 'http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/squarefour.png',
+                file: images.path('squarefour.png'),
                 dimensions: { width: 400, height: 400 }
             }], 'cutoutImageOrigin');
             dropTarget.dropInEditor(droppableEditor, sourceImage);
@@ -131,13 +130,15 @@ describe('Media Service', function () {
                     position: 'internal-code/page/1',
                     itemMeta: {
                         group: '0',
-                        imageCutoutSrc: 'http://localhost:9876/base/test/public/fixtures/squarefour.png',
+                        imageCutoutSrc: images.path('squarefour.png'),
                         imageCutoutSrcHeight: '400',
                         imageCutoutSrcWidth: '400',
+                        imageCutoutSrcOrigin: 'cutoutImageOrigin',
                         imageReplace: true,
-                        imageSrc: 'http://localhost:9876/base/test/public/fixtures/fivethree.png',
+                        imageSrc: images.path('fivethree.png'),
                         imageSrcHeight: '300',
-                        imageSrcWidth: '500'
+                        imageSrcWidth: '500',
+                        imageSrcOrigin: images.path('fivethree.png')
                     }
                 }
             });

--- a/facia-tool/test/public/spec/validate.image.spec.js
+++ b/facia-tool/test/public/spec/validate.image.spec.js
@@ -1,122 +1,336 @@
-import {CONST} from 'modules/vars';
+import ko from 'knockout';
+import * as vars from 'modules/vars';
 import validate from 'utils/validate-image-src';
+import GridUtil from 'grid-util-js';
+import images from 'test/utils/images';
 
 describe('Validate images', function () {
     beforeEach(function () {
-        this.originalCDNDomain = CONST.imageCdnDomain;
+        images.setup();
+
+        this.originalModel = vars.model;
+        vars.setModel({
+            state: ko.observable({
+                defaults: { apiBaseUrl: '/api.grid', mediaBaseUrl: 'http://media' }
+            })
+        });
+
+        validate.gridInstance = new GridUtil('/api.grid');
     });
     afterEach(function () {
-        CONST.imageCdnDomain = this.originalCDNDomain;
+        images.dispose();
+        validate.gridInstance = null;
+        vars.setModel(this.originalModel);
     });
 
-    it('fails on missing images', function (done) {
-        validate()
-        .then(done.fail, function (err) {
-            expect(err.message).toMatch(/missing/i);
-            done();
+    describe('- invalid', function () {
+        it('missing images', function (done) {
+            validate()
+            .then(done.fail, function (err) {
+                expect(err.message).toMatch(/missing/i);
+                done();
+            });
+        });
+
+        it('unknown domain', function (done) {
+            validate('http://another-host/image.png')
+            .then(done.fail, function (err) {
+                expect(err.message).toMatch(/images must come/i);
+                done();
+            });
         });
     });
 
-    it('fails on wrong domain', function (done) {
-        CONST.imageCdnDomain = 'funny-host';
+    describe('- from image CDN', function () {
+        it('fails if the image can\'t be found', function (done) {
+            validate(images.path('this_image_doesnt_exists__promised.png'))
+            .then(done.fail, err => {
+                expect(err.message).toMatch(/could not be found/i);
+                done();
+            });
+        });
 
-        validate('http://another-host/image.png')
-        .then(done.fail, function (err) {
-            expect(err.message).toMatch(/images must come/i);
-            done();
+        it('fails if the image is too big', function (done) {
+            var criteria = {
+                maxWidth: 50
+            };
+
+            validate(images.path('square.png'), criteria)
+            .then(done.fail, err => {
+                expect(err.message).toMatch(/cannot be more/i);
+                done();
+            });
+        });
+
+        it('fails if the image is too small', function (done) {
+            var criteria = {
+                minWidth: 200
+            };
+
+            validate(images.path('square.png'), criteria)
+            .then(done.fail, err => {
+                expect(err.message).toMatch(/cannot be less/i);
+                done();
+            });
+        });
+
+        it('fails if the aspect ratio is wrong', function (done) {
+            var criteria = {
+                widthAspectRatio: 5,
+                heightAspectRatio: 3
+            };
+
+            validate(images.path('square.png'), criteria)
+            .then(done.fail, err => {
+                expect(err.message).toMatch(/aspect ratio/i);
+                done();
+            });
+        });
+
+        it('works with no criteria', function (done) {
+            validate(images.path('square.png'))
+            .then(image => {
+                expect(image.width).toBe(140);
+                expect(image.height).toBe(140);
+                expect(image.src).toMatch(/square\.png/);
+                expect(image.origin).toMatch(/square\.png/);
+                done();
+            }, done.fail);
+        });
+
+        it('works with if all criteria are met', function (done) {
+            var criteria = {
+                minWidth: 100,
+                maxWidth: 200,
+                widthAspectRatio: 1,
+                heightAspectRatio: 1
+            };
+
+            validate(images.path('square.png'), criteria)
+            .then(image => {
+                expect(image.width).toBe(140);
+                expect(image.height).toBe(140);
+                expect(image.src).toMatch(/square\.png/);
+                expect(image.origin).toMatch(/square\.png/);
+                done();
+            }, done.fail);
         });
     });
 
-    it('fails if the image can\'t be found', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-
-        validate('http://' + CONST.imageCdnDomain + '/this_image_doesnt_exists__promised.png')
-        .then(done.fail, function (err) {
-            expect(err.message).toMatch(/could not be found/i);
-            done();
+    describe('- from imgIX', function () {
+        it('strips unnecessary parameters', function (done) {
+            validate(images.imgIX('square.png?s=82a57a91afadd159bb4639d6b798f6c5&other=params'))
+            .then(function (image) {
+                expect(image.width).toBe(140);
+                expect(image.height).toBe(140);
+                expect(image.src).toMatch(/square\.png$/);
+                expect(image.origin).toMatch(/square\.png$/);
+                done();
+            }, done.fail);
         });
     });
 
-    it('fails if the image is too big', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-        var criteria = {
-            maxWidth: 50
-        };
+    describe('- from the Grid', function () {
+        it('fails if media is not accessible', function (done) {
+            validate.gridInstance.getImage = () => {
+                return Promise.reject('error while loading');
+            };
 
-        validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(done.fail, function (err) {
-            expect(err.message).toMatch(/cannot be more/i);
-            done();
+            validate('http://grid.co.uk/1234567890123456789012345678901234567890')
+            .then(done.fail, err => {
+                expect(err.message).toMatch(/unable to locate/i);
+                done();
+            });
         });
-    });
 
-    it('fails if the image is too small', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-        var criteria = {
-            minWidth: 200
-        };
+        describe('- link include crop id', function () {
+            it('fails if crop id is invalid', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: {
+                            exports: [{ id: 'nice_crop_id' }]
+                        }
+                    });
+                };
 
-        validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(done.fail, function (err) {
-            expect(err.message).toMatch(/cannot be less/i);
-            done();
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop')
+                .then(done.fail, err => {
+                    expect(err.message).toMatch(/does not have a valid crop/i);
+                    done();
+                });
+            });
+
+            it('fails if crop doesn\'t respect criteria', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: {
+                            exports: [{
+                                id: 'image_crop',
+                                assets: [
+                                    { dimensions: { width: 5000, height: 100 } },
+                                    { dimensions: { width: 500, height: 10 } },
+                                    { dimensions: { width: 50, height: 1 } }
+                                ]
+                            }]
+                        }
+                    });
+                };
+
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop', {
+                    minWidth: 100,
+                    maxWidth: 1000,
+                    widthAspectRatio: 5,
+                    heightAspectRatio: 4
+                })
+                .then(done.fail, err => {
+                    expect(err.message).toMatch(/does not have a valid crop/i);
+                    done();
+                });
+            });
+
+            it('gets the specified asset', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: {
+                            exports: [{
+                                id: 'image_crop',
+                                assets: [
+                                    { dimensions: { width: 1400, height: 1400 } },
+                                    {
+                                        file: images.path('square.png'),
+                                        dimensions: { width: 140, height: 140 }
+                                    }
+                                ]
+                            }]
+                        }
+                    });
+                };
+
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop', {
+                    minWidth: 100,
+                    maxWidth: 1000,
+                    widthAspectRatio: 1,
+                    heightAspectRatio: 1
+                })
+                .then(image => {
+                    expect(image.width).toBe(140);
+                    expect(image.height).toBe(140);
+                    expect(image.src).toMatch(/square\.png$/);
+                    expect(image.origin).toBe('http://media/image/1234567890123456789012345678901234567890');
+                })
+                .then(done)
+                .catch(done.fail);
+            });
         });
-    });
 
-    it('fails if the aspect ratio is wrong', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-        var criteria = {
-            widthAspectRatio: 5,
-            heightAspectRatio: 3
-        };
+        describe('- link does not include crop id', function () {
+            it('fails if there are no crops', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: { exports: [] }
+                    });
+                };
 
-        validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(done.fail, function (err) {
-            expect(err.message).toMatch(/aspect ratio/i);
-            done();
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890')
+                .then(done.fail, err => {
+                    expect(err.message).toMatch(/does not have a valid crop/i);
+                    done();
+                });
+            });
+
+            it('fails if crops don\'t respect criteria', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: {
+                            exports: [{
+                                id: 'image_crop',
+                                assets: [
+                                    { dimensions: { width: 5000, height: 100 } },
+                                    { dimensions: { width: 500, height: 10 } },
+                                    { dimensions: { width: 50, height: 1 } }
+                                ]
+                            }]
+                        }
+                    });
+                };
+
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890', {
+                    minWidth: 100,
+                    maxWidth: 1000,
+                    widthAspectRatio: 5,
+                    heightAspectRatio: 4
+                })
+                .then(done.fail, err => {
+                    expect(err.message).toMatch(/does not have a valid crop/i);
+                    done();
+                });
+            });
+
+            it('gets the first valid asset', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: {
+                            exports: [{
+                                id: 'image_crop',
+                                assets: [
+                                    { dimensions: { width: 1400, height: 1400 } },
+                                    {
+                                        file: images.path('square.png'),
+                                        dimensions: { width: 140, height: 140 }
+                                    }
+                                ]
+                            }]
+                        }
+                    });
+                };
+
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890', {
+                    minWidth: 100,
+                    maxWidth: 1000,
+                    widthAspectRatio: 1,
+                    heightAspectRatio: 1
+                })
+                .then(image => {
+                    expect(image.width).toBe(140);
+                    expect(image.height).toBe(140);
+                    expect(image.src).toMatch(/square\.png$/);
+                    expect(image.origin).toBe('http://media/image/1234567890123456789012345678901234567890');
+                })
+                .then(done)
+                .catch(done.fail);
+            });
+
+            it('gets the first asset when no criteria', function (done) {
+                validate.gridInstance.getImage = () => {
+                    return Promise.resolve({
+                        data: {
+                            exports: [{
+                                id: 'image_crop',
+                                assets: [
+                                    {
+                                        file: images.path('square.png'),
+                                        dimensions: { width: 800, height: 800 }
+                                    }, {
+                                        file: 'thumbnail',
+                                        dimensions: { width: 140, height: 140 }
+                                    }
+                                ]
+                            }]
+                        }
+                    });
+                };
+
+                validate('http://grid.co.uk/1234567890123456789012345678901234567890')
+                .then(image => {
+                    expect(image.width).toBe(140);
+                    expect(image.height).toBe(140);
+                    expect(image.src).toMatch(/square\.png$/);
+                    expect(image.origin).toBe('http://media/image/1234567890123456789012345678901234567890');
+                    expect(image.thumb).toBe('thumbnail');
+                })
+                .then(done)
+                .catch(done.fail);
+            });
         });
-    });
-
-    it('works with no criteria', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-
-        validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png')
-        .then(function (image) {
-            expect(image.width).toBe(140);
-            expect(image.height).toBe(140);
-            expect(image.src).toMatch(/square\.png/);
-            done();
-        }, done.fail);
-    });
-
-    it('works with if all criteria are met', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-        var criteria = {
-            minWidth: 100,
-            maxWidth: 200,
-            widthAspectRatio: 1,
-            heightAspectRatio: 1
-        };
-
-        validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(function (image) {
-            expect(image.width).toBe(140);
-            expect(image.height).toBe(140);
-            expect(image.src).toMatch(/square\.png/);
-            done();
-        }, done.fail);
-    });
-
-    it('strips unnecessary parameters', function (done) {
-        CONST.imageCdnDomain = window.location.host;
-
-        validate('http://' + CONST.imageCdnDomain + CONST.imgIXBasePath +
-            'base/test/public/fixtures/square.png?s=82a57a91afadd159bb4639d6b798f6c5&other=params')
-        .then(function (image) {
-            expect(image.width).toBe(140);
-            expect(image.height).toBe(140);
-            expect(image.src).toMatch(/square\.png$/);
-            done();
-        }, done.fail);
     });
 });

--- a/facia-tool/test/public/utils/images.js
+++ b/facia-tool/test/public/utils/images.js
@@ -1,0 +1,37 @@
+import * as vars from 'modules/vars';
+
+var originalValues = {
+    imageCdnDomainExpr: '',
+    imgIXDomainExpr: '',
+    staticImageCdnDomain: '',
+    imageCdnDomain: ''
+};
+var overrides = {
+    imageCdnDomainExpr: new RegExp('http://' + window.location.host),
+    imgIXDomainExpr: /http:\/\/imgix\//,
+    staticImageCdnDomain: 'http://' + window.location.host + '/base/test/public/fixtures/',
+    imageCdnDomain: window.location.host
+};
+
+function setup () {
+    Object.keys(originalValues).forEach(key => {
+        originalValues[key] = vars.CONST[key];
+        vars.CONST[key] = overrides[key];
+    });
+}
+
+function dispose () {
+    Object.keys(originalValues).forEach(key => {
+        vars.CONST[key] = originalValues[key];
+    });
+}
+
+function path (image) {
+    return 'http://' + window.location.host + '/base/test/public/fixtures/' + image;
+}
+
+function imgIX (image) {
+    return 'http://imgix/' + image;
+}
+
+export default {setup, dispose, path, imgIX};

--- a/facia-tool/test/public/utils/inject.js
+++ b/facia-tool/test/public/utils/inject.js
@@ -35,6 +35,9 @@ export default function (html) {
                     identity: { email: 'someone@theguardian.com' },
                     isPasteActive: ko.observable(),
                     frontsList: ko.observableArray(),
+                    state: ko.observable({
+                        defaults: { apiBaseUrl: '/api.grid', mediaBaseUrl: 'http://media' }
+                    }),
                     dispose: () => {}
                 });
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "css": "github:systemjs/plugin-css@^0.1.18",
       "es5-shim": "github:es-shims/es5-shim@^4.1.14",
       "font-awesome": "npm:font-awesome@4.4.0",
+      "grid-util-js": "npm:grid-util-js@^1.0.5",
       "jquery": "npm:jquery@2.1.4",
       "jquery-mockjax": "npm:jquery-mockjax@^2.0.1",
       "jquery-ui": "github:jquery/jquery-ui@1.11.3",


### PR DESCRIPTION
Any image URL containing a Grid id is now transformed into it's actual crop image.
If an image doesn't have a valid crop, show an error.
It's now possible (again) to drag the main image from an article page.
There's also some better logic for imgix URLs