### PR TITLE
do not reorder group items if target item and source item are same

### DIFF
--- a/facia-tool/public/js/utils/drag-dispatcher.js
+++ b/facia-tool/public/js/utils/drag-dispatcher.js
@@ -55,6 +55,11 @@ function handleMedia ({sourceItem, mediaItem}, targetItem, targetGroup) {
 }
 
 function handleInternalClass ({sourceItem, sourceGroup}, targetItem, targetGroup) {
+
+    if (targetItem instanceof Article && targetItem.id() === sourceItem.id) {
+        return;
+    }
+
     var {position, target, isAfter} = normalizeTarget(sourceItem, targetItem, targetGroup);
 
     removeById(targetGroup.items, urlAbsPath(sourceItem.id));


### PR DESCRIPTION
When dragging and dropping an article back to its original location, there no reordering of group items should be visible. Currently the dropped article gets first placed at the end of the group list and then is moved back to its original location.