### PR TITLE
used mirror image thumbnail for slow-v-half

### DIFF
--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -159,6 +159,9 @@ object ContainerThumbnails {
       case "dynamic/slow-mpu" =>
         Some(Seq(HalfHalf, Hl3Mpu))
 
+      case "fixed/small/slow-V-half" =>
+        Some(Seq(HalfHl4))
+
       case _ =>
         FixedContainers.unapply(Some(id)).map(_.slices)
     }


### PR DESCRIPTION
fixed/small/slow-V-half container should appear as a mirror image in thumbnail. 
<img width="299" alt="screen shot 2015-11-11 at 16 35 30" src="https://cloud.githubusercontent.com/assets/3066534/11096676/3e7baa0c-8893-11e5-930b-e06919859692.png">
