### PR TITLE
don't match hash when getting article path

### DIFF
--- a/facia-tool/public/js/utils/article-path.js
+++ b/facia-tool/public/js/utils/article-path.js
@@ -7,7 +7,7 @@ export default function(url) {
     var host = urlHost(url);
 
     if (host === CONST.viewerHost) {
-      return url.match(/(preview|live)\/(.*)/)[2];
+      return url.match(/(preview|live)\/(.*[^#])/)[2];
     }
 
     return urlAbsPath(url);


### PR DESCRIPTION
Fixes the following bug: When copying a link from viewer tools, if the link ends in a hash, the copying fails. 