### PR TITLE
Advertisement priority

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -25,10 +25,12 @@ GET         /                                        controllers.FaciaToolContro
 GET         /editorial                               controllers.FaciaToolController.collectionEditor()
 GET         /commercial                              controllers.FaciaToolController.collectionEditor()
 GET         /training                                controllers.FaciaToolController.collectionEditor()
+GET         /advertisement                           controllers.FaciaToolController.collectionEditor()
 
 GET         /editorial/config                        controllers.FaciaToolController.configEditor()
 GET         /commercial/config                       controllers.FaciaToolController.configEditor()
 GET         /training/config                         controllers.FaciaToolController.configEditor()
+GET         /advertisement/config                    controllers.FaciaToolController.configEditor()
 
 POST        /collection/publish/*collectionId        controllers.FaciaToolController.publishCollection(collectionId)
 POST        /collection/discard/*collectionId        controllers.FaciaToolController.discardCollection(collectionId)

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -71,7 +71,8 @@ export default {
     maxFronts: {
         'editorial': 200,
         'commercial': 350,
-        'training': 50
+        'training': 50,
+        'advertisement': 100
     },
     frontAlertLimit: 10,
     frontGroups: [

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -219,7 +219,7 @@ export default class ConfigFront extends BaseClass {
     }
 
     applyConstraints() {
-        if (this.props.priority() === 'training') {
+        if (this.props.priority() === 'training' || this.props.priority() === 'advertisement') {
             this.state.isTypeLocked = true;
             this.props.isHidden(true);
         }

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -220,8 +220,15 @@ export default class ConfigFront extends BaseClass {
 
     applyConstraints() {
         if (this.props.priority() === 'training' || this.props.priority() === 'advertisement') {
-            this.state.isTypeLocked = true;
             this.props.isHidden(true);
+        }
+
+        if (this.props.priority() === 'training') {
+            this.state.isTypeLocked = true;
+        }
+
+        if (this.props.priority() === 'advertisement') {
+            this.state.isMetaLocked = true;
         }
     }
 

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -126,7 +126,10 @@
              <!-- ko if: id -->
                 <div class="instructions">
                     <!-- ko if: !state.isOpenProps() && collections.items().length -->
-                        <span class="linky tool--metadata" data-bind="click: openProps">edit metadata</span>
+                        <span class="linky tool--metadata" data-bind="
+                          click: openProps,
+                          visible: !state.isMetaLocked
+                        ">edit metadata</span>
                         &middot;
                         <a class='tool--content' data-bind="attr: {href: '/' + $root.fullPriority + '?layout=latest,front:' + id()}">edit content</a>
                         &middot;


### PR DESCRIPTION
Add a route for fronts that have priority advertisement, are always hidden and don't allow for editing metadata.

<img width="706" alt="screen shot 2015-12-16 at 15 17 22" src="https://cloud.githubusercontent.com/assets/3066534/11844713/1c2d8a5c-a408-11e5-94d3-fd29c64f3d98.png">
