### PR TITLE
don't show contributor image if more than one contributor

### DIFF
--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -514,7 +514,10 @@ define([
         }
 
         function getContributorImage(contentApiArticle) {
-            return _.chain(contentApiArticle.tags).where({type: 'contributor'}).pluck('bylineLargeImageUrl').first().value();
+            var contributors = _.chain(contentApiArticle.tags).where({type: 'contributor'});
+
+            return contributors.value().length === 1 ? contributors.pluck('bylineLargeImageUrl').first().value() : undefined;
+
         }
 
         function isPremium(contentApiArticle) {


### PR DESCRIPTION
Do not show the contributor image cutout if the article has more than contributor.