### PR TITLE
Breaking news hide image

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -86,7 +86,10 @@ object BreakingNewsUpdate {
       thumbnailUrl = trail.thumb.map{new URI(_)},
       sender = email,
       link = createLinkDetails(trail),
-      imageUrl = trail.image,
+      imageUrl = trail.imageHide match {
+        case Some(true) => None
+        case _ => trail.image
+      },
       importance = parseImportance(trail.group),
       topic =  parseTopic(trail.topic),
       debug = false

--- a/app/updates/ClientHydratedCollection.scala
+++ b/app/updates/ClientHydratedCollection.scala
@@ -9,6 +9,7 @@ case class ClientHydratedTrail (
   isArticle: Boolean,
   thumb: Option[String],
   image: Option[String],
+  imageHide: Option[Boolean],
   path: Option[String],
   shortUrl: Option[String],
   alert: Option[Boolean]

--- a/public/src/js/constants/article-meta-fields.js
+++ b/public/src/js/constants/article-meta-fields.js
@@ -194,6 +194,7 @@ export default Object.freeze([
     {
         key: 'imageHide',
         editable: true,
+        slimEditable: 'true',
         omitForSupporting: true,
         singleton: 'images',
         label: 'hide image',

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -485,6 +485,7 @@ define([
                         isArticle: !trail.meta.snapType(),
                         thumb: trail.thumbImage(),
                         image: trail.mainImage(),
+                        imageHide: trail.meta.imageHide(),
                         path: trail.meta.snapType() ? trail.meta.href() : trail.state.capiId(),
                         shortUrl: trail.state.shortUrl(),
                         topic: topic,


### PR DESCRIPTION
Add hide-image checkbox to breaking news collection editor.
<img width="617" alt="screen shot 2016-01-12 at 14 06 42" src="https://cloud.githubusercontent.com/assets/3066534/12265605/de70bf16-b935-11e5-9e17-9b51c02eb8ad.png">
