### PR TITLE
collection history background to grey

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -35,13 +35,14 @@ a:hover,
 }
 
 .collections-published {
-    background-color: #fff;
+    background-color: #ddd;
     padding: 5px 10px;
     box-shadow: 0 1px 6px rgba(0, 0, 0, 0.32), 0 1px 6px rgba(0, 0, 0, 0.32);
     border: 1px solid #ddd;
     margin: 16px 8px 16px 8px;
     display: flex;
     flex-flow: row wrap;
+    color: #666666;
 }
 
 .published-collection {
@@ -52,12 +53,10 @@ a:hover,
 
 .collection-age {
     font-size: 12px;
-    color: #CCCCCC;
 }
 
 .collection-title {
     font-size: 14px;
-    color: #666666;
     font-family: Georgia;
 }
 


### PR DESCRIPTION
Light grey background for collection history
<img width="680" alt="screen shot 2016-01-15 at 12 54 54" src="https://cloud.githubusercontent.com/assets/3066534/12353441/34a70798-bb87-11e5-9aff-093eb4303ffe.png">
