### PR TITLE
store default truthy values

### DIFF
--- a/public/test/spec/serialize-article-meta.spec.js
+++ b/public/test/spec/serialize-article-meta.spec.js
@@ -19,10 +19,11 @@ describe('Serialize Article Meta', function () {
         });
     });
 
-    it('ignores values equal to their default', function () {
+    it('explicit about values equal to their default', function () {
         const article = new Article({
             meta: {
                 showQuotedHeadline: true,
+                showByline: false,
                 headline: 'meta defaults'
             },
             webUrl: 'something',
@@ -31,14 +32,17 @@ describe('Serialize Article Meta', function () {
             },
             frontsMeta: {
                 defaults: {
-                    showQuotedHeadline: true
+                    showQuotedHeadline: true,
+                    showByline: true
                 }
             },
             group: {}
         }, true);
 
         expect(serialize(article)).toEqual({
-            headline: 'meta defaults'
+            headline: 'meta defaults',
+            showQuotedHeadline: true,
+            showByline: false
         });
     });
 


### PR DESCRIPTION
prior to this, client and server had a list of defaults that depends on the article tags.
with this, when a value is not specified it always means `false`.

@janua if I understand it correctly, this PR alone doesn't have any effect, new comments will have `showQuotedHeadline:true` while old comments have it empty.

Step 2: Rewrite all collections and be explicit about those defaults

Step 3: Shuffle around the default handling in frontend.

right?