### PR TITLE
add an extra check for groups when creating commercial fronts

### DIFF
--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -149,6 +149,10 @@ export default class ConfigFront extends BaseClass {
     }
 
     isUnderCreation() {
+        if (this.hideCreationForm()) {
+            return false;
+        }
+
         var id = this.id();
         if (!id) {
             return true;

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -136,33 +136,23 @@ export default class ConfigFront extends BaseClass {
 
         this.groups = ko.observableArray(vars.CONST.frontGroups);
 
-        this.hideCreationForm = ko.observable(false);
-        this.underCreation = ko.pureComputed(this.isUnderCreation, this);
+        this.isNew = ko.observable(false);
     }
 
-    hideCreation() {
+    createFront() {
         if (!this.id() || (this.props.priority() === 'commercial' && !this.props.group())) {
             alert('You must select all properties');
             return;
         }
-        this.hideCreationForm(true);
-    }
 
-    isUnderCreation() {
-        if (this.hideCreationForm()) {
-            return false;
-        }
-
-        var id = this.id();
-        if (!id) {
-            return true;
-        }
-        if (_.every(vars.model.frontsList(), front => {
-            return front.id !== id;
+        if (_.some(vars.model.frontsList(), front => {
+            return front.id === this.id();
         }) ) {
-            return true;
+            alert('A front with this name exists already');
+            return;
         }
-        return false;
+
+        this.isNew(false);
     }
 
     updateConfig(config) {

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -135,6 +135,29 @@ export default class ConfigFront extends BaseClass {
         });
 
         this.groups = ko.observableArray(vars.CONST.frontGroups);
+
+        this.hideCreationForm = ko.observable(false);
+        this.underCreation = ko.pureComputed(this.isUnderCreation, this);
+    }
+
+    hideCreation() {
+        if (!this.id() || (this.props.priority() === 'commercial' && !this.props.group())) {
+            alert('You must select all properties');
+            return;
+        }
+        this.hideCreationForm(true);
+    }
+
+    isUnderCreation() {
+        if (!this.id()) {
+            return true;
+        }
+        if (!(_.find(vars.model.frontsList(), front => {
+            return front.id === this.id();
+        }) )) {
+            return true;
+        }
+        return false;
     }
 
     updateConfig(config) {

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -149,12 +149,13 @@ export default class ConfigFront extends BaseClass {
     }
 
     isUnderCreation() {
-        if (!this.id()) {
+        var id = this.id();
+        if (!id) {
             return true;
         }
-        if (!(_.find(vars.model.frontsList(), front => {
-            return front.id === this.id();
-        }) )) {
+        if (_.every(vars.model.frontsList(), front => {
+            return front.id !== id;
+        }) ) {
             return true;
         }
         return false;

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -145,9 +145,7 @@ export default class ConfigFront extends BaseClass {
             return;
         }
 
-        if (_.some(vars.model.frontsList(), front => {
-            return front.id === this.id();
-        }) ) {
+        if (vars.model.state().config.fronts[this.id()]) {
             alert('A front with this name exists already');
             return;
         }

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -17,7 +17,7 @@
         ownerClass: $data,
         css: {open: state.isOpen}">
 
-        <div class="title" data-bind="visible: id">
+        <div class="title" data-bind="visible: !underCreation() || hideCreationForm()">
             <span class="title--text" data-bind="
                 text: id,
                 click: toggleOpen
@@ -28,13 +28,21 @@
             <!-- /ko -->
         </div>
 
-        <!-- ko if: !id() -->
+        <!-- ko if: underCreation() && !hideCreationForm() -->
             <div class="cnf-front__inner cnf-form">
                 <label>URL path</label>
                 <input class="input-url-path" type="text" placeholder="eg. world/middleeast" data-bind="value: id"/>
+                <!-- ko if: showGroups() -->
+                <label>Group</label>
+                <select data-bind="
+                    optionsCaption: 'Select a group',
+                    options: groups,
+                    value: props.group,
+                    valueAllowUnset: true"></select>
+                <!-- /ko -->
 
                 <div class="tools action-buttons">
-                    <span class="tool create-new-front">Create front</span>
+                    <button class="tool create-new-front" data-bind="click: hideCreation">Create front</button>
                 </div>
             </div>
         <!-- /ko -->
@@ -123,7 +131,7 @@
                 </div>
             <!-- /ko -->
 
-             <!-- ko if: id -->
+             <!-- ko if: !underCreation() || hideCreationForm() -->
                 <div class="instructions">
                     <!-- ko if: !state.isOpenProps() && collections.items().length -->
                         <span class="linky tool--metadata" data-bind="click: openProps">edit metadata</span>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -17,7 +17,7 @@
         ownerClass: $data,
         css: {open: state.isOpen}">
 
-        <div class="title" data-bind="visible: !underCreation()">
+        <div class="title" data-bind="visible: !isNew()">
             <span class="title--text" data-bind="
                 text: id,
                 click: toggleOpen
@@ -28,7 +28,7 @@
             <!-- /ko -->
         </div>
 
-        <!-- ko if: underCreation() -->
+        <!-- ko if: isNew() -->
             <div class="cnf-front__inner cnf-form">
                 <label>URL path</label>
                 <input class="input-url-path" type="text" placeholder="eg. world/middleeast" data-bind="value: id"/>
@@ -42,7 +42,7 @@
                 <!-- /ko -->
 
                 <div class="tools action-buttons">
-                    <button class="tool create-new-front" data-bind="click: hideCreation">Create front</button>
+                    <button class="tool create-new-front" data-bind="click: createFront">Create front</button>
                 </div>
             </div>
         <!-- /ko -->
@@ -131,7 +131,7 @@
                 </div>
             <!-- /ko -->
 
-             <!-- ko if: !underCreation() -->
+             <!-- ko if: !isNew() -->
                 <div class="instructions">
                     <!-- ko if: !state.isOpenProps() && collections.items().length -->
                         <span class="linky tool--metadata" data-bind="click: openProps">edit metadata</span>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -17,7 +17,7 @@
         ownerClass: $data,
         css: {open: state.isOpen}">
 
-        <div class="title" data-bind="visible: !underCreation() || hideCreationForm()">
+        <div class="title" data-bind="visible: !underCreation()">
             <span class="title--text" data-bind="
                 text: id,
                 click: toggleOpen
@@ -28,7 +28,7 @@
             <!-- /ko -->
         </div>
 
-        <!-- ko if: underCreation() && !hideCreationForm() -->
+        <!-- ko if: underCreation() -->
             <div class="cnf-front__inner cnf-form">
                 <label>URL path</label>
                 <input class="input-url-path" type="text" placeholder="eg. world/middleeast" data-bind="value: id"/>
@@ -131,7 +131,7 @@
                 </div>
             <!-- /ko -->
 
-             <!-- ko if: !underCreation() || hideCreationForm() -->
+             <!-- ko if: !underCreation() -->
                 <div class="instructions">
                     <!-- ko if: !state.isOpenProps() && collections.items().length -->
                         <span class="linky tool--metadata" data-bind="click: openProps">edit metadata</span>

--- a/public/src/js/widgets/columns/fronts-config.js
+++ b/public/src/js/widgets/columns/fronts-config.js
@@ -71,6 +71,7 @@ export default class FrontConfig extends ColumnWidget {
         } else {
             front = new Front({priority: this.baseModel.priority, isHidden: true});
             front.setOpen(true);
+            front.isNew(true);
             this.pinnedFront(front);
         }
     }

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -89,10 +89,8 @@ describe('Config Front', function () {
             $('.title .linky').click();
             // some form of validation
             dom.type('.input-url-path', '/something////here/');
-            // There's an onchange event, no need to click on save
-
+            $('.create-new-front').click();
             expect(textInside('.title--text')).toBe('something/here');
-
             $('.linky.tool--container').click();
             $('#showDateHeader').click();
             dom.type('.title--input', 'new collection');

--- a/public/test/spec/config.spec.js
+++ b/public/test/spec/config.spec.js
@@ -65,7 +65,7 @@ describe('Config', function () {
             return configAction(mockConfig, baseModel, () => {
                 dom.click(dom.$('.title .linky'));
                 dom.type($('.cnf-form input[type=text]'), 'test/front');
-                // There's an onchange event, no need to click on save
+                dom.click(dom.$('.create-new-front'));
 
                 var newFront = dom.$('.cnf-front.open');
                 dom.click(newFront.querySelector('.tool--container'));


### PR DESCRIPTION
Require specifying a group for all new commercial fronts as they are created.