### PR TITLE
Don't hold page load in case of CAPI errors

### DIFF
--- a/public/src/js/models/collections/latest-articles.js
+++ b/public/src/js/models/collections/latest-articles.js
@@ -96,7 +96,8 @@ class Latest extends BaseClass {
     }
 
     [fetchSym](request) {
-        var loadCallback = this.opts.callback || function () {};
+        const isOnPageLoad = !!this.opts.callback;
+        const loadCallback = this.opts.callback || function () {};
 
         this[debounceSym](request)
         .then(({
@@ -105,7 +106,7 @@ class Latest extends BaseClass {
             currentPage
         }) => {
             this.errorCount = 0;
-            var scrollable = this.opts.container.querySelector('.scrollable'),
+            const scrollable = this.opts.container.querySelector('.scrollable'),
                 initialScroll = scrollable.scrollTop;
 
             this.lastSearch(request);
@@ -126,8 +127,8 @@ class Latest extends BaseClass {
         })
         .catch((error = {}) => {
             this.errorCount += 1;
-            if (this.errorCount > CONST.failsBeforeError) {
-                var errMsg = error.message || 'Invalid CAPI result. Please try again';
+            if (this.errorCount > CONST.failsBeforeError || isOnPageLoad) {
+                const errMsg = error.message || 'Invalid CAPI result. Please try again';
                 mediator.emit('capi:error', errMsg);
                 this.flush(errMsg);
                 loadCallback();

--- a/public/test/spec/latest.articles.errors.spec.js
+++ b/public/test/spec/latest.articles.errors.spec.js
@@ -1,0 +1,88 @@
+import EventEmitter from 'EventEmitter';
+import LatestArticles from 'models/collections/latest-articles';
+import * as capi from 'modules/content-api';
+import {CONST} from 'modules/vars';
+import mediator from 'utils/mediator';
+import * as wait from 'test/utils/wait';
+
+describe('Latest articles errors', function() {
+    beforeEach(function () {
+        this.originalSearchDebounce = CONST.searchDebounceMs;
+        CONST.searchDebounceMs = 100;
+
+        this.loadSpy = jasmine.createSpy('loadSpy');
+        this.errorSpy = jasmine.createSpy('errorSpy');
+        this.fetchEmitter = new EventEmitter();
+        this.shouldNextRequestFail = true;
+
+        spyOn(capi, 'fetchLatest').and.callFake(() => {
+            setTimeout(() => {
+                this.fetchEmitter.emit('done');
+            }, 10);
+            return this.shouldNextRequestFail ?
+                Promise.reject(new Error('this is bad')) :
+                Promise.resolve({ results: [] });
+        });
+        mediator.on('capi:error', this.errorSpy);
+    });
+    afterEach(function () {
+        CONST.searchDebounceMs = this.originalSearchDebounce;
+    });
+
+    it('doesn\'t stop page load', function (done) {
+        const latest = new LatestArticles({
+            callback: this.loadSpy,
+            showingDrafts: () => false
+        });
+        latest.search();
+
+        wait.event('done', this.fetchEmitter).then(() => {
+            expect(this.loadSpy).toHaveBeenCalled();
+            expect(this.errorSpy).toHaveBeenCalled();
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('hides some errors when page is already loaded', function (done) {
+        const latest = new LatestArticles({
+            callback: false, // <- not in the loading process
+            showingDrafts: () => false,
+            container: {
+                querySelector: () => { return {}; }
+            }
+        });
+        latest.on('search:update', this.loadSpy);
+        latest.search();
+
+        wait.event('done', this.fetchEmitter).then(() => {
+            expect(this.loadSpy).not.toHaveBeenCalled();
+            expect(latest.errorCount).toBe(1);
+
+            this.shouldNextRequestFail = false;
+            latest.search();
+            return wait.event('done', this.fetchEmitter);
+        })
+        .then(() => {
+            expect(this.loadSpy).toHaveBeenCalled();
+
+            this.shouldNextRequestFail = true;
+            this.loadSpy.calls.reset();
+
+            let waiting = Promise.resolve();
+            for (let i = 0; i < CONST.failsBeforeError + 1; i += 1) {
+                waiting = waiting.then(() => {
+                    latest.search();
+                    return wait.event('done', this.fetchEmitter);
+                });
+            }
+            return waiting;
+        })
+        .then(() => {
+            expect(this.loadSpy).toHaveBeenCalled();
+            expect(this.errorSpy).toHaveBeenCalled();
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+});


### PR DESCRIPTION
@desbo this would make facia tool fail fast in case of CAPI errors.

I'll write another PR to handle `200 errors` better