### PR TITLE
Recover from 200 errors

### DIFF
--- a/public/src/js/utils/lenient-json-parse.js
+++ b/public/src/js/utils/lenient-json-parse.js
@@ -1,0 +1,35 @@
+export default function (jsonString) {
+    const errors = [];
+
+    return {
+        json: tryParsingString(jsonString, errors),
+        errors: errors
+    };
+}
+
+function tryParsingString (jsonString, errors) {
+    try {
+        return JSON.parse(jsonString);
+    } catch (ex) {
+        return reportUnexpectedToken(jsonString, ex.message, errors);
+    }
+}
+
+function reportUnexpectedToken (jsonString, error, listOfErrors) {
+    const match = error.match(/^unexpected token (.*)/i);
+    if (match) {
+        const parts = jsonString.split(match[1]);
+        const firstQuote = parts[0].lastIndexOf('"');
+        const lastQuote = parts[1].indexOf('"');
+        const firstPart = parts[0].substring(firstQuote + 1);
+        const secondPart = parts[1].substring(0, lastQuote);
+
+        const invalidString = firstPart + secondPart;
+        const sourceMatch = parts[0].substring(0, firstQuote).match(/"([^"]+)"\s?:\s?$/);
+        const source = sourceMatch ? sourceMatch[1] : 'symbol';
+        listOfErrors.push('Invalid ' + source + ' in \'' + invalidString + '\' between \'' + firstPart + '\' and \'' + secondPart + '\'');
+        return tryParsingString(parts.join(''), listOfErrors);
+    } else {
+        listOfErrors.push(error);
+    }
+}

--- a/public/test/spec/lenient.json.parse.spec.js
+++ b/public/test/spec/lenient.json.parse.spec.js
@@ -1,0 +1,83 @@
+import parseJson from 'utils/lenient-json-parse';
+
+describe('Lenient Json parse', function () {
+    it('recovers one error', function () {
+        const original = {
+            message: 'banana'
+        };
+        const json = JSON.stringify(original)
+            .replace('banana', 'ban' + String.fromCharCode(0x10) + 'ana');
+
+        try {
+            JSON.parse(json);
+            fail('Expecting JSON.parse to throw an error');
+        } catch (ex) {
+            if (!ex.message.match(/unterminated string/i)) {
+                const parsed = parseJson(json);
+                expect(parsed.json).toEqual(original);
+                expect(parsed.errors.length).toBe(1);
+                expect(parsed.errors[0]).toMatch(/message.*'ban'.*'ana'/i);
+            }
+        }
+    });
+
+    it('recovers multiple errors', function () {
+        const original = {
+            results: [{
+                one: 'banana'
+            }, {
+                two: 'apple'
+            }]
+        };
+        const json = JSON.stringify(original)
+            .replace('banana', 'ban' + String.fromCharCode(0x10) + 'ana')
+            .replace('apple', 'ap' + String.fromCharCode(0x5) + 'ple');
+
+        try {
+            JSON.parse(json);
+            fail('Expecting JSON.parse to throw an error');
+        } catch (ex) {
+            if (!ex.message.match(/unterminated string/i)) {
+                const parsed = parseJson(json);
+                expect(parsed.json).toEqual(original);
+                expect(parsed.errors.length).toBe(2);
+                expect(parsed.errors[0]).toMatch(/one.*'ban'.*'ana'/i);
+                expect(parsed.errors[1]).toMatch(/two.*'ap'.*'ple'/i);
+            }
+        }
+    });
+
+    it('recovers on key symbols', function () {
+        const original = {
+            fruit: 'pear'
+        };
+        const json = JSON.stringify(original)
+            .replace('fruit', 'fru' + String.fromCharCode(0x10) + 'it');
+
+        try {
+            JSON.parse(json);
+            fail('Expecting JSON.parse to throw an error');
+        } catch (ex) {
+            if (!ex.message.match(/unterminated string/i)) {
+                const parsed = parseJson(json);
+                expect(parsed.json).toEqual(original);
+                expect(parsed.errors.length).toBe(1);
+                expect(parsed.errors[0]).toMatch(/symbol.*'fru'.*'it'/i);
+            }
+        }
+    });
+
+    it('doesn\'t recover on invalid json', function () {
+        const json = 'string';
+
+        try {
+            JSON.parse(json);
+            fail('Expecting JSON.parse to throw an error');
+        } catch (ex) {
+            if (!ex.message.match(/unterminated string/i)) {
+                const parsed = parseJson(json);
+                expect(parsed.json).toBeUndefined();
+            }
+        }
+    });
+});


### PR DESCRIPTION
Sometimes CAPI contains invalid characters that break the latest feed.

Instead of failing, try to recover from these errors and display a useful message.

That's how it looks like when you add an invisible character in the headline

![screen shot 2016-03-14 at 15 12 55](https://cloud.githubusercontent.com/assets/680284/13748999/695a19f0-e9f7-11e5-8db6-9c673ea7c653.png)

@desbo this is the other PR ;)