### PR TITLE
Collection cap modal

### DIFF
--- a/public/src/js/models/widgets.js
+++ b/public/src/js/models/widgets.js
@@ -102,6 +102,12 @@ var register = _.once(() => {
         },
         template: { text: 'widgets/modals/select-snap-type.html' }
     });
+    ko.components.register('collection_cap_alert', {
+        viewModel: {
+            createViewModel: (params) => params
+        },
+        template: { text: 'widgets/modals/collection-cap-alert.html' }
+    });
     ko.components.register('autocomplete', {
         viewModel: { jspm: 'widgets/autocomplete' },
         template: { text: 'widgets/autocomplete.html' }

--- a/public/src/js/utils/drag-dispatcher.js
+++ b/public/src/js/utils/drag-dispatcher.js
@@ -97,7 +97,9 @@ function handleInternalClass ({sourceItem, sourceGroup}, targetItem, targetGroup
         })
         .catch(err => {
             _.each(newItems, item => targetGroup.items.remove(item));
-            alert(err);
+            if (err) {
+                alert(err);
+            }
         });
     }
 }
@@ -206,15 +208,11 @@ function validate (sourceItem, newItems, context) {
                 if (restrictedLiveMode.indexOf(front) > -1 && context.mode() === 'live') {
                     err = 'Sorry, ' + front + ' items cannot be added in Live Front mode. Switch to Draft Front then try again.';
                 }
-                if (!err) {
-                    err = context.newItemValidator(item);
+                if (err) {
+                    return Promise.reject(err);
                 }
-            }
 
-            if (err) {
-                throw new Error(err);
-            } else {
-                return item;
+                return context.newItemValidator(item);
             }
         });
     }

--- a/public/src/js/widgets/modals/collection-cap-alert.html
+++ b/public/src/js/widgets/modals/collection-cap-alert.html
@@ -1,0 +1,9 @@
+<div class="modalDialog-message">
+    <h3>Collection limit</h3>
+    <p>You can have maximum of <span data-bind="text: collectionCap"></span> articles in a collection.</p>
+    <p>You can proceed, and the last article in the collection will be removed automatically, or you can cancel, and remove articles from the collection yourself.</p>
+</div>
+<div class="buttons modalDialog-confirm">
+    <button class="button-action" data-bind="click: ok">Proceed</button>
+    <button class="draw-attention" data-bind="click: cancel">Cancel</button>
+</div>


### PR DESCRIPTION
Display a collection cap modal that allows users to either remove articles from collections manually or have this done automatically once the collection cap has been reached. 

<img width="883" alt="screen shot 2016-03-22 at 10 55 16" src="https://cloud.githubusercontent.com/assets/3066534/13949383/95e66ebc-f01c-11e5-90d6-6ba7257273c8.png">
