### PR TITLE
sanitize slashes in capi query

### DIFF
--- a/public/src/js/utils/sanitize-api-query.js
+++ b/public/src/js/utils/sanitize-api-query.js
@@ -1,20 +1,20 @@
 import _ from 'underscore';
 import parseQueryParams from 'utils/parse-query-params';
 
-export default function(url) {
-    var bits = (url + '').split('?');
+export default function (url) {
+    const bits = (url + '').split('?');
 
     if (bits.length <= 1) {
         return url;
     }
 
-    var params = _.map(
+    const params = _.map(
         parseQueryParams(url, {
-            predicateKey: function(key) { return key !== 'api-key'; },
-            predicateVal: function(val) { return val; }
+            predicateKey: key => key !== 'api-key',
+            predicateVal: val => val
         }),
-        function(val, key) { return key + '=' + val; }
+        (val, key) => key + '=' + val
     ).join('&');
 
-    return bits[0] + (params ? '?' + params : '');
+    return bits[0].replace(/^\/+/, '') + (params ? '?' + params : '');
 }

--- a/public/test/spec/string.manipulation.spec.js
+++ b/public/test/spec/string.manipulation.spec.js
@@ -139,6 +139,7 @@ describe('utils/sanitize-api-query', function () {
         expect(sanitizeQuery('search?q=fruit&color=yellow')).toBe('search?q=fruit&color=yellow');
         expect(sanitizeQuery('search?q=fruit&api-key=xxx&shape=&ripe=true')).toBe('search?q=fruit&ripe=true');
         expect(sanitizeQuery('search?q=&shape=')).toBe('search');
+        expect(sanitizeQuery('/search?q=slash')).toBe('search?q=slash');
     });
 });
 


### PR DESCRIPTION
@davidfurey 

This prevents new `/search` from being added. I'll have to remove the ones already in.