### PR TITLE
Provide a user agent to WS requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ TwirlKeys.templateImports ++= Seq(
     "play.api.Play.current"
 )
 
-val awsVersion = "1.10.76"
+val awsVersion = "1.10.77"
 val capiModelsVersion = "8.11"
 
 libraryDependencies ++= Seq(
@@ -68,11 +68,11 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
-    "com.gu" %% "auditing-thrift-model" % "0.1.0",
+    "com.gu" %% "auditing-thrift-model" % "0.2",
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "1.5.3",
+    "com.gu" %% "fapi-client" % "1.6.1",
     "com.gu" % "kinesis-logback-appender" % "1.2.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.27",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.13",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -46,6 +46,7 @@ play {
 
   ws {
     compressionEnabled: true
+    useragent: "facia-tool"
   }
 
   http {

--- a/public/src/js/modules/content-api.js
+++ b/public/src/js/modules/content-api.js
@@ -81,7 +81,7 @@ function validateItem (item) {
             fetchContent(capiId)
             .then(function(res = {}) {
                 var results = res.content,
-                    resultsTitle = res.title,
+                    resultsTitle = res.title || 'Unknown title',
                     capiItem,
                     pageCode,
                     err;


### PR DESCRIPTION
theguardian.com on HTTPS is configured to reject requests with an empty user agent