### PR TITLE
Display front tags

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -2013,6 +2013,15 @@ ol.search_list > li::before {
     background-color: #999999;
 }
 
+.tagLabel {
+    background: lightblue;
+    border: 1px solid #cccccc;
+    border-radius: 1px;
+    padding: 2px;
+    font-size: 10px;
+    margin: 0px 3px 0px 3px;
+}
+
 .has-playable {
     position: absolute;
     top: 0;

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -659,6 +659,13 @@ h1 {
     left: 9px;
 }
 
+.tag-list {
+    font-weight: bold;
+    color: #CCCCCC;
+    padding-right: 3px;
+    font-size: 12px;
+}
+
 .count {
     font-weight: normal;
     margin-left: 0.4em;

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -53,7 +53,9 @@ export default class Collection extends BaseClass {
             'displayName',
             'hideShowMore',
             'href',
-            'uneditable']);
+            'uneditable',
+            'metadata'
+        ]);
         populateObservables(this.configMeta, opts);
 
         // properties from the collection itself

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -24,6 +24,9 @@
         <span class="title" data-bind="
             text: configMeta.displayName() || collectionMeta.displayName() || '(no title)'"></span>
 
+        <span data-bind="foreach: configMeta.metadata()">
+            <span class="tag-list" data-bind="text: type"></span>
+        </span>
         <span class="count" data-bind="if: !isPending() && !configMeta.uneditable()">
             (<span data-bind="
                 text: state.count() ? state.count() : 'empty',

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -186,6 +186,12 @@
             </span>
         </span>
 
+        <!-- ko if: !state.isOpen() -->
+            <span data-bind="foreach: meta.metadata">
+               <span class="tagLabel" data-bind="text: type"></span>
+            </span>
+        <!-- /ko -->
+
         <!-- ko if: state.isOpen -->
         <div class="cnf-form">
             <div class="type-option type-option-chosen" data-bind="click: toggleOpenTypePicker">


### PR DESCRIPTION
This pr makes front collection tags more visible in the tool. 

- It displays collection tags on the front configuration page without having to click the collection open: 

<img width="434" alt="screen shot 2016-09-12 at 08 15 16" src="https://cloud.githubusercontent.com/assets/3066534/18437019/f88f98b8-78f2-11e6-8cc0-6923b070c86d.png">


- It displays the tags on the front edit page without having to click through to the configuration page: 

<img width="628" alt="screen shot 2016-09-12 at 08 14 52" src="https://cloud.githubusercontent.com/assets/3066534/18437010/f21f04dc-78f2-11e6-8695-442ab13fb69d.png">
