### PR TITLE
Remove redundant commercial container types

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -58,9 +58,7 @@ export default {
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },
-        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
-        { name: 'commercial/single-campaign' },
-        { name: 'commercial/multi-campaign' }
+        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] }
     ],
 
     navSections: [


### PR DESCRIPTION
Now same effect is achieved by standard container types with the branded tag.