### PR TITLE
convert empty content to snap

### DIFF
--- a/public/src/js/modules/content-api.js
+++ b/public/src/js/modules/content-api.js
@@ -111,8 +111,12 @@ function validateItem (item) {
                 } else if (item.id().indexOf(window.location.hostname) > -1) {
                     err = 'Sorry, that link cannot be added to a front';
 
-                // A snap, but a link to unavailable guardian content
+                //A snap, section/tag with no content in it
                 } else if (results && results.length === 0 && isGuardianUrl(item.id())) {
+                    item.convertToLinkSnap();
+
+                // A snap, but a link to unavailable guardian content
+                } else if (!results && isGuardianUrl(item.id())) {
                     err = 'Sorry, that Guardian content is unavailable';
 
                 // A snap, that's setting it's own type, ie via dragged-in query params

--- a/public/test/spec/capi.spec.js
+++ b/public/test/spec/capi.spec.js
@@ -496,6 +496,26 @@ describe('Content API', function () {
                 url: CONST.apiSearchBase + '/something?*',
                 status: 200,
                 responseText: {
+                    response: {}
+                }
+            });
+
+            capi.validateItem(item)
+            .then(done.fail, (error) => {
+                expect(error.message).toMatch(/Guardian content is unavailable/i);
+                done();
+            });
+        });
+
+        it('validates empty guardian content', function (done) {
+            var item = this.createItem({
+                id: 'http://' + CONST.mainDomain + '/something'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
                     response: {
                         results: []
                     }
@@ -503,8 +523,9 @@ describe('Content API', function () {
             });
 
             capi.validateItem(item)
-            .then(done.fail, (error) => {
-                expect(error.message).toMatch(/Guardian content is unavailable/i);
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.convertToLinkSnap).toHaveBeenCalled();
                 done();
             });
         });


### PR DESCRIPTION
Allow for adding empty tags to fronts, but convert them to snap links so that the front still presses. Only error if a piece of guardian content cannot be found. 

@piuccio 