### PR TITLE
convert all without content to snap

### DIFF
--- a/public/src/js/modules/content-api.js
+++ b/public/src/js/modules/content-api.js
@@ -111,14 +111,6 @@ function validateItem (item) {
                 } else if (item.id().indexOf(window.location.hostname) > -1) {
                     err = 'Sorry, that link cannot be added to a front';
 
-                //A snap, section/tag with no content in it
-                } else if (results && results.length === 0 && isGuardianUrl(item.id())) {
-                    item.convertToLinkSnap();
-
-                // A snap, but a link to unavailable guardian content
-                } else if (!results && isGuardianUrl(item.id())) {
-                    err = 'Sorry, that Guardian content is unavailable';
-
                 // A snap, that's setting it's own type, ie via dragged-in query params
                 } else if (item.meta.snapType()) {
                     item.convertToSnap();

--- a/public/test/spec/capi.spec.js
+++ b/public/test/spec/capi.spec.js
@@ -487,26 +487,6 @@ describe('Content API', function () {
             });
         });
 
-        it('fails on guardian content not available', function (done) {
-            var item = this.createItem({
-                id: 'http://' + CONST.mainDomain + '/something'
-            });
-            cache.put('contentApi', 'something', null);
-            this.scope({
-                url: CONST.apiSearchBase + '/something?*',
-                status: 200,
-                responseText: {
-                    response: {}
-                }
-            });
-
-            capi.validateItem(item)
-            .then(done.fail, (error) => {
-                expect(error.message).toMatch(/Guardian content is unavailable/i);
-                done();
-            });
-        });
-
         it('validates empty guardian content', function (done) {
             var item = this.createItem({
                 id: 'http://' + CONST.mainDomain + '/something'


### PR DESCRIPTION
- If there is no content from the capi response, facia-tool should convert link to snap, even if the url comes from the guardian. 

@ShaunYearStrong 