### PR TITLE
Update FAPI client

### DIFF
--- a/app/util/ContentUpgrade.scala
+++ b/app/util/ContentUpgrade.scala
@@ -1,14 +1,15 @@
 package util
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.contentapi.json.JsonParser
-import com.gu.contentapi.json.JsonParser._
 import com.gu.facia.api.utils.{CardStyle, ResolvedMetaData}
 import com.gu.facia.client.models.TrailMetaData
 import org.json4s.JValue
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
+import io.circe._
+import io.circe.parser._
+import com.gu.contentapi.json.CirceDecoders._
 
 import scala.util.{Failure, Success, Try}
 
@@ -46,7 +47,8 @@ object ContentUpgrade {
   def upgradeItem(json: JValue): JValue = {
     Try({
       val jsonString = JsonMethods.compact(JsonMethods.render(json))
-      val maybeCapiContent = JsonParser.parseContent(jsonString)
+      val maybeParsedJson: Option[Json] = parse(jsonString).toOption
+      val maybeCapiContent: Option[Content] = maybeParsedJson.flatMap(json => json.as[Content].toOption)
 
       (json, maybeCapiContent) match {
         case (jsObject: JObject, content: Content) =>

--- a/app/util/ContentUpgrade.scala
+++ b/app/util/ContentUpgrade.scala
@@ -7,8 +7,7 @@ import org.json4s.JValue
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
-import io.circe._
-import io.circe.parser._
+import io.circe.{Json, parser}
 import com.gu.contentapi.json.CirceDecoders._
 
 import scala.util.{Failure, Success, Try}
@@ -47,7 +46,7 @@ object ContentUpgrade {
   def upgradeItem(json: JValue): JValue = {
     Try({
       val jsonString = JsonMethods.compact(JsonMethods.render(json))
-      val maybeParsedJson: Option[Json] = parse(jsonString).toOption
+      val maybeParsedJson: Option[Json] = parser.parse(jsonString).toOption
       val maybeCapiContent: Option[Content] = maybeParsedJson.flatMap(json => json.as[Content].toOption)
 
       (json, maybeCapiContent) match {

--- a/app/util/ContentUpgrade.scala
+++ b/app/util/ContentUpgrade.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.TrailMetaData
 import org.json4s.JValue
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
-import org.json4s.native.JsonMethods
+import org.json4s.jackson.JsonMethods
 
 import scala.util.{Failure, Success, Try}
 

--- a/app/util/ContentUpgrade.scala
+++ b/app/util/ContentUpgrade.scala
@@ -51,7 +51,7 @@ object ContentUpgrade {
       val maybeCapiContent: Option[Content] = maybeParsedJson.flatMap(json => json.as[Content].toOption)
 
       (json, maybeCapiContent) match {
-        case (jsObject: JObject, content: Content) =>
+        case (jsObject: JObject, Some(content)) =>
           val cardStyle = CardStyle(content, TrailMetaData.empty)
           val metaDataMap: Map[String, Boolean] = ResolvedMetaData.toMap(ResolvedMetaData.fromContent(content, cardStyle))
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ packageDescription := "Guardian front pages editor"
 
 scalaVersion := "2.11.8"
 
-resolvers += Resolver.sonatypeRepo("public")
-
 import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd
 serverLoading in Debian := Systemd
 
@@ -75,7 +73,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.6",
+    "com.gu" %% "fapi-client" % "2.0.5-SNAPSHOT",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ packageDescription := "Guardian front pages editor"
 
 scalaVersion := "2.11.8"
 
+resolvers += Resolver.sonatypeRepo("public")
+
 import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd
 serverLoading in Debian := Systemd
 
@@ -73,7 +75,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.5-SNAPSHOT",
+    "com.gu" %% "fapi-client" % "2.0.6",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.1",
+    "com.gu" %% "fapi-client" % "2.0.5-SNAPSHOT",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
@@ -81,6 +81,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "thrift-serializer" % "1.1.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
     "org.julienrf" %% "play-json-variants" % "2.0",
+    "org.json4s" % "json4s-native_2.11" % "3.5.0",
     "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -78,16 +78,25 @@ libraryDependencies ++= Seq(
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
+
+    // Circe 0.5.2 depends on Cats 0.7.2
+    // content-api-models depends on Circe 0.5.2 which depends on Cats 0.7.2
+    // Scanamo 0.7.0 depends on Cats 0.7.0.
+    // change with caution as must be upgraded in sync.
+
+    "io.circe" %% "circe-core" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.circe" %% "circe-parser" % circeVersion,
     "com.gu" %% "scanamo" % "0.7.0",
+
+
     "com.gu" %% "thrift-serializer" % "1.1.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
     "org.julienrf" %% "play-json-variants" % "2.0",
     "org.json4s" % "json4s-native_2.11" % "3.5.0",
     "org.json4s" % "json4s-jackson_2.11" % "3.5.0",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion
+    "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging)

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ TwirlKeys.templateImports ++= Seq(
 val awsVersion = "1.11.18"
 val capiModelsVersion = "10.17"
 val circeVersion = "0.5.2"
+val json4sVersion = "3.5.0"
 
 libraryDependencies ++= Seq(
     ws,
@@ -93,8 +94,8 @@ libraryDependencies ++= Seq(
     "com.gu" %% "thrift-serializer" % "1.1.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
     "org.julienrf" %% "play-json-variants" % "2.0",
-    "org.json4s" % "json4s-native_2.11" % "3.5.0",
-    "org.json4s" % "json4s-jackson_2.11" % "3.5.0",
+    "org.json4s" %% "json4s-native" % json4sVersion,
+    "org.json4s" %% "json4s-jackson" % json4sVersion,
     "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 
 )

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ TwirlKeys.templateImports ++= Seq(
 )
 
 val awsVersion = "1.11.18"
-val capiModelsVersion = "8.17"
+val capiModelsVersion = "10.17"
+val circeVersion = "0.5.2"
 
 libraryDependencies ++= Seq(
     ws,
@@ -77,12 +78,16 @@ libraryDependencies ++= Seq(
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
-    "com.gu" %% "scanamo" % "0.6.0",
+    "com.gu" %% "scanamo" % "0.7.0",
     "com.gu" %% "thrift-serializer" % "1.1.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
     "org.julienrf" %% "play-json-variants" % "2.0",
     "org.json4s" % "json4s-native_2.11" % "3.5.0",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+    "org.json4s" % "json4s-jackson_2.11" % "3.5.0",
+    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+    "io.circe" %% "circe-core" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.circe" %% "circe-parser" % circeVersion
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging)

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.5-SNAPSHOT",
+    "com.gu" %% "fapi-client" % "2.0.6",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/public/src/js/jspm-config.js
+++ b/public/src/js/jspm-config.js
@@ -107,7 +107,6 @@ System.config({
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "inherits": "npm:inherits@2.0.1",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
     "npm:assert@1.3.0": {
@@ -117,8 +116,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:bn.js@4.11.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
     "npm:browserify-aes@1.0.6": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -143,16 +141,14 @@ System.config({
       "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "des.js": "npm:des.js@1.0.0",
-      "inherits": "npm:inherits@2.0.1",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "inherits": "npm:inherits@2.0.1"
     },
     "npm:browserify-rsa@4.0.1": {
       "bn.js": "npm:bn.js@4.11.3",
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "constants": "github:jspm/nodelibs-constants@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "randombytes": "npm:randombytes@2.0.3",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "randombytes": "npm:randombytes@2.0.3"
     },
     "npm:browserify-sign@4.0.0": {
       "bn.js": "npm:bn.js@4.11.3",
@@ -182,8 +178,7 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "inherits": "npm:inherits@2.0.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
-      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
     },
     "npm:clean-css@3.4.12": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -250,8 +245,7 @@ System.config({
       "inherits": "npm:inherits@2.0.1",
       "pbkdf2": "npm:pbkdf2@3.0.4",
       "public-encrypt": "npm:public-encrypt@4.0.0",
-      "randombytes": "npm:randombytes@2.0.3",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "randombytes": "npm:randombytes@2.0.3"
     },
     "npm:des.js@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -276,8 +270,7 @@ System.config({
     "npm:evp_bytestokey@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "create-hash": "npm:create-hash@1.1.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0"
     },
     "npm:font-awesome@4.5.0": {
       "css": "github:systemjs/plugin-css@0.1.20"
@@ -366,8 +359,7 @@ System.config({
     "npm:randombytes@2.0.3": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:raven-js@2.3.0": {
       "path": "github:jspm/nodelibs-path@0.1.0",

--- a/public/src/js/jspm-config.js
+++ b/public/src/js/jspm-config.js
@@ -107,6 +107,7 @@ System.config({
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "inherits": "npm:inherits@2.0.1",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
     "npm:assert@1.3.0": {
@@ -116,7 +117,8 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:bn.js@4.11.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:browserify-aes@1.0.6": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -141,14 +143,16 @@ System.config({
       "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "des.js": "npm:des.js@1.0.0",
-      "inherits": "npm:inherits@2.0.1"
+      "inherits": "npm:inherits@2.0.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:browserify-rsa@4.0.1": {
       "bn.js": "npm:bn.js@4.11.3",
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "constants": "github:jspm/nodelibs-constants@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "randombytes": "npm:randombytes@2.0.3"
+      "randombytes": "npm:randombytes@2.0.3",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:browserify-sign@4.0.0": {
       "bn.js": "npm:bn.js@4.11.3",
@@ -178,7 +182,8 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "inherits": "npm:inherits@2.0.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
-      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
+      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:clean-css@3.4.12": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -245,7 +250,8 @@ System.config({
       "inherits": "npm:inherits@2.0.1",
       "pbkdf2": "npm:pbkdf2@3.0.4",
       "public-encrypt": "npm:public-encrypt@4.0.0",
-      "randombytes": "npm:randombytes@2.0.3"
+      "randombytes": "npm:randombytes@2.0.3",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:des.js@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -270,7 +276,8 @@ System.config({
     "npm:evp_bytestokey@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "create-hash": "npm:create-hash@1.1.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0"
+      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:font-awesome@4.5.0": {
       "css": "github:systemjs/plugin-css@0.1.20"
@@ -359,7 +366,8 @@ System.config({
     "npm:randombytes@2.0.3": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2"
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:raven-js@2.3.0": {
       "path": "github:jspm/nodelibs-path@0.1.0",


### PR DESCRIPTION
Updates FAPI client, this required the following additional changes:

* Explicitly import `json4s` as this is no longer provided by the CAPI models used by FAPI
* Use `CirceDecoders` to decode JSON into Content model as `parseContent` is no longer provided by the CAPI models used by FAPI
* Change Scanamo version to match the version of Cats used by other dependencies (see comment in `build.sbt` for more details)

CC @Reettaphant @janua @LATaylor-guardian 