### PR TITLE
Add video media atom main media to hasMainVideo condition [DO NOT MERGE DURING PEN TEST]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.6",
+    "com.gu" %% "fapi-client" % "2.0.7-SNAPSHOT",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.7-SNAPSHOT",
+    "com.gu" %% "fapi-client" % "2.0.7",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -189,6 +189,7 @@ export default {
         'show-elements=video,main',
         'show-blocks=main',
         'show-tags=all',
+        'show-atoms=media',
         'show-fields=' + [
             'internalPageCode',
             'isLive',

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -4,7 +4,7 @@ import deepGet from 'utils/deep-get';
 import getMediaMainImage from 'utils/get-media-main-image';
 
 export function getMainMediaType(contentApiArticle) {
-    return _.chain(contentApiArticle.elements).where({relation: 'main'}).pluck('type').first().value();
+    return _.chain(contentApiArticle.elements).where({relation: 'main'}).pluck('type').first().value() || contentApiArticle.blocks;
 }
 
 export function getPrimaryTag(contentApiArticle) {
@@ -24,12 +24,17 @@ export function isPremium(contentApiArticle) {
         !!_.find(contentApiArticle.tags, {id: 'news/series/looking-back'});
 }
 
+export function hasMainMediaAtom(contentApiArticle) {
+    var mainBlockElement = _.chain(deepGet(contentApiArticle, '.blocks.main.elements')).first().value() || undefined;
+    return deepGet(mainBlockElement,'.contentAtomTypeData.atomType') === "media"
+}
+
 export default function capiToInternalState(opts, article) {
     article.state.sectionName(article.props.sectionName());
     article.state.primaryTag(getPrimaryTag(opts));
     article.state.imageCutoutSrcFromCapi(getContributorImage(opts));
     article.state.imageSrcFromCapi(getMediaMainImage(opts));
-    article.state.hasMainVideo(getMainMediaType(opts) === 'video');
+    article.state.hasMainVideo(getMainMediaType(opts) === 'video' || hasMainMediaAtom(opts));
     article.state.tone(opts.frontsMeta && opts.frontsMeta.tone);
     article.state.viewUrl(getViewUrl(article));
     article.state.ophanUrl(getOphanUrl(opts.webUrl));

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -37,7 +37,7 @@ export function hasMainMediaVideoAtom(contentApiArticle) {
         var firstAsset = _.chain(deepGet(atom,'.data.media.assets')).first().value() || undefined;
         return _.isMatch(firstAsset, {assetType: 'video'});
     }
-    return hasMediaAtomMainMedia(mainBlockElement) && isVideo(mainBlockElement);
+    return typeof mainBlockElement !== 'undefined' && hasMediaAtomMainMedia(mainBlockElement) && isVideo(mainBlockElement);
 }
 
 export default function capiToInternalState(opts, article) {

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -4,7 +4,7 @@ import deepGet from 'utils/deep-get';
 import getMediaMainImage from 'utils/get-media-main-image';
 
 export function getMainMediaType(contentApiArticle) {
-    return _.chain(contentApiArticle.elements).where({relation: 'main'}).pluck('type').first().value() || contentApiArticle.blocks;
+    return _.chain(contentApiArticle.elements).where({relation: 'main'}).pluck('type').first().value();
 }
 
 export function getPrimaryTag(contentApiArticle) {
@@ -26,7 +26,7 @@ export function isPremium(contentApiArticle) {
 
 export function hasMainMediaAtom(contentApiArticle) {
     var mainBlockElement = _.chain(deepGet(contentApiArticle, '.blocks.main.elements')).first().value() || undefined;
-    return deepGet(mainBlockElement,'.contentAtomTypeData.atomType') === "media"
+    return deepGet(mainBlockElement,'.contentAtomTypeData.atomType') === 'media';
 }
 
 export default function capiToInternalState(opts, article) {

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -24,8 +24,10 @@ export function isPremium(contentApiArticle) {
         !!_.find(contentApiArticle.tags, {id: 'news/series/looking-back'});
 }
 
-export function hasMainMediaAtom(contentApiArticle) {
+export function hasMainMediaVideoAtom(contentApiArticle) {
     var mainBlockElement = _.chain(deepGet(contentApiArticle, '.blocks.main.elements')).first().value() || undefined;
+    var atomId = deepGet(mainBlockElement,'.contentAtomTypeData.atomId');
+    console.log(atomId);
     return deepGet(mainBlockElement,'.contentAtomTypeData.atomType') === 'media';
 }
 
@@ -34,7 +36,7 @@ export default function capiToInternalState(opts, article) {
     article.state.primaryTag(getPrimaryTag(opts));
     article.state.imageCutoutSrcFromCapi(getContributorImage(opts));
     article.state.imageSrcFromCapi(getMediaMainImage(opts));
-    article.state.hasMainVideo(getMainMediaType(opts) === 'video' || hasMainMediaAtom(opts));
+    article.state.hasMainVideo(getMainMediaType(opts) === 'video' || hasMainMediaVideoAtom(opts));
     article.state.tone(opts.frontsMeta && opts.frontsMeta.tone);
     article.state.viewUrl(getViewUrl(article));
     article.state.ophanUrl(getOphanUrl(opts.webUrl));

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -26,9 +26,18 @@ export function isPremium(contentApiArticle) {
 
 export function hasMainMediaVideoAtom(contentApiArticle) {
     var mainBlockElement = _.chain(deepGet(contentApiArticle, '.blocks.main.elements')).first().value() || undefined;
-    var atomId = deepGet(mainBlockElement,'.contentAtomTypeData.atomId');
-    console.log(atomId);
-    return deepGet(mainBlockElement,'.contentAtomTypeData.atomType') === 'media';
+
+    function hasMediaAtomMainMedia(mainBlockElement){
+        return deepGet(mainBlockElement,'.contentAtomTypeData.atomType') === 'media';
+    }
+
+    function isVideo(mainBlockElement) {
+        var atomId = deepGet(mainBlockElement,'.contentAtomTypeData.atomId');
+        var atom = _.chain(deepGet(contentApiArticle,'.atoms.media')).findWhere({id: atomId}).value() || undefined;
+        var firstAsset = _.chain(deepGet(atom,'.data.media.assets')).first().value() || undefined;
+        return _.isMatch(firstAsset, {assetType: 'video'});
+    }
+    return hasMediaAtomMainMedia(mainBlockElement) && isVideo(mainBlockElement)
 }
 
 export default function capiToInternalState(opts, article) {

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -37,7 +37,7 @@ export function hasMainMediaVideoAtom(contentApiArticle) {
         var firstAsset = _.chain(deepGet(atom,'.data.media.assets')).first().value() || undefined;
         return _.isMatch(firstAsset, {assetType: 'video'});
     }
-    return hasMediaAtomMainMedia(mainBlockElement) && isVideo(mainBlockElement)
+    return hasMediaAtomMainMedia(mainBlockElement) && isVideo(mainBlockElement);
 }
 
 export default function capiToInternalState(opts, article) {


### PR DESCRIPTION
Adds content containing a Video Media Atom as Main Media to the `hasMainVideo` condition. This means that the option is displayed in facia-tool to _show video_ for such items.

This is a prerequisite for supporting playable media atoms on frontend.

CC @Reettaphant @janua 

![fronts](https://cloud.githubusercontent.com/assets/1764158/21422591/48a4966e-c830-11e6-8185-5fda9bed02ea.gif)

