### PR TITLE
Email front layouts

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1949,7 +1949,7 @@ ol.search_list > li::before {
     flex-wrap: wrap;
     position: absolute;
     top: 25px;
-    left: 0;
+    right: 0;
     padding: 10px;
     background: #FFFFFF;
     z-index: 1;

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -137,7 +137,7 @@ export default {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: true,
-            isHiddenLocked: true
+            isHiddenLocked: false
         }
 
     },

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -58,8 +58,14 @@ export default {
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },
-        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
-        { name: 'email'}
+        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] }
+    ],
+
+    emailTypes: [
+        { name: 'fast' },
+        { name: 'medium' },
+        { name: 'slow' },
+        { name: 'most-popular' }
     ],
 
     navSections: [

--- a/public/src/js/widgets/config-card-types.js
+++ b/public/src/js/widgets/config-card-types.js
@@ -5,11 +5,19 @@ import Extension from 'models/extension';
 
 export default class extends Extension {
     constructor(baseModel) {
+    	var types;
+
         super(baseModel);
 
-        baseModel.types = ko.observableArray(_.pluck(vars.CONST.types, 'name'));
+        if (baseModel.priority === 'email') {
+        	types = vars.CONST.emailTypes;
+        } else {
+        	types = vars.CONST.types;
+        }
+
+        baseModel.types = ko.observableArray(_.pluck(types, 'name'));
         var groups = {};
-        _.each(vars.CONST.types, type => {
+        _.each(types, type => {
             groups[type.name] = type.groups;
         });
         baseModel.typesGroups = groups;

--- a/public/src/js/widgets/config-card-types.js
+++ b/public/src/js/widgets/config-card-types.js
@@ -5,14 +5,14 @@ import Extension from 'models/extension';
 
 export default class extends Extension {
     constructor(baseModel) {
-    	var types;
+        var types;
 
         super(baseModel);
 
         if (baseModel.priority === 'email') {
-        	types = vars.CONST.emailTypes;
+            types = vars.CONST.emailTypes;
         } else {
-        	types = vars.CONST.types;
+            types = vars.CONST.types;
         }
 
         baseModel.types = ko.observableArray(_.pluck(types, 'name'));


### PR DESCRIPTION
Email fronts now have these layouts:

- Fast
- Medium
- Slow
- Most Popular

rather than the huge list of layouts that are only applicable to web.

Currently it looks a bit weird because for some reason its width shrinks right down when it has fewer than six items in it. In a future PR @superfrank is going to supply some SVGs for thumbnails and I'll try and sort out the width issue then:

![picture 374](https://cloud.githubusercontent.com/assets/5122968/21431903/236bbf90-c861-11e6-9ffa-495c589db60e.png)


@Reettaphant 