### PR TITLE
Allow unhiding of email fronts

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -136,7 +136,7 @@ export default {
         'email': {
             maxFronts: 50,
             hasGroups: false,
-            isTypeLocked: true,
+            isTypeLocked: false,
             isHiddenLocked: false
         }
 


### PR DESCRIPTION
For some reason `isTypeLocked` also needs to be false to allow me to unhide an email front

@philmcmahon 