### PR TITLE
Add backfill limit for email fronts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.10",
+    "com.gu" %% "fapi-client" % "2.0.11",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "content-api-models" % capiModelsVersion,
     "com.gu" % "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.7",
+    "com.gu" %% "fapi-client" % "2.0.10",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1154,6 +1154,7 @@ collection-widget:first-child .collection {
     display: none;
  }
 
+input[type="number"],
 input[type="text"],
 textarea,
 select{
@@ -1162,6 +1163,7 @@ select{
 
 select,
 textarea,
+input[type="number"],
 input[type="text"] {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -1181,6 +1183,7 @@ select:focus {
     border-color: #ffc107;
 }
 
+input[type="number"],
 input[type="text"] {
     padding: 2px 5px;
 }
@@ -1873,6 +1876,7 @@ ol.search_list > li::before {
     color: #000000;
 }
 
+.cnf-form input[type="number"],
 .cnf-form input[type="text"],
 .cnf-form textarea,
 .cnf-form select {

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -5,6 +5,7 @@ import persistence from 'models/config/persistence';
 import * as vars from 'modules/vars';
 import alert from 'utils/alert';
 import asObservableProps from 'utils/as-observable-props';
+import observableNumeric from 'utils/observable-numeric';
 import deepGet from 'utils/deep-get';
 import fullTrim from 'utils/full-trim';
 import populateObservables from 'utils/populate-observables';
@@ -18,24 +19,30 @@ export default class ConfigCollection extends DropTarget {
 
         this.parents = ko.observableArray(findParents(opts.id));
 
-        this.meta = asObservableProps([
-            'displayName',
-            'href',
-            'groups',
-            'type',
-            'uneditable',
-            'showTags',
-            'showSections',
-            'hideKickers',
-            'showDateHeader',
-            'showLatestUpdate',
-            'showTimestamps',
-            'excludeFromRss',
-            'hideShowMore',
-            'backfill',
-            'description',
-            'metadata'
-        ]);
+        this.meta = Object.assign(
+            asObservableProps([
+                'displayName',
+                'href',
+                'groups',
+                'type',
+                'uneditable',
+                'showTags',
+                'showSections',
+                'hideKickers',
+                'showDateHeader',
+                'showLatestUpdate',
+                'showTimestamps',
+                'excludeFromRss',
+                'hideShowMore',
+                'backfill',
+                'description',
+                'metadata'
+            ]),
+            asObservableProps([
+                'backfillLimit'
+            ], observableNumeric)
+        );
+
 
         populateObservables(this.meta, opts);
 

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -38,9 +38,11 @@ export default class ConfigCollection extends DropTarget {
                 'description',
                 'metadata'
             ]),
-            asObservableProps([
-                'backfillLimit'
-            ], observableNumeric)
+            {
+                displayHints: asObservableProps([
+                    'maxItemsToDisplay'
+                ], observableNumeric)
+            }
         );
 
 

--- a/public/src/js/models/config/persistence.js
+++ b/public/src/js/models/config/persistence.js
@@ -55,7 +55,8 @@ function flattenModel (model) {
         if (_.isFunction(value)) {
             return value();
         } else if (_.isObject(value)) {
-            return flattenModel(value);
+            var flattened = flattenModel(value);
+            return Object.keys(flattened).length === 0 ? null : flattened;
         } else {
             return value;
         }

--- a/public/src/js/models/config/persistence.js
+++ b/public/src/js/models/config/persistence.js
@@ -50,8 +50,19 @@ let publicInterface = new Persistence();
  * Copies properties and the current value of observables from a knockout model.
  */
 function flattenModel (model) {
+
+    function flattenValue(value) {
+        if (_.isFunction(value)) {
+            return value();
+        } else if (_.isObject(value)) {
+            return flattenModel(value);
+        } else {
+            return value;
+        }
+    }
+
     return _.reduce(model, function (accumulator, value, key) {
-        var x = _.isFunction(value) ? value() : value;
+        var x = flattenValue(value);
 
         if (x) {
             accumulator[key] = x;

--- a/public/src/js/utils/as-observable-props.js
+++ b/public/src/js/utils/as-observable-props.js
@@ -1,8 +1,9 @@
 import _ from 'underscore';
 import ko from 'knockout';
 
-export default function(props) {
+export default function(props, createObservable) {
+    createObservable = createObservable || ko.observable;
     return _.object(_.map(props, function(prop) {
-        return [prop, ko.observable()];
+        return [prop, createObservable()];
     }));
 }

--- a/public/src/js/utils/observable-numeric.js
+++ b/public/src/js/utils/observable-numeric.js
@@ -3,12 +3,10 @@ import ko from 'knockout';
 export default function(initialValue) {
     var actual = ko.observable(initialValue);
     return ko.dependentObservable({
-        read: function ()
-        {
+        read() {
             return actual();
         },
-        write: function (newValue)
-        {
+        write(newValue) {
             var parsedValue = parseFloat(newValue);
             actual(isNaN(parsedValue) ? newValue : parsedValue);
         }

--- a/public/src/js/utils/observable-numeric.js
+++ b/public/src/js/utils/observable-numeric.js
@@ -1,0 +1,16 @@
+import ko from 'knockout';
+
+export default function(initialValue) {
+    var actual = ko.observable(initialValue);
+    return ko.dependentObservable({
+        read: function ()
+        {
+            return actual();
+        },
+        write: function (newValue)
+        {
+            var parsedValue = parseFloat(newValue);
+            actual(isNaN(parsedValue) ? newValue : parsedValue);
+        }
+    });
+}

--- a/public/src/js/utils/populate-observables.js
+++ b/public/src/js/utils/populate-observables.js
@@ -1,10 +1,16 @@
 import _ from 'underscore';
 
-export default function(target, opts) {
-    if (!_.isObject(target) || !_.isObject(opts)) { return; }
-    _.keys(target).forEach(function(key){
+function populateObservables(target, opts) {
+    if (!_.isObject(target) || !_.isObject(opts)) {
+        return;
+    }
+    _.keys(target).forEach((key) => {
         if (_.isFunction(target[key]) && _.isUndefined(target[key]())) {
             target[key](opts[key]);
+        } else if (_.isObject(target[key]) && _.isObject(opts[key])) {
+            populateObservables(target[key], opts[key]);
         }
     });
 }
+
+export default populateObservables;

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -234,7 +234,7 @@
 
             <div data-bind="visible: $root.priority == 'email' ">
             <label for="backfillLimit">Maximum number of items to render</label>
-            <input id="backfillLimit" type="number" data-bind="value: meta.backfillLimit">
+            <input id="backfillLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay">
             </div>
 
             <label for="showTags" >Show tag kickers</label>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -232,6 +232,11 @@
                 <span class="cnf-form__value" data-bind="text: meta.groups"></span>
             <!-- /ko -->
 
+            <div data-bind="visible: $root.priority == 'email' ">
+            <label for="backfillLimit">Maximum number of items to render</label>
+            <input id="backfillLimit" type="number" data-bind="value: meta.backfillLimit">
+            </div>
+
             <label for="showTags" >Show tag kickers</label>
             <input id="showTags" type="checkbox" data-bind="checked: meta.showTags" />
 

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -226,16 +226,18 @@
                     value: meta.description"/>
 
             <config-collection-backfill params="backfill: meta.backfill"></config-collection-backfill>
+
+            <div data-bind="visible: $root.priority == 'email' ">
+                <label for="backfillLimit" title="Maximum number of items to include in email">Max items to render</label>
+                <input id="backfillLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" placeholder="6">
+            </div>
+
             <config-collection-tags params="tags: meta.metadata" class="tags"></config-collection-tags>
             <!-- ko if: meta.groups -->
                 <label>Groups</label>
                 <span class="cnf-form__value" data-bind="text: meta.groups"></span>
             <!-- /ko -->
 
-            <div data-bind="visible: $root.priority == 'email' ">
-            <label for="backfillLimit">Maximum number of items to render</label>
-            <input id="backfillLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay">
-            </div>
 
             <label for="showTags" >Show tag kickers</label>
             <input id="showTags" type="checkbox" data-bind="checked: meta.showTags" />

--- a/public/test/spec/config.persistence.spec.js
+++ b/public/test/spec/config.persistence.spec.js
@@ -166,6 +166,51 @@ describe('Persistence', function () {
         .catch(done.fail);
     });
 
+    it('creates a collection with display hints', function (done) {
+        var front = new Front({
+            id: 'fruit/front',
+            webTitle: 'fruit loops',
+            title: 'cereal',
+            isHidden: false,
+            priority: 'food'
+        });
+        var collection = new Collection({
+            displayName: 'green apple',
+            groups: [],
+            uneditable: true,
+            displayHints: {
+                maxItemsToDisplay: 3
+            }
+        });
+        collection.parents.push(front);
+
+        var request = persistence.collection.save(collection);
+        var call = ajax.request.calls.argsFor(0)[0], data = JSON.parse(call.data);
+        expect(call.type).toBe('POST');
+        expect(call.url).toBe('/config/collections');
+        expect(data).toEqual({
+            frontIds: ['fruit/front'],
+            collection: {
+                displayName: 'green apple',
+                uneditable: true,
+                groups: [],
+                displayHints: {
+                    maxItemsToDisplay: 3
+                }
+            }
+        });
+        expect(this.events.before).toHaveBeenCalled();
+        expect(this.events.after).not.toHaveBeenCalled();
+        request.then(() => {
+                expect(this.events.after).toHaveBeenCalled();
+
+                front.dispose();
+                collection.dispose();
+            })
+            .then(done)
+            .catch(done.fail);
+    });
+
     it('updates a collection', function (done) {
         var one = new Front({
             id: 'fruit/front',

--- a/test/config/TransformationsSpec.scala
+++ b/test/config/TransformationsSpec.scala
@@ -51,6 +51,7 @@ import org.scalatest._
     None,
     None,
     None,
+    None,
     None
   )
 


### PR DESCRIPTION
Allows email fronts to use backfill but still restrict the maximum number of articles in a collection.  Depends on https://github.com/guardian/facia-scala-client/pull/182, and will require a change to frontend to respect the new field.

![screen shot 2017-02-10 at 14 04 13](https://cloud.githubusercontent.com/assets/2619836/22829313/e3030a20-ef99-11e6-9a52-1116cdb47b14.png)