### PR TITLE
Add free-text layout type for email

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -66,7 +66,7 @@ export default {
         { name: 'fast-images' },
         { name: 'medium' },
         { name: 'slow' },
-        { name: 'most-popular' }
+        { name: 'free-text' }
     ],
 
     navSections: [


### PR DESCRIPTION
Adds a free text layout type to be used for containers which just contain a message from the editor, typically used at the top or bottom or an email.

For now, editorial will drop a card into this container and write all their text in the headline field (sadly, using `<br>` tags for newlines. Hopefully at some point this can be replaced with real rich text editor in the fronts tool).

Frontend will know to render this card differently because it's in a container with "free text" layout type.

I also removed the `most-popular` layout since we don't use it