### PR TITLE
update readme 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,3 @@ developer.properties
 local.conf
 application.local.conf
 
-#Node Version Manager
-.nvmrc

--- a/GUIDE_TO_FRONTS.md
+++ b/GUIDE_TO_FRONTS.md
@@ -1,8 +1,8 @@
-#Instructions for developers
+# Instructions for developers
 - The client side of the fronts tool uses [knockout](http://knockoutjs.com/)
 - The backend uses Play
 
-##The app
+## The app
 - The fronts tool is used to edit fronts. Fronts contain collections that users can add articles to.
 - This is a picture of the uk front (we can find it on www.theguardian.com/uk):
 ![front](docs/front.png)
@@ -19,15 +19,15 @@
 3. A page for sending breaking news at `https://fronts.local.dev-gutools.co.uk/breaking-news`
    * Breaking news alerts are sent by dragging an articles to a special breaking news front
 
-##Dragging images from the grid
+## Dragging images from the grid
 - You can drag an image to an article on the fronts tool from the grid [here](https://media.test.dev-gutools.co.uk/search).
 - To use an image you need to make a 5:3 crop of it first using the grid.
 
-##Pressing fronts
+## Pressing fronts
 - Before fronts can appear on frontend, they have to be pressed by Facia-Press which lives on the frontend account.
 - The fronts tool sends events to an sqs queue which Facia-Press listens. You can read more about Facia-Press [here](https://github.com/guardian/frontend/blob/ad74a1da567f047b7b824650e6e1be0f0262952b/docs/02-architecture/01-applications-architecture.md).
 
-###Developing locally
+### Developing locally
 - If you are adding a new kind of content to a front or changing the front configuration, you should check that the front can still be pressed.
 
 - To check this, check that a piece of content still appears on frontend. Edit the articles appearing on a front, launch the front and check that your changes are appearing here: `http://m.code.dev-theguardian.com/{name-of-front}`
@@ -38,14 +38,14 @@
 
 - If you are developing locally and do not have frontend credentials from janus, the fronts tool won't have permissions to push events to the sqs queue that Facia-Press reads from. To test that a front is pressed, you will have to deploy your changes to code, and test the code from there.
 
-##Client side code
-###Models
+## Client side code
+### Models
 - As explained above, the fronts tool is used to create and edit fronts containing collections that articles can be added to.
 - The models for these and associated data are found in the `models` folder
 - Note: thre are two different collection models, on the page for editing collections and articles in the `models` folder
 and another for the fronts configuration page, in the `models/config` folder. Don't confuse them.
 
-###Column widgets and extension widgets
+### Column widgets and extension widgets
 - Html for the project is located in the `widgets` folder. These are usually accompanied by javascript files.
 - Included in this folder are column widgets and extension widgets that appear outside the column. Columns and extensions are added
 to the page in the route-handler (in `modules/route-handlers`)
@@ -56,12 +56,12 @@ to the page in the route-handler (in `modules/route-handlers`)
 - Extensions are elements that live outside these columns, e.g. a warning that a front is stale
 (a front becomes stale if it fails to press)
 
-####Adding new widgets
+#### Adding new widgets
 - To add a new widget, add it in the `models/widgets` folder
 - To define new columns or widgets, add them `models/available-columns.js` or
 `models/available-extensions.js`, and by adding them in `modules/route-handlers.js`
 
-####Base model
+#### Base model
 - Column widgets have access to the baseModel
 - The baseModel stores information about the current fronts and collections in them, and about other configuration properties
 - If you want to access fronts or collections, you can do so through the baseModel

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Mac:
 brew install node
 ```
 
+#### NVM
+Optional: Install nvm to manage your node versions
+
 #### Grunt (build tool)
 
 Ubuntu/Mac:
@@ -159,16 +162,20 @@ Create the files
 
 ### Credentials
 
-You need valid developer credentials for `cmsFronts` and `workflow`.
-You can get keys temporary keys from `janus`. Note that the recommended way to get Janus credentials for *facia-tool* is to use feria and run:
+You need valid developer credentials for `cmsFronts` and `workflow.s3Read`.
+You can get keys temporary keys from `janus`. You can copy these credentials manually from `janus`
+
+You can also get credentials for *facia-tool* by using feria:
 
 ```
 $ feria cmsFronts && feria --access s3-read workflow && feria --access sqs-consumer frontend
 ```
 (You should first checkout the repository and follow the install instructions for *feria*.)
 
+
 You can run the fronts tool without frontend credentials, but you will not be able to check how your changes to fronts appear on frontend without
 these credentials. You will need to test your changes on `CODE` to see these changes.
+
 ### Code Dependencies
 
 Inside the project
@@ -190,6 +197,9 @@ If it is your first time, compile the project.
 ```
 compile
 ```
+
+Ensure that you are running to correct version of node (4.1 or higher).
+You can get this by running `nvm use`
 
 Run the project locally by typing
 ```
@@ -226,4 +236,13 @@ You can run a single test going to [http://localhost:9876/debug.html?test=collec
 
 You need to have version 4.1 or higher of node installed to be able to run the tests
 
+### Linting
+
+Fronts tool uses `eslint` to ensure consistent style. Run `eslint` with
+
+```bash
+grunt eslint
+```
+
+More detailed instructions of how to develop fronts tool available [here](./GUIDE_TO_FRONTS.md)
 Enjoy!


### PR DESCRIPTION
Adds more detail to the fronts docs

- instructions for linting
- adds `.nvmrc` file 
- specifies which workflow credentials to use
- fixes formatting of the instructions file and gives it a more appropriate name.