### PR TITLE
leave campaign codes in for snap links

### DIFF
--- a/public/src/js/constants/campaign-code-params.js
+++ b/public/src/js/constants/campaign-code-params.js
@@ -1,0 +1,10 @@
+export default [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'utm_term',
+    'CMPT_TU',
+    'CMP_BUNIT',
+    'INTCMP'
+];

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -29,7 +29,7 @@ import openGraph from 'utils/open-graph';
 import populateObservables from 'utils/populate-observables';
 import serializeArticleMeta from 'utils/serialize-article-meta';
 import * as snap from 'utils/snap';
-import urlAbsPath from 'utils/url-abs-path';
+import pathWithCampaignCodes from 'utils/path-with-campaign-codes';
 import visitedArticleStorage from 'utils/visited-article-storage';
 
 const capiProps = [
@@ -243,7 +243,7 @@ export default class Article extends DropTarget {
         let href;
 
         if (isGuardianUrl(id) || isPreviewUrl(id)) {
-            href = '/' + urlAbsPath(id);
+            href = '/' + pathWithCampaignCodes(id);
         } else {
             href = id;
         }
@@ -265,7 +265,7 @@ export default class Article extends DropTarget {
 
     convertToLatestSnap(kicker) {
         this.meta.snapType('latest');
-        this.meta.snapUri(urlAbsPath(this.id()));
+        this.meta.snapUri(pathWithCampaignCodes(this.id()));
 
         this.meta.showKickerCustom(true);
         this.meta.customKicker(kicker);

--- a/public/src/js/utils/path-with-campaign-codes.js
+++ b/public/src/js/utils/path-with-campaign-codes.js
@@ -1,0 +1,27 @@
+import urlAbsPath from 'utils/url-abs-path';
+import campaignCodeParams from 'constants/campaign-code-params';
+import _ from 'underscore';
+
+export default function(url) {
+    const queryParameters = url.split('?')[1];
+
+    let campaignCodes;
+    if (queryParameters) {
+        const paramsList = queryParameters.split('&');
+        campaignCodes = _.reduce(paramsList, (campaignCodes, queryParam) => {
+            const paramName = queryParam.split('=')[0];
+            if  (campaignCodeParams.indexOf(paramName) !== -1) {
+                campaignCodes += queryParam + '&';
+            }
+            return campaignCodes;
+        }, '?');
+    } else {
+        campaignCodes = '';
+    }
+
+    //If there were query parameters, there is either an extra '?' or '&'
+    //appended to the end of the campaign codes string
+    const trimmedCodes = campaignCodes.substring(0, campaignCodes.length - 1);
+
+    return urlAbsPath(url) + trimmedCodes;
+}

--- a/public/test/spec/string.manipulation.spec.js
+++ b/public/test/spec/string.manipulation.spec.js
@@ -5,6 +5,7 @@ import serialize from 'utils/serialize-query-params';
 import trim from 'utils/full-trim';
 import isGuardian from 'utils/is-guardian-url';
 import urlAbsPath from 'utils/url-abs-path';
+import pathWithCampaignCodes from 'utils/path-with-campaign-codes';
 import urlHost from 'utils/url-host';
 import sanitizeQuery from 'utils/sanitize-api-query';
 import sanitizeHtml from 'utils/sanitize-html';
@@ -219,3 +220,27 @@ describe('utils/human-time', function () {
         expect(humanTime(future, now)).toBe('in 2 mins');
     });
 });
+
+
+describe('utils/path-with-campaign-codes', function () {
+    const path = 'path';
+    const testUrl = 'https://base.co.uk/' + path;
+
+    it('parses an empty string', function() {
+        expect(pathWithCampaignCodes('')).toBe('');
+    });
+
+    it('parses a url with no parameters', function() {
+        expect(pathWithCampaignCodes(testUrl)).toBe(path);
+    });
+
+    it('does not include parameters that are not campaing codes', function() {
+        const urlWithParams = testUrl + '?someParam=param&another=param';
+        expect(pathWithCampaignCodes(urlWithParams)).toBe(path);
+    });
+    it('does not include parameters that are not campaing codes', function() {
+        const urlWithParams = testUrl + '?someParam=param&utm_source=source&utm_medium=medium&another=param';
+        expect(pathWithCampaignCodes(urlWithParams)).toBe(path + '?utm_source=source&utm_medium=medium');
+    });
+});
+


### PR DESCRIPTION
Fronts tool strips out query parameters for guardian snap links, but parameters that set campaign codes are needed. This pr makes sure that we keep these parameters for snaps.