### PR TITLE
add viewUrl to snap links

### DIFF
--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -138,12 +138,6 @@ export default class Article extends DropTarget {
             contentApi.decorateItems(this.meta.supporting.items());
         }
 
-        // Add viewUrl to snap links
-        const viewUrl = getViewUrl(this);
-        if (viewUrl) {
-            this.state.viewUrl = viewUrl;
-        }
-
         if (withCapiData) {
             this.addCapiData(opts);
         } else {
@@ -257,6 +251,12 @@ export default class Article extends DropTarget {
 
         this.meta.href(href);
         this.id(snap.generateId());
+
+        // Add viewUrl to snap links
+        const viewUrl = getViewUrl(this);
+        if (viewUrl) {
+            this.state.viewUrl(viewUrl);
+        }
         this.updateEditorsDisplay();
     }
 

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -12,6 +12,7 @@ import {default as assignState} from 'models/article/transform';
 import persistence from 'models/collections/persistence';
 import DropTarget from 'models/drop-target';
 import Group from 'models/group';
+import {getViewUrl} from 'models/article/links';
 
 import * as contentApi from 'modules/content-api';
 import copiedArticle from 'modules/copied-article';
@@ -135,6 +136,12 @@ export default class Article extends DropTarget {
             }));
 
             contentApi.decorateItems(this.meta.supporting.items());
+        }
+
+        // Add viewUrl to snap links
+        const viewUrl = getViewUrl(this);
+        if (viewUrl) {
+            this.state.viewUrl = viewUrl;
         }
 
         if (withCapiData) {

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -136,6 +136,13 @@ export default class Article extends DropTarget {
             }));
 
             contentApi.decorateItems(this.meta.supporting.items());
+
+            // Add viewUrl to snap links
+            const viewUrl = getViewUrl(this);
+            if (viewUrl) {
+                this.state.viewUrl(viewUrl);
+            }
+
         }
 
         if (withCapiData) {
@@ -252,11 +259,6 @@ export default class Article extends DropTarget {
         this.meta.href(href);
         this.id(snap.generateId());
 
-        // Add viewUrl to snap links
-        const viewUrl = getViewUrl(this);
-        if (viewUrl) {
-            this.state.viewUrl(viewUrl);
-        }
         this.updateEditorsDisplay();
     }
 


### PR DESCRIPTION
snap links were missing a viewUrl due to a refactor in https://github.com/guardian/facia-tool/commit/f736976083867b6b40bec4959ad512601b500111 missing them out.

/cc @Reettaphant 