### PR TITLE
grunt upload fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
         var riffraff = require('node-riffraff-artefact');
         var path = require('path');
         riffraff.settings.leadDir = path.join(__dirname, 'tmp');
-        riffraff.settings.manifestProjectName = "cms-fronts::facia-tool";
+        riffraff.settings.manifestProjectName = 'facia-tool';
         riffraff.s3Upload()
         .then(function () {
             grunt.log.writeln('Artifacts uploaded!');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "karma-phantomjs-launcher": "1.0.0",
     "karma-spec-reporter": "0.0.26",
     "load-grunt-config": "0.19.2",
-    "node-riffraff-artefact": "1.7.2",
+    "node-riffraff-artefact": "1.8.1",
     "phantomjs-prebuilt": "2.1.7",
     "time-grunt": "1.3.0"
   },


### PR DESCRIPTION
Grunt was running deployments against the old project name, which were failing (https://riffraff.gutools.co.uk/deployment/view/0631c7f6-a0ae-4150-9ea8-9490534d8ef5). This will fix it