### PR TITLE
Adding a warning to shared containers on fronts

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -2042,6 +2042,11 @@ ol.search_list > li::before {
     color: #555;
 }
 
+span.also a{
+  color: red;
+  font-size: 20px;
+}
+
 .also {
     margin: 6px;
     line-height: 24px;

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -64,6 +64,9 @@
         css: {'dropdown-open': state.alsoOnVisible},
         slideVisible: state.alsoOnVisible() && !state.collapsed()
     ">
+        <p>
+            Warning! This container is shared on other fronts, be careful when editing.
+        </p>
         <ul data-bind="foreach: alsoOn">
             <li><a class="list-header__also-on" data-bind="
                 click: $parent.front.setFront,


### PR DESCRIPTION
BEFORE
<img width="633" alt="screen shot 2017-08-01 at 15 34 40" src="https://user-images.githubusercontent.com/2051501/28830586-199e0d70-76cf-11e7-86ff-11deb1b10932.png">


AFTER
<img width="637" alt="screen shot 2017-08-01 at 15 32 00" src="https://user-images.githubusercontent.com/2051501/28830469-b16d2fd8-76ce-11e7-9808-7e6bb79bed32.png">

Some fronts editors have mentioned that other users often edit shared containers, affecting them in multiple places. This should provide a quick mental check that they're approaching the task in the right way.