### PR TITLE
Changing limit again, due to unforeseen case for the upper limit

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -129,7 +129,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
 
   object facia {
     lazy val stage = getString("facia.stage").getOrElse(stageFromProperties)
-    lazy val collectionCap: Int = 20
+    lazy val collectionCap: Int = 25
   }
 
   object logging {


### PR DESCRIPTION
Because we can't control how many teams are in a football league....... Sport are making containers for every team in certain leagues, where there are 24 teams. And I've added one for luck.