### PR TITLE
upgrade the notification library

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -159,8 +159,6 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
   object notification {
     lazy val host = getMandatoryString("notification.host")
     lazy val key = getMandatoryString("notification.key")
-    lazy val legacyHost = getMandatoryString("notification.legacy.host")
-    lazy val legacyKey = getMandatoryString("notification.legacy.key")
   }
 
   object pandomain {

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -25,13 +25,11 @@ class InvalidNotificationContentType(msg: String) extends Throwable(msg) {}
 
 class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSAPI) {
   lazy val client = {
-    Logger.info(s"Configuring breaking news client to send notifications to ${config.notification.host} and ${config.notification.legacyHost}")
+    Logger.info(s"Configuring breaking news client to send notifications to ${config.notification.host}")
     ApiClient(
       host = config.notification.host,
       apiKey = config.notification.key,
-      httpProvider = new NotificationHttpProvider(ws),
-      legacyHost = config.notification.legacyHost,
-      legacyApiKey = config.notification.legacyKey
+      httpProvider = new NotificationHttpProvider(ws)
     )
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "0.3",
     "com.gu" %% "fapi-client" % "2.0.14",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
-    "com.gu" %% "mobile-notifications-client-play-2-4" % "0.5.29",
+    "com.gu" %% "mobile-notifications-client" % "1.0",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
 
     // Circe 0.6.1 depends on Cats 0.8.1


### PR DESCRIPTION
It drops support for the legacy notification system, and supports play2.4 by default

cc @NathanielBennett 

(I wasn't sure who to ask the review to, so I picked you two)