### PR TITLE
Fix missing query string on URLs pasted into clipboard

### DIFF
--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -247,7 +247,7 @@ export default class Article extends DropTarget {
         let href;
 
         if (isGuardianUrl(id) || isPreviewUrl(id)) {
-            href = '/' + urlAbsPath(id);
+            href = '/' + urlAbsPath(id, true);
         } else {
             href = id;
         }

--- a/public/src/js/utils/url-abs-path.js
+++ b/public/src/js/utils/url-abs-path.js
@@ -1,13 +1,15 @@
 var a = document.createElement('a');
 
-export default function(url) {
+export default function(url, keepQueryString) {
     if (typeof url === 'string') {
         // If necessary, add a leading slash to stop the browser resolving it against the current path
         url = url.match(/^\//) || url.match(/^https?:\/\//) ? url : '/' + url;
 
         a.href = url;
 
+        var path = a.pathname.replace(/^\//, '');
+
         // Return the abspath without a leading slash, because ContentApi ids are formed like that
-        return a.pathname.replace(/^\//, '');
+        return keepQueryString ? path + a.search : path;
     }
 }

--- a/public/src/js/utils/url-abs-path.js
+++ b/public/src/js/utils/url-abs-path.js
@@ -1,5 +1,12 @@
 var a = document.createElement('a');
 
+/*
+ * @param {string} url
+ * @param {bool} keepQueryString
+ * @description gets the absolute path, keepQueryString was added where campaign
+ * params where being removed. Because this helper is many other places keeping
+ * queryStrings is opt in
+ */
 export default function(url, keepQueryString) {
     if (typeof url === 'string') {
         // If necessary, add a leading slash to stop the browser resolving it against the current path

--- a/public/test/spec/string.manipulation.spec.js
+++ b/public/test/spec/string.manipulation.spec.js
@@ -174,6 +174,7 @@ describe('utils/url-abs-path', function () {
         expect(urlAbsPath('/banana#handle')).toBe('banana');
         expect(urlAbsPath('https://anotherurl.com/banana#handle')).toBe('banana');
         expect(urlAbsPath('https://anotherurl.com/banana/for/free?q=hello')).toBe('banana/for/free');
+        expect(urlAbsPath('https://anotherurl.com/banana/for/free?q=hello', true)).toBe('banana/for/free?q=hello');
     });
 });
 


### PR DESCRIPTION
I've added a flag argument in the helper function that returns the cleaned URL. I'm not quite sure whether we can keep the query string across every usage of this function in the app, but given there was a test that checked that the query string _does_ get removed I decided to leave it as it was everywhere else.