### PR TITLE
depopulate container without validating groups

### DIFF
--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -239,7 +239,12 @@ export default class ConfigFront extends BaseClass {
         if (this.props.canonical() === collection.id) {
             this.props.canonical(null);
         }
-        this.saveProps();
+
+        // Save front without checking if it's valid
+        // Groups are validated upon creation and editing anyway
+        this.applyConstraints();
+        this.state.isOpenProps(false);
+        return persistence.front.update(this);
     }
 
     applyConstraints() {


### PR DESCRIPTION
The validation in place makes it impossible to create a front without a group, or to remove it. For some reason, the front mentioned in the tasks did not have a group. This shouldn't affect deletion of containers though. This fixes that.