### PR TITLE
Revert quoted headlines changes

### DIFF
--- a/public/src/js/constants/article-meta-fields.js
+++ b/public/src/js/constants/article-meta-fields.js
@@ -167,7 +167,6 @@ export default Object.freeze([
     },
     {
         key: 'showQuotedHeadline',
-        ifState: 'isComment',
         editable: true,
         omitForSupporting: true,
         label: 'quote headline',

--- a/public/src/js/models/article/transform.js
+++ b/public/src/js/models/article/transform.js
@@ -53,7 +53,6 @@ export default function capiToInternalState(opts, article) {
     if (deepGet(opts, '.fields.liveBloggingNow') === 'true') {
         article.state.isLiveBlog(true);
     }
-    opts.frontsMeta && article.state.isComment(opts.frontsMeta.tone === 'comment');
     article.state.capiId(opts.capiId);
     article.state.shortUrl(opts.fields.shortUrl);
 }

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -82,7 +82,6 @@ export default class Article extends DropTarget {
             'underControlDrag',
             'isOpen',
             'isLiveBlog',
-            'isComment',
             'isLoaded',
             'isEmpty',
             'visited',


### PR DESCRIPTION
We have been asked to revert this change for the time being. They want this to be rolled out once the Garnett changes have been better communicated to editorial.