### PR TITLE
Add button for clearing all clipboard items

### DIFF
--- a/public/src/js/models/group.js
+++ b/public/src/js/models/group.js
@@ -32,6 +32,10 @@ export default class Group extends DropTarget {
         }, this, this);
     }
 
+    omitAllItems() {
+        _.each(this.items.slice(0), item => this.omitItem(item));
+    }
+
     omitItem(item) {
         this.items.remove(item);
         if (_.isFunction(this.opts.omitItem)) {

--- a/public/src/js/widgets/clipboard.html
+++ b/public/src/js/widgets/clipboard.html
@@ -1,6 +1,11 @@
 <div class="col__inner">
     <div class="title title--clipboard">
         <span>clipboard</span>
+        <a class="tool tool--small tool--small--remove" title="Clear all" data-bind="
+                clickBubble: false,
+                click: clearAll">
+                <i class="fa fa-trash"></i>
+        </a>
         <div class="clipboard-indicator dropdown fadeElement" data-bind="
             css: {
                 'dropdown-open': dropdownOpen,

--- a/public/src/js/widgets/clipboard.js
+++ b/public/src/js/widgets/clipboard.js
@@ -51,6 +51,10 @@ class Clipboard extends BaseWidget {
         }
     }
 
+    clearAll() {
+        this.group.omitAllItems();
+    }
+
     flushCopiedArticles() {
         copiedArticle.flush();
     }


### PR DESCRIPTION
Reuses the rubbish recepticle icon and adds it to floated right of the 'clipboard' title - I didn't deal with the slight movement when the scroll bars disappear but it doesn't seem to much of a hindrance

![frontclearclipboard](https://user-images.githubusercontent.com/1652187/34262783-3d956042-e665-11e7-9347-4c45147ce000.gif)
