### PR TITLE
add additional logging for sending breaking news alerts

### DIFF
--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -10,6 +10,7 @@ import frontsapi.model._
 import metrics.FaciaToolMetrics
 import model.NoCache
 import permissions.BreakingNewsEditCollectionsCheck
+import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
 import services._
@@ -59,8 +60,10 @@ class FaciaToolController(val config: ApplicationConfiguration, val acl: Acl, va
           case None => Future.successful(NoCache(Ok))}}}
 
   private def maybeSendBreakingAlert(request: UserRequest[AnyContent], collectionId: String): Future[Result] = {
+    Logger.info(s"maybe sending a breaking news alert with collection $collectionId")
     if (configAgent.isCollectionInBreakingNewsFront(collectionId)) {
       val identity = request.user
+      Logger.info(s"$collectionId was a breaking news collection")
       request.body.asJson.flatMap(_.asOpt[ClientHydratedCollection]).map {
         case clientCollection: ClientHydratedCollection =>
           breakingNewsUpdate.putBreakingNewsUpdate(

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -38,6 +38,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSAPI) {
     collection: ClientHydratedCollection,
     email: String
   ): Future[Result] = {
+    Logger.info("Now putting a new breaking news update")
     val futurePossibleErrors = Future.traverse(collection.trails)(trail => sendAlert(trail, email))
     futurePossibleErrors.map { listOfPossibleErrors => {
       val errors = listOfPossibleErrors.flatten


### PR DESCRIPTION
Adding some extra logging for breaking news. We don't have to revert the PR and add logging to what was there before (unless problems resurface) because a breaking news alert was sent this morning.