### PR TITLE
Make sure that all fronts users are in the ed tools users group

### DIFF
--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -4,7 +4,8 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
-import com.gu.pandomainauth.{PanDomain, PanDomainAuth}
+import com.gu.pandomainauth.{PanDomain, PanDomainAuth, PublicSettings}
+import com.gu.pandomainauth.service.GoogleGroupChecker
 import conf.ApplicationConfiguration
 import play.api.Logger
 import play.api.mvc._
@@ -12,8 +13,18 @@ import play.api.mvc._
 trait PanDomainAuthActions extends AuthActions with PanDomainAuth with Results {
   def config: ApplicationConfiguration
 
+  private lazy val groupChecker = settings.google2FAGroupSettings.map(new GoogleGroupChecker(_, this.bucket))
+
+  def userInGroups(authedUser: AuthenticatedUser): Boolean = groupChecker.exists{ checker =>
+    checker.checkGroups(authedUser, config.pandomain.userGroups).fold(
+      error => {
+        Logger.warn(error)
+        false
+      }, identity)
+  }
+
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    PanDomain.guardianValidation(authedUser)
+    PanDomain.guardianValidation(authedUser) && userInGroups(authedUser)
   }
 
   override def authCallbackUrl: String = config.pandomain.host  + "/oauthCallback"
@@ -24,12 +35,13 @@ trait PanDomainAuthActions extends AuthActions with PanDomainAuth with Results {
   }
 
   override def invalidUserMessage(claimedAuth: AuthenticatedUser): String = {
-    if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor) {
+    if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor) 
       s"${claimedAuth.user.email} is not valid for use with the Fronts Tool as you need to have two factor authentication enabled." +
        s" Please contact the Helpdesk by emailing 34444@theguardian.com or calling 34444 and request access to Composer CMS tools."
-    } else {
-      s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
-    }
+    else if (!userInGroups(claimedAuth)) s"${claimedAuth.user.email} is not a member of required google groups. Please contact the Helpdesk by emailing 34444@theguardian.com"
+
+    else s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
+
   }
 
   override lazy val domain: String = config.pandomain.domain

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -42,6 +42,10 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
   private def getMandatoryBoolean(property: String): Boolean = getBoolean(property)
     .getOrElse(throw new BadConfigurationException(s"$property of type boolean not configured for stage $stageFromProperties"))
 
+  def getMandatoryStringPropertiesSplitByComma(propertyName: String): List[String] = {
+    getMandatoryString(propertyName).split(",").toList
+  }
+
   object environment {
     val stage = stageFromProperties.toLowerCase
     val applicationName = "facia-tool"
@@ -166,6 +170,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     lazy val domain = getMandatoryString("pandomain.domain")
     lazy val service = getMandatoryString("pandomain.service")
     lazy val roleArn = getMandatoryString("pandomain.roleArn")
+    lazy val userGroups = getMandatoryStringPropertiesSplitByComma("pandomain.user.groups")
   }
 
   object permission {

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "fapi-client" % "2.0.14",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client" % "1.0",
-    "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
+    "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.4.1",
 
     // Circe 0.6.1 depends on Cats 0.8.1
     // content-api-models depends on Circe 0.6.1 which depends on Cats 0.8.1


### PR DESCRIPTION
I have talked to esd about this and they want the fronts tool to be locked down by membership of the ed tools users group just like composer. We'll be ready to merge this once they've communicated these changes to everyone and made sure that everyone who needs to can still access the tool. 