### PR TITLE
Platform-specific collections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ TwirlKeys.templateImports ++= Seq(
 )
 
 val awsVersion = "1.11.188"
-val capiModelsVersion = "11.12"
+val capiModelsVersion = "11.33"
 val circeVersion = "0.7.0"
 val json4sVersion = "3.5.0"
 
@@ -80,11 +80,11 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
-    "com.gu" % "content-api-models" % capiModelsVersion,
-    "com.gu" % "content-api-models-json" % capiModelsVersion,
+    "com.gu" %% "content-api-models" % capiModelsVersion,
+    "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "editorial-permissions-client" % "0.3",
-    "com.gu" %% "fapi-client" % "2.0.14",
+    "com.gu" %% "fapi-client" % "2.5.3",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "mobile-notifications-client" % "1.0",
     "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.4.1",

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1535,6 +1535,10 @@ button {
     margin: 0 10px 0 0;
 }
 
+.tool--remove-button {
+    background: #ed5935 !important;
+}
+
 .tool:hover {
     background: #BBBBBB;
     color: #ffffff;
@@ -1906,6 +1910,12 @@ ol.search_list > li::before {
     padding: 10px 0;
     clear: left;
     height: 30px;
+}
+
+.cnf-form .platform-edit {
+    padding: 10px 0;
+    clear: left;
+    height: 50px;
 }
 
 .cnf-form .action-buttons {

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -239,5 +239,11 @@ export default {
 
     internalPagePrefix:    'internal-code/page/',
 
-    sparksBatchQueue:      15
+    sparksBatchQueue:      15,
+
+    platforms: {
+        app: 'App',
+        web: 'Web',
+        any: 'Any'
+    }
 };

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -16,6 +16,7 @@ import mediator from 'utils/mediator';
 import populateObservables from 'utils/populate-observables';
 import reportErrors from 'utils/report-errors';
 import success from 'utils/success';
+import isPlatformSpecificCollection from 'utils/platform';
 
 export default class Collection extends BaseClass {
     constructor(opts = {}) {
@@ -54,7 +55,8 @@ export default class Collection extends BaseClass {
             'hideShowMore',
             'href',
             'uneditable',
-            'metadata'
+            'metadata',
+            'platform'
         ]);
         populateObservables(this.configMeta, opts);
 
@@ -476,6 +478,13 @@ export default class Collection extends BaseClass {
         if (this.history().length > 0) {
             return this.history()[0].frontPublicationTime();
         }
+    }
+
+    getDisplayName() {
+        const platform = isPlatformSpecificCollection(this.configMeta.platform()) ? ` (${this.configMeta.platform()} only)` : '';
+        const name = this.configMeta.displayName() || this.collectionMeta.displayName() || '(no title)';
+
+        return name + platform;
     }
 }
 

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -10,6 +10,7 @@ import deepGet from 'utils/deep-get';
 import fullTrim from 'utils/full-trim';
 import populateObservables from 'utils/populate-observables';
 import urlAbsPath from 'utils/url-abs-path';
+import isPlatformSpecificCollection from 'utils/platform';
 
 export default class ConfigCollection extends DropTarget {
     constructor(opts = {}) {
@@ -36,7 +37,8 @@ export default class ConfigCollection extends DropTarget {
                 'hideShowMore',
                 'backfill',
                 'description',
-                'metadata'
+                'metadata',
+                'platform'
             ]),
             {
                 displayHints: asObservableProps([
@@ -44,7 +46,6 @@ export default class ConfigCollection extends DropTarget {
                 ], observableNumeric)
             }
         );
-
 
         populateObservables(this.meta, opts);
 
@@ -70,6 +71,21 @@ export default class ConfigCollection extends DropTarget {
         });
 
         this.typePicker = this._typePicker.bind(this);
+
+        this.thisIsPlatformSpecificCollection = isPlatformSpecificCollection(this.meta.platform());
+    }
+
+    getPlatform() {
+        switch (this.meta.platform()) {
+            case vars.CONST.platforms.app: return 'app only';
+            case vars.CONST.platforms.web: return 'web only';
+            default: return 'any';
+        }
+    }
+
+    getDisplayName() {
+        const platform = isPlatformSpecificCollection(this.meta.platform()) ? ` (${this.meta.platform()} only)` : '';
+        return this.meta.displayName() + platform || '(no title)';
     }
 
     toggleOpen() {

--- a/public/src/js/utils/platform.js
+++ b/public/src/js/utils/platform.js
@@ -1,0 +1,7 @@
+import CONST from '../constants/defaults';
+
+function isPlatformSpecificCollection(platform) {
+    return platform === CONST.platforms.app || platform === CONST.platforms.web;
+}
+
+export default isPlatformSpecificCollection;

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -22,7 +22,7 @@
         </span>
 
         <span class="title" data-bind="
-            text: configMeta.displayName() || collectionMeta.displayName() || '(no title)'"></span>
+            text: getDisplayName()"></span>
 
         <span data-bind="foreach: configMeta.metadata()">
             <span class="tag-list" data-bind="text: type"></span>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -170,7 +170,7 @@
         <a class="cnf-collection__name" data-bind="
             click: toggleOpen,
             attr: {href: '/' + id, title: id},
-            text: meta.displayName() || '(no title)'"></a>
+            text: getDisplayName()"></a>
 
         <span class="placements" data-bind="
             if: parents().length,
@@ -264,11 +264,23 @@
             <input type="checkbox" data-bind="
                 checked: meta.uneditable" />
 
+            <div class="platform-edit">
+                <span>Platform: </span><span data-bind="text: getPlatform()"></span>
+                <!-- ko if: !thisIsPlatformSpecificCollection && parents().length <= 1 -->
+                <span class="tools"><button class="tool" data-bind="click: $parents[1].splitCollection.bind($parents[1], meta, parents)">Split into app/web</button></span>
+                <!-- /ko -->
+                <!-- ko if: thisIsPlatformSpecificCollection -->
+                <span class="tools"><button class="tool" data-bind="
+                  disable: !$parents[1].isUniqueCollection(meta.displayName()),
+                  click: $parents[1].changeToAnyPlatform.bind($parents[1], meta)">Change to any</button></span>
+                <!-- /ko -->
+            </div>
+
             <div class="tools">
                 <button class="tool tool-save-container" data-bind="
                     click: save.bind($data, $parents[1])">Save container</button>
 
-                <button class="tool tool--rhs" data-bind="
+                <button class="tool tool--rhs tool--remove-button" data-bind="
                     click: $parents[1].depopulateCollection">Remove</button>
             </div>
         </div>

--- a/public/test/spec/config.spec.js
+++ b/public/test/spec/config.spec.js
@@ -179,7 +179,7 @@ describe('Config', function () {
                 dom.click(newFront.querySelector('.cnf-form .type-option-chosen'));
                 dom.click(newFront.querySelector('.cnf-form .type-picker .type-option'));
 
-                dom.click(newFront.querySelector('button.tool'));
+                dom.click(newFront.querySelector('button.tool-save-container'));
 
                 return {
                     fronts: {

--- a/test/config/TransformationsSpec.scala
+++ b/test/config/TransformationsSpec.scala
@@ -52,6 +52,7 @@ import org.scalatest._
     None,
     None,
     None,
+    None,
     None
   )
 


### PR DESCRIPTION
Introduces Any/Web/App collections. A very simple implementation while we test app-only collections.

1. Collections are Any by default.
2. Does not allow an Any collection to exist with the same name as an App/Web collection. But there may be both an App and Web version of a collection.
3. Does not allow App/Web collections to be dragged into other fronts.

An Any collection can be split into Web/App if it only belongs to one front:
<img width="316" alt="picture 6" src="https://user-images.githubusercontent.com/1513454/36838293-b423298a-1d36-11e8-93bf-0cfae90d2b37.png">

<img width="608" alt="picture 5" src="https://user-images.githubusercontent.com/1513454/36838292-b40b15c0-1d36-11e8-96f8-206cd8d5467e.png">

A platform-specific collection can be reverted to an Any if it's the only one:
<img width="353" alt="picture 7" src="https://user-images.githubusercontent.com/1513454/36838294-b467d4a4-1d36-11e8-8f46-f11a42db33f1.png">

Web/App collections are indicated on the main page:
<img width="618" alt="picture 4" src="https://user-images.githubusercontent.com/1513454/36838291-b3f0f136-1d36-11e8-9695-5008c4ea53d9.png">
