### PR TITLE
Code env warning

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -218,7 +218,6 @@ label, button.fstChoiceRemove {
 }
 
 .alert-message {
-    height: 45px;
     padding: 12px 17px;
     font-size: 15px;
     background: #3f51b5;

--- a/public/src/js/utils/is-code-environment.js
+++ b/public/src/js/utils/is-code-environment.js
@@ -1,0 +1,3 @@
+export default function (defaults) {
+    return defaults.env === 'code' && !defaults.dev;
+}

--- a/public/src/js/widgets/columns/fronts-config.js
+++ b/public/src/js/widgets/columns/fronts-config.js
@@ -17,14 +17,20 @@ export default class FrontConfig extends ColumnWidget {
         this.populate();
         this.subscribeOn(this.baseModel.state, this.populate);
         this.loaded = Promise.resolve();
-        this.calculateRemainingFronts();
-        this.subscribeOn(this.baseModel.state, this.calculateRemainingFronts);
+        this.setConfigMessages();
+        this.subscribeOn(this.baseModel.state, this.setConfigMessages);
 
     }
 
-    calculateRemainingFronts() {
-        var num = frontCount(this.baseModel.state().config.fronts, this.baseModel.priority);
-        var remainingFronts = num.max - num.count;
+    setConfigMessages() {
+        const defaults = this.baseModel.state().defaults;
+        if (defaults.env === 'code' && !defaults.dev) {
+            this.baseModel.message.codeEnvMessage(true);
+
+        }
+
+        const num = frontCount(this.baseModel.state().config.fronts, this.baseModel.priority);
+        const remainingFronts = num.max - num.count;
         if (remainingFronts < CONST.frontAlertLimit) {
             this.baseModel.message.textMessage('You have ' + remainingFronts + ' fronts remaining');
         } else {

--- a/public/src/js/widgets/columns/fronts-config.js
+++ b/public/src/js/widgets/columns/fronts-config.js
@@ -6,6 +6,7 @@ import frontCount from 'utils/front-count';
 import ColumnWidget from 'widgets/column-widget';
 import alert from 'utils/alert';
 import CONST from 'constants/defaults';
+import isCodeEnvironment from 'utils/is-code-environment';
 
 export default class FrontConfig extends ColumnWidget {
     constructor(params, element) {
@@ -23,10 +24,8 @@ export default class FrontConfig extends ColumnWidget {
     }
 
     setConfigMessages() {
-        const defaults = this.baseModel.state().defaults;
-        if (defaults.env === 'code' && !defaults.dev) {
+        if (isCodeEnvironment(this.baseModel.state().defaults)) {
             this.baseModel.message.codeEnvMessage(true);
-
         }
 
         const num = frontCount(this.baseModel.state().config.fronts, this.baseModel.priority);

--- a/public/src/js/widgets/columns/fronts.js
+++ b/public/src/js/widgets/columns/fronts.js
@@ -11,10 +11,15 @@ import * as sparklines from 'utils/sparklines';
 import ColumnWidget from 'widgets/column-widget';
 import deepGet from 'utils/deep-get';
 import modalDialog from 'modules/modal-dialog';
+import isCodeEnvironment from 'utils/is-code-environment';
 
 export default class Front extends ColumnWidget {
     constructor(params, element) {
         super(params, element);
+
+        if (isCodeEnvironment(this.baseModel.state().defaults)) {
+            this.baseModel.message.codeEnvMessage(true);
+        }
 
         var frontId = params.column.config();
         this.front = ko.observable(frontId);

--- a/public/src/js/widgets/message.html
+++ b/public/src/js/widgets/message.html
@@ -1,4 +1,14 @@
-<div class="alert-message" data-bind="
-    text: textMessage,
-    visible: textMessage
-"></div>
+<!-- ko if: codeEnvMessage -->
+<div class="alert-message">
+    Code version of the fronts tool is unstable and should
+    be used for software development work only. If you are using it for any other work,
+    you should use <a href='https://fronts.gutools.co.uk'>the main tool</a> instead.
+    Please contact central production for advice.
+</div>
+<!-- /ko  -->
+<div class="alert-message"
+    data-bind="
+        text: textMessage,
+        visible: textMessage
+     ">
+</div>

--- a/public/src/js/widgets/message.js
+++ b/public/src/js/widgets/message.js
@@ -3,6 +3,7 @@ import ko from 'knockout';
 class Message {
     constructor() {
         this.textMessage = ko.observable();
+        this.codeEnvMessage = ko.observable();
     }
 }
 

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -253,7 +253,8 @@ describe('Config Front', function () {
                     pear: { displayName: 'pear' },
                     kiwi: { displayName: 'kiwi' }
                 }
-            }
+            },
+            defaults: {}
         }), frontsList = ko.observableArray([{ id: 'one', collections: ['apple'] }]);
 
         this.loadFront({state, frontsList})

--- a/public/test/utils/inject.js
+++ b/public/test/utils/inject.js
@@ -26,7 +26,10 @@ export default function inject (html) {
                 _.defaults(model, {
                     title: ko.observable('test'),
                     modalDialog: modal,
-                    message: { textMessage: ko.observable() },
+                    message: {
+                        textMessage: ko.observable(),
+                        codeEnvMessage: ko.observable()
+                    },
                     extensions: [],
                     permissions: ko.observable(),
                     registerExtension: () => {},


### PR DESCRIPTION
- Display a message on code asking people who are not software developers to use prod instead
- We use the same area for displaying other messages in the tool e.g. too many created fronts 