### PR TITLE
Tidy Backend: Updating AWS libraries

### DIFF
--- a/app/Loader.scala
+++ b/app/Loader.scala
@@ -17,7 +17,8 @@ class Loader extends ApplicationLoader {
       objectKey = components.appConfiguration.switchBoard.objectKey,
       bucket = components.appConfiguration.switchBoard.bucket,
       credentials = components.appConfiguration.aws.mandatoryCredentials,
-      endpoint = components.awsEndpoints.s3
+      endpoint = components.awsEndpoints.s3,
+      region = components.appConfiguration.aws.region
     ), components.actorSystem.scheduler)
 
     components.actorSystem.scheduler.schedule(initialDelay = 1.seconds, interval = 1.minute) { components.configAgent.refresh() }

--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -1,11 +1,11 @@
 package auth
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, BasicSessionCredentials, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
-import com.gu.pandomainauth.{PanDomain, PanDomainAuth, PublicSettings}
 import com.gu.pandomainauth.service.GoogleGroupChecker
+import com.gu.pandomainauth.{PanDomain, PanDomainAuth}
 import conf.ApplicationConfiguration
 import play.api.Logger
 import play.api.mvc._

--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -1,7 +1,7 @@
 package auth
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.auth.{AWSCredentialsProviderChain, BasicSessionCredentials, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuth, PublicSettings}
@@ -37,7 +37,7 @@ trait PanDomainAuthActions extends AuthActions with PanDomainAuth with Results {
   }
 
   override def invalidUserMessage(claimedAuth: AuthenticatedUser): String = {
-    if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor) 
+    if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor)
       s"${claimedAuth.user.email} is not valid for use with the Fronts Tool as you need to have two factor authentication enabled." +
        s" Please contact the Helpdesk by emailing 34444@theguardian.com or calling 34444 and request access to Composer CMS tools."
     else if (!userInGroups(claimedAuth)) s"${claimedAuth.user.email} is not a member of required google groups. Please contact the Helpdesk by emailing 34444@theguardian.com"
@@ -50,6 +50,6 @@ trait PanDomainAuthActions extends AuthActions with PanDomainAuth with Results {
   override lazy val system: String = config.pandomain.service
   override def awsCredentialsProvider = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("workflow"),
-    new STSAssumeRoleSessionCredentialsProvider(config.pandomain.roleArn, config.pandomain.service)
+    new STSAssumeRoleSessionCredentialsProvider.Builder(config.pandomain.roleArn, config.pandomain.service).build()
   )
 }

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -4,10 +4,10 @@ import java.io.{File, FileInputStream, InputStream}
 import java.net.URL
 
 import com.amazonaws.AmazonClientException
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import org.apache.commons.io.IOUtils
-import play.api.{Configuration => PlayConfiguration, Logger, Play}
+import play.api.{Logger, Configuration => PlayConfiguration}
 
 import scala.collection.JavaConversions._
 import scala.language.reflectiveCalls

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -92,7 +92,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     var crossAccount: Option[AWSCredentialsProvider] = {
       val provider = new AWSCredentialsProviderChain(
         new ProfileCredentialsProvider("frontend"),
-        new STSAssumeRoleSessionCredentialsProvider(faciatool.stsRoleToAssume, "frontend")
+        new STSAssumeRoleSessionCredentialsProvider.Builder(faciatool.stsRoleToAssume, "frontend").build()
       )
 
       // this is a bit of a convoluted way to check whether we actually have credentials.

--- a/app/config/Transformations.scala
+++ b/app/config/Transformations.scala
@@ -1,6 +1,6 @@
 package config
 
-import com.gu.facia.client.models.{CollectionConfigJson => CollectionConfig, ConfigJson, FrontJson => Front}
+import com.gu.facia.client.models.{ConfigJson, CollectionConfigJson => CollectionConfig, FrontJson => Front}
 import updates.CreateFront
 
 object Transformations {

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -5,8 +5,6 @@ import com.gu.facia.client.models.Metadata
 import conf.ApplicationConfiguration
 import model.Cached
 import permissions.Permissions
-import play.api.Play
-import play.api.Play.current
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import switchboard.SwitchManager

--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -16,7 +16,6 @@ import play.api.mvc._
 import services._
 import tools.FaciaApiIO
 import updates._
-import scala.concurrent.ExecutionContext
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/app/controllers/PressController.scala
+++ b/app/controllers/PressController.scala
@@ -1,7 +1,8 @@
 package controllers
 
 import auth.PanDomainAuthActions
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
 import com.gu.scanamo.{Scanamo, Table}
 import conf.ApplicationConfiguration
 import play.api.libs.json.Json
@@ -22,10 +23,12 @@ case class FrontPressRecord (
 )
 
 class PressController (val config: ApplicationConfiguration, awsEndpoints: AwsEndpoints) extends Controller with PanDomainAuthActions {
-  private lazy val client = {
-    val client = new AmazonDynamoDBClient(config.aws.mandatoryCredentials)
-    client.setEndpoint(awsEndpoints.dynamoDb)
-    client
+  private lazy val client: AmazonDynamoDB = {
+    val endpoint = new AwsClientBuilder.EndpointConfiguration(awsEndpoints.dynamoDb, config.aws.region)
+    val builder: AmazonDynamoDBClientBuilder = AmazonDynamoDBClientBuilder.standard()
+      .withCredentials(config.aws.mandatoryCredentials)
+      .withEndpointConfiguration(endpoint)
+    builder.build()
   }
 
   private lazy val pressedTable = Table[FrontPressRecord](config.faciatool.frontPressUpdateTable)

--- a/app/logging/LogStash.scala
+++ b/app/logging/LogStash.scala
@@ -40,9 +40,9 @@ object LogStash {
     val a = new KinesisAppender[ILoggingEvent]()
     a.setStreamName(appenderConfig.stream)
     a.setRegion(appenderConfig.region)
-    a.setCredentialsProvider(new STSAssumeRoleSessionCredentialsProvider(
+    a.setCredentialsProvider(new STSAssumeRoleSessionCredentialsProvider.Builder(
       appenderConfig.roleArn, appenderConfig.sessionName
-    ))
+    ).build())
     a.setBufferSize(appenderConfig.bufferSize)
 
     a.setContext(context)

--- a/app/logging/LogStash.scala
+++ b/app/logging/LogStash.scala
@@ -1,13 +1,13 @@
 package logging
 
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
+import ch.qos.logback.classic.{LoggerContext, Logger => LogbackLogger}
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 import com.gu.logback.appender.kinesis.KinesisAppender
 import conf.ApplicationConfiguration
 import net.logstash.logback.layout.LogstashLayout
 import org.slf4j.LoggerFactory
-import play.api.{Logger => PlayLogger, LoggerLike}
+import play.api.{LoggerLike, Logger => PlayLogger}
 
 object LogStash {
 

--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -2,8 +2,8 @@ package metrics
 
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient, AmazonCloudWatchAsyncClientBuilder}
 import com.amazonaws.services.cloudwatch.model._
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClientBuilder}
 import conf.ApplicationConfiguration
 import play.api.Logger
 import services.AwsEndpoints

--- a/app/metrics/CloudWatch.scala
+++ b/app/metrics/CloudWatch.scala
@@ -1,7 +1,8 @@
 package metrics
 
+import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient, AmazonCloudWatchAsyncClientBuilder}
 import com.amazonaws.services.cloudwatch.model._
 import conf.ApplicationConfiguration
 import play.api.Logger
@@ -11,11 +12,12 @@ import scala.collection.JavaConversions._
 
 class CloudWatch(val config: ApplicationConfiguration, val awsEndpoints: AwsEndpoints) {
 
-  lazy val cloudwatch: Option[AmazonCloudWatchAsyncClient] = config.aws.credentials.map{ credentials =>
-    val client = new AmazonCloudWatchAsyncClient(credentials)
-    client.setEndpoint(awsEndpoints.monitoring)
-    client
-  }
+  lazy val cloudwatch: Option[AmazonCloudWatchAsync] = config.aws.credentials.map(credentials => {
+    val endpoint = new AwsClientBuilder.EndpointConfiguration(awsEndpoints.monitoring, config.aws.region)
+    AmazonCloudWatchAsyncClientBuilder.standard()
+      .withCredentials(credentials)
+      .withEndpointConfiguration(endpoint).build()
+  })
 
   trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] {
     def onError(exception: Exception)

--- a/app/services/FaciaPress.scala
+++ b/app/services/FaciaPress.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.{AmazonSQSAsyncClient, AmazonSQSAsyncClientBuilder}
 import com.amazonaws.services.sqs.model.SendMessageResult
 import conf.ApplicationConfiguration
 import metrics.FaciaToolMetrics.{EnqueuePressFailure, EnqueuePressSuccess}
@@ -30,7 +30,9 @@ class FaciaPressQueue(val config: ApplicationConfiguration) {
   val maybeQueue = config.faciatool.frontPressToolQueue map { queueUrl =>
     val credentials = config.aws.mandatoryCrossAccountCredentials
     JsonMessageQueue[PressJob](
-      new AmazonSQSAsyncClient(credentials).withRegion(Region.getRegion(Regions.EU_WEST_1)),
+      AmazonSQSAsyncClientBuilder.standard()
+        .withCredentials(credentials)
+        .withRegion(Regions.EU_WEST_1).build(),
       queueUrl
     )
   }

--- a/app/services/FaciaPress.scala
+++ b/app/services/FaciaPress.scala
@@ -1,7 +1,7 @@
 package services
 
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.sqs.{AmazonSQSAsyncClient, AmazonSQSAsyncClientBuilder}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.model.SendMessageResult
 import conf.ApplicationConfiguration
 import metrics.FaciaToolMetrics.{EnqueuePressFailure, EnqueuePressSuccess}

--- a/app/services/FrontsApi.scala
+++ b/app/services/FrontsApi.scala
@@ -1,6 +1,7 @@
 package services
 
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
 import conf.ApplicationConfiguration
 
@@ -9,8 +10,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class FrontsApi(val config: ApplicationConfiguration, val awsEndpoints: AwsEndpoints) {
   val amazonClient: ApiClient = {
 
-    val client = new AmazonS3Client(config.aws.mandatoryCredentials)
-    client.setEndpoint(awsEndpoints.s3)
+    val endpoint = new AwsClientBuilder.EndpointConfiguration(awsEndpoints.s3, config.aws.region)
+
+    val client: AmazonS3 = AmazonS3ClientBuilder.standard()
+      .withCredentials(config.aws.mandatoryCredentials)
+      .withEndpointConfiguration(endpoint)
+      .build()
+
     val bucket = config.aws.frontsBucket
     val stage = config.facia.stage.toUpperCase
     ApiClient(bucket, stage, AmazonSdkS3Client(client))

--- a/app/services/MediaApi.scala
+++ b/app/services/MediaApi.scala
@@ -1,8 +1,9 @@
 package services
 
 import conf.ApplicationConfiguration
-import play.api.libs.ws.WSAPI
 import play.api.libs.json._
+import play.api.libs.ws.WSAPI
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 

--- a/app/services/MediaServiceClient.scala
+++ b/app/services/MediaServiceClient.scala
@@ -2,8 +2,9 @@ package services
 
 import com.gu.facia.client.models.{CollectionJson, Trail, TrailMetaData}
 import play.api.libs.json.JsString
-import scala.concurrent.Future
+
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class MediaServiceClient(val mediaApi: MediaApi) {
 

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -1,13 +1,13 @@
 package services
 
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import _root_.metrics.S3Metrics.S3ClientExceptionsMetric
+import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.s3.model.CannedAccessControlList.{Private, PublicRead}
 import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.util.StringInputStream
 import com.gu.pandomainauth.model.User
 import conf.ApplicationConfiguration
-import _root_.metrics.S3Metrics.S3ClientExceptionsMetric
-import com.amazonaws.client.builder.AwsClientBuilder
 import org.joda.time.DateTime
 import play.api.Logger
 

--- a/app/services/SQSQueues.scala
+++ b/app/services/SQSQueues.scala
@@ -3,7 +3,7 @@ package services
 import java.util.concurrent.{Future => JavaFuture}
 
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model._
 import play.api.libs.json.{Json, Writes}
 
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
 object SQSQueues {
-  implicit class RichAmazonSQSAsyncClient(client: AmazonSQSAsyncClient) {
+  implicit class RichAmazonSQSAsyncClient(client: AmazonSQSAsync) {
     private def createHandler[A <: com.amazonaws.AmazonWebServiceRequest, B]() = {
       val promise = Promise[B]()
 
@@ -36,7 +36,7 @@ object SQSQueues {
 }
 
 /** Utility class for SQS queues that use JSON to serialize their messages */
-case class JsonMessageQueue[A](client: AmazonSQSAsyncClient, queueUrl: String)
+case class JsonMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)
                               (implicit executionContext: ExecutionContext) {
   import SQSQueues._
 

--- a/app/slices/DynamicContainer.scala
+++ b/app/slices/DynamicContainer.scala
@@ -1,7 +1,7 @@
 package slices
 
-import util.Seqs._
 import slices.Story._
+import util.Seqs._
 
 /** Used for calculating the final slice -- any stories that are not standard are considered 'bigs' for the standard
   * slice

--- a/app/slices/Story.scala
+++ b/app/slices/Story.scala
@@ -1,7 +1,7 @@
 package slices
 
-import util.Maps._
 import play.api.libs.json.Json
+import util.Maps._
 
 object Story {
   implicit val jsonFormat = Json.format[Story]

--- a/app/switchboard/S3client.scala
+++ b/app/switchboard/S3client.scala
@@ -1,10 +1,11 @@
 package switchboard
 
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.s3.model._
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Json}
-import services.AwsEndpoints
 
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
@@ -14,10 +15,12 @@ class S3client (conf: SwitchboardConfiguration, endpoint: String) {
   lazy val bucket = conf.bucket
   lazy val objectKey = conf.objectKey
 
-  lazy val client: AmazonS3Client = {
-    val client = new AmazonS3Client(conf.credentials)
-    client.setEndpoint(endpoint)
-    client
+  lazy val client: AmazonS3 = {
+    val endpointConf = new AwsClientBuilder.EndpointConfiguration(endpoint, conf.region)
+    AmazonS3ClientBuilder.standard()
+      .withCredentials(conf.credentials)
+      .withEndpointConfiguration(endpointConf)
+      .build()
   }
 
   def getSwitches(): Option[Map[String, Boolean]] = {

--- a/app/switchboard/S3client.scala
+++ b/app/switchboard/S3client.scala
@@ -1,9 +1,8 @@
 package switchboard
 
 import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Json}
 

--- a/app/switchboard/Switchboard.scala
+++ b/app/switchboard/Switchboard.scala
@@ -11,7 +11,8 @@ case class SwitchboardConfiguration (
   bucket: String,
   objectKey: String,
   credentials: AWSCredentialsProvider,
-  endpoint: String
+  endpoint: String,
+  region: String
 )
 
 class Lifecycle(conf: SwitchboardConfiguration, scheduler: Scheduler) {

--- a/app/updates/AuditingUpdates.scala
+++ b/app/updates/AuditingUpdates.scala
@@ -5,6 +5,7 @@ import net.logstash.logback.marker.Markers
 import play.api.Logger
 import play.api.libs.json._
 import services.ConfigAgent
+
 import scala.collection.JavaConverters._
 
 class AuditingUpdates(val config: ApplicationConfiguration, val configAgent: ConfigAgent) {

--- a/app/util/ContentUpgrade.scala
+++ b/app/util/ContentUpgrade.scala
@@ -1,14 +1,14 @@
 package util
 
 import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.json.CirceDecoders._
 import com.gu.facia.api.utils.{CardStyle, ResolvedMetaData}
 import com.gu.facia.client.models.TrailMetaData
+import io.circe.{Json, parser}
 import org.json4s.JValue
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
-import io.circe.{Json, parser}
-import com.gu.contentapi.json.CirceDecoders._
 
 import scala.util.{Failure, Success, Try}
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ TwirlKeys.templateImports ++= Seq(
     "play.api.Play.current"
 )
 
-val awsVersion = "1.11.188"
+val awsVersion = "1.11.293"
 val capiModelsVersion = "11.33"
 val circeVersion = "0.7.0"
 val json4sVersion = "3.5.0"

--- a/test/config/TransformationsSpec.scala
+++ b/test/config/TransformationsSpec.scala
@@ -1,8 +1,8 @@
 package config
 
 import com.gu.facia.client.models.{CollectionConfigJson => CollectionConfig, ConfigJson => Config, FrontJson => Front}
-import updates.CreateFront
 import org.scalatest._
+import updates.CreateFront
 
 @DoNotDiscover class TransformationsSpec extends FlatSpec with ShouldMatchers {
   val collectionFixture = CollectionConfig.withDefaults(


### PR DESCRIPTION
As part of the work to modernise and tidy up the back end of the tool

1. Optimise imports
2. Update version of AWS SDK to latest version
3. Stop using deprecated methods from AWS SDK

This also makes sbt much quieter by getting rid of the vast majority of compilation warnings