### PR TITLE
Temporarily disable Panda group checks

### DIFF
--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -15,12 +15,17 @@ trait PanDomainAuthActions extends AuthActions with PanDomainAuth with Results {
 
   private lazy val groupChecker = settings.google2FAGroupSettings.map(new GoogleGroupChecker(_, this.bucket))
 
-  def userInGroups(authedUser: AuthenticatedUser): Boolean = groupChecker.exists{ checker =>
-    checker.checkGroups(authedUser, config.pandomain.userGroups).fold(
-      error => {
-        Logger.warn(error)
-        false
-      }, identity)
+  def userInGroups(authedUser: AuthenticatedUser): Boolean = {
+    Logger.warn(s"Multifactor checks have been temporarily disabled. User: ${authedUser.user.email}")
+    true
+
+//    groupChecker.exists{ checker =>
+//      checker.checkGroups(authedUser, config.pandomain.userGroups).fold(
+//        error => {
+//          Logger.warn(error)
+//          false
+//        }, identity)
+//    }
   }
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {


### PR DESCRIPTION
We have had recent incidents where the Google Directory API returns a rate limit exception. The reasons remain unclear as we are confident that we remained under the limit.

In such situations we would normally enable the emergency login switch however that was not fully reliable during the last outage. Pending further testing this PR will disable the checks that were calling the offending API.

It should only be merged if the problem recurs.