### PR TITLE
App preview

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -42,6 +42,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val encryption = new Encryption(config)
   val mediaApi = new MediaApi(config, wsClient)
   val mediaServiceClient = new MediaServiceClient(mediaApi)
+  val emailService = new Email(appConfiguration)
   override lazy val httpErrorHandler = new LoggingHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
 
 //  Controllers
@@ -62,14 +63,14 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val views = new ViewsController(acl, assetsManager, isDev, encryption, this)
   val pressController = new PressController(awsEndpoints, this)
   val v2App = new V2App(isDev, acl, this)
+  val emailController = new EmailController(appConfiguration, emailService)
   val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, this)
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
     allowedOrigins = Origins.Matching(Set(config.environment.applicationUrl))
   )
-
   override lazy val assets: Assets = new controllers.Assets(httpErrorHandler, assetsMetadata)
-  val router: Router = new Routes(httpErrorHandler, status, pandaAuth, v2Assets, uncachedAssets, views, faciaTool, pressController, faciaToolV2, defaults, faciaCapiProxy, thumbnail, front, collection, storiesVisible, vanityRedirects,
+  val router: Router = new Routes(httpErrorHandler, status, pandaAuth, v2Assets, uncachedAssets, views, faciaTool, pressController, faciaToolV2, defaults, emailController, faciaCapiProxy, thumbnail, front, collection, storiesVisible, vanityRedirects,
     troubleshoot, v2App)
 
   override lazy val httpFilters = Seq(

--- a/app/Components.scala
+++ b/app/Components.scala
@@ -42,7 +42,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val encryption = new Encryption(config)
   val mediaApi = new MediaApi(config, wsClient)
   val mediaServiceClient = new MediaServiceClient(mediaApi)
-  val emailService = new Email(appConfiguration)
+  val emailService = new Email(config)
   override lazy val httpErrorHandler = new LoggingHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
 
 //  Controllers
@@ -63,7 +63,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val views = new ViewsController(acl, assetsManager, isDev, encryption, this)
   val pressController = new PressController(awsEndpoints, this)
   val v2App = new V2App(isDev, acl, this)
-  val emailController = new EmailController(appConfiguration, emailService)
+  val emailController = new EmailController(emailService, this)
   val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, this)
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -1,15 +1,12 @@
 package controllers
 
-import auth.PanDomainAuthActions
-import conf.ApplicationConfiguration
 import EmailController._
 import play.api.Logger
-import play.api.mvc.Controller
 import services.Email
 
 import scala.util.{Failure, Success}
 
-class EmailController(val config: ApplicationConfiguration, email: Email) extends Controller with PanDomainAuthActions {
+class EmailController(email: Email, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
 
   def sendEmail(path: String) = APIAuthAction { request =>
     val mapiPath = buildMapiPath(path)

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import auth.PanDomainAuthActions
 import conf.ApplicationConfiguration
+import EmailController._
 import play.api.Logger
 import play.api.mvc.Controller
 import services.Email
@@ -9,8 +10,6 @@ import services.Email
 import scala.util.{Failure, Success}
 
 class EmailController(val config: ApplicationConfiguration, email: Email) extends Controller with PanDomainAuthActions {
-
-  private val Editions = Set("uk", "us", "au")
 
   def sendEmail(path: String) = APIAuthAction { request =>
     val mapiPath = buildMapiPath(path)
@@ -26,15 +25,12 @@ class EmailController(val config: ApplicationConfiguration, email: Email) extend
         InternalServerError
     }
   }
+}
 
-  private def buildMapiPath(path: String): String = {
-    /**
-      * TODO - move to tests
-      * E.g.
-      *  - 'uk/film' -> '/uk/fronts/film'
-      *  - 'uk'      -> '/uk/fronts/home'
-      *  - 'audio'   -> '/uk/fronts/audio'
-      */
+object EmailController {
+  private val Editions = Set("uk", "us", "au")
+
+  def buildMapiPath(path: String): String = {
     val pathTokens = path.split("/")
     pathTokens.toList match {
       case x :: Nil if Editions.contains(x) => s"$x/fronts/home"
@@ -43,7 +39,7 @@ class EmailController(val config: ApplicationConfiguration, email: Email) extend
     }
   }
 
-  private def buildBody(path: String): String = {
+  def buildBody(path: String): String = {
     s"""iOS: https://entry.mobile-apps.guardianapis.com/deeplink/$path
        |Android: https://mobile-preview.guardianapis.com/$path
        |

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -1,0 +1,53 @@
+package controllers
+
+import auth.PanDomainAuthActions
+import conf.ApplicationConfiguration
+import play.api.Logger
+import play.api.mvc.Controller
+import services.Email
+
+import scala.util.{Failure, Success}
+
+class EmailController(val config: ApplicationConfiguration, email: Email) extends Controller with PanDomainAuthActions {
+
+  private val Editions = Set("uk", "us", "au")
+
+  def sendEmail(path: String) = APIAuthAction { request =>
+    val mapiPath = buildMapiPath(path)
+
+    email.sendEmail(
+      to = request.user.email,
+      subject = s"App preview URLs for front: $path",
+      body = buildBody(mapiPath)
+    ) match {
+      case Success(_) => Ok
+      case Failure(e) =>
+        Logger.warn(s"Error sending app preview email to ${request.user.email}: ${e.getMessage}", e)
+        InternalServerError
+    }
+  }
+
+  private def buildMapiPath(path: String): String = {
+    /**
+      * TODO - move to tests
+      * E.g.
+      *  - 'uk/film' -> '/uk/fronts/film'
+      *  - 'uk'      -> '/uk/fronts/home'
+      *  - 'audio'   -> '/uk/fronts/audio'
+      */
+    val pathTokens = path.split("/")
+    pathTokens.toList match {
+      case x :: Nil if Editions.contains(x) => s"$x/fronts/home"
+      case x :: xs if Editions.contains(x) => s"$x/fronts/${xs.mkString("/")}"
+      case _ => s"uk/fronts/$path"
+    }
+  }
+
+  private def buildBody(path: String): String = {
+    s"""iOS: https://entry.mobile-apps.guardianapis.com/deeplink/$path
+       |Android: https://mobile-preview.guardianapis.com/$path
+       |
+       |
+       |If you were not expecting this email please contact: digitalcms.dev@guardian.co.uk""".stripMargin
+  }
+}

--- a/app/services/Email.scala
+++ b/app/services/Email.scala
@@ -1,0 +1,31 @@
+package services
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder
+import com.amazonaws.services.simpleemail.model._
+import conf.ApplicationConfiguration
+
+import collection.JavaConverters._
+import scala.util.Try
+
+class Email(val config: ApplicationConfiguration) {
+  private val emailClient = AmazonSimpleEmailServiceClientBuilder.standard
+    .withRegion(config.aws.region)
+    .build
+
+  private val from = "noreply-viewer@guardian.co.uk"
+
+  def sendEmail(to: String, subject: String, body: String): Try[SendEmailResult] = {
+    val message = new Message(
+      new Content(subject),
+      new Body(new Content(body))
+    )
+
+    val request = new SendEmailRequest(
+      from,
+      new Destination(Seq(to).asJava),
+      message
+    )
+
+    Try(emailClient.sendEmail(request))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
+    "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
     "com.gu" %% "content-api-models" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",

--- a/conf/routes
+++ b/conf/routes
@@ -51,6 +51,8 @@ GET         /metadata                                controllers.FaciaToolContro
 
 POST        /treats/*collectionId                    controllers.FaciaToolController.treatEdits(collectionId)
 
+POST        /send-email                              controllers.EmailController.sendEmail(path)
+
 # endpoints for proxying https
 GET         /api/preview/*path                       controllers.FaciaContentApiProxy.capiPreview(path)
 GET         /api/live/*path                          controllers.FaciaContentApiProxy.capiLive(path)

--- a/public/src/js/widgets/columns/fronts.html
+++ b/public/src/js/widgets/columns/fronts.html
@@ -22,10 +22,15 @@
    ><a class="breaking-mode active" data-bind="visible: confirmSendingAlert()">Breaking News</a
    ><a class="preview" target="preview" data-bind="
         click: trackPreviewClick,
-        attr: { href: previewUrl },
+        attr: { href: previewWebUrl },
         visible: front">
-        <span data-bind="if: mode() === 'live'">View live</span>
-        <span data-bind="if: mode() === 'draft'">Preview draft</span>
+        <span data-bind="if: mode() === 'live'">View live on web</span>
+        <span data-bind="if: mode() === 'draft'">Preview draft on web</span>
+    </a>
+    <a class="preview" target="preview" data-bind="
+        click: emailPreviewAppUrls,
+        visible: front">
+        <span data-bind="if: mode() === 'draft'">Get app draft link</span>
     </a>
     <!-- ko if: front -->
     <a class='performances' target='_blank' data-bind="

--- a/public/src/js/widgets/columns/fronts.js
+++ b/public/src/js/widgets/columns/fronts.js
@@ -80,14 +80,11 @@ export default class Front extends ColumnWidget {
                 type: 'post',
                 url: CONST.apiBase + '/send-email?path=' + this.front()
             })
-            .catch(error => {
-                const errorMessages = [];
-                try {
-                    errorMessages.push.apply(errorMessages, JSON.parse(error.responseText));
-                } catch (ex) {
-                    errorMessages.push(error.responseText || error.message);
-                }
-                const message = 'Error sending email: ' + errorMessages.join('<br>');
+            .then(() => {
+                alert("An email has been sent to your Guardian email address. To preview this page in the app, open your email on the device and follow the instructions.");
+            })
+            .catch(() => {
+                const message = 'Error sending email';
                 alert(message);
                 reportErrors(new Error(message));
             });

--- a/test/package.scala
+++ b/test/package.scala
@@ -6,4 +6,5 @@ class FaciaToolTestSuite extends Suites (
   new config.TransformationsSpec,
   new metrics.DurationMetricTest,
   new util.SanitizeInputTest,
+  new util.MapiPathTest,
   new tools.FaciaApiTest) {}

--- a/test/util/MapiPathTest.scala
+++ b/test/util/MapiPathTest.scala
@@ -1,0 +1,12 @@
+package util
+
+import controllers.EmailController
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+
+@DoNotDiscover class MapiPathTest extends FlatSpec with Matchers {
+  it should "construct mapi front paths correctly" in {
+    EmailController.buildMapiPath("uk/film") should be("uk/fronts/film")
+    EmailController.buildMapiPath("uk") should be("uk/fronts/home")
+    EmailController.buildMapiPath("audio") should be("uk/fronts/audio")
+  }
+}


### PR DESCRIPTION
Adds the ability to view draft fronts on the app. This uses the same mechanism already being used by composer: it emails two urls (ios + android) to the user, who can then open them on their device.

### Before:
<img width="640" alt="picture 11" src="https://user-images.githubusercontent.com/1513454/38429122-67cb6962-39b5-11e8-9ab8-59a0a7cddca2.png">

### After:
<img width="646" alt="picture 10" src="https://user-images.githubusercontent.com/1513454/38429063-45cef3c4-39b5-11e8-9a16-6dada376f03a.png">

### The email:
<img width="598" alt="picture 12" src="https://user-images.githubusercontent.com/1513454/38429533-8d68ee1e-39b6-11e8-8565-68354ac0d179.png">
