### PR TITLE
remove accidental .vscode from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ application.local.conf
 
 ##
 public/client-v2
+.vscode
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "eslint.enable": true,
   "eslint.packageManager": "yarn",
   "javascript.validate.enable": false,
-  "typescript.format.enable": false
+  "typescript.format.enable": false,
+  "flow.useNPMPackagedFlow": true
 }


### PR DESCRIPTION
Happy to keep it checked in but I assume other people will want other things - plus it's always there, unstaged, every time I edit it!