### PR TITLE
Display collections

### DIFF
--- a/client-v2/src/actions/Articles.js
+++ b/client-v2/src/actions/Articles.js
@@ -1,0 +1,51 @@
+// @flow
+
+import type { Action } from '../types/Action';
+import type { ThunkAction } from '../types/Store';
+
+import { getCollectionArticles } from '../services/faciaApi';
+import type { CapiArticle } from '../types/Capi';
+import type { Collection } from '../types/Collection';
+
+function collectionArticlesReceived(
+  collectionId: string,
+  articles: Array<CapiArticle>
+): Action {
+  return {
+    type: 'CAPI_ARTICLES_RECEIVED',
+    id: collectionId,
+    payload: articles
+  };
+}
+
+function requestCollectionArticles(): Action {
+  return {
+    type: 'CAPI_ARTICLES_GET_RECEIVE',
+    receivedAt: Date.now()
+  };
+}
+
+function errorReceivingCollectionArticles(error: string): Action {
+  return {
+    type: 'CAUGHT_ERROR',
+    message: 'Could not fetch collection articles from capi',
+    error,
+    receivedAt: Date.now()
+  };
+}
+
+export default function getArticlesForCollection(
+  collection: Collection,
+  collectionId: string
+): ThunkAction {
+  return (dispatch: Dispatch) => {
+    dispatch(requestCollectionArticles());
+    return getCollectionArticles(collection)
+      .then((res: Array<CapiArticle>) => {
+        dispatch(collectionArticlesReceived(collectionId, res));
+      })
+      .catch((error: string) =>
+        dispatch(errorReceivingCollectionArticles(error))
+      );
+  };
+}

--- a/client-v2/src/actions/Collection.js
+++ b/client-v2/src/actions/Collection.js
@@ -4,11 +4,11 @@ import type { Action } from '../types/Action';
 import type { ThunkAction } from '../types/Store';
 
 import { getCollection } from '../services/faciaApi';
-import type { FrontCollectionDetail } from '../types/Fronts';
+import type { Collection } from '../types/Collection';
 
 function frontCollectionReceived(
   collectionId: string,
-  collectionDetail: FrontCollectionDetail
+  collectionDetail: Collection
 ): Action {
   return {
     type: 'FRONTS_COLLECTION_RECEIVED',

--- a/client-v2/src/actions/Collection.js
+++ b/client-v2/src/actions/Collection.js
@@ -1,0 +1,45 @@
+// @flow
+
+import type { Action } from '../types/Action';
+import type { ThunkAction } from '../types/Store';
+
+import { getCollection } from '../services/faciaApi';
+import type { FrontCollectionDetail } from '../types/Fronts';
+
+function frontCollectionReceived(
+  collectionId: string,
+  collectionDetail: FrontCollectionDetail
+): Action {
+  return {
+    type: 'FRONTS_COLLECTION_RECEIVED',
+    id: collectionId,
+    payload: collectionDetail
+  };
+}
+
+function requestFrontCollection(): Action {
+  return {
+    type: 'FRONTS_COLLECTION_GET_RECEIVE',
+    receivedAt: Date.now()
+  };
+}
+
+function errorReceivingFrontCollection(error: string): Action {
+  return {
+    type: 'CAUGHT_ERROR',
+    message: 'Could not fetch collection',
+    error,
+    receivedAt: Date.now()
+  };
+}
+
+export default function getFrontCollection(collectionId: string): ThunkAction {
+  return (dispatch: Dispatch) => {
+    dispatch(requestFrontCollection());
+    return getCollection(collectionId)
+      .then((res: Object) => {
+        dispatch(frontCollectionReceived(collectionId, res));
+      })
+      .catch((error: string) => dispatch(errorReceivingFrontCollection(error)));
+  };
+}

--- a/client-v2/src/actions/FrontsConfig.js
+++ b/client-v2/src/actions/FrontsConfig.js
@@ -2,7 +2,7 @@
 
 import type { Action } from '../types/Action';
 import type { ThunkAction } from '../types/Store';
-import type { FrontsConfig } from '../types/Fronts';
+import type { FrontsConfig } from '../types/FrontsConfig';
 
 import { fetchFrontsConfig } from '../services/faciaApi';
 

--- a/client-v2/src/actions/FrontsConfig.js
+++ b/client-v2/src/actions/FrontsConfig.js
@@ -4,7 +4,7 @@ import type { Action } from '../types/Action';
 import type { ThunkAction } from '../types/Store';
 import type { FrontsConfig } from '../types/Fronts';
 
-import fetchFrontsConfig from '../services/faciaApi';
+import { fetchFrontsConfig } from '../services/faciaApi';
 
 function frontsConfigReceived(config: FrontsConfig): Action {
   return {

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -8,23 +8,27 @@ import CollectionDetail from './CollectionDetail';
 import { getArticlesForCollection } from '../../util/collectionUtils';
 
 import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
+import type { Collection } from '../../types/Collection';
+import type { CapiArticle } from '../../types/Capi';
 import type { State } from '../../types/State';
+
 
 type Props = {
   collection: ConfigCollectionDetailWithId
 };
 
-// TODO
 type ConnectedComponentProps = Props & {
   frontsActions: Object,
-  collections: Object
+  collections: {
+    [string]: Collection
+  }
 };
 
 type ComponentState = {
-  collectionArticles: Array<Object>
+  collectionArticles: Array<CapiArticle>
 };
 
-class Collections extends React.Component<
+class CollectionContainer extends React.Component<
   ConnectedComponentProps,
   ComponentState
 > {
@@ -73,4 +77,4 @@ const mapDispatchToProps = (dispatch: *) => ({
   )
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(Collections);
+export default connect(mapStateToProps, mapDispatchToProps)(CollectionContainer);

--- a/client-v2/src/components/FrontsEdit/CollectionDetail.js
+++ b/client-v2/src/components/FrontsEdit/CollectionDetail.js
@@ -1,0 +1,19 @@
+// @flow
+
+import React from 'react';
+
+import type { ConfigCollectionDetailWithId, FrontCollectionDetail } from '../../types/Fronts';
+
+type Props = {
+  collectionConfig: ConfigCollectionDetailWithId,
+  collection: FrontCollectionDetail
+};
+
+const CollectionDetail = (props: Props) => (
+  <div>
+    {props.collectionConfig.displayName}
+  </div>
+);
+
+export default CollectionDetail;
+

--- a/client-v2/src/components/FrontsEdit/CollectionDetail.js
+++ b/client-v2/src/components/FrontsEdit/CollectionDetail.js
@@ -1,19 +1,45 @@
 // @flow
 
 import React from 'react';
+import styled from 'styled-components';
 
-import type { ConfigCollectionDetailWithId, FrontCollectionDetail } from '../../types/Fronts';
+import type {
+  ConfigCollectionDetailWithId,
+  CapiArticle
+} from '../../types/Fronts';
 
 type Props = {
   collectionConfig: ConfigCollectionDetailWithId,
-  collection: FrontCollectionDetail
+  articles: Array<CapiArticle>
 };
 
+const CollectionContainer = styled('div')`
+  background-color: white;
+  padding: 5px;
+  margin: 5px;
+  color: black;
+`;
+
+const CollectionHeadline = styled('div')`
+  font-weight: bold;
+  padding: 7px;
+`;
+
+const ArticleContainer = styled('div')`
+  padding: 5px;
+`;
+
 const CollectionDetail = (props: Props) => (
-  <div>
-    {props.collectionConfig.displayName}
-  </div>
+  <CollectionContainer>
+    <CollectionHeadline>
+      {props.collectionConfig.displayName}
+    </CollectionHeadline>
+    {props.articles.map(article => (
+      <ArticleContainer key={article.headline}>
+        {article.headline}
+      </ArticleContainer>
+    ))}
+  </CollectionContainer>
 );
 
 export default CollectionDetail;
-

--- a/client-v2/src/components/FrontsEdit/CollectionDetail.js
+++ b/client-v2/src/components/FrontsEdit/CollectionDetail.js
@@ -3,10 +3,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import type {
-  ConfigCollectionDetailWithId,
-  CapiArticle
-} from '../../types/Fronts';
+import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
+import type { CapiArticle } from '../../types/Capi';
 
 type Props = {
   collectionConfig: ConfigCollectionDetailWithId,

--- a/client-v2/src/components/FrontsEdit/Collections.js
+++ b/client-v2/src/components/FrontsEdit/Collections.js
@@ -36,15 +36,19 @@ class Collections extends React.Component<
     if (!this.props.collections[this.props.collection.id]) {
       this.props.frontsActions
         .getFrontCollection(this.props.collection.id)
-        .then(() =>
-          getArticlesForCollection(
-            this.props.collections[this.props.collection.id]
-          ).then(articles => {
-            this.setState({ collectionArticles: articles });
-          })
-        );
+        .then(this.getComponentArticles);
+    } else {
+      this.getComponentArticles();
     }
   }
+
+  getComponentArticles = () => {
+    getArticlesForCollection(
+      this.props.collections[this.props.collection.id]
+    ).then(articles => {
+      this.setState({ collectionArticles: articles });
+    });
+  };
 
   render() {
     return (

--- a/client-v2/src/components/FrontsEdit/Collections.js
+++ b/client-v2/src/components/FrontsEdit/Collections.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import getFrontCollection from '../../actions/Collection';
+import CollectionDetail from './CollectionDetail';
 
 import type { ConfigCollectionDetailWithId } from '../../types/Fronts';
 import type { State } from '../../types/State';
@@ -26,7 +27,12 @@ class Collections extends React.Component<ConnectedComponentProps> {
   }
 
   render() {
-    return <div>{this.props.collection.displayName}</div>;
+    return (
+      <CollectionDetail
+        collectionConfig={this.props.collection}
+        collection={this.props.collections[this.props.collection.id]}
+      />
+    );
   }
 }
 

--- a/client-v2/src/components/FrontsEdit/Collections.js
+++ b/client-v2/src/components/FrontsEdit/Collections.js
@@ -1,0 +1,24 @@
+// @flow
+
+import React from 'react';
+
+import type { ConfigCollectionDetail } from '../../types/Fronts';
+
+type Props = {
+  collections: Array<ConfigCollectionDetail>
+};
+
+const renderCollection = (
+  collection: ConfigCollectionDetail,
+  index: number
+) => <div key={index}>{collection.displayName}</div>;
+
+const Collections = (props: Props) => (
+  <div>
+    {props.collections.map((collection, index) =>
+      renderCollection(collection, index)
+    )}{' '}
+  </div>
+);
+
+export default Collections;

--- a/client-v2/src/components/FrontsEdit/Collections.js
+++ b/client-v2/src/components/FrontsEdit/Collections.js
@@ -1,24 +1,46 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import getFrontCollection from '../../actions/Collection';
 
-import type { ConfigCollectionDetail } from '../../types/Fronts';
+import type { ConfigCollectionDetailWithId } from '../../types/Fronts';
+import type { State } from '../../types/State';
 
 type Props = {
-  collections: Array<ConfigCollectionDetail>
+  collection: ConfigCollectionDetailWithId
 };
 
-const renderCollection = (
-  collection: ConfigCollectionDetail,
-  index: number
-) => <div key={index}>{collection.displayName}</div>;
+// TODO
+type ConnectedComponentProps = Props & {
+  frontsActions: Object,
+  collections: Object
+};
 
-const Collections = (props: Props) => (
-  <div>
-    {props.collections.map((collection, index) =>
-      renderCollection(collection, index)
-    )}{' '}
-  </div>
-);
+class Collections extends React.Component<ConnectedComponentProps> {
+  componentDidMount() {
+    if (!this.props.collections[this.props.collection.id]) {
+      this.props.frontsActions.getFrontCollection(this.props.collection.id);
+    }
+  }
 
-export default Collections;
+  render() {
+    return <div>{this.props.collection.displayName}</div>;
+  }
+}
+
+const mapStateToProps = (state: State) => ({
+  collections: state.collections
+});
+
+const mapDispatchToProps = (dispatch: *) => ({
+  frontsActions: bindActionCreators(
+    {
+      getFrontCollection
+    },
+    dispatch
+  )
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Collections);

--- a/client-v2/src/components/FrontsEdit/Collections.js
+++ b/client-v2/src/components/FrontsEdit/Collections.js
@@ -7,7 +7,7 @@ import getFrontCollection from '../../actions/Collection';
 import CollectionDetail from './CollectionDetail';
 import { getArticlesForCollection } from '../../util/collectionUtils';
 
-import type { ConfigCollectionDetailWithId } from '../../types/Fronts';
+import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
 import type { State } from '../../types/State';
 
 type Props = {

--- a/client-v2/src/components/FrontsEdit/Collections.js
+++ b/client-v2/src/components/FrontsEdit/Collections.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import getFrontCollection from '../../actions/Collection';
 import CollectionDetail from './CollectionDetail';
+import { getArticlesForCollection } from '../../util/collectionUtils';
 
 import type { ConfigCollectionDetailWithId } from '../../types/Fronts';
 import type { State } from '../../types/State';
@@ -19,10 +20,29 @@ type ConnectedComponentProps = Props & {
   collections: Object
 };
 
-class Collections extends React.Component<ConnectedComponentProps> {
+type ComponentState = {
+  collectionArticles: Array<Object>
+};
+
+class Collections extends React.Component<
+  ConnectedComponentProps,
+  ComponentState
+> {
+  state = {
+    collectionArticles: []
+  };
+
   componentDidMount() {
     if (!this.props.collections[this.props.collection.id]) {
-      this.props.frontsActions.getFrontCollection(this.props.collection.id);
+      this.props.frontsActions
+        .getFrontCollection(this.props.collection.id)
+        .then(() =>
+          getArticlesForCollection(
+            this.props.collections[this.props.collection.id]
+          ).then(articles => {
+            this.setState({ collectionArticles: articles });
+          })
+        );
     }
   }
 
@@ -30,7 +50,7 @@ class Collections extends React.Component<ConnectedComponentProps> {
     return (
       <CollectionDetail
         collectionConfig={this.props.collection}
-        collection={this.props.collections[this.props.collection.id]}
+        articles={this.state.collectionArticles}
       />
     );
   }

--- a/client-v2/src/components/FrontsEdit/Edit.js
+++ b/client-v2/src/components/FrontsEdit/Edit.js
@@ -16,6 +16,8 @@ type Props = {
   history: RouterHistory
 };
 
+const getFrontId = (frontId: ?string): string => (frontId ? decodeURIComponent(frontId) : '');
+
 const FrontsEdit = (props: Props) => (
   <React.Fragment>
     <ErrorBannner error={props.error} />
@@ -25,7 +27,7 @@ const FrontsEdit = (props: Props) => (
         <FrontsContainer
           history={props.history}
           priority={props.match.params.priority || ''}
-          frontId={props.match.params.frontId || ''}
+          frontId={getFrontId(props.match.params.frontId)}
         />
       }
     />

--- a/client-v2/src/components/FrontsEdit/Edit.js
+++ b/client-v2/src/components/FrontsEdit/Edit.js
@@ -16,7 +16,8 @@ type Props = {
   history: RouterHistory
 };
 
-const getFrontId = (frontId: ?string): string => (frontId ? decodeURIComponent(frontId) : '');
+const getFrontId = (frontId: ?string): string =>
+  frontId ? decodeURIComponent(frontId) : '';
 
 const FrontsEdit = (props: Props) => (
   <React.Fragment>

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
 import getFrontsConfig from '../../actions/FrontsConfig';
 import { GetFrontsConfigStateSelector } from '../../selectors/frontsSelectors';
-import Collections from './Collections';
+import CollectionContainer from './CollectionContainer';
 import { getFrontCollections } from '../../util/frontsUtils';
 import type { FrontDetail, FrontsClientConfig } from '../../types/FrontsConfig';
 import type { State } from '../../types/State';
@@ -66,7 +66,7 @@ class Fronts extends React.Component<FrontsComponentProps> {
         </select>
         {collectionsWithId.map(collection => (
           <div key={collection.id}>
-            <Collections collection={collection} />
+            <CollectionContainer collection={collection} />
           </div>
         ))}
       </div>

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -41,19 +41,18 @@ class Fronts extends React.Component<FrontsComponentProps> {
   };
 
   render() {
-    // TODO assign consts from props
+    const { frontsConfig: { fronts, collections } } = this.props;
     if (
-      !this.props.frontsConfig.fronts ||
-      this.props.frontsConfig.fronts.length === 0
+      !fronts ||
+      fronts.length === 0
     ) {
       return <div>Loading</div>;
     }
 
-    const { frontsConfig: { fronts } } = this.props;
     const collectionsWithId = getFrontCollections(
       this.props.frontId,
       fronts,
-      this.props.frontsConfig.collections
+      collections
     );
 
     return (

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -42,10 +42,7 @@ class Fronts extends React.Component<FrontsComponentProps> {
 
   render() {
     const { frontsConfig: { fronts, collections } } = this.props;
-    if (
-      !fronts ||
-      fronts.length === 0
-    ) {
+    if (!fronts || fronts.length === 0) {
       return <div>Loading</div>;
     }
 

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -7,6 +7,7 @@ import { withRouter } from 'react-router';
 import getFrontsConfig from '../../actions/FrontsConfig';
 import { GetFrontsConfigStateSelector } from '../../selectors/frontsSelectors';
 import Collections from './Collections';
+import { getFrontCollections } from '../../util/frontsUtils';
 import type { FrontDetail, FrontsClientConfig } from '../../types/Fronts';
 import type { State } from '../../types/State';
 import type { PropsBeforeFetch } from './FrontsContainer';
@@ -17,7 +18,6 @@ type FrontsComponentProps = PropsBeforeFetch & {
 };
 
 class Fronts extends React.Component<FrontsComponentProps> {
-
   componentDidMount() {
     this.props.frontsActions.getFrontsConfig();
   }
@@ -50,6 +50,11 @@ class Fronts extends React.Component<FrontsComponentProps> {
     }
 
     const { frontsConfig: { fronts } } = this.props;
+    const collectionsWithId = getFrontCollections(
+      this.props.frontId,
+      fronts,
+      this.props.frontsConfig.collections
+    );
 
     return (
       <div>
@@ -60,13 +65,11 @@ class Fronts extends React.Component<FrontsComponentProps> {
           {this.renderSelectPrompt()}
           {fronts.map(this.renderFrontOption)};
         </select>
-        <Collections
-          collections={getFrontCollections(
-            this.props.frontId,
-            fronts,
-            this.props.frontsConfig.collections
-          )}
-        />
+        {collectionsWithId.map(collection => (
+          <div key={collection.id}>
+            <Collections collection={collection} />
+          </div>
+        ))}
       </div>
     );
   }

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -8,7 +8,7 @@ import getFrontsConfig from '../../actions/FrontsConfig';
 import { GetFrontsConfigStateSelector } from '../../selectors/frontsSelectors';
 import Collections from './Collections';
 import { getFrontCollections } from '../../util/frontsUtils';
-import type { FrontDetail, FrontsClientConfig } from '../../types/Fronts';
+import type { FrontDetail, FrontsClientConfig } from '../../types/FrontsConfig';
 import type { State } from '../../types/State';
 import type { PropsBeforeFetch } from './FrontsContainer';
 

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
 import getFrontsConfig from '../../actions/FrontsConfig';
 import { GetFrontsConfigStateSelector } from '../../selectors/frontsSelectors';
-
+import Collections from './Collections';
 import type { FrontDetail, FrontsClientConfig } from '../../types/Fronts';
 import type { State } from '../../types/State';
 import type { PropsBeforeFetch } from './FrontsContainer';
@@ -17,6 +17,7 @@ type FrontsComponentProps = PropsBeforeFetch & {
 };
 
 class Fronts extends React.Component<FrontsComponentProps> {
+
   componentDidMount() {
     this.props.frontsActions.getFrontsConfig();
   }
@@ -40,20 +41,33 @@ class Fronts extends React.Component<FrontsComponentProps> {
   };
 
   render() {
-    if (!this.props.frontsConfig.fronts) {
+    // TODO assign consts from props
+    if (
+      !this.props.frontsConfig.fronts ||
+      this.props.frontsConfig.fronts.length === 0
+    ) {
       return <div>Loading</div>;
     }
 
     const { frontsConfig: { fronts } } = this.props;
 
     return (
-      <select
-        value={decodeURIComponent(this.props.frontId)}
-        onChange={e => this.selectFront(e.target.value)}
-      >
-        {this.renderSelectPrompt()}
-        {fronts.map(this.renderFrontOption)};
-      </select>
+      <div>
+        <select
+          value={this.props.frontId}
+          onChange={e => this.selectFront(e.target.value)}
+        >
+          {this.renderSelectPrompt()}
+          {fronts.map(this.renderFrontOption)};
+        </select>
+        <Collections
+          collections={getFrontCollections(
+            this.props.frontId,
+            fronts,
+            this.props.frontsConfig.collections
+          )}
+        />
+      </div>
     );
   }
 }

--- a/client-v2/src/components/FrontsEdit/FrontsContainer.js
+++ b/client-v2/src/components/FrontsEdit/FrontsContainer.js
@@ -25,7 +25,7 @@ class FrontsContainer extends React.Component<Props> {
   componentDidMount() {
     this.props.frontsActions.getFrontsConfig().then(() => {
       if (this.props.frontId) {
-        const frontId = decodeURIComponent(this.props.frontId);
+        const { props: { frontId } } = this;
         if (!this.props.frontsIds.includes(frontId)) {
           this.props.history.push(`/${this.props.priority}`);
         }

--- a/client-v2/src/components/Home.js
+++ b/client-v2/src/components/Home.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { priorities } from '../constants/priorities';
-import type { Priorities } from '../types/Fronts';
+import type { Priorities } from '../types/Priority';
 
 const renderPriority = (priority: string) => (
   <li key={priority}>

--- a/client-v2/src/components/__tests__/Fronts.spec.js
+++ b/client-v2/src/components/__tests__/Fronts.spec.js
@@ -6,7 +6,7 @@ import { FrontsComponent } from '../FrontsEdit/Fronts';
 import { frontsActions } from '../../mocks';
 import { frontsClientConfig } from '../../fixtures';
 
-import type { PriorityName } from '../../types/Fronts';
+import type { PriorityName } from '../../types/Priority';
 import type { FrontsComponentProps } from '../FrontsEdit/Fronts';
 
 const selectors = {

--- a/client-v2/src/constants/priorities.js
+++ b/client-v2/src/constants/priorities.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Priorities } from '../types/Fronts.js';
+import type { Priorities } from '../types/Priority';
 
 export const priorities: Priorities = {
   editorial: {},

--- a/client-v2/src/fixtures.js
+++ b/client-v2/src/fixtures.js
@@ -33,7 +33,12 @@ const frontsClientConfig: FrontsClientConfig = {
       collections: ['collection1']
     }
   ],
-  collections: []
+  collections: {
+    collection1: {
+      displayName: 'name',
+      type: 'collection'
+    }
+  }
 };
 
 export { frontsClientConfig, frontsConfig };

--- a/client-v2/src/fixtures.js
+++ b/client-v2/src/fixtures.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { FrontsConfig, FrontsClientConfig } from './types/Fronts';
+import type { FrontsConfig, FrontsClientConfig } from './types/FrontsConfig';
 
 const frontsConfig: FrontsConfig = {
   fronts: {

--- a/client-v2/src/reducers/collectionArticlesReducer.js
+++ b/client-v2/src/reducers/collectionArticlesReducer.js
@@ -4,9 +4,9 @@ import { type Action } from '../types/Action';
 
 type State = Object;
 
-const collections = (state: State = {}, action: Action) => {
+const collectionArticles = (state: State = {}, action: Action) => {
   switch (action.type) {
-    case 'FRONTS_COLLECTION_RECEIVED': {
+    case 'CAPI_ARTICLES_RECEIVED': {
       const { id, payload } = action;
       return Object.assign({}, state, { [id]: payload });
     }
@@ -16,4 +16,4 @@ const collections = (state: State = {}, action: Action) => {
   }
 };
 
-export default collections;
+export default collectionArticles;

--- a/client-v2/src/reducers/collectionsReducer.js
+++ b/client-v2/src/reducers/collectionsReducer.js
@@ -1,0 +1,19 @@
+// @flow
+
+import { type Action } from '../types/Action';
+
+type State = Object;
+
+const collections = (state: State = {}, action: Action) => {
+  switch (action.type) {
+    case 'FRONTS_COLLECTION_RECEIVED': {
+      const { id, payload } = action;
+      return Object.assign(state, { [id]: payload });
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default collections;

--- a/client-v2/src/reducers/rootReducer.js
+++ b/client-v2/src/reducers/rootReducer.js
@@ -5,12 +5,14 @@ import config from './configReducer';
 import frontsConfig from './frontsConfigReducer';
 import error from './errorReducer';
 import path from './pathReducer';
+import collections from './collectionsReducer';
 
 const reducers = {
   config,
   frontsConfig,
   error,
-  path
+  path,
+  collections
 };
 
 export type Reducers = typeof reducers;

--- a/client-v2/src/reducers/rootReducer.js
+++ b/client-v2/src/reducers/rootReducer.js
@@ -6,13 +6,15 @@ import frontsConfig from './frontsConfigReducer';
 import error from './errorReducer';
 import path from './pathReducer';
 import collections from './collectionsReducer';
+import collectionArticles from './collectionArticlesReducer';
 
 const reducers = {
   config,
   frontsConfig,
   error,
   path,
-  collections
+  collections,
+  collectionArticles
 };
 
 export type Reducers = typeof reducers;

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.js
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.js
@@ -2,7 +2,7 @@
 
 import { getFrontsConfig } from '../frontsSelectors';
 import { frontsConfig } from '../../fixtures';
-import type { FrontDetail } from '../../types/Fronts';
+import type { FrontDetail } from '../../types/FrontsConfig';
 
 const editorialFronts: Array<FrontDetail> = [
   { collections: ['collection1'], id: 'editorialFront' }

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.js
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.js
@@ -18,9 +18,9 @@ const commercialFronts: Array<FrontDetail> = [
 
 describe('Filtering fronts correctly', () => {
   it('return an empty array if config is empty', () => {
-    expect(getFrontsConfig({}, [], 'editorial')).toEqual({
+    expect(getFrontsConfig({}, {}, [], 'editorial')).toEqual({
       fronts: [],
-      collections: []
+      collections: {}
     });
   });
 
@@ -28,12 +28,13 @@ describe('Filtering fronts correctly', () => {
     expect(
       getFrontsConfig(
         frontsConfig.fronts,
+        frontsConfig.collections,
         Object.keys(frontsConfig.fronts),
         'editorial'
       )
     ).toEqual({
       fronts: editorialFronts,
-      collections: []
+      collections: frontsConfig.collections
     });
   });
 
@@ -41,12 +42,13 @@ describe('Filtering fronts correctly', () => {
     expect(
       getFrontsConfig(
         frontsConfig.fronts,
+        frontsConfig.collections,
         Object.keys(frontsConfig.fronts),
         'commercial'
       )
     ).toEqual({
       fronts: commercialFronts,
-      collections: []
+      collections: frontsConfig.collections
     });
   });
 });

--- a/client-v2/src/selectors/frontsSelectors.js
+++ b/client-v2/src/selectors/frontsSelectors.js
@@ -8,7 +8,7 @@ import type {
   FrontsClientConfig,
   Front,
   ConfigCollection
-} from '../types/Fronts';
+} from '../types/FrontsConfig';
 
 import type { State } from '../types/State';
 

--- a/client-v2/src/selectors/frontsSelectors.js
+++ b/client-v2/src/selectors/frontsSelectors.js
@@ -13,7 +13,8 @@ import type {
 import type { State } from '../types/State';
 
 const frontsSelector = (state: State): Front => state.frontsConfig.fronts;
-const collectionsSelector = (state: State): Front => state.frontsConfig.collections;
+const collectionsSelector = (state: State): ConfigCollection =>
+  state.frontsConfig.collections;
 
 const prioritySelector = (_, priority: string) => priority;
 

--- a/client-v2/src/selectors/frontsSelectors.js
+++ b/client-v2/src/selectors/frontsSelectors.js
@@ -6,12 +6,14 @@ import type {
   FrontConfig,
   FrontDetail,
   FrontsClientConfig,
-  Front
+  Front,
+  ConfigCollection
 } from '../types/Fronts';
 
 import type { State } from '../types/State';
 
 const frontsSelector = (state: State): Front => state.frontsConfig.fronts;
+const collectionsSelector = (state: State): Front => state.frontsConfig.collections;
 
 const prioritySelector = (_, priority: string) => priority;
 
@@ -24,11 +26,12 @@ const frontsIdSelector = createSelector([frontsSelector], fronts => {
 
 const getFrontsConfig = (
   fronts: Front,
+  collections: ConfigCollection,
   frontIds: Array<string>,
   priority: string
 ): FrontsClientConfig => {
   if (frontIds.length === 0) {
-    return { fronts: [], collections: [] };
+    return { fronts: [], collections: {} };
   }
   const frontsWithPriority = frontIds.reduce(
     (acc: Array<FrontDetail>, key: string) => {
@@ -46,7 +49,6 @@ const getFrontsConfig = (
     },
     []
   );
-  const collections = [];
   return {
     fronts: frontsWithPriority,
     collections
@@ -54,7 +56,7 @@ const getFrontsConfig = (
 };
 
 const GetFrontsConfigStateSelector = createSelector(
-  [frontsSelector, frontsIdSelector, prioritySelector],
+  [frontsSelector, collectionsSelector, frontsIdSelector, prioritySelector],
   getFrontsConfig
 );
 

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -2,8 +2,15 @@
 
 import pandaFetch from './pandaFetch';
 
-export default function fetchFrontsConfig() {
+export function fetchFrontsConfig() {
   return pandaFetch('/config', {
+    method: 'get',
+    credentials: 'same-origin'
+  }).then(response => response.json());
+}
+
+export function getCollection(collectionId: string) {
+  return pandaFetch(`/collection/${collectionId}`, {
     method: 'get',
     credentials: 'same-origin'
   }).then(response => response.json());

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -15,3 +15,10 @@ export function getCollection(collectionId: string) {
     credentials: 'same-origin'
   }).then(response => response.json());
 }
+
+export function searchCapi(stage: string, queryString: string) {
+  return pandaFetch(`/api/${stage}/search?${queryString}`, {
+    method: 'get',
+    credentials: 'same-origin'
+  }).then(response => response.json());
+}

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -1,6 +1,9 @@
 // @flow
 
 import pandaFetch from './pandaFetch';
+import { getCollectionArticleQueryString } from '../util/collectionUtils';
+import type { Collection } from '../types/Collection';
+import type { CapiArticle } from '../types/Capi';
 
 export function fetchFrontsConfig() {
   return pandaFetch('/config', {
@@ -16,9 +19,23 @@ export function getCollection(collectionId: string) {
   }).then(response => response.json());
 }
 
-export function searchCapi(stage: string, queryString: string) {
-  return pandaFetch(`/api/${stage}/search?${queryString}`, {
-    method: 'get',
-    credentials: 'same-origin'
-  }).then(response => response.json());
+export function getCollectionArticles(
+  collection: Collection,
+  stage: string = 'preview'
+): Promise<Array<CapiArticle>> {
+  const ids = getCollectionArticleQueryString(collection);
+
+  if (ids) {
+    return pandaFetch(`/api/${stage}/search?ids=${ids}`, {
+      method: 'get',
+      credentials: 'same-origin'
+    })
+      .then(response => response.json())
+      .then(json =>
+        Promise.resolve(
+          json.response.results.map(result => ({ headline: result.webTitle }))
+        )
+      );
+  }
+  return Promise.resolve([]);
 }

--- a/client-v2/src/types/Action.js
+++ b/client-v2/src/types/Action.js
@@ -7,7 +7,7 @@ import { type Config } from './Config';
  * for typing to work nicely in reducers
  */
 
-import type { FrontCollectionDetail } from './Fronts';
+import type { Collection } from './Collection';
 
 type ErrorActionType = 'CAUGHT_ERROR';
 type ConfigReceivedAction = {
@@ -46,7 +46,7 @@ type PathUpdate = {
 type FrontCollectionReceivedAction = {
   type: 'FRONTS_COLLECTION_RECEIVED',
   id: string,
-  payload: FrontCollectionDetail
+  payload: Collection
 };
 
 type RequestFrontCollectionAction = {

--- a/client-v2/src/types/Action.js
+++ b/client-v2/src/types/Action.js
@@ -7,6 +7,9 @@ import { type Config } from './Config';
  * for typing to work nicely in reducers
  */
 
+import type { FrontCollectionDetail } from './Fronts';
+
+type ErrorActionType = 'CAUGHT_ERROR';
 type ConfigReceivedAction = {
   type: 'CONFIG_RECEIVED',
   payload: Config
@@ -23,7 +26,7 @@ type RequestFrontsConfigAction = {
 };
 
 type FrontsConfigError = {
-  type: 'CAUGHT_ERROR',
+  type: ErrorActionType,
   message: 'Could not fetch fronts config',
   // eslint-disable-next-line no-use-before-define
   error: string,
@@ -40,14 +43,38 @@ type PathUpdate = {
   path: string
 };
 
+type FrontCollectionReceivedAction = {
+  type: 'FRONTS_COLLECTION_RECEIVED',
+  id: string,
+  payload: FrontCollectionDetail
+};
+
+type RequestFrontCollectionAction = {
+  type: 'FRONTS_COLLECTION_GET_RECEIVE',
+  receivedAt: number
+};
+
+type ErrorReceivingFrontCollectionAction = {
+  type: ErrorActionType,
+  message: 'Could not fetch collection',
+  error: string,
+  receivedAt: number
+};
+
 export type Action =
   | ConfigReceivedAction
   | FrontsConfigReceivedAction
   | RequestFrontsConfigAction
   | FrontsConfigError
   | ClearError
-  | PathUpdate;
+  | PathUpdate
+  | FrontCollectionReceivedAction
+  | RequestFrontCollectionAction
+  | ErrorReceivingFrontCollectionAction;
 
 export type ActionType = $ElementType<Action, 'type'>;
 
-export type ActionError = 'Could not fetch fronts config' | '';
+export type ActionError =
+  | 'Could not fetch fronts config'
+  | 'Could not fetch collection'
+  | '';

--- a/client-v2/src/types/Action.js
+++ b/client-v2/src/types/Action.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { type Config } from './Config';
+import { type CapiArticle } from './Capi';
 
 /**
  * Need to add new types into here and union them with `Action` in order
@@ -8,6 +9,12 @@ import { type Config } from './Config';
  */
 
 import type { Collection } from './Collection';
+
+type ActionError =
+  | 'Could not fetch fronts config'
+  | 'Could not fetch collection'
+  | 'Could not fetch collection articles from capi'
+  | '';
 
 type ErrorActionType = 'CAUGHT_ERROR';
 type ConfigReceivedAction = {
@@ -22,14 +29,6 @@ type FrontsConfigReceivedAction = {
 
 type RequestFrontsConfigAction = {
   type: 'FRONTS_CONFIG_GET_RECEIVE',
-  receivedAt: number
-};
-
-type FrontsConfigError = {
-  type: ErrorActionType,
-  message: 'Could not fetch fronts config',
-  // eslint-disable-next-line no-use-before-define
-  error: string,
   receivedAt: number
 };
 
@@ -54,10 +53,21 @@ type RequestFrontCollectionAction = {
   receivedAt: number
 };
 
-type ErrorReceivingFrontCollectionAction = {
+type ErrorInAction = {
   type: ErrorActionType,
-  message: 'Could not fetch collection',
+  message: ActionError,
   error: string,
+  receivedAt: number
+};
+
+type CollectionArticlesReceived = {
+  type: 'CAPI_ARTICLES_RECEIVED',
+  id: string,
+  payload: Array<CapiArticle>
+};
+
+type RequestCollectionArticles = {
+  type: 'CAPI_ARTICLES_GET_RECEIVE',
   receivedAt: number
 };
 
@@ -65,16 +75,13 @@ export type Action =
   | ConfigReceivedAction
   | FrontsConfigReceivedAction
   | RequestFrontsConfigAction
-  | FrontsConfigError
   | ClearError
   | PathUpdate
   | FrontCollectionReceivedAction
   | RequestFrontCollectionAction
-  | ErrorReceivingFrontCollectionAction;
+  | ErrorInAction
+  | CollectionArticlesReceived
+  | RequestCollectionArticles;
 
 export type ActionType = $ElementType<Action, 'type'>;
-
-export type ActionError =
-  | 'Could not fetch fronts config'
-  | 'Could not fetch collection'
-  | '';
+export type { ActionError };

--- a/client-v2/src/types/Article.js
+++ b/client-v2/src/types/Article.js
@@ -1,0 +1,13 @@
+// @flow
+
+// TODO: fill this in as we start to display overrides
+type Meta = Object;
+
+type Article = {
+  id: string,
+  frontPublicationDate: number,
+  publishedBy: string,
+  meta: Meta
+};
+
+export type { Article };

--- a/client-v2/src/types/Capi.js
+++ b/client-v2/src/types/Capi.js
@@ -1,0 +1,7 @@
+// @flow
+
+type CapiArticle = {
+  headline: string
+};
+
+export type { CapiArticle };

--- a/client-v2/src/types/Collection.js
+++ b/client-v2/src/types/Collection.js
@@ -1,0 +1,14 @@
+// @flow
+
+import type { Article } from '../types/Article';
+
+type Collection = {
+  draft: Array<Article>,
+  live: Array<Article>,
+  previously: Array<Article>,
+  lastUpdated: number,
+  updatedBy: string,
+  updatedEmail: string
+};
+
+export type { Collection };

--- a/client-v2/src/types/Collection.js
+++ b/client-v2/src/types/Collection.js
@@ -3,12 +3,12 @@
 import type { Article } from '../types/Article';
 
 type Collection = {
-  draft: Array<Article>,
-  live: Array<Article>,
-  previously: Array<Article>,
-  lastUpdated: number,
-  updatedBy: string,
-  updatedEmail: string
+  draft?: Array<Article>,
+  live?: Array<Article>,
+  previously?: Array<Article>,
+  lastUpdated?: number,
+  updatedBy?: string,
+  updatedEmail?: string
 };
 
 export type { Collection };

--- a/client-v2/src/types/Fronts.js
+++ b/client-v2/src/types/Fronts.js
@@ -48,6 +48,8 @@ type ConfigCollectionDetail = {
   platform?: Platform
 };
 
+type ConfigCollectionDetailWithId = ConfigCollectionDetail & { id: string };
+
 type ConfigCollection = {
   [string]: ConfigCollectionDetail
 };
@@ -69,6 +71,25 @@ type Priorities = {
   email: Object
 };
 
+// TODO
+type Meta = Object;
+
+type Article = {
+  id: string,
+  frontPublicationDate: number,
+  publishedBy: string,
+  meta: Meta
+};
+
+type FrontCollectionDetail = {
+  draft: Array<Article>,
+  live: Array<Article>,
+  previously: Array<Article>,
+  lastUpdated: number,
+  updatedBy: string,
+  updatedEmail: string
+};
+
 export type {
   FrontsConfig,
   FrontConfig,
@@ -76,7 +97,10 @@ export type {
   FrontDetail,
   ConfigCollection,
   ConfigCollectionDetail,
+  ConfigCollectionDetailWithId,
   Priorities,
   PriorityName,
-  FrontsClientConfig
+  FrontsClientConfig,
+  FrontCollectionDetail,
+  Article
 };

--- a/client-v2/src/types/Fronts.js
+++ b/client-v2/src/types/Fronts.js
@@ -59,7 +59,7 @@ type FrontsConfig = {
 
 type FrontsClientConfig = {
   fronts: Array<FrontDetail>,
-  collections: Array<CollectionDetail>
+  collections: Collection
 };
 
 type Priorities = {

--- a/client-v2/src/types/Fronts.js
+++ b/client-v2/src/types/Fronts.js
@@ -90,6 +90,10 @@ type FrontCollectionDetail = {
   updatedEmail: string
 };
 
+type CapiArticle = {
+  headline: string
+};
+
 export type {
   FrontsConfig,
   FrontConfig,
@@ -102,5 +106,6 @@ export type {
   PriorityName,
   FrontsClientConfig,
   FrontCollectionDetail,
-  Article
+  Article,
+  CapiArticle
 };

--- a/client-v2/src/types/Fronts.js
+++ b/client-v2/src/types/Fronts.js
@@ -27,7 +27,7 @@ type Front = {
 
 type Platform = 'Web' | 'Platform';
 
-type CollectionDetail = {
+type ConfigCollectionDetail = {
   displayName: string,
   type: string,
   backfill?: Object,
@@ -48,18 +48,18 @@ type CollectionDetail = {
   platform?: Platform
 };
 
-type Collection = {
-  [string]: CollectionDetail
+type ConfigCollection = {
+  [string]: ConfigCollectionDetail
 };
 
 type FrontsConfig = {
   fronts: Front,
-  collections: Collection
+  collections: ConfigCollection
 };
 
 type FrontsClientConfig = {
   fronts: Array<FrontDetail>,
-  collections: Collection
+  collections: ConfigCollection
 };
 
 type Priorities = {
@@ -74,8 +74,8 @@ export type {
   FrontConfig,
   Front,
   FrontDetail,
-  Collection,
-  CollectionDetail,
+  ConfigCollection,
+  ConfigCollectionDetail,
   Priorities,
   PriorityName,
   FrontsClientConfig

--- a/client-v2/src/types/FrontsConfig.js
+++ b/client-v2/src/types/FrontsConfig.js
@@ -1,6 +1,6 @@
 // @flow
 
-type PriorityName = 'editorial' | 'commercial' | 'training' | 'email';
+import type { PriorityName } from '../types/Priority';
 
 type FrontConfig = {
   collections: Array<string>,
@@ -64,36 +64,6 @@ type FrontsClientConfig = {
   collections: ConfigCollection
 };
 
-type Priorities = {
-  editorial: Object,
-  commercial: Object,
-  training: Object,
-  email: Object
-};
-
-// TODO
-type Meta = Object;
-
-type Article = {
-  id: string,
-  frontPublicationDate: number,
-  publishedBy: string,
-  meta: Meta
-};
-
-type FrontCollectionDetail = {
-  draft: Array<Article>,
-  live: Array<Article>,
-  previously: Array<Article>,
-  lastUpdated: number,
-  updatedBy: string,
-  updatedEmail: string
-};
-
-type CapiArticle = {
-  headline: string
-};
-
 export type {
   FrontsConfig,
   FrontConfig,
@@ -102,10 +72,5 @@ export type {
   ConfigCollection,
   ConfigCollectionDetail,
   ConfigCollectionDetailWithId,
-  Priorities,
-  PriorityName,
-  FrontsClientConfig,
-  FrontCollectionDetail,
-  Article,
-  CapiArticle
+  FrontsClientConfig
 };

--- a/client-v2/src/types/Priority.js
+++ b/client-v2/src/types/Priority.js
@@ -1,0 +1,12 @@
+// @flow
+
+type PriorityName = 'editorial' | 'commercial' | 'training' | 'email';
+
+type Priorities = {
+  editorial: Object,
+  commercial: Object,
+  training: Object,
+  email: Object
+};
+
+export type { PriorityName, Priorities };

--- a/client-v2/src/util/__tests__/collectionUtils.spec.js
+++ b/client-v2/src/util/__tests__/collectionUtils.spec.js
@@ -1,0 +1,79 @@
+// @flow
+
+import {
+  getDraftArticles,
+  getCollectionArticleQueryString
+} from '../collectionUtils';
+
+const liveArticle = {
+  id: 'live',
+  frontPublicationDate: 1,
+  publishedBy: 'Computers',
+  meta: {}
+};
+
+const draftArticle = {
+  id: 'draft',
+  frontPublicationDate: 1,
+  publishedBy: 'Computers',
+  meta: {}
+};
+
+const snapArticle = {
+  id: 'snap/link',
+  frontPublicationDate: 1,
+  publishedBy: 'Computers',
+  meta: {}
+};
+
+const collectionWithNoDraftArticles = {
+  live: [liveArticle],
+  lastUpdated: 1,
+  updatedBy: 'computer',
+  updatedEmail: 'email'
+};
+
+const collectionWithDraftArticles = {
+  live: [liveArticle],
+  draft: [draftArticle],
+  lastUpdated: 1,
+  updatedBy: 'computer',
+  updatedEmail: 'email'
+};
+
+const collectionWithSnapArticles = {
+  live: [liveArticle],
+  draft: [draftArticle, snapArticle],
+  lastUpdated: 1,
+  updatedBy: 'computer',
+  updatedEmail: 'email'
+};
+
+describe('getDraftArticles', () => {
+  it('returns empty list if collection is missing', () => {
+    expect(getDraftArticles(null)).toEqual([]);
+  });
+  it('returns list of live articles if draft list is missing', () => {
+    expect(getDraftArticles(collectionWithNoDraftArticles)).toEqual([
+      liveArticle
+    ]);
+  });
+  it('returns list of draft articles when draft articles exist', () => {
+    expect(getDraftArticles(collectionWithDraftArticles)).toEqual([
+      draftArticle
+    ]);
+  });
+});
+
+describe('getCollectionArticleQueryString', () => {
+  it('returns article ids', () => {
+    expect(getCollectionArticleQueryString(collectionWithDraftArticles)).toBe(
+      'draft'
+    );
+  });
+  it('filters out snap links', () => {
+    expect(getCollectionArticleQueryString(collectionWithSnapArticles)).toBe(
+      'draft'
+    );
+  });
+});

--- a/client-v2/src/util/collectionUtils.js
+++ b/client-v2/src/util/collectionUtils.js
@@ -1,10 +1,14 @@
 // @flow
 
 import { searchCapi } from '../services/faciaApi';
-import type { FrontCollectionDetail, Article } from '../types/Fronts';
+import type {
+  FrontCollectionDetail,
+  Article,
+  CapiArticle
+} from '../types/Fronts';
 
 const getDraftArticles = (
-  collection: FrontCollectionDetail
+  collection: ?FrontCollectionDetail
 ): Array<Article> => {
   if (!collection) {
     return [];
@@ -20,21 +24,23 @@ const getDraftArticles = (
 
 const getArticlesForCollection = (
   collection: FrontCollectionDetail
-): Promise<Array<Object>> => {
+): Promise<Array<CapiArticle>> => {
   if (!collection) {
     return Promise.resolve([]);
   }
 
   const articles = getDraftArticles(collection);
-  const idsToFetch = articles.map(article => article.id).join(',');
+  const idsToFetch = articles
+    .map(article => article.id)
+    .filter(id => !id.match(/^snap/))
+    .join(',');
 
-  return (
-    searchCapi('preview', `ids=${idsToFetch}`)
-      // What is this actually returnig???
-      .then(response =>
-        response.response.results.map(result => ({ headline: result.webTitle }))
-      )
-  );
+  if (idsToFetch) {
+    return searchCapi('preview', `ids=${idsToFetch}`).then(response =>
+      response.response.results.map(result => ({ headline: result.webTitle }))
+    );
+  }
+  return Promise.resolve([]);
 };
 
 export { getArticlesForCollection };

--- a/client-v2/src/util/collectionUtils.js
+++ b/client-v2/src/util/collectionUtils.js
@@ -1,15 +1,11 @@
 // @flow
 
 import { searchCapi } from '../services/faciaApi';
-import type {
-  FrontCollectionDetail,
-  Article,
-  CapiArticle
-} from '../types/Fronts';
+import type { Collection } from '../types/Collection';
+import type { Article } from '../types/Article';
+import type { CapiArticle } from '../types/Capi';
 
-const getDraftArticles = (
-  collection: ?FrontCollectionDetail
-): Array<Article> => {
+const getDraftArticles = (collection: ?Collection): Array<Article> => {
   if (!collection) {
     return [];
   }
@@ -23,7 +19,7 @@ const getDraftArticles = (
 };
 
 const getArticlesForCollection = (
-  collection: FrontCollectionDetail
+  collection: Collection
 ): Promise<Array<CapiArticle>> => {
   if (!collection) {
     return Promise.resolve([]);

--- a/client-v2/src/util/collectionUtils.js
+++ b/client-v2/src/util/collectionUtils.js
@@ -1,0 +1,40 @@
+// @flow
+
+import { searchCapi } from '../services/faciaApi';
+import type { FrontCollectionDetail, Article } from '../types/Fronts';
+
+const getDraftArticles = (
+  collection: FrontCollectionDetail
+): Array<Article> => {
+  if (!collection) {
+    return [];
+  }
+
+  // Draft and live versions of the collection are in sync
+  if (!collection.draft) {
+    return collection.live;
+  }
+
+  return collection.draft;
+};
+
+const getArticlesForCollection = (
+  collection: FrontCollectionDetail
+): Promise<Array<Object>> => {
+  if (!collection) {
+    return Promise.resolve([]);
+  }
+
+  const articles = getDraftArticles(collection);
+  const idsToFetch = articles.map(article => article.id).join(',');
+
+  return (
+    searchCapi('preview', `ids=${idsToFetch}`)
+      // What is this actually returnig???
+      .then(response =>
+        response.response.results.map(result => ({ headline: result.webTitle }))
+      )
+  );
+};
+
+export { getArticlesForCollection };

--- a/client-v2/src/util/collectionUtils.js
+++ b/client-v2/src/util/collectionUtils.js
@@ -1,42 +1,27 @@
 // @flow
 
-import { searchCapi } from '../services/faciaApi';
 import type { Collection } from '../types/Collection';
 import type { Article } from '../types/Article';
-import type { CapiArticle } from '../types/Capi';
 
-const getDraftArticles = (collection: ?Collection): Array<Article> => {
+const getDraftArticles = (collection: Collection): Array<Article> => {
   if (!collection) {
     return [];
   }
 
   // Draft and live versions of the collection are in sync
   if (!collection.draft) {
-    return collection.live;
+    return collection.live || [];
   }
 
   return collection.draft;
 };
 
-const getArticlesForCollection = (
-  collection: Collection
-): Promise<Array<CapiArticle>> => {
-  if (!collection) {
-    return Promise.resolve([]);
-  }
-
+const getCollectionArticleQueryString = (collection: Collection): string => {
   const articles = getDraftArticles(collection);
-  const idsToFetch = articles
+  return articles
     .map(article => article.id)
     .filter(id => !id.match(/^snap/))
     .join(',');
-
-  if (idsToFetch) {
-    return searchCapi('preview', `ids=${idsToFetch}`).then(response =>
-      response.response.results.map(result => ({ headline: result.webTitle }))
-    );
-  }
-  return Promise.resolve([]);
 };
 
-export { getArticlesForCollection };
+export { getCollectionArticleQueryString, getDraftArticles };

--- a/client-v2/src/util/frontsUtils.js
+++ b/client-v2/src/util/frontsUtils.js
@@ -1,0 +1,30 @@
+// @flow
+
+import type {
+  FrontDetail,
+  ConfigCollection,
+  ConfigCollectionDetailWithId
+} from '../types/Fronts';
+
+const getFrontCollections = (
+  frontId: ?string,
+  fronts: Array<FrontDetail>,
+  collections: ConfigCollection
+): Array<ConfigCollectionDetailWithId> => {
+  if (!frontId) {
+    return [];
+  }
+  const selectedFront: ?FrontDetail = fronts.find(
+    (front: FrontDetail) => front.id === frontId
+  );
+
+  if (selectedFront) {
+    return selectedFront.collections.map(collectionId =>
+      Object.assign({}, collections[collectionId], { id: collectionId })
+    );
+  }
+
+  return [];
+};
+
+export { getFrontCollections };

--- a/client-v2/src/util/frontsUtils.js
+++ b/client-v2/src/util/frontsUtils.js
@@ -4,7 +4,7 @@ import type {
   FrontDetail,
   ConfigCollection,
   ConfigCollectionDetailWithId
-} from '../types/Fronts';
+} from '../types/FrontsConfig';
 
 const getFrontCollections = (
   frontId: ?string,


### PR DESCRIPTION
Display collections and draft articles on the front
Collection info is fetched from three different places: config bucket, collection bucket and capi. I split the fronts type files into different files to reflect this. Some of the types are very stripped down but we can build on them as we start to build more functionality.
 Didn't use any of the existing capi stuff to query capi because wanted to talk to Rich about it when he get back.