### PR TITLE
remove display flex

### DIFF
--- a/client-v2/src/components/App.js
+++ b/client-v2/src/components/App.js
@@ -11,7 +11,6 @@ import { priorities } from '../constants/priorities';
 const AppContainer = styled('div')`
   background-color: #221133;
   color: white;
-  display: flex;
   font-family: 'Helvetica Neue', Helvetica, Arial;
   font-size: 16px;
   font-weight: 100;


### PR DESCRIPTION
We don't want to display everything in appContainer alongside each other because we want the error banner to appear on top of everything. When we start playing around with layouts we can wrap the actual fronts edit components inside a flexbox.