### PR TITLE
Fronts dropdown improvements

### DIFF
--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -7,8 +7,9 @@ import { withRouter } from 'react-router';
 import getFrontsConfig from '../../actions/FrontsConfig';
 import { GetFrontsConfigStateSelector } from '../../selectors/frontsSelectors';
 import CollectionContainer from './CollectionContainer';
+import FrontsDropDown from './FrontsDropdown';
 import { getFrontCollections } from '../../util/frontsUtils';
-import type { FrontDetail, FrontsClientConfig } from '../../types/FrontsConfig';
+import type { FrontsClientConfig } from '../../types/FrontsConfig';
 import type { State } from '../../types/State';
 import type { PropsBeforeFetch } from './FrontsContainer';
 
@@ -22,29 +23,8 @@ class Fronts extends React.Component<FrontsComponentProps> {
     this.props.frontsActions.getFrontsConfig();
   }
 
-  selectFront = (frontId: string) => {
-    const encodedUri = encodeURIComponent(frontId);
-    this.props.history.push(`/${this.props.priority}/${encodedUri}`);
-  };
-
-  renderFrontOption = (front: FrontDetail) => (
-    <option value={front.id} key={front.id}>
-      {front.id}
-    </option>
-  );
-
-  renderSelectPrompt = () => {
-    if (!this.props.frontId) {
-      return <option value="">Choose a front...</option>;
-    }
-    return null;
-  };
-
   render() {
     const { frontsConfig: { fronts, collections } } = this.props;
-    if (!fronts || fronts.length === 0) {
-      return <div>Loading</div>;
-    }
 
     const collectionsWithId = getFrontCollections(
       this.props.frontId,
@@ -54,13 +34,12 @@ class Fronts extends React.Component<FrontsComponentProps> {
 
     return (
       <div>
-        <select
-          value={this.props.frontId}
-          onChange={e => this.selectFront(e.target.value)}
-        >
-          {this.renderSelectPrompt()}
-          {fronts.map(this.renderFrontOption)};
-        </select>
+        <FrontsDropDown
+          fronts={fronts}
+          frontId={this.props.frontId}
+          history={this.props.history}
+          priority={this.props.priority}
+        />
         {collectionsWithId.map(collection => (
           <div key={collection.id}>
             <CollectionContainer collection={collection} />

--- a/client-v2/src/components/FrontsEdit/FrontsDropdown.js
+++ b/client-v2/src/components/FrontsEdit/FrontsDropdown.js
@@ -14,6 +14,11 @@ type Props = {
 
 const DropDownSelector = styled('select')`
   padding: 10px;
+  margin-left: 5px;
+  margin-top: 10px;
+  border: 1px solid;
+  height: 30px;
+  font-size: 16px;
 `;
 
 const selectFront = (

--- a/client-v2/src/components/FrontsEdit/FrontsDropdown.js
+++ b/client-v2/src/components/FrontsEdit/FrontsDropdown.js
@@ -1,0 +1,55 @@
+// @flow
+
+import React from 'react';
+import styled from 'styled-components';
+import type { RouterHistory } from 'react-router-dom';
+import type { FrontDetail } from '../../types/FrontsConfig';
+
+type Props = {
+  fronts: Array<FrontDetail>,
+  frontId: ?string,
+  history: RouterHistory,
+  priority: string
+};
+
+const DropDownSelector = styled('select')`
+  padding: 10px;
+`;
+
+const selectFront = (
+  frontId: string,
+  history: RouterHistory,
+  priority: string
+) => {
+  const encodedUri = encodeURIComponent(frontId);
+  history.push(`/${priority}/${encodedUri}`);
+};
+
+const renderSelectPrompt = (frontId: ?string) => {
+  if (!frontId) {
+    return <option value="">Choose a front...</option>;
+  }
+  return null;
+};
+
+const FrontsDropDown = (props: Props) => {
+  if (!props.fronts) {
+    return <div>Loading</div>;
+  }
+
+  return (
+    <DropDownSelector
+      value={props.frontId}
+      onChange={e => selectFront(e.target.value, props.history, props.priority)}
+    >
+      {renderSelectPrompt(props.frontId)}
+      {props.fronts.map(front => (
+        <option value={front.id} key={front.id}>
+          {front.id}
+        </option>
+      ))}
+    </DropDownSelector>
+  );
+};
+
+export default FrontsDropDown;

--- a/client-v2/src/components/FrontsEdit/FrontsDropdown.js
+++ b/client-v2/src/components/FrontsEdit/FrontsDropdown.js
@@ -57,4 +57,5 @@ const FrontsDropDown = (props: Props) => {
   );
 };
 
+export type { Props };
 export default FrontsDropDown;

--- a/client-v2/src/components/__tests__/Fronts.spec.js
+++ b/client-v2/src/components/__tests__/Fronts.spec.js
@@ -2,50 +2,33 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { FrontsComponent } from '../FrontsEdit/Fronts';
-import { frontsActions } from '../../mocks';
+import { createMemoryHistory } from 'history';
+import FrontsDropdown from '../FrontsEdit/FrontsDropdown';
 import { frontsClientConfig } from '../../fixtures';
 
 import type { PriorityName } from '../../types/Priority';
-import type { FrontsComponentProps } from '../FrontsEdit/Fronts';
+import type { Props } from '../FrontsEdit/FrontsDropdown';
 
-const selectors = {
-  FRONTS_SELECT: 'select'
-};
-
-const setup = (priority: PriorityName) => {
-  const props: FrontsComponentProps = Object.assign({
-    frontsActions,
+const setup = (priority: PriorityName, frontId: ?string) => {
+  const history = createMemoryHistory(`/{priority`);
+  const props: Props = Object.assign({
     priority,
-    frontsConfig: frontsClientConfig
+    frontId,
+    fronts: frontsClientConfig.fronts,
+    history
   });
 
-  const wrapper = shallow(<FrontsComponent {...props} />);
+  const wrapper = shallow(<FrontsDropdown {...props} />);
 
   return {
-    wrapper,
-    fronts: wrapper.find(selectors.FRONTS_SELECT)
+    wrapper
   };
 };
 
-describe('Fronts', () => {
+describe('FrontsDropdown', () => {
   it('should render correctly', () => {
     const { wrapper } = setup('editorial');
 
     expect(wrapper.exists()).toBe(true);
-  });
-
-  it('should render editorial fronts', () => {
-    const { fronts } = setup('editorial');
-
-    expect(fronts.text()).toMatch(/editorialFront/);
-    expect(fronts.text()).toMatch(/(?<!\.commercialFront)/);
-  });
-
-  it('should render commercial fronts', () => {
-    const { fronts } = setup('commercial');
-
-    expect(fronts.text()).toMatch(/commercialFront/);
-    expect(fronts.text()).toMatch(/(?<!\.editoriaFront)/);
   });
 });

--- a/client-v2/src/constants/fronts.js
+++ b/client-v2/src/constants/fronts.js
@@ -1,0 +1,3 @@
+// @flow
+
+export const breakingNewsFrontId: string = 'breaking-news';

--- a/client-v2/src/selectors/frontsSelectors.js
+++ b/client-v2/src/selectors/frontsSelectors.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { createSelector } from 'reselect';
+import { breakingNewsFrontId } from '../constants/fronts';
 
 import type {
   FrontConfig,
@@ -22,7 +23,9 @@ const frontsIdSelector = createSelector([frontsSelector], fronts => {
   if (!fronts) {
     return [];
   }
-  return Object.keys(fronts);
+  return Object.keys(fronts)
+    .filter(front => front !== breakingNewsFrontId)
+    .sort();
 });
 
 const getFrontsConfig = (


### PR DESCRIPTION
- Sort fronts alphabetically (we can do something smarter later)
- Don't display breaking news in fronts dropdown
- Fronts dropdown should be a separate component
- I removed most of the fronts dropdown tests because they didn't really make any sense (we are testing fronts filtering elsewhere). I added them just to get enzyme into the project in the first place.