### PR TITLE
Live collections

### DIFF
--- a/client-v2/src/actions/Articles.js
+++ b/client-v2/src/actions/Articles.js
@@ -4,12 +4,11 @@ import type { Action } from '../types/Action';
 import type { ThunkAction } from '../types/Store';
 
 import { getCollectionArticles } from '../services/faciaApi';
-import type { CapiArticle } from '../types/Capi';
-import type { Collection } from '../types/Collection';
+import type { Collection, CollectionArticles } from '../types/Collection';
 
 function collectionArticlesReceived(
   collectionId: string,
-  articles: Array<CapiArticle>
+  articles: CollectionArticles
 ): Action {
   return {
     type: 'CAPI_ARTICLES_RECEIVED',
@@ -41,7 +40,7 @@ export default function getArticlesForCollection(
   return (dispatch: Dispatch) => {
     dispatch(requestCollectionArticles());
     return getCollectionArticles(collection)
-      .then((res: Array<CapiArticle>) => {
+      .then((res: CollectionArticles) => {
         dispatch(collectionArticlesReceived(collectionId, res));
       })
       .catch((error: string) =>

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -6,11 +6,12 @@ import { bindActionCreators } from 'redux';
 import getFrontCollection from '../../actions/Collection';
 import getArticlesForCollection from '../../actions/Articles';
 import CollectionDetail from './CollectionDetail';
+import Button from '../Button';
 
 import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
-import type { Collection } from '../../types/Collection';
-import type { CapiArticle } from '../../types/Capi';
+import type { Collection, CollectionArticles } from '../../types/Collection';
 import type { State } from '../../types/State';
+import type { CapiArticle } from '../../types/Capi';
 
 type Props = {
   collection: ConfigCollectionDetailWithId
@@ -22,11 +23,25 @@ type ConnectedComponentProps = Props & {
     [string]: Collection
   },
   collectionArticles: {
-    [string]: Array<CapiArticle>
+    [string]: {
+      draft: CollectionArticles,
+      live: CollectionArticles
+    }
   }
 };
 
-class CollectionContainer extends React.Component<ConnectedComponentProps> {
+type ComponentState = {
+  browsingState: 'draft' | 'live'
+};
+
+class CollectionContainer extends React.Component<
+  ConnectedComponentProps,
+  ComponentState
+> {
+  state = {
+    browsingState: 'draft'
+  };
+
   componentDidMount() {
     const { props: { collection: { id } } } = this;
     const currentCollection = this.props.collections[id];
@@ -43,10 +58,16 @@ class CollectionContainer extends React.Component<ConnectedComponentProps> {
   }
 
   render() {
+    const collectionArticles: CollectionArticles = this.props
+      .collectionArticles[this.props.collection.id];
+    const articlesWithState: Array<CapiArticle> = collectionArticles
+      ? collectionArticles[this.state.browsingState]
+      : [];
+
     return (
       <CollectionDetail
         collectionConfig={this.props.collection}
-        articles={this.props.collectionArticles[this.props.collection.id] || []}
+        articles={articlesWithState}
       />
     );
   }

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -6,44 +6,25 @@ import { bindActionCreators } from 'redux';
 import getFrontCollection from '../../actions/Collection';
 import getArticlesForCollection from '../../actions/Articles';
 import CollectionDetail from './CollectionDetail';
-import Button from '../Button';
-import Col from '../Col';
-import Row from '../Row';
-import { frontStages } from '../../constants/fronts';
 import { collectionSelector } from '../../selectors/collectionSelectors';
-
+import { collectionArticlesSelector } from '../../selectors/collectionArticleSelectors';
 import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
-import type { Collection, CollectionArticles } from '../../types/Collection';
+import type { Collection } from '../../types/Collection';
 import type { State } from '../../types/State';
 import type { CapiArticle } from '../../types/Capi';
 
 type Props = {
-  collectionConfig: ConfigCollectionDetailWithId
+  collectionConfig: ConfigCollectionDetailWithId,
+  browsingStage: string // eslint-disable-line react/no-unused-prop-types
 };
 
 type ConnectedComponentProps = Props & {
   frontsActions: Object,
   collection: ?Collection,
-  collectionArticles: {
-    [string]: {
-      draft: CollectionArticles,
-      live: CollectionArticles
-    }
-  }
+  collectionArticles: Array<CapiArticle>
 };
 
-type ComponentState = {
-  browsingStage: 'draft' | 'live'
-};
-
-class CollectionContainer extends React.Component<
-  ConnectedComponentProps,
-  ComponentState
-> {
-  state = {
-    browsingStage: frontStages.draft
-  };
-
+class CollectionContainer extends React.Component<ConnectedComponentProps> {
   componentDidMount() {
     const { props: { collectionConfig: { id }, collection } } = this;
     if (!collection) {
@@ -58,36 +39,13 @@ class CollectionContainer extends React.Component<
     }
   }
 
-  handleStageSelect(key) {
-    this.setState({
-      browsingStage: frontStages[key]
-    });
-  }
-
   render() {
-    const collectionArticles: CollectionArticles = this.props
-      .collectionArticles[this.props.collectionConfig.id];
-    const articlesWithState: Array<CapiArticle> = collectionArticles
-      ? collectionArticles[this.state.browsingStage]
-      : [];
 
     return (
       <div>
-        <Row>
-          {Object.keys(frontStages).map(key => (
-            <Col key={key}>
-              <Button
-                selected={frontStages[key] === this.state.browsingStage}
-                onClick={() => this.handleStageSelect(key)}
-              >
-                {frontStages[key]}
-              </Button>
-            </Col>
-          ))}
-        </Row>
         <CollectionDetail
           collectionConfig={this.props.collectionConfig}
-          articles={articlesWithState}
+          articles={this.props.collectionArticles}
         />
       </div>
     );
@@ -96,7 +54,7 @@ class CollectionContainer extends React.Component<
 
 const mapStateToProps = (state: State, props: Props) => ({
   collection: collectionSelector(state, props.collectionConfig.id),
-  collectionArticles: state.collectionArticles
+  collectionArticles: collectionArticlesSelector(state, props.collectionConfig.id, props.browsingStage)
 });
 
 const mapDispatchToProps = (dispatch: *) => ({

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -10,6 +10,7 @@ import Button from '../Button';
 import Col from '../Col';
 import Row from '../Row';
 import { frontStages } from '../../constants/fronts';
+import { collectionSelector } from '../../selectors/collectionSelectors';
 
 import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
 import type { Collection, CollectionArticles } from '../../types/Collection';
@@ -17,14 +18,12 @@ import type { State } from '../../types/State';
 import type { CapiArticle } from '../../types/Capi';
 
 type Props = {
-  collection: ConfigCollectionDetailWithId
+  collectionConfig: ConfigCollectionDetailWithId
 };
 
 type ConnectedComponentProps = Props & {
   frontsActions: Object,
-  collections: {
-    [string]: Collection
-  },
+  collection: ?Collection,
   collectionArticles: {
     [string]: {
       draft: CollectionArticles,
@@ -46,17 +45,16 @@ class CollectionContainer extends React.Component<
   };
 
   componentDidMount() {
-    const { props: { collection: { id } } } = this;
-    const currentCollection = this.props.collections[id];
-    if (!currentCollection) {
+    const { props: { collectionConfig: { id }, collection } } = this;
+    if (!collection) {
       this.props.frontsActions.getFrontCollection(id).then(() => {
         this.props.frontsActions.getArticlesForCollection(
-          this.props.collections[id],
+          this.props.collection,
           id
         );
       });
     } else {
-      this.props.frontsActions.getArticlesForCollection(currentCollection, id);
+      this.props.frontsActions.getArticlesForCollection(collection, id);
     }
   }
 
@@ -68,7 +66,7 @@ class CollectionContainer extends React.Component<
 
   render() {
     const collectionArticles: CollectionArticles = this.props
-      .collectionArticles[this.props.collection.id];
+      .collectionArticles[this.props.collectionConfig.id];
     const articlesWithState: Array<CapiArticle> = collectionArticles
       ? collectionArticles[this.state.browsingStage]
       : [];
@@ -88,7 +86,7 @@ class CollectionContainer extends React.Component<
           ))}
         </Row>
         <CollectionDetail
-          collectionConfig={this.props.collection}
+          collectionConfig={this.props.collectionConfig}
           articles={articlesWithState}
         />
       </div>
@@ -96,8 +94,8 @@ class CollectionContainer extends React.Component<
   }
 }
 
-const mapStateToProps = (state: State) => ({
-  collections: state.collections,
+const mapStateToProps = (state: State, props: Props) => ({
+  collection: collectionSelector(state, props.collectionConfig.id),
   collectionArticles: state.collectionArticles
 });
 

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -7,6 +7,9 @@ import getFrontCollection from '../../actions/Collection';
 import getArticlesForCollection from '../../actions/Articles';
 import CollectionDetail from './CollectionDetail';
 import Button from '../Button';
+import Col from '../Col';
+import Row from '../Row';
+import { frontStages } from '../../constants/fronts';
 
 import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
 import type { Collection, CollectionArticles } from '../../types/Collection';
@@ -31,7 +34,7 @@ type ConnectedComponentProps = Props & {
 };
 
 type ComponentState = {
-  browsingState: 'draft' | 'live'
+  browsingStage: 'draft' | 'live'
 };
 
 class CollectionContainer extends React.Component<
@@ -39,7 +42,7 @@ class CollectionContainer extends React.Component<
   ComponentState
 > {
   state = {
-    browsingState: 'draft'
+    browsingStage: 'draft'
   };
 
   componentDidMount() {
@@ -57,18 +60,38 @@ class CollectionContainer extends React.Component<
     }
   }
 
+  handleStageSelect(key) {
+    this.setState({
+      browsingStage: frontStages[key]
+    });
+  }
+
   render() {
     const collectionArticles: CollectionArticles = this.props
       .collectionArticles[this.props.collection.id];
     const articlesWithState: Array<CapiArticle> = collectionArticles
-      ? collectionArticles[this.state.browsingState]
+      ? collectionArticles[this.state.browsingStage]
       : [];
 
     return (
-      <CollectionDetail
-        collectionConfig={this.props.collection}
-        articles={articlesWithState}
-      />
+      <div>
+        <Row>
+          {Object.keys(frontStages).map(key => (
+            <Col key={key}>
+              <Button
+                selected={frontStages[key] === this.state.browsingStage}
+                onClick={() => this.handleStageSelect(key)}
+              >
+                {frontStages[key]}
+              </Button>
+            </Col>
+          ))}
+        </Row>
+        <CollectionDetail
+          collectionConfig={this.props.collection}
+          articles={articlesWithState}
+        />
+      </div>
     );
   }
 }

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -42,7 +42,7 @@ class CollectionContainer extends React.Component<
   ComponentState
 > {
   state = {
-    browsingStage: 'draft'
+    browsingStage: frontStages.draft
   };
 
   componentDidMount() {

--- a/client-v2/src/components/FrontsEdit/CollectionContainer.js
+++ b/client-v2/src/components/FrontsEdit/CollectionContainer.js
@@ -40,21 +40,22 @@ class CollectionContainer extends React.Component<ConnectedComponentProps> {
   }
 
   render() {
-
     return (
-      <div>
-        <CollectionDetail
-          collectionConfig={this.props.collectionConfig}
-          articles={this.props.collectionArticles}
-        />
-      </div>
+      <CollectionDetail
+        displayName={this.props.collectionConfig.displayName}
+        articles={this.props.collectionArticles}
+      />
     );
   }
 }
 
 const mapStateToProps = (state: State, props: Props) => ({
   collection: collectionSelector(state, props.collectionConfig.id),
-  collectionArticles: collectionArticlesSelector(state, props.collectionConfig.id, props.browsingStage)
+  collectionArticles: collectionArticlesSelector(
+    state,
+    props.collectionConfig.id,
+    props.browsingStage
+  )
 });
 
 const mapDispatchToProps = (dispatch: *) => ({

--- a/client-v2/src/components/FrontsEdit/CollectionDetail.js
+++ b/client-v2/src/components/FrontsEdit/CollectionDetail.js
@@ -3,11 +3,10 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import type { ConfigCollectionDetailWithId } from '../../types/FrontsConfig';
 import type { CapiArticle } from '../../types/Capi';
 
 type Props = {
-  collectionConfig: ConfigCollectionDetailWithId,
+  displayName: string,
   articles: Array<CapiArticle>
 };
 
@@ -29,9 +28,7 @@ const ArticleContainer = styled('div')`
 
 const CollectionDetail = (props: Props) => (
   <CollectionContainer>
-    <CollectionHeadline>
-      {props.collectionConfig.displayName}
-    </CollectionHeadline>
+    <CollectionHeadline>{props.displayName}</CollectionHeadline>
     {props.articles.map(article => (
       <ArticleContainer key={article.headline}>
         {article.headline}

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -9,6 +9,10 @@ import { GetFrontsConfigStateSelector } from '../../selectors/frontsSelectors';
 import CollectionContainer from './CollectionContainer';
 import FrontsDropDown from './FrontsDropdown';
 import { getFrontCollections } from '../../util/frontsUtils';
+import { frontStages } from '../../constants/fronts';
+import Button from '../Button';
+import Col from '../Col';
+import Row from '../Row';
 import type { FrontsClientConfig } from '../../types/FrontsConfig';
 import type { State } from '../../types/State';
 import type { PropsBeforeFetch } from './FrontsContainer';
@@ -18,9 +22,23 @@ type FrontsComponentProps = PropsBeforeFetch & {
   frontsActions: Object
 };
 
-class Fronts extends React.Component<FrontsComponentProps> {
+type ComponentState = {
+  browsingStage: 'draft' | 'live'
+};
+
+class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
+  state = {
+    browsingStage: frontStages.draft
+  };
+
   componentDidMount() {
     this.props.frontsActions.getFrontsConfig();
+  }
+
+  handleStageSelect(key: string) {
+    this.setState({
+      browsingStage: frontStages[key]
+    });
   }
 
   render() {
@@ -40,9 +58,24 @@ class Fronts extends React.Component<FrontsComponentProps> {
           history={this.props.history}
           priority={this.props.priority}
         />
+        <Row>
+          {Object.keys(frontStages).map(key => (
+            <Col key={key}>
+              <Button
+                selected={frontStages[key] === this.state.browsingStage}
+                onClick={() => this.handleStageSelect(key)}
+              >
+                {frontStages[key]}
+              </Button>
+            </Col>
+          ))}
+        </Row>
         {collectionsWithId.map(collection => (
           <div key={collection.id}>
-            <CollectionContainer collectionConfig={collection} />
+            <CollectionContainer
+              collectionConfig={collection}
+              browsingStage={this.state.browsingStage}
+            />
           </div>
         ))}
       </div>

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -42,7 +42,7 @@ class Fronts extends React.Component<FrontsComponentProps> {
         />
         {collectionsWithId.map(collection => (
           <div key={collection.id}>
-            <CollectionContainer collection={collection} />
+            <CollectionContainer collectionConfig={collection} />
           </div>
         ))}
       </div>

--- a/client-v2/src/constants/fronts.js
+++ b/client-v2/src/constants/fronts.js
@@ -3,6 +3,6 @@
 export const breakingNewsFrontId: string = 'breaking-news';
 
 export const frontStages = {
-  live: 'live',
-  draft: 'draft'
+  draft: 'draft',
+  live: 'live'
 };

--- a/client-v2/src/constants/fronts.js
+++ b/client-v2/src/constants/fronts.js
@@ -1,3 +1,8 @@
 // @flow
 
 export const breakingNewsFrontId: string = 'breaking-news';
+
+export const frontStages = {
+  live: 'live',
+  draft: 'draft'
+};

--- a/client-v2/src/selectors/collectionArticleSelectors.js
+++ b/client-v2/src/selectors/collectionArticleSelectors.js
@@ -1,0 +1,34 @@
+// @flow
+
+import { createSelector } from 'reselect';
+
+import type { State } from '../types/State';
+import type { CollectionArticles } from '../types/Collection';
+import type { CapiArticle } from '../types/Capi';
+
+const allCollectionArticlesSelector = (
+  state: State
+): { [string]: CollectionArticles } => state.collectionArticles;
+
+const collectionIdSelector = (state: State, id: string) => id;
+
+const articleStageSelector = (state: State, id: string, stage: string) => stage;
+
+const getCollectionArticles = (
+  collectionArticles: { [string]: CollectionArticles },
+  id: string,
+  stage: string
+): Array<CapiArticle> => {
+  if (!collectionArticles || !collectionArticles[id]) {
+    return [];
+  }
+
+  return collectionArticles[id][stage];
+};
+
+const collectionArticlesSelector = createSelector(
+  [allCollectionArticlesSelector, collectionIdSelector, articleStageSelector],
+  getCollectionArticles
+);
+
+export { collectionArticlesSelector };

--- a/client-v2/src/selectors/collectionSelectors.js
+++ b/client-v2/src/selectors/collectionSelectors.js
@@ -1,0 +1,28 @@
+// @flow
+
+import { createSelector } from 'reselect';
+
+import type { State } from '../types/State';
+import type { Collection } from '../types/Collection';
+
+const allCollectionsSelector = (state: State): { [string]: Collection } =>
+  state.collections;
+
+const collectionIdSelector = (_, id: string) => id;
+
+const getCollection = (
+  collections: { [string]: Collection },
+  id: string
+): ?Collection => {
+  if (!collections) {
+    return null;
+  }
+  return collections[id];
+};
+
+const collectionSelector = createSelector(
+  [allCollectionsSelector, collectionIdSelector],
+  getCollection
+);
+
+export { collectionSelector };

--- a/client-v2/src/selectors/frontsSelectors.js
+++ b/client-v2/src/selectors/frontsSelectors.js
@@ -17,7 +17,7 @@ const frontsSelector = (state: State): Front => state.frontsConfig.fronts;
 const collectionsSelector = (state: State): ConfigCollection =>
   state.frontsConfig.collections;
 
-const prioritySelector = (_, priority: string) => priority;
+const prioritySelector = (state: State, priority: string) => priority;
 
 const frontsIdSelector = createSelector([frontsSelector], fronts => {
   if (!fronts) {

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -22,7 +22,7 @@ export function getCollection(collectionId: string) {
 
 export function getCollectionArticles(
   collection: Collection
-): Promise<Array<CollectionArticles>> {
+): Promise<CollectionArticles> {
   const parseArticleListFromResponse = (text: ?string): Array<CapiArticle> => {
     if (text) {
       return JSON.parse(text).response.results.map(result => ({

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -2,6 +2,7 @@
 
 import pandaFetch from './pandaFetch';
 import { getCollectionArticleQueryString } from '../util/collectionUtils';
+import { frontStages } from '../constants/fronts';
 import type { Collection, CollectionArticles } from '../types/Collection';
 import type { CapiArticle } from '../types/Capi';
 
@@ -31,8 +32,11 @@ export function getCollectionArticles(
     return [];
   };
 
-  const draftIds = getCollectionArticleQueryString(collection, 'draft');
-  const liveIds = getCollectionArticleQueryString(collection, 'live');
+  const draftIds = getCollectionArticleQueryString(
+    collection,
+    frontStages.draft
+  );
+  const liveIds = getCollectionArticleQueryString(collection, frontStages.live);
 
   const draftArticlePromise = pandaFetch(
     `/api/preview/search?ids=${draftIds}`,

--- a/client-v2/src/types/Action.js
+++ b/client-v2/src/types/Action.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { type Config } from './Config';
-import { type CapiArticle } from './Capi';
+import { type CollectionArticles } from './Collection';
 
 /**
  * Need to add new types into here and union them with `Action` in order
@@ -63,7 +63,7 @@ type ErrorInAction = {
 type CollectionArticlesReceived = {
   type: 'CAPI_ARTICLES_RECEIVED',
   id: string,
-  payload: Array<CapiArticle>
+  payload: Array<CollectionArticles>
 };
 
 type RequestCollectionArticles = {

--- a/client-v2/src/types/Action.js
+++ b/client-v2/src/types/Action.js
@@ -63,7 +63,7 @@ type ErrorInAction = {
 type CollectionArticlesReceived = {
   type: 'CAPI_ARTICLES_RECEIVED',
   id: string,
-  payload: Array<CollectionArticles>
+  payload: CollectionArticles
 };
 
 type RequestCollectionArticles = {

--- a/client-v2/src/types/Collection.js
+++ b/client-v2/src/types/Collection.js
@@ -1,14 +1,20 @@
 // @flow
 
 import type { Article } from '../types/Article';
+import type { CapiArticle } from '../types/Capi';
 
 type Collection = {
   draft?: Array<Article>,
-  live?: Array<Article>,
+  live: Array<Article>,
   previously?: Array<Article>,
   lastUpdated?: number,
   updatedBy?: string,
   updatedEmail?: string
 };
 
-export type { Collection };
+type CollectionArticles = {
+  draft: Array<CapiArticle>,
+  live: Array<CapiArticle>
+};
+
+export type { Collection, CollectionArticles };

--- a/client-v2/src/util/__tests__/collectionUtils.spec.js
+++ b/client-v2/src/util/__tests__/collectionUtils.spec.js
@@ -1,16 +1,17 @@
 // @flow
 
 import { getCollectionArticleQueryString } from '../collectionUtils';
+import { frontStages } from '../../constants/fronts';
 
 const liveArticle = {
-  id: 'live',
+  id: frontStages.live,
   frontPublicationDate: 1,
   publishedBy: 'Computers',
   meta: {}
 };
 
 const draftArticle = {
-  id: 'draft',
+  id: frontStages.draft,
   frontPublicationDate: 1,
   publishedBy: 'Computers',
   meta: {}
@@ -49,22 +50,28 @@ const collectionWithSnapArticles = {
 describe('getCollectionArticleQueryString', () => {
   it('returns draft article ids', () => {
     expect(
-      getCollectionArticleQueryString(collectionWithArticles, 'draft')
-    ).toBe('draft');
+      getCollectionArticleQueryString(collectionWithArticles, frontStages.draft)
+    ).toBe(frontStages.draft);
   });
   it('returns live article ids if draft is missing', () => {
     expect(
-      getCollectionArticleQueryString(collectionWithNoDraftArticles, 'draft')
-    ).toBe('live');
+      getCollectionArticleQueryString(
+        collectionWithNoDraftArticles,
+        frontStages.draft
+      )
+    ).toBe(frontStages.live);
   });
   it('returns live article ids', () => {
     expect(
-      getCollectionArticleQueryString(collectionWithArticles, 'live')
-    ).toBe('live');
+      getCollectionArticleQueryString(collectionWithArticles, frontStages.live)
+    ).toBe(frontStages.live);
   });
   it('filters out snap links', () => {
     expect(
-      getCollectionArticleQueryString(collectionWithSnapArticles, 'draft')
-    ).toBe('draft');
+      getCollectionArticleQueryString(
+        collectionWithSnapArticles,
+        frontStages.draft
+      )
+    ).toBe(frontStages.draft);
   });
 });

--- a/client-v2/src/util/__tests__/collectionUtils.spec.js
+++ b/client-v2/src/util/__tests__/collectionUtils.spec.js
@@ -1,9 +1,6 @@
 // @flow
 
-import {
-  getDraftArticles,
-  getCollectionArticleQueryString
-} from '../collectionUtils';
+import { getCollectionArticleQueryString } from '../collectionUtils';
 
 const liveArticle = {
   id: 'live',
@@ -33,7 +30,7 @@ const collectionWithNoDraftArticles = {
   updatedEmail: 'email'
 };
 
-const collectionWithDraftArticles = {
+const collectionWithArticles = {
   live: [liveArticle],
   draft: [draftArticle],
   lastUpdated: 1,
@@ -49,31 +46,25 @@ const collectionWithSnapArticles = {
   updatedEmail: 'email'
 };
 
-describe('getDraftArticles', () => {
-  it('returns empty list if collection is missing', () => {
-    expect(getDraftArticles(null)).toEqual([]);
-  });
-  it('returns list of live articles if draft list is missing', () => {
-    expect(getDraftArticles(collectionWithNoDraftArticles)).toEqual([
-      liveArticle
-    ]);
-  });
-  it('returns list of draft articles when draft articles exist', () => {
-    expect(getDraftArticles(collectionWithDraftArticles)).toEqual([
-      draftArticle
-    ]);
-  });
-});
-
 describe('getCollectionArticleQueryString', () => {
-  it('returns article ids', () => {
-    expect(getCollectionArticleQueryString(collectionWithDraftArticles)).toBe(
-      'draft'
-    );
+  it('returns draft article ids', () => {
+    expect(
+      getCollectionArticleQueryString(collectionWithArticles, 'draft')
+    ).toBe('draft');
+  });
+  it('returns live article ids if draft is missing', () => {
+    expect(
+      getCollectionArticleQueryString(collectionWithNoDraftArticles, 'draft')
+    ).toBe('live');
+  });
+  it('returns live article ids', () => {
+    expect(
+      getCollectionArticleQueryString(collectionWithArticles, 'live')
+    ).toBe('live');
   });
   it('filters out snap links', () => {
-    expect(getCollectionArticleQueryString(collectionWithSnapArticles)).toBe(
-      'draft'
-    );
+    expect(
+      getCollectionArticleQueryString(collectionWithSnapArticles, 'draft')
+    ).toBe('draft');
   });
 });

--- a/client-v2/src/util/collectionUtils.js
+++ b/client-v2/src/util/collectionUtils.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { frontStages } from '../constants/fronts';
 import type { Collection } from '../types/Collection';
 import type { Article } from '../types/Article';
 
@@ -11,7 +12,7 @@ const getArticleIds = (
     return [];
   }
 
-  if (stage === 'draft') {
+  if (stage === frontStages.draft) {
     // Draft and live versions of the collection are in sync
     if (!collection.draft) {
       return collection.live || [];

--- a/client-v2/src/util/collectionUtils.js
+++ b/client-v2/src/util/collectionUtils.js
@@ -3,25 +3,35 @@
 import type { Collection } from '../types/Collection';
 import type { Article } from '../types/Article';
 
-const getDraftArticles = (collection: Collection): Array<Article> => {
+const getArticleIds = (
+  collection: Collection,
+  stage: string
+): Array<Article> => {
   if (!collection) {
     return [];
   }
 
-  // Draft and live versions of the collection are in sync
-  if (!collection.draft) {
-    return collection.live || [];
+  if (stage === 'draft') {
+    // Draft and live versions of the collection are in sync
+    if (!collection.draft) {
+      return collection.live || [];
+    }
+
+    return collection.draft;
   }
 
-  return collection.draft;
+  return collection.live;
 };
 
-const getCollectionArticleQueryString = (collection: Collection): string => {
-  const articles = getDraftArticles(collection);
+const getCollectionArticleQueryString = (
+  collection: Collection,
+  stage: string
+): string => {
+  const articles = getArticleIds(collection, stage);
   return articles
     .map(article => article.id)
     .filter(id => !id.match(/^snap/))
     .join(',');
 };
 
-export { getCollectionArticleQueryString, getDraftArticles };
+export { getCollectionArticleQueryString };


### PR DESCRIPTION
Allows for toggling between live and preview collections on a front.
Also uses selectors for getting collections and articles as this is what we should be doing anyway.