### PR TITLE
Fix panda fetch

### DIFF
--- a/client-v2/src/services/pandaFetch.js
+++ b/client-v2/src/services/pandaFetch.js
@@ -5,20 +5,20 @@ import { reEstablishSession } from 'panda-session';
 const reauthUrl = '/auth';
 const pandaFetch = (
   url: string,
-  body: Object = {},
+  options: Object = {},
   count: number = 0
 ): Promise<Response> =>
   new Promise(
     async (resolve: (r: Response) => mixed, reject: (r: Response) => mixed) => {
       const res = await fetch(url, {
-        body,
+        ...options,
         credentials: 'same-origin'
       });
 
       if (res.status === 419 && count < 1) {
         await reEstablishSession(reauthUrl, 5000);
         try {
-          const res2 = await pandaFetch(url, body, count + 1);
+          const res2 = await pandaFetch(url, options, count + 1);
           return resolve(res2);
         } catch (e) {
           return reject(e);


### PR DESCRIPTION
Fix bad object creation - we're adding the `options` (formally `body`) object to the `body` key in the fetch call - hence things like `method` and `credentials` were being passed in the body! Think this was my doing ...