### PR TITLE
Fix 'also on' not appearing for commercial collections used elsewhere, and improve the messaging.

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -723,7 +723,6 @@ h1 {
 .list-header {
     color: #999999;
     padding: 5px 8px 0 0;
-    height: 34px;
     overflow: hidden;
     position: relative;
     margin-bottom: 8px;
@@ -2053,13 +2052,12 @@ ol.search_list > li::before {
 
 span.also a{
   color: red;
-  font-size: 20px;
+  font-size: 16px;
 }
 
 .also {
     margin: 6px;
     line-height: 24px;
-    white-space: nowrap;
 }
 .autocompleter.dropdown > ul {
     padding: 0;

--- a/public/src/js/models/base-model.js
+++ b/public/src/js/models/base-model.js
@@ -27,6 +27,7 @@ export default class BaseModel extends BaseClass {
         this.message = message;
         this.state = ko.observable();
         this.frontsList = ko.observableArray();
+        this.allFrontsList = ko.observableArray();
         this.frontsMap = ko.observable();
         this.switches = ko.observable();
         this.permissions = ko.observable();
@@ -76,7 +77,7 @@ export default class BaseModel extends BaseClass {
     }
 
     update(res) {
-        var frontsList = [], frontsMap = {};
+        var frontsList = [], allFrontsList = [], frontsMap = {};
 
         for (let front in res.config.fronts) {
             const frontConfig = res.config.fronts[front];
@@ -84,9 +85,11 @@ export default class BaseModel extends BaseClass {
             if (frontConfig.priority === this.priority) {
                 frontsList.push(frontConfigWithId);
             }
+            allFrontsList.push(frontConfigWithId);
             frontsMap[front] = frontConfigWithId;
         }
         this.frontsList(_.sortBy(frontsList, 'id'));
+        this.allFrontsList(_.sortBy(allFrontsList, 'id'));
         this.frontsMap(frontsMap);
 
         if (!_.isEqual(this.switches(), res.defaults.switches)) {

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -33,6 +33,8 @@ export default class Collection extends BaseClass {
 
         this.alsoOn = opts.alsoOn || [];
         this.alsoOnHasDifferentPriority = opts.alsoOn.some(also => also.isDifferentPriority)
+        this.alsoOnMeritsWarning = this.alsoOnHasDifferentPriority
+            && this.alsoOn.some(also => also.priority === 'commercial')
 
         this.isDynamic = opts.type.indexOf('dynamic/') === 0;
 

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -21,7 +21,6 @@ import isPlatformSpecificCollection from 'utils/platform';
 export default class Collection extends BaseClass {
     constructor(opts = {}) {
         super();
-
         if (!opts.id) { return; }
 
         this.id = opts.id;
@@ -33,6 +32,7 @@ export default class Collection extends BaseClass {
         this.groups = this.createGroups(opts.groups);
 
         this.alsoOn = opts.alsoOn || [];
+        this.alsoOnHasDifferentPriority = opts.alsoOn.some(also => also.isDifferentPriority)
 
         this.isDynamic = opts.type.indexOf('dynamic/') === 0;
 

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -32,9 +32,9 @@ export default class Collection extends BaseClass {
         this.groups = this.createGroups(opts.groups);
 
         this.alsoOn = opts.alsoOn || [];
-        this.alsoOnHasDifferentPriority = opts.alsoOn.some(also => also.isDifferentPriority)
+        this.alsoOnHasDifferentPriority = opts.alsoOn.some(also => also.isDifferentPriority);
         this.alsoOnMeritsWarning = this.alsoOnHasDifferentPriority
-            && this.alsoOn.some(also => also.priority === 'commercial')
+            && this.alsoOn.some(also => also.priority === 'commercial');
 
         this.isDynamic = opts.type.indexOf('dynamic/') === 0;
 

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -32,8 +32,8 @@ export default class Collection extends BaseClass {
         this.groups = this.createGroups(opts.groups);
 
         this.alsoOn = opts.alsoOn || [];
-        this.alsoOnDedupedPriorities = _.uniq(opts.alsoOn.map(front => front.priority));
-        this.alsoOnHasDifferentPriority = opts.alsoOn.some(front => front.isDifferentPriority);
+        this.alsoOnDedupedPriorities = _.uniq(this.alsoOn.map(front => front.priority));
+        this.alsoOnHasDifferentPriority = this.alsoOn.some(front => front.isDifferentPriority);
         this.alsoOnMeritsWarning = this.alsoOnHasDifferentPriority
             && this.alsoOn.some(front => front.priority === 'commercial');
 

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -32,9 +32,10 @@ export default class Collection extends BaseClass {
         this.groups = this.createGroups(opts.groups);
 
         this.alsoOn = opts.alsoOn || [];
-        this.alsoOnHasDifferentPriority = opts.alsoOn.some(also => also.isDifferentPriority);
+        this.alsoOnDedupedPriorities = _.uniq(opts.alsoOn.map(front => front.priority));
+        this.alsoOnHasDifferentPriority = opts.alsoOn.some(front => front.isDifferentPriority);
         this.alsoOnMeritsWarning = this.alsoOnHasDifferentPriority
-            && this.alsoOn.some(also => also.priority === 'commercial');
+            && this.alsoOn.some(front => front.priority === 'commercial');
 
         this.isDynamic = opts.type.indexOf('dynamic/') === 0;
 

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -38,7 +38,13 @@
         </span>
 
         <span class="also" data-bind="if: alsoOn.length">
-            <a class="alsoOnToggle" data-bind="click: alsoOnToggle">also on&hellip;</a>
+            <a class="alsoOnToggle" data-bind="click: alsoOnToggle">also on&hellip;
+                <span data-bind="if: alsoOnHasDifferentPriority">
+                    <span data-bind="foreach: alsoOn">
+                         <span data-bind="text: priority" />
+                    </span>
+                </span>
+            </a>
         </span>
 
         <span class="list-header__timings" data-bind="

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -47,8 +47,8 @@
                     <span data-bind="if: !alsoOnMeritsWarning">
                         Also on
                     </span>
-                    <span data-bind="foreach: alsoOn">
-                        <span data-bind="text: priority" /><span data-bind="if: $index() < $parent.alsoOn.length - 1">, </span>
+                    <span data-bind="foreach: alsoOnDedupedPriorities">
+                        <span data-bind="text: $data" /><span data-bind="if: $index() < $parent.alsoOnDedupedPriorities.length - 1">, </span>
                     </span>
                     fronts.
                 </span>

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -37,12 +37,20 @@
             (<span class="non-zero">updating...</span>)
         </span>
 
-        <span class="also" data-bind="if: alsoOn.length">
-            <a class="alsoOnToggle" data-bind="click: alsoOnToggle">also on&hellip;
+        <span class="also" data-bind="if: alsoOn && alsoOn.length">
+            <a class="alsoOnToggle" data-bind="click: alsoOnToggle">
+                <span data-bind="if: !alsoOnHasDifferentPriority">Also on&hellip;</span>
                 <span data-bind="if: alsoOnHasDifferentPriority">
-                    <span data-bind="foreach: alsoOn">
-                         <span data-bind="text: priority" />
+                    <span data-bind="if: alsoOnMeritsWarning">
+                        Careful: also on
                     </span>
+                    <span data-bind="if: !alsoOnMeritsWarning">
+                        Also on
+                    </span>
+                    <span data-bind="foreach: alsoOn">
+                        <span data-bind="text: priority" /><span data-bind="if: $index() < $parent.alsoOn.length - 1">, </span>
+                    </span>
+                    fronts.
                 </span>
             </a>
         </span>
@@ -76,7 +84,7 @@
         <ul data-bind="foreach: alsoOn">
             <li><a class="list-header__also-on" data-bind="
                 click: $parent.front.setFront,
-                text: $data"></a>
+                text: $data.id"></a>
             </li>
         </ul>
     </div>

--- a/public/src/js/widgets/columns/fronts.js
+++ b/public/src/js/widgets/columns/fronts.js
@@ -150,7 +150,6 @@ export default class Front extends ColumnWidget {
         }
         const allCollections = this.baseModel.state().config.collections;
         const front = this.baseModel.frontsMap()[frontId] || {};
-
         this.isHidden(front.isHidden);
         this.allExpanded(true);
         this.collections(
@@ -161,9 +160,13 @@ export default class Front extends ColumnWidget {
                     allCollections[id],
                     {
                         id: id,
-                        alsoOn: _.reduce(this.baseModel.frontsList(), (alsoOn, front) => {
-                            if (front.id !== frontId && (front.collections || []).indexOf(id) > -1) {
-                                alsoOn.push(front.id);
+                        alsoOn: _.reduce(this.baseModel.allFrontsList(), (alsoOn, frontFromList) => {
+                            if (frontFromList.id !== frontId && (frontFromList.collections || []).indexOf(id) > -1) {
+                                alsoOn.push({
+                                    id: frontFromList.id,
+                                    priority: frontFromList.priority,
+                                    isDifferentPriority: frontFromList.priority !== front.priority
+                                });
                             }
                             return alsoOn;
                         }, []),

--- a/public/src/js/widgets/columns/fronts.js
+++ b/public/src/js/widgets/columns/fronts.js
@@ -164,7 +164,7 @@ export default class Front extends ColumnWidget {
                             if (frontFromList.id !== frontId && (frontFromList.collections || []).indexOf(id) > -1) {
                                 alsoOn.push({
                                     id: frontFromList.id,
-                                    priority: frontFromList.priority,
+                                    priority: frontFromList.priority || 'editorial',
                                     isDifferentPriority: frontFromList.priority !== front.priority
                                 });
                             }

--- a/public/test/spec/collections.front.spec.js
+++ b/public/test/spec/collections.front.spec.js
@@ -27,6 +27,7 @@ describe('Front', function () {
         this.model = {
             identity: { email: 'fabio.crisci@theguardian.com' },
             frontsList: ko.observableArray(_.values(fronts)),
+            allFrontsList: ko.observableArray(_.values(fronts)),
             frontsMap: ko.observable(fronts),
             testColumn: {
                 config: ko.observable(),


### PR DESCRIPTION
'Also on' now appears when collections that appear in a front with a commercial priority are used elsewhere.

The 'Also on' notice is now followed by a list of the priorities of other fronts that use that collection.

If users are working on a collection that also appears in a front with a commercial priority, they receive a 'Careful: ' warning, too.