### PR TITLE
Add d option to Webpack development start up 

### DIFF
--- a/client-v2/config/webpack.config.dev.js
+++ b/client-v2/config/webpack.config.dev.js
@@ -4,6 +4,7 @@ import common from './webpack.config.common.js';
 export default {
   ...common,
   mode: 'development',
+  devtool: 'cheap-module-eval-source-map',
   devServer: {
     contentBase: path.join(__dirname, '../'),
     compress: true,


### PR DESCRIPTION
My Webpack knowledge is stale, so feel free to reject for alternatives, but turning on sourcemaps with `-d` is a shortcut for `--debug --devtool cheap-module-eval-source-map --output-pathinfo`

> -d is a shortcut for --debug --devtool source-map --output-pathinfo where:

> - --debug activates debug mode for loaders and its behaviour depends on each loader. You can activate it via param { debug: true } in your webpack.config.js
> - --devtool is basically allow to select type of sourcemaps for your files via param { devtool: "sourcemap" } or if you use webpack@2: { devtool: 'eval-cheap-module-source-map' }(See all options)
> - --output-pathinfo will write original filepath into webpack's requires like this: __webpack_require__(/* ./src/containers/App/App.js */15). 
You can activate it via: { output: { pathinfo: true } }

## Before

![before](https://user-images.githubusercontent.com/638051/39637774-ebaebfc4-4fbb-11e8-9e8f-fcb38b4945fe.gif)


## After
![after](https://user-images.githubusercontent.com/638051/39637783-eee03cc2-4fbb-11e8-846e-1fa666fcc5da.gif)

Longest description for a 2 char change.