### PR TITLE
Display draft and take down labels

### DIFF
--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -64,7 +64,9 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     if (text) {
       return JSON.parse(text).response.results.map(result => ({
         headline: result.webTitle,
-        id: result.fields.internalPageCode
+        id: result.fields.internalPageCode,
+        isLive: result.fields.isLive === 'true',
+        firstPublicationDate: result.fields.firstPublicationDate
       }));
     }
     return [];
@@ -74,15 +76,15 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     .filter(id => !id.match(/^snap/))
     .join(',');
 
-  const liveArticlePromise = pandaFetch(
-    `/api/live/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode`,
+  const articlePromise = pandaFetch(
+    `/api/preview/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate`,
     {
       method: 'get',
       credentials: 'same-origin'
     }
   );
 
-  return liveArticlePromise
+  return articlePromise
     .then(response => response.text())
     .then(articles =>
       Promise.resolve([...parseArticleListFromResponse(articles)])

--- a/client-v2/src/shared/components/Article.js
+++ b/client-v2/src/shared/components/Article.js
@@ -28,6 +28,11 @@ const ArticleComponent = ({ article }: ComponentProps) =>
   article && (
     <ArticleContainer key={article.headline}>
       {article.headline}
+      <div>
+        {!article.isLive &&
+          (article.firstPublicationDate ? 'Taken Down' : 'Draft')}
+      </div>
+
       {article.supporting && (
         <div style={{ paddingLeft: '10px', borderLeft: '3px solid blue' }}>
           <h4>Supporting</h4>

--- a/client-v2/src/shared/types/ExternalArticle.js
+++ b/client-v2/src/shared/types/ExternalArticle.js
@@ -2,7 +2,9 @@
 
 type ExternalArticle = {
   id: string,
-  headline: string
+  headline: string,
+  isLive: boolean,
+  firstPublicationDate?: string
 };
 
 export type { ExternalArticle };

--- a/client-v2/src/types/Article.js
+++ b/client-v2/src/types/Article.js
@@ -9,6 +9,8 @@ type Article = {
   id: string,
   frontPublicationDate: number,
   publishedBy: string,
+  isLive: boolean,
+  firstPublicationDate?: string,
   meta: Meta
 };
 


### PR DESCRIPTION
To accomplish replicating the current behaviour of the fronts tool: 

- We fetch all external articles from preview capi
- We also fetch `isLive` and `firstPublicationDate` fields from capi
- We use this info to determine if we need to display draft or taken down labels

This approach is not entirely correct as we might end up displaying unpublished changes in live articles without flagging this. We need to speak with ux and find out if we can keep the old, slightly faulty logic in the tool in the future. Should be ok for now though! 