### PR TITLE
Show is hidden warning

### DIFF
--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -72,6 +72,8 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
           ))}
         </Row>
         {this.props.selectedFront &&
+          this.props.selectedFront.isHidden && <div>This front is hidden</div>}
+        {this.props.selectedFront &&
           this.props.selectedFront.collections.map(id => (
             <Row key={id}>
               <Collection id={id} stage={this.state.browsingStage} />


### PR DESCRIPTION
This ended up being a super short pr as all the info we needed to display the Front is hidden warning was already in place but at least it's there now.