### PR TITLE
New collection endpoints

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -64,15 +64,14 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val views = new ViewsController(acl, assetsManager, isDev, encryption, this)
   val pressController = new PressController(awsEndpoints, this)
   val v2App = new V2App(isDev, acl, this)
-
+  val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, this)
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
     allowedOrigins = Origins.Matching(Set(config.environment.applicationUrl))
   )
 
   override lazy val assets: Assets = new controllers.Assets(loggingHttpErrorHandler, assetsMetadata)
-  val router: Router = new Routes(loggingHttpErrorHandler, status, pandaAuth, v2Assets, uncachedAssets, views, faciaTool,
-    pressController, defaults, faciaCapiProxy, thumbnail, front, collection, storiesVisible, vanityRedirects,
+  val router: Router = new Routes(loggingHttpErrorHandler, status, pandaAuth, v2Assets, uncachedAssets, views, faciaTool, pressController, faciaToolV2, defaults, faciaCapiProxy, thumbnail, front, collection, storiesVisible, vanityRedirects,
     troubleshoot, v2App)
 
   override lazy val httpFilters = Seq(

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -33,17 +33,15 @@ class FaciaToolV2Controller(
       case Some(update) => {
           val identity = request.user
 
-          val shouldUpdateLive: Boolean = update.isLive
-
           updateActions.v2UpdateCollection(update.id, update.collection, identity)
 
           faciaPress.press(PressCommand(
             Set(update.id),
-            live = update.isLive,
-            draft = (update.collection.draft.isEmpty && shouldUpdateLive) || !shouldUpdateLive)
-          )
+            live = false,
+            draft = true
+          ))
 
-          structuredLogger.putLog(LogUpdate(V2CollectionUpdate(update.id, update.updateType), identity.email))
+          structuredLogger.putLog(LogUpdate(V2CollectionUpdate(update.id, update.collection), identity.email))
 
           Ok(Json.toJson(update.collection)).as("application/json")
 

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import frontsapi.model.UpdateActions
+import logging.Logging
+import metrics.FaciaToolMetrics
+import model.Cached
+import permissions.BreakingNewsEditCollectionsCheck
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, AnyContent}
+import services._
+import updates._
+import util.Acl
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class FaciaToolV2Controller(
+                           val acl: Acl,
+                           val structuredLogger: StructuredLogger,
+                           val faciaPress: FaciaPress,
+                           val updateActions: UpdateActions,
+                           val deps: BaseFaciaControllerComponents
+                         )(implicit ec: ExecutionContext)
+  extends BaseFaciaController(deps) with Logging {
+
+
+  def collectionEdits() = APIAuthAction { implicit request =>
+
+    FaciaToolMetrics.ApiUsageCount.increment()
+
+    val v2Update: Option[V2Update] = request.body.asJson.flatMap(jsValue => jsValue.asOpt[V2Update])
+    v2Update match {
+      case Some(update) => {
+          val identity = request.user
+
+          val shouldUpdateLive: Boolean = update.isLive
+
+          updateActions.v2UpdateCollection(update.id, update.collection, identity)
+
+          faciaPress.press(PressCommand(
+            Set(update.id),
+            live = update.isLive,
+            draft = (update.collection.draft.isEmpty && shouldUpdateLive) || !shouldUpdateLive)
+          )
+
+          structuredLogger.putLog(LogUpdate(V2CollectionUpdate(update.id, update.updateType), identity.email))
+
+          Ok(Json.toJson(update.collection)).as("application/json")
+
+      }
+      case None => BadRequest
+    }
+
+  }
+}
+

--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -145,8 +145,10 @@ trait UpdateActionsTrait {
   }
 
   def v2UpdateCollection(id: String, collection: CollectionJson, identity: User): CollectionJson = {
-    putCollectionJson(id, collection)
-    v2ArchiveUpdateBlock(id, collection, identity)
+    val collectionWithGroupsRemoved = removeGroupIfNoLongerGrouped(id, collection)
+    val prunedCollection = pruneBlock(collectionWithGroupsRemoved)
+    putCollectionJson(id, prunedCollection)
+    v2ArchiveUpdateBlock(id, prunedCollection, identity)
   }
 
   def updateCollectionList(id: String, update: UpdateList, identity: User): Future[Option[CollectionJson]] = {

--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -52,6 +52,14 @@ class FaciaApiIO(val frontsApi: FrontsApi, val s3FrontsApi: S3FrontsApi) extends
     }
   }
 
+  def v2Archive(id: String, collectionJson: CollectionJson, identity: User): Unit = {
+    Json.toJson(collectionJson).transform[JsObject](Reads.JsObjectReads) match {
+      case JsSuccess(result, _) =>
+        s3FrontsApi.archive(id, Json.prettyPrint(result), identity)
+      case JsError(errors) => throw new Exception(s"Could not archive $id: $errors")
+    }
+  }
+
   def putMasterConfig(config: ConfigJson): Option[ConfigJson] = {
     Try(s3FrontsApi.putMasterConfig(Json.prettyPrint(Json.toJson(config)))).map(_ => config).toOption
   }

--- a/app/updates/UpdateMessage.scala
+++ b/app/updates/UpdateMessage.scala
@@ -95,6 +95,10 @@ case class ArchiveUpdate(id: String) extends UpdateMessage {
   def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
 }
 
+case class V2CollectionUpdate(id: String, updateType: String) extends UpdateMessage {
+  def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
+}
+
 /* Macro - Watch out, this needs to be after the case classes */
 object UpdateMessage {
   implicit val format = derived.flat.oformat[UpdateMessage]((__ \ "type").format[String])

--- a/app/updates/UpdateMessage.scala
+++ b/app/updates/UpdateMessage.scala
@@ -1,6 +1,6 @@
 package updates
 
-import com.gu.facia.client.models.{CollectionConfigJson, FrontJson, TrailMetaData}
+import com.gu.facia.client.models.{CollectionJson, CollectionConfigJson, FrontJson, TrailMetaData}
 import julienrf.json.derived
 import org.joda.time.DateTime
 import play.api.libs.json._
@@ -95,7 +95,7 @@ case class ArchiveUpdate(id: String) extends UpdateMessage {
   def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
 }
 
-case class V2CollectionUpdate(id: String, updateType: String) extends UpdateMessage {
+case class V2CollectionUpdate(id: String, collection: CollectionJson) extends UpdateMessage {
   def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
 }
 

--- a/app/updates/V2Update.scala
+++ b/app/updates/V2Update.scala
@@ -3,7 +3,7 @@ package updates
 import com.gu.facia.client.models.CollectionJson
 import play.api.libs.json.{Format, Json}
 
-case class V2Update (id: String, updateType: String, collection: CollectionJson, isLive: Boolean)
+case class V2Update (id: String, collection: CollectionJson)
 
 object V2Update {
   implicit val jsonFormat: Format[V2Update] = Json.format[V2Update]

--- a/app/updates/V2Update.scala
+++ b/app/updates/V2Update.scala
@@ -1,0 +1,11 @@
+package updates
+
+import com.gu.facia.client.models.CollectionJson
+import play.api.libs.json.{Format, Json}
+
+case class V2Update (id: String, updateType: String, collection: CollectionJson, isLive: Boolean)
+
+object V2Update {
+  implicit val jsonFormat: Format[V2Update] = Json.format[V2Update]
+}
+

--- a/conf/routes
+++ b/conf/routes
@@ -44,6 +44,7 @@ GET         /front/lastmodifiedstatus/:stage/*path   controllers.PressController
 
 GET         /collection/*collectionId                controllers.FaciaToolController.getCollection(collectionId)
 POST        /edits                                   controllers.FaciaToolController.collectionEdits
+POST        /v2Edits                                 controllers.FaciaToolV2Controller.collectionEdits
 GET         /config                                  controllers.FaciaToolController.getConfig
 GET         /defaults                                controllers.DefaultsController.configuration()
 GET         /metadata                                controllers.FaciaToolController.getMetadata()


### PR DESCRIPTION
New endpoint now prunes unnecessary metadata on save. We don't need to worry about the weird live/draft format behaviour if we don't allow edits to live collections - the publish endpoint will take care of all of this.