### PR TITLE
Update notification client

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -119,16 +119,16 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
     }
   }
 
-  private def parseTopic(topic: Option[String]): Set[Topic] = {
+  private def parseTopic(topic: Option[String]): List[Topic] = {
     topic match {
-      case Some("global") => Set(BreakingNewsUk, BreakingNewsUs, BreakingNewsAu, BreakingNewsInternational)
-      case Some("au") => Set(BreakingNewsAu)
-      case Some("international") => Set(BreakingNewsInternational)
-      case Some("uk") => Set(BreakingNewsUk)
-      case Some("us") => Set(BreakingNewsUs)
-      case Some("sport") => Set(BreakingNewsSport)
+      case Some("global") => List(BreakingNewsUk, BreakingNewsUs, BreakingNewsAu, BreakingNewsInternational)
+      case Some("au") => List(BreakingNewsAu)
+      case Some("international") => List(BreakingNewsInternational)
+      case Some("uk") => List(BreakingNewsUk)
+      case Some("us") => List(BreakingNewsUs)
+      case Some("sport") => List(BreakingNewsSport)
       case Some("") => throw new InvalidParameterException(s"Invalid empty string topic")
-      case Some(notYetImplementedTopic) => Set(Topic(Breaking, notYetImplementedTopic))
+      case Some(notYetImplementedTopic) => List(Topic(Breaking, notYetImplementedTopic))
       case None => throw new InvalidParameterException(s"Invalid empty topic")
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "0.8",
     "com.gu" %% "fapi-client-play26" % "2.5.4",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "mobile-notifications-client" % "1.1",
+    "com.gu" %% "mobile-notifications-client" % "1.2",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.1",
 
     "io.circe" %% "circe-core" % circeVersion,


### PR DESCRIPTION
It provides the necessary changes in order to migrate the notificationservice to Firebase. The Breaking news are now sent in a loop though it is transparent as the interface remain the same.

Topics are now a `List` as it needs to be ordered. This has no impact on breaking news but makes sense for other type of notifications (content)

 - [x] Test on CODE