### PR TITLE
Access permission

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -3,18 +3,17 @@ import config.{CustomGzipFilter, UpdateManager}
 import controllers._
 import frontsapi.model.UpdateActions
 import metrics.CloudWatch
-import permissions.Permissions
 import play.api.ApplicationLoader.Context
 import play.api.Mode
 import play.api.routing.Router
-import play.filters.cors.CORSConfig.Origins
 import play.filters.cors.CORSConfig
+import play.filters.cors.CORSConfig.Origins
 import router.Routes
 import services._
 import slices.{Containers, FixedContainers}
 import thumbnails.ContainerThumbnails
 import tools.FaciaApiIO
-import updates.{StructuredLogger, BreakingNewsUpdate}
+import updates.{BreakingNewsUpdate, StructuredLogger}
 import util.{Acl, Encryption}
 
 class AppComponents(context: Context) extends BaseFaciaControllerComponents(context) {
@@ -23,7 +22,6 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val isDev: Boolean = context.environment.mode == Mode.Dev
   val config = new ApplicationConfiguration(configuration, isProd)
   val awsEndpoints = new AwsEndpoints(config)
-  val permissions = new Permissions(config)
   val acl = new Acl(permissions)
   val frontsApi = new FrontsApi(config, awsEndpoints)
   val s3FrontsApi = new S3FrontsApi(config, isTest, awsEndpoints)

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -1,17 +1,21 @@
 package controllers
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.gu.editorial.permissions.client.PermissionGranted
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
 import conf.ApplicationConfiguration
+import permissions.Permissions
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{BaseController, ControllerComponents, RequestHeader, Result}
 import play.api.{BuiltInComponentsFromContext, Logger}
 import play.filters.cors.CORSComponents
+import switchboard.SwitchManager
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 abstract class BaseFaciaControllerComponents(context: Context) extends BuiltInComponentsFromContext(context) with AhcWSComponents with AssetsComponents with CORSComponents {
 
@@ -20,6 +24,7 @@ abstract class BaseFaciaControllerComponents(context: Context) extends BuiltInCo
   lazy val panDomainSettings: PanDomainAuthSettingsRefresher =
     new PanDomainAuthSettingsRefresher(config.pandomain.domain, config.pandomain.service, actorSystem, config.aws.cmsFrontsAccountCredentials)
 
+  lazy val permissions = new Permissions(config)
 }
 
 abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends BaseController with AuthActions {
@@ -34,13 +39,20 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
 
   override def authCallbackUrl: String = config.pandomain.host  + "/oauthCallback"
 
-  private def userInGroups(authedUser: AuthenticatedUser): Boolean = groupChecker.exists(checker =>
-    checker.checkGroups(authedUser, config.pandomain.userGroups).fold(
-      error => {
-        Logger.warn(error)
-        false
-      }, identity)
-  )
+  private def userInGroups(authedUser: AuthenticatedUser): Boolean = {
+    if(SwitchManager.getStatus("permissions_access")) {
+      // TODO MRB: avoid await with new permissions library
+      Await.result(deps.permissions.get(Permissions.FrontsAccess), Duration.Inf) == PermissionGranted
+    } else {
+      groupChecker.exists(checker =>
+        checker.checkGroups(authedUser, config.pandomain.userGroups).fold(
+          error => {
+            Logger.warn(error)
+            false
+          }, identity)
+      )
+    }
+  }
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = PanDomain.guardianValidation(authedUser) && userInGroups(authedUser)
 
@@ -55,7 +67,7 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
     if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor)
       s"${claimedAuth.user.email} is not valid for use with the Fronts Tool as you need to have two factor authentication enabled." +
         s" Please contact Central Production by emailing core.central.production@guardian.co.uk and request access to The Fronts Tool."
-    else if (!userInGroups(claimedAuth)) s"${claimedAuth.user.email} is not a member of required google groups. Please contact Central Production by emailing core.central.production@guardian.co.uk"
+    else if (!userInGroups(claimedAuth)) s"${claimedAuth.user.email} does not have permission to access the Fronts tool. Please contact Central Production by emailing core.central.production@guardian.co.uk"
 
     else s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
 

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.util.Locale
+
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
@@ -22,7 +24,7 @@ abstract class BaseFaciaControllerComponents(context: Context) extends BuiltInCo
     new PanDomainAuthSettingsRefresher(config.pandomain.domain, config.pandomain.service, actorSystem, config.aws.cmsFrontsAccountCredentials)
 
   lazy val permissions = PermissionsProvider(PermissionsConfig(
-    stage = config.environment.stage,
+    stage = config.environment.stage.toUpperCase(Locale.UK),
     region = config.aws.region,
     awsCredentials = config.aws.cmsFrontsAccountCredentials
   ))
@@ -70,7 +72,7 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
 
   override def invalidUserMessage(claimedAuth: AuthenticatedUser): String = {
     if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor)
-      s"${claimedAuth.user.email} is not valid for use with the Fronts Tool as you need to have two factor authentication enabled." +
+      s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to have two factor authentication enabled and be granted permission." +
         s" Please contact Central Production by emailing core.central.production@guardian.co.uk and request access to The Fronts Tool."
     else if (!userInGroups(claimedAuth)) s"${claimedAuth.user.email} does not have permission to access the Fronts tool. Please contact Central Production by emailing core.central.production@guardian.co.uk"
 

--- a/app/controllers/CollectionController.scala
+++ b/app/controllers/CollectionController.scala
@@ -29,7 +29,7 @@ case class CreateCollectionResponse(id: String)
 class CollectionController(val acl: Acl, val structuredLogger: StructuredLogger,
                            val updateManager: UpdateManager, val press: Press, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with Logging {
-  def create = (APIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
+  def create = (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
     request.body.read[CollectionRequest] match {
       case Some(CollectionRequest(frontIds, collection)) =>
 
@@ -43,7 +43,7 @@ class CollectionController(val acl: Acl, val structuredLogger: StructuredLogger,
     }
   }
 
-  def update(collectionId: String) =  (APIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
+  def update(collectionId: String) =  (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
     request.body.read[CollectionRequest] match {
       case Some(CollectionRequest(frontIds, collection)) =>
 

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -33,7 +33,7 @@ case class Defaults(
 )
 
 class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def configuration = APIAuthAction { implicit request =>
+  def configuration = AccessAPIAuthAction { implicit request =>
     val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(request.user.email)
     val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(request.user.email)
 

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -7,8 +7,6 @@ import play.api.libs.json.{JsValue, Json}
 import switchboard.SwitchManager
 import util.{Acl, AclJson}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 object Defaults {
   implicit val jsonFormat = Json.writes[Defaults]
 }
@@ -35,39 +33,36 @@ case class Defaults(
 )
 
 class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def configuration = APIAuthAction.async { implicit request =>
+  def configuration = APIAuthAction { implicit request =>
+    val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(request.user.email)
+    val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(request.user.email)
 
-    for {
-      hasBreakingNews <- acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(request.user.email)
-      hasConfigureFronts <- acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(request.user.email)
-    } yield {
-      val acls = AclJson(
-        fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
-        permissions = Map("configure-config" -> hasConfigureFronts)
-      )
+    val acls = AclJson(
+      fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
+      permissions = Map("configure-config" -> hasConfigureFronts)
+    )
 
-      Cached(60) {
-        Ok(Json.toJson(Defaults(
-          isDev,
-          config.environment.stage,
-          Seq("uk", "us", "au"),
-          request.user.email,
-          request.user.avatarUrl,
-          request.user.firstName,
-          request.user.lastName,
-          config.sentry.publicDSN,
-          config.media.baseUrl.get,
-          config.media.apiUrl,
-          SwitchManager.getSwitchesAsJson(),
-          acls,
-          config.facia.collectionCap,
-          config.facia.navListCap,
-          config.facia.navListType,
-          Metadata.tags.map{
-            case (_, meta) => meta
-          }
-        )))
-      }
+    Cached(60) {
+      Ok(Json.toJson(Defaults(
+        isDev,
+        config.environment.stage,
+        Seq("uk", "us", "au"),
+        request.user.email,
+        request.user.avatarUrl,
+        request.user.firstName,
+        request.user.lastName,
+        config.sentry.publicDSN,
+        config.media.baseUrl.get,
+        config.media.apiUrl,
+        SwitchManager.getSwitchesAsJson(),
+        acls,
+        config.facia.collectionCap,
+        config.facia.navListCap,
+        config.facia.navListType,
+        Metadata.tags.map{
+          case (_, meta) => meta
+        }
+      )))
     }
   }
 }

--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -35,7 +35,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
   private def getPreviewHeaders(url: String): Seq[(String,String)] =
     previewSigner.addIAMHeaders(headers = Map.empty, URI.create(url)).toSeq
 
-  def capiPreview(path: String) = APIAuthAction.async { request =>
+  def capiPreview(path: String) = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val queryString = IAMEncoder.encodeParams(request.queryString)
 
@@ -54,7 +54,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def capiLive(path: String) = APIAuthAction.async { request =>
+  def capiLive(path: String) = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val queryString = request.queryString.filter(_._2.exists(_.nonEmpty)).map { p =>
        "%s=%s".format(p._1, p._2.head.urlEncoded)
@@ -71,7 +71,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def http(url: String) = APIAuthAction.async { request =>
+  def http(url: String) = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
     wsClient.url(url).get().map { response =>
@@ -81,7 +81,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def json(url: String) = APIAuthAction.async { request =>
+  def json(url: String) = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
     wsClient.url(url).withHttpHeaders(getPreviewHeaders(url): _*).get().map { response =>
@@ -91,7 +91,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def ophan(path: String) = APIAuthAction.async { request =>
+  def ophan(path: String) = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val paths = request.queryString.get("path").map(_.mkString("path=", "&path=", "")).getOrElse("")
     val queryString = request.queryString.filterNot(_._1 == "path").filter(_._2.exists(_.nonEmpty)).map { p =>

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -3,15 +3,12 @@ package controllers
 import frontsapi.model.UpdateActions
 import logging.Logging
 import metrics.FaciaToolMetrics
-import model.Cached
-import permissions.BreakingNewsEditCollectionsCheck
-import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.{Action, AnyContent}
+import play.api.libs.json.Json
 import services._
 import updates._
 import util.Acl
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 
 class FaciaToolV2Controller(
@@ -24,7 +21,7 @@ class FaciaToolV2Controller(
   extends BaseFaciaController(deps) with Logging {
 
 
-  def collectionEdits() = APIAuthAction { implicit request =>
+  def collectionEdits() = AccessAPIAuthAction { implicit request =>
 
     FaciaToolMetrics.ApiUsageCount.increment()
 

--- a/app/controllers/FrontController.scala
+++ b/app/controllers/FrontController.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 class FrontController(val acl: Acl, val structuredLogger: StructuredLogger,
                       val updateManager: UpdateManager, val press: Press, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with Logging {
-  def create = (APIAuthAction andThen new ConfigPermissionCheck(acl)) { request =>
+  def create = (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)) { request =>
     request.body.read[CreateFront] match {
       case Some(createFrontRequest) =>
         val identity = request.user
@@ -27,7 +27,7 @@ class FrontController(val acl: Acl, val structuredLogger: StructuredLogger,
     }
   }
 
-  def update(frontId: String) = (APIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
+  def update(frontId: String) = (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
     request.body.read[FrontJson] match {
       case Some(front) =>
         val identity = request.user

--- a/app/controllers/PandaAuthController.scala
+++ b/app/controllers/PandaAuthController.scala
@@ -15,11 +15,11 @@ class PandaAuthController(val deps: BaseFaciaControllerComponents)(implicit ec: 
     Future(Forbidden(views.html.auth.login(Some(message))))
   }
 
-  def user() = AuthAction { implicit request =>
+  def user() = AccessAuthAction { implicit request =>
     Ok(request.user.toJson).as(JSON)
   }
 
-  def status = AuthAction { request =>
+  def status = AccessAuthAction { request =>
     val user = request.user
     Ok(views.html.auth.status(user.toJson))
   }

--- a/app/controllers/PressController.scala
+++ b/app/controllers/PressController.scala
@@ -30,7 +30,7 @@ class PressController (awsEndpoints: AwsEndpoints, val deps: BaseFaciaController
 
   private lazy val pressedTable = Table[FrontPressRecord](config.faciatool.frontPressUpdateTable)
 
-  def getLastModified (path: String) = APIAuthAction { request =>
+  def getLastModified (path: String) = AccessAPIAuthAction { request =>
     import com.gu.scanamo.syntax._
 
     val record: Option[FrontPressRecord] = Scanamo.exec(client)(
@@ -38,7 +38,7 @@ class PressController (awsEndpoints: AwsEndpoints, val deps: BaseFaciaController
     record.map(r => Ok(r.pressedTime)).getOrElse(NotFound)
   }
 
-  def getLastModifiedStatus (stage: String, path: String) = APIAuthAction { request =>
+  def getLastModifiedStatus (stage: String, path: String) = AccessAPIAuthAction { request =>
     import com.gu.scanamo.syntax._
 
     val record: Option[FrontPressRecord] = Scanamo.exec(client)(

--- a/app/controllers/StatusController.scala
+++ b/app/controllers/StatusController.scala
@@ -2,5 +2,11 @@ package controllers
 
 class StatusController(deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
 
-  def healthStatus = Action(_ => Ok("Ok."))
+  def healthStatus = Action {
+    if(deps.permissions.storeIsEmpty) {
+      ServiceUnavailable("Permissions store is empty")
+    } else {
+      Ok("Ok.")
+    }
+  }
 }

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -21,7 +21,7 @@ case class StoriesVisibleResponse(
 )
 
 class StoriesVisibleController(val containers: Containers, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def storiesVisible(containerType: String) = APIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
+  def storiesVisible(containerType: String) = AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
     val numberOfStories = request.body.stories.length
 
     containers.all.get(containerType) map {

--- a/app/controllers/ThumbnailController.scala
+++ b/app/controllers/ThumbnailController.scala
@@ -4,7 +4,7 @@ import model.Cached
 import thumbnails.ContainerThumbnails
 
 class ThumbnailController(val containerThumbnails: ContainerThumbnails, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def container(id: String) = APIAuthAction {
+  def container(id: String) = AccessAPIAuthAction {
     containerThumbnails.fromId(id) match {
       case Some(thumbnail) =>
         Cached(86400)(Ok(thumbnail).as("image/svg+xml"))

--- a/app/controllers/TroubleshootController.scala
+++ b/app/controllers/TroubleshootController.scala
@@ -3,7 +3,7 @@ package controllers
 import model.Cached
 
 class TroubleshootController(val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def troubleshoot(section: String) = AuthAction { request =>
+  def troubleshoot(section: String) = AccessAuthAction { request =>
     val identity = request.user
     Cached(60) { Ok(views.html.troubleshoot(identity)) }}
 }

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -9,7 +9,7 @@ import util.{Acl, AclJson}
 
 class V2App(isDev: Boolean, val acl: Acl, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def index(priority: String = "", frontId: String = "") = APIAuthAction { implicit req =>
+  def index(priority: String = "", frontId: String = "") = AccessAuthAction { implicit req =>
 
     val jsFileName = "dist/app.bundle.js"
 

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -9,50 +9,48 @@ import util.{Acl, AclJson}
 
 class V2App(isDev: Boolean, val acl: Acl, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def index(priority: String = "", frontId: String = "") = APIAuthAction.async { implicit req =>
+  def index(priority: String = "", frontId: String = "") = APIAuthAction { implicit req =>
 
     val jsFileName = "dist/app.bundle.js"
 
     val jsLocation: String = routes.V2Assets.at(jsFileName).toString
 
-    for {
-      hasBreakingNews <- acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
-      hasConfigureFronts <- acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
-    } yield {
-      val acls = AclJson(
-        fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
-        permissions = Map("configure-config" -> hasConfigureFronts)
-      )
+    val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
+    val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
 
-      val conf = Defaults(
-        isDev,
-        config.environment.stage,
-        Seq("uk", "us", "au"),
-        req.user.email,
-        req.user.avatarUrl,
-        req.user.firstName,
-        req.user.lastName,
-        config.sentry.publicDSN,
-        config.media.baseUrl.get,
-        config.media.apiUrl,
-        SwitchManager.getSwitchesAsJson(),
-        acls,
-        config.facia.collectionCap,
-        config.facia.navListCap,
-        config.facia.navListType,
-        Metadata.tags.map {
-          case (_, meta) => meta
-        },
-        routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
-        routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
-      )
+    val acls = AclJson(
+      fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
+      permissions = Map("configure-config" -> hasConfigureFronts)
+    )
 
-      Ok(views.html.V2App.app(
-        "Fronts Tool",
-        jsLocation,
-        Json.toJson(conf).toString()
-      ))
-    }
+    val conf = Defaults(
+      isDev,
+      config.environment.stage,
+      Seq("uk", "us", "au"),
+      req.user.email,
+      req.user.avatarUrl,
+      req.user.firstName,
+      req.user.lastName,
+      config.sentry.publicDSN,
+      config.media.baseUrl.get,
+      config.media.apiUrl,
+      SwitchManager.getSwitchesAsJson(),
+      acls,
+      config.facia.collectionCap,
+      config.facia.navListCap,
+      config.facia.navListType,
+      Metadata.tags.map {
+        case (_, meta) => meta
+      },
+      routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
+      routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
+    )
+
+    Ok(views.html.V2App.app(
+      "Fronts Tool",
+      jsLocation,
+      Json.toJson(conf).toString()
+    ))
   }
 
 }

--- a/app/controllers/VanityRedirects.scala
+++ b/app/controllers/VanityRedirects.scala
@@ -7,7 +7,7 @@ import util.Acl
 
 class VanityRedirects(val acl: Acl, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def breakingnews = (AuthAction andThen new BreakingNewsPermissionCheck(acl)) { request =>
+  def breakingnews = (AccessAuthAction andThen new BreakingNewsPermissionCheck(acl)) { request =>
     NoCache(Redirect("/editorial?layout=latest,front:breaking-news", 301))}
 
   def untrail(path: String) = Action { request =>

--- a/app/controllers/ViewsController.scala
+++ b/app/controllers/ViewsController.scala
@@ -11,14 +11,14 @@ import util.{Acl, Encryption}
 class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean,
                       crypto: Encryption, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def priorities() = AuthAction { request =>
+  def priorities() = AccessAuthAction { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.priority(Option(identity), config.facia.stage, isDev))
     }
   }
 
-  def collectionEditor() = AuthAction { request =>
+  def collectionEditor() = AccessAuthAction { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),
@@ -26,7 +26,7 @@ class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean
     }
   }
 
-  def configEditor() = (AuthAction andThen new ConfigPermissionCheck(acl)) { request =>
+  def configEditor() = (AccessAuthAction andThen new ConfigPermissionCheck(acl)) { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -17,8 +17,9 @@ class Permissions(val appConfig: ApplicationConfiguration)(implicit executionCon
 }
 
 object Permissions {
+  val FrontsAccess = Permission("fronts_access", "fronts", PermissionDenied)
   val ConfigureFronts = Permission("configure_fronts", "fronts", PermissionDenied)
   val BreakingNewsAlert = Permission("breaking_news_alert", "fronts", PermissionDenied)
 
-  val all = Seq(ConfigureFronts, BreakingNewsAlert)
+  val all = Seq(FrontsAccess, ConfigureFronts, BreakingNewsAlert)
 }

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -1,25 +1,9 @@
 package permissions
 
-import com.gu.editorial.permissions.client._
-import conf.ApplicationConfiguration
-
-import scala.concurrent.ExecutionContext
-
-class Permissions(val appConfig: ApplicationConfiguration)(implicit executionContext: ExecutionContext) extends PermissionsProvider {
-
-  implicit def config = PermissionsConfig(
-    app = "fronts",
-    all = Permissions.all,
-    s3BucketPrefix = appConfig.environment.stage.toUpperCase,
-    awsCredentials = appConfig.aws.cmsFrontsAccountCredentials,
-    s3Region = Some("eu-west-1")
-  )
-}
+import com.gu.permissions.PermissionDefinition
 
 object Permissions {
-  val FrontsAccess = Permission("fronts_access", "fronts", PermissionDenied)
-  val ConfigureFronts = Permission("configure_fronts", "fronts", PermissionDenied)
-  val BreakingNewsAlert = Permission("breaking_news_alert", "fronts", PermissionDenied)
-
-  val all = Seq(FrontsAccess, ConfigureFronts, BreakingNewsAlert)
+  val FrontsAccess = PermissionDefinition("fronts_access", "fronts")
+  val ConfigureFronts = PermissionDefinition("configure_fronts", "fronts")
+  val BreakingNewsAlert = PermissionDefinition("breaking_news_alert", "fronts")
 }

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -9,7 +9,8 @@ object Authorization {
   implicit val authorizationWrites = new Writes[Authorization] {
     def writes(access: Authorization): JsValue = access match {
       case AccessGranted => JsBoolean(true)
-      case AccessDenied => JsBoolean(false)}}}
+      case AccessDenied => JsBoolean(false)}}
+}
 
 sealed trait Authorization
 object AccessGranted extends Authorization

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-models" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
-    "com.gu" %% "editorial-permissions-client" % "0.8",
+    "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.gu" %% "fapi-client-play26" % "2.6.2",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-client" % "1.2",


### PR DESCRIPTION
Adds a switch to check the `fronts_access` user permission before allowing access.

The compile errors are because it requires v2 of the permissions client: https://github.com/guardian/permissions/pull/103.

Once we are happy that the permission is effective I will remove the switch and the google group checker.