### PR TITLE
Add info about types to readme

### DIFF
--- a/client-v2/src/shared/README.md
+++ b/client-v2/src/shared/README.md
@@ -12,35 +12,22 @@ The shared collections library provides:
 The consumer application is responsible for fetching data (collections, details of the articles in the collections) from its own data store and from an external store in (e.g. capi) and passing
 this data on to the shared collections module.
 
+Collections and articles should be passed to the shared collections library in a normalised format. There are utility functions to normalised collections as they are stored in facia-tool or story packages but if the consumer uses a different datastructure, they will have to do perform this normalisation. The `Data types in the library` section contains details of what normalised collections and articles look like.
+
 We assume articles are stored in the consumer application and in an external datastore because the consumer application should never edit the articles themselves as they appear in capi. It only edits the way articles are displayed in a particular collection. To understand what an article looks like, we look at how that article appears in the external store and what edits we have applied to that article within our application.
 
 The consumer application also controls the stage of the collection we want to view, e.g. in the case of the fronts tool whether we want to render draft or live collections.
 
-## Using the library
+## Data types in the library
 
-### Fetching data
+There are a few data types in this library which represent articles and collections.
+There are types to represent articles and collections before they are normalised, after
+they are normalised and finally, a data type to represent an article in a way that it can
+be rendered by a component.
 
-To use the library, you have to dispatch three actions: `articleFragmentsReceived`, `externalArticlesReceived` and `collectionReceived` actions.
-
-### External Articles
-External articles represent the articles as they exist in external to your application e.g. in the content api.
-
-They look like this:
-
-```
-type ExternalArticle = {
-  id: string,
-  headline: string
-};
-```
-
-`externalArticlesReceived` expects a payload that is an object, which has external article ids as keys and external articles as values.
+Here are the data types used in the shared library:
 
 ### Collection
-
-`collectionReceived` action expects a collection in its payload.
-
-The collection looks like this:
 
 ```
 type Collection = {
@@ -58,11 +45,21 @@ type Collection = {
 
 ```
 
-Note that the articles in the Collection are stored as an array of ids. The articles that these ids refer to should be passed to the `articleFragmentsReceived` action.
+### CollectionResponse
+
+The `CollectionResponse` type represents collections as they are stored in facia tool or story packages.
+They are different from `Collections` because they have not yet been normalised. A consumer application does
+not have to store collections in the form of the `CollectionResponse` as long as they provide a way of transforming
+the stored collections in the type `Collection` which the shared curation library can understand.
 
 ### Article Fragments
-These article fragments take the following shape:
 
+Article fragments contain information about the article created by
+the collections tool: when was it added to a live collection, who did this,
+are any of the fields (e.g. headline, trail)  present in the external article
+overriden. These overrides are stored in the `Meta` object.
+
+These article fragments take the following shape:
 
 ```
 type ArticleFragment = {
@@ -74,7 +71,45 @@ type ArticleFragment = {
 };
 ```
 
+### Nested Article Fragments
+
+Nested article fragments represent article fragments are they appear in collections prior to
+normalisation. They look like article fragments but are missing a uuid.
+
+### External Articles
+External articles represent the articles as they exist in external to your application e.g. in the content api.
+
+They look like this:
+
+```
+type ExternalArticle = {
+  id: string,
+  headline: string
+};
+```
+
+### Articles
+
+Articles represent the articles which are being rendered by
+the components. They hold all the information needed to render an article.
+They are selected from the state by combining article fragments with
+external articles. If the article fragment metadata contains any overrides,
+these override the external article data.
+
+## Using the library
+
+### Fetching data
+
+To use the library, you have to dispatch three actions: `articleFragmentsReceived`, `externalArticlesReceived` and `collectionReceived` actions.
+
+`externalArticlesReceived` expects a payload that is an object, which has external article ids as keys and external articles as values.
+
+
+Note that the articles in the Collection are stored as an array of ids. The articles that these ids refer to should be passed to the `articleFragmentsReceived` action.
+
 `articleFragmentsReceived` expects in it's payload on object where keys are Article Fragment uuids and values are the article fragments themselves.
+
+`collectionReceived` action expects a collection in its payload.
 
 We provide an utility function `normaliseCollectionWithNestedArticles` to generate collections and article fragments from collections which have a shape similar to the collections as they appear in the fronts tool.
 


### PR DESCRIPTION
Add some documentation around the types we are using in the shared library. We must remember to keep updating this as we keep developing the libaray.