### PR TITLE
Fix fetch config script

### DIFF
--- a/fetch-config.sh
+++ b/fetch-config.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-mkdir -p ~/etc/gu
-aws s3 cp s3://facia-private/facia-tool.application.secrets.local.conf /etc/gu/facia-tool.application.secrets.conf --profile cmsFronts
-aws s3 cp s3://facia-private/facia-tool.local.properties /etc/gu/facia-tool.properties --profile cmsFronts
+sudo mkdir -p /etc/gu
+sudo aws s3 cp s3://facia-private/facia-tool.application.secrets.local.conf /etc/gu/facia-tool.application.secrets.conf --profile cmsFronts
+sudo aws s3 cp s3://facia-private/facia-tool.local.properties /etc/gu/facia-tool.properties --profile cmsFronts


### PR DESCRIPTION
Config script wasn't creating a `gu` directory in the same place. `/etc` isn't writeable by default so I've added sudo. Adding sudo doesn't feel great. Maybe we should reconsider where config lives on local machines.