### PR TITLE
Revert "Access permission"

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -3,17 +3,18 @@ import config.{CustomGzipFilter, UpdateManager}
 import controllers._
 import frontsapi.model.UpdateActions
 import metrics.CloudWatch
+import permissions.Permissions
 import play.api.ApplicationLoader.Context
 import play.api.Mode
 import play.api.routing.Router
-import play.filters.cors.CORSConfig
 import play.filters.cors.CORSConfig.Origins
+import play.filters.cors.CORSConfig
 import router.Routes
 import services._
 import slices.{Containers, FixedContainers}
 import thumbnails.ContainerThumbnails
 import tools.FaciaApiIO
-import updates.{BreakingNewsUpdate, StructuredLogger}
+import updates.{StructuredLogger, BreakingNewsUpdate}
 import util.{Acl, Encryption}
 
 class AppComponents(context: Context) extends BaseFaciaControllerComponents(context) {
@@ -22,6 +23,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val isDev: Boolean = context.environment.mode == Mode.Dev
   val config = new ApplicationConfiguration(configuration, isProd)
   val awsEndpoints = new AwsEndpoints(config)
+  val permissions = new Permissions(config)
   val acl = new Acl(permissions)
   val frontsApi = new FrontsApi(config, awsEndpoints)
   val s3FrontsApi = new S3FrontsApi(config, isTest, awsEndpoints)

--- a/app/controllers/CollectionController.scala
+++ b/app/controllers/CollectionController.scala
@@ -29,7 +29,7 @@ case class CreateCollectionResponse(id: String)
 class CollectionController(val acl: Acl, val structuredLogger: StructuredLogger,
                            val updateManager: UpdateManager, val press: Press, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with Logging {
-  def create = (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
+  def create = (APIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
     request.body.read[CollectionRequest] match {
       case Some(CollectionRequest(frontIds, collection)) =>
 
@@ -43,7 +43,7 @@ class CollectionController(val acl: Acl, val structuredLogger: StructuredLogger,
     }
   }
 
-  def update(collectionId: String) =  (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
+  def update(collectionId: String) =  (APIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
     request.body.read[CollectionRequest] match {
       case Some(CollectionRequest(frontIds, collection)) =>
 

--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -35,7 +35,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
   private def getPreviewHeaders(url: String): Seq[(String,String)] =
     previewSigner.addIAMHeaders(headers = Map.empty, URI.create(url)).toSeq
 
-  def capiPreview(path: String) = AccessAPIAuthAction.async { request =>
+  def capiPreview(path: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val queryString = IAMEncoder.encodeParams(request.queryString)
 
@@ -54,7 +54,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def capiLive(path: String) = AccessAPIAuthAction.async { request =>
+  def capiLive(path: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val queryString = request.queryString.filter(_._2.exists(_.nonEmpty)).map { p =>
        "%s=%s".format(p._1, p._2.head.urlEncoded)
@@ -71,7 +71,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def http(url: String) = AccessAPIAuthAction.async { request =>
+  def http(url: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
     wsClient.url(url).get().map { response =>
@@ -81,7 +81,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def json(url: String) = AccessAPIAuthAction.async { request =>
+  def json(url: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
     wsClient.url(url).withHttpHeaders(getPreviewHeaders(url): _*).get().map { response =>
@@ -91,7 +91,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     }
   }
 
-  def ophan(path: String) = AccessAPIAuthAction.async { request =>
+  def ophan(path: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val paths = request.queryString.get("path").map(_.mkString("path=", "&path=", "")).getOrElse("")
     val queryString = request.queryString.filterNot(_._1 == "path").filter(_._2.exists(_.nonEmpty)).map { p =>

--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -33,13 +33,13 @@ class FaciaToolController(
                          )(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with BreakingNewsEditCollectionsCheck with Logging {
 
-  def getConfig = AccessAPIAuthAction.async { request =>
+  def getConfig = APIAuthAction.async { request =>
     FaciaToolMetrics.ApiUsageCount.increment()
     frontsApi.amazonClient.config.map { configJson =>
       NoCache {
         Ok(Json.toJson(configJson)).as("application/json")}}}
 
-  def getCollection(collectionId: String) = AccessAPIAuthAction.async { request =>
+  def getCollection(collectionId: String) = APIAuthAction.async { request =>
 
     FaciaToolMetrics.ApiUsageCount.increment()
     val collection = frontsApi.amazonClient.collection(collectionId).flatMap{ collectionJson =>
@@ -52,7 +52,7 @@ class FaciaToolController(
       Ok(Json.toJson(c)).as("application/json")})
   }
 
-  def publishCollection(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
+  def publishCollection(collectionId: String) = APIAuthAction.async { implicit request =>
     withModifyPermissionForCollections(Set(collectionId)) {
       val identity = request.user
       FaciaToolMetrics.DraftPublishCount.increment()
@@ -84,7 +84,7 @@ class FaciaToolController(
     } else
       Future.successful(NoCache(Ok))}
 
-  def discardCollection(collectionId: String) = AccessAPIAuthAction.async { request =>
+  def discardCollection(collectionId: String) = APIAuthAction.async { request =>
     val identity = request.user
     val futureCollectionJson = faciaApiIO.discardCollectionJson(collectionId, identity)
     futureCollectionJson.map { maybeCollectionJson =>
@@ -95,7 +95,7 @@ class FaciaToolController(
       }
       NoCache(Ok)}}
 
-  def treatEdits(collectionId: String) = AccessAPIAuthAction.async { request =>
+  def treatEdits(collectionId: String) = APIAuthAction.async { request =>
     request.body.asJson.flatMap(_.asOpt[UpdateMessage]).map {
       case update: Update =>
         val identity = request.user
@@ -132,7 +132,7 @@ class FaciaToolController(
     }.getOrElse(Future.successful(NotAcceptable))
   }
 
-  def collectionEdits(): Action[AnyContent] = AccessAPIAuthAction.async { implicit request =>
+  def collectionEdits(): Action[AnyContent] = APIAuthAction.async { implicit request =>
     FaciaToolMetrics.ApiUsageCount.increment()
       request.body.asJson.flatMap (_.asOpt[UpdateMessage]).map {
         case update: Update =>
@@ -203,17 +203,17 @@ class FaciaToolController(
       } getOrElse Future.successful(NotFound)
   }
 
-  def pressLivePath(path: String) = AccessAPIAuthAction { request =>
+  def pressLivePath(path: String) = APIAuthAction { request =>
     faciaPressQueue.enqueue(PressJob(FrontPath(path), Live, forceConfigUpdate = Option(true)))
     NoCache(Ok)
   }
 
-  def pressDraftPath(path: String) = AccessAPIAuthAction { request =>
+  def pressDraftPath(path: String) = APIAuthAction { request =>
     faciaPressQueue.enqueue(PressJob(FrontPath(path), Draft, forceConfigUpdate = Option(true)))
     NoCache(Ok)
   }
 
-  def getMetadata() = AccessAPIAuthAction { request =>
+  def getMetadata() = APIAuthAction { request =>
     val matchingTags = request.queryString.get("query") match {
       case Some(Seq(search)) if search.nonEmpty => Metadata.tags.filterKeys(_ contains search)
       case _ => Metadata.tags

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -3,12 +3,15 @@ package controllers
 import frontsapi.model.UpdateActions
 import logging.Logging
 import metrics.FaciaToolMetrics
-import play.api.libs.json.Json
+import model.Cached
+import permissions.BreakingNewsEditCollectionsCheck
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, AnyContent}
 import services._
 import updates._
 import util.Acl
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 
 class FaciaToolV2Controller(
@@ -21,7 +24,7 @@ class FaciaToolV2Controller(
   extends BaseFaciaController(deps) with Logging {
 
 
-  def collectionEdits() = AccessAPIAuthAction { implicit request =>
+  def collectionEdits() = APIAuthAction { implicit request =>
 
     FaciaToolMetrics.ApiUsageCount.increment()
 

--- a/app/controllers/FrontController.scala
+++ b/app/controllers/FrontController.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 class FrontController(val acl: Acl, val structuredLogger: StructuredLogger,
                       val updateManager: UpdateManager, val press: Press, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with Logging {
-  def create = (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)) { request =>
+  def create = (APIAuthAction andThen new ConfigPermissionCheck(acl)) { request =>
     request.body.read[CreateFront] match {
       case Some(createFrontRequest) =>
         val identity = request.user
@@ -27,7 +27,7 @@ class FrontController(val acl: Acl, val structuredLogger: StructuredLogger,
     }
   }
 
-  def update(frontId: String) = (AccessAPIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
+  def update(frontId: String) = (APIAuthAction andThen new ConfigPermissionCheck(acl)){ request =>
     request.body.read[FrontJson] match {
       case Some(front) =>
         val identity = request.user

--- a/app/controllers/PandaAuthController.scala
+++ b/app/controllers/PandaAuthController.scala
@@ -15,11 +15,11 @@ class PandaAuthController(val deps: BaseFaciaControllerComponents)(implicit ec: 
     Future(Forbidden(views.html.auth.login(Some(message))))
   }
 
-  def user() = AccessAuthAction { implicit request =>
+  def user() = AuthAction { implicit request =>
     Ok(request.user.toJson).as(JSON)
   }
 
-  def status = AccessAuthAction { request =>
+  def status = AuthAction { request =>
     val user = request.user
     Ok(views.html.auth.status(user.toJson))
   }

--- a/app/controllers/PressController.scala
+++ b/app/controllers/PressController.scala
@@ -30,7 +30,7 @@ class PressController (awsEndpoints: AwsEndpoints, val deps: BaseFaciaController
 
   private lazy val pressedTable = Table[FrontPressRecord](config.faciatool.frontPressUpdateTable)
 
-  def getLastModified (path: String) = AccessAPIAuthAction { request =>
+  def getLastModified (path: String) = APIAuthAction { request =>
     import com.gu.scanamo.syntax._
 
     val record: Option[FrontPressRecord] = Scanamo.exec(client)(
@@ -38,7 +38,7 @@ class PressController (awsEndpoints: AwsEndpoints, val deps: BaseFaciaController
     record.map(r => Ok(r.pressedTime)).getOrElse(NotFound)
   }
 
-  def getLastModifiedStatus (stage: String, path: String) = AccessAPIAuthAction { request =>
+  def getLastModifiedStatus (stage: String, path: String) = APIAuthAction { request =>
     import com.gu.scanamo.syntax._
 
     val record: Option[FrontPressRecord] = Scanamo.exec(client)(

--- a/app/controllers/StatusController.scala
+++ b/app/controllers/StatusController.scala
@@ -2,11 +2,5 @@ package controllers
 
 class StatusController(deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
 
-  def healthStatus = Action {
-    if(deps.permissions.storeIsEmpty) {
-      ServiceUnavailable("Permissions store is empty")
-    } else {
-      Ok("Ok.")
-    }
-  }
+  def healthStatus = Action(_ => Ok("Ok."))
 }

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -21,7 +21,7 @@ case class StoriesVisibleResponse(
 )
 
 class StoriesVisibleController(val containers: Containers, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def storiesVisible(containerType: String) = AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
+  def storiesVisible(containerType: String) = APIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
     val numberOfStories = request.body.stories.length
 
     containers.all.get(containerType) map {

--- a/app/controllers/ThumbnailController.scala
+++ b/app/controllers/ThumbnailController.scala
@@ -4,7 +4,7 @@ import model.Cached
 import thumbnails.ContainerThumbnails
 
 class ThumbnailController(val containerThumbnails: ContainerThumbnails, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def container(id: String) = AccessAPIAuthAction {
+  def container(id: String) = APIAuthAction {
     containerThumbnails.fromId(id) match {
       case Some(thumbnail) =>
         Cached(86400)(Ok(thumbnail).as("image/svg+xml"))

--- a/app/controllers/TroubleshootController.scala
+++ b/app/controllers/TroubleshootController.scala
@@ -3,7 +3,7 @@ package controllers
 import model.Cached
 
 class TroubleshootController(val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  def troubleshoot(section: String) = AccessAuthAction { request =>
+  def troubleshoot(section: String) = AuthAction { request =>
     val identity = request.user
     Cached(60) { Ok(views.html.troubleshoot(identity)) }}
 }

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -9,48 +9,50 @@ import util.{Acl, AclJson}
 
 class V2App(isDev: Boolean, val acl: Acl, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def index(priority: String = "", frontId: String = "") = AccessAuthAction { implicit req =>
+  def index(priority: String = "", frontId: String = "") = APIAuthAction.async { implicit req =>
 
     val jsFileName = "dist/app.bundle.js"
 
     val jsLocation: String = routes.V2Assets.at(jsFileName).toString
 
-    val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
-    val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
+    for {
+      hasBreakingNews <- acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
+      hasConfigureFronts <- acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
+    } yield {
+      val acls = AclJson(
+        fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
+        permissions = Map("configure-config" -> hasConfigureFronts)
+      )
 
-    val acls = AclJson(
-      fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
-      permissions = Map("configure-config" -> hasConfigureFronts)
-    )
+      val conf = Defaults(
+        isDev,
+        config.environment.stage,
+        Seq("uk", "us", "au"),
+        req.user.email,
+        req.user.avatarUrl,
+        req.user.firstName,
+        req.user.lastName,
+        config.sentry.publicDSN,
+        config.media.baseUrl.get,
+        config.media.apiUrl,
+        SwitchManager.getSwitchesAsJson(),
+        acls,
+        config.facia.collectionCap,
+        config.facia.navListCap,
+        config.facia.navListType,
+        Metadata.tags.map {
+          case (_, meta) => meta
+        },
+        routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
+        routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
+      )
 
-    val conf = Defaults(
-      isDev,
-      config.environment.stage,
-      Seq("uk", "us", "au"),
-      req.user.email,
-      req.user.avatarUrl,
-      req.user.firstName,
-      req.user.lastName,
-      config.sentry.publicDSN,
-      config.media.baseUrl.get,
-      config.media.apiUrl,
-      SwitchManager.getSwitchesAsJson(),
-      acls,
-      config.facia.collectionCap,
-      config.facia.navListCap,
-      config.facia.navListType,
-      Metadata.tags.map {
-        case (_, meta) => meta
-      },
-      routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
-      routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
-    )
-
-    Ok(views.html.V2App.app(
-      "Fronts Tool",
-      jsLocation,
-      Json.toJson(conf).toString()
-    ))
+      Ok(views.html.V2App.app(
+        "Fronts Tool",
+        jsLocation,
+        Json.toJson(conf).toString()
+      ))
+    }
   }
 
 }

--- a/app/controllers/VanityRedirects.scala
+++ b/app/controllers/VanityRedirects.scala
@@ -7,7 +7,7 @@ import util.Acl
 
 class VanityRedirects(val acl: Acl, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def breakingnews = (AccessAuthAction andThen new BreakingNewsPermissionCheck(acl)) { request =>
+  def breakingnews = (AuthAction andThen new BreakingNewsPermissionCheck(acl)) { request =>
     NoCache(Redirect("/editorial?layout=latest,front:breaking-news", 301))}
 
   def untrail(path: String) = Action { request =>

--- a/app/controllers/ViewsController.scala
+++ b/app/controllers/ViewsController.scala
@@ -11,14 +11,14 @@ import util.{Acl, Encryption}
 class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean,
                       crypto: Encryption, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
-  def priorities() = AccessAuthAction { request =>
+  def priorities() = AuthAction { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.priority(Option(identity), config.facia.stage, isDev))
     }
   }
 
-  def collectionEditor() = AccessAuthAction { request =>
+  def collectionEditor() = AuthAction { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),
@@ -26,7 +26,7 @@ class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean
     }
   }
 
-  def configEditor() = (AccessAuthAction andThen new ConfigPermissionCheck(acl)) { request =>
+  def configEditor() = (AuthAction andThen new ConfigPermissionCheck(acl)) { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -1,9 +1,24 @@
 package permissions
 
-import com.gu.permissions.PermissionDefinition
+import com.gu.editorial.permissions.client._
+import conf.ApplicationConfiguration
+
+import scala.concurrent.ExecutionContext
+
+class Permissions(val appConfig: ApplicationConfiguration)(implicit executionContext: ExecutionContext) extends PermissionsProvider {
+
+  implicit def config = PermissionsConfig(
+    app = "fronts",
+    all = Permissions.all,
+    s3BucketPrefix = appConfig.environment.stage.toUpperCase,
+    awsCredentials = appConfig.aws.cmsFrontsAccountCredentials,
+    s3Region = Some("eu-west-1")
+  )
+}
 
 object Permissions {
-  val FrontsAccess = PermissionDefinition("fronts_access", "fronts")
-  val ConfigureFronts = PermissionDefinition("configure_fronts", "fronts")
-  val BreakingNewsAlert = PermissionDefinition("breaking_news_alert", "fronts")
+  val ConfigureFronts = Permission("configure_fronts", "fronts", PermissionDenied)
+  val BreakingNewsAlert = Permission("breaking_news_alert", "fronts", PermissionDenied)
+
+  val all = Seq(ConfigureFronts, BreakingNewsAlert)
 }

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -1,57 +1,38 @@
 package permissions
 
 import com.gu.pandomainauth.action.UserRequest
-import com.gu.permissions.PermissionsProvider
 import controllers.BaseFaciaController
 import play.api.mvc._
 import services.ConfigAgent
 import util.{AccessDenied, AccessGranted, Acl, Authorization}
 import logging.Logging
-import switchboard.SwitchManager
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait PermissionActionFilter extends ActionFilter[UserRequest] with Logging {
 
   implicit val executionContext: ExecutionContext
-  val testAccess: String => Authorization
+  val testAccess: String => Future[Authorization]
   val restrictedAction: String
 
 
-  override def filter[A](request: UserRequest[A]): Future[Option[Result]] = Future.successful {
-    testAccess(request.user.email) match {
+  override def filter[A](request: UserRequest[A]) =
+    testAccess(request.user.email).map {
       case AccessGranted => None
       case AccessDenied =>
         logger.info(s"User with e-mail ${request.user.email} not authorized to $restrictedAction")
-        Some(Results.Unauthorized(views.html.unauthorized()))
-    }
-  }
-}
-
-class AccessPermissionCheck(client: PermissionsProvider)(implicit ec: ExecutionContext) extends PermissionActionFilter {
-  val executionContext = ec
-  val restrictedAction = "access fronts"
-  val testAccess: String => Authorization = (email: String) => {
-    val switchEnabled = SwitchManager.getStatus("facia-tool-permissions-access")
-    val hasPermission = client.hasPermission(Permissions.FrontsAccess, email)
-
-    if(switchEnabled) {
-      if(hasPermission) { AccessGranted } else { AccessDenied }
-    } else {
-      AccessGranted
-    }
-  }
+        Some(Results.Unauthorized(views.html.unauthorized()))}
 }
 
 class ConfigPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   val executionContext = ec
-  val testAccess: String => Authorization = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")
+  val testAccess: String => Future[Authorization] = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")
   val restrictedAction = "configure fronts"
 }
 
 class BreakingNewsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   val executionContext = ec
-  val testAccess: String => Authorization = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")
+  val testAccess: String => Future[Authorization] = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")
   val restrictedAction = "send breaking news alerts"
 }
 
@@ -59,15 +40,13 @@ trait BreakingNewsEditCollectionsCheck extends Logging { self: BaseFaciaControll
   def acl: Acl
   def configAgent: ConfigAgent
 
-  private def testAccess(email: String, collections: Set[String]) = {
-    acl.testUserAndCollections(configAgent.getBreakingNewsCollectionIds, Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(email, collections)
-  }
+  private def testAccess(email: String, collections: Set[String]) = acl.testUserAndCollections(configAgent.getBreakingNewsCollectionIds, Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(email, collections)
 
   def withModifyPermissionForCollections[A](collectionIds: Set[String])(block: => Future[Result])
     (implicit request: UserRequest[A],
               executionContext: ExecutionContext): Future[Result] = {
 
-    testAccess(request.user.email, collectionIds) match {
+    testAccess(request.user.email, collectionIds).flatMap {
       case AccessGranted => block
       case AccessDenied =>
         logger.info(s"User with e-mail ${request.user.email} not authorized to send breaking news alerts")

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-models" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
-    "com.gu" %% "editorial-permissions-client" % "2.0",
+    "com.gu" %% "editorial-permissions-client" % "0.8",
     "com.gu" %% "fapi-client-play26" % "2.6.2",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-client" % "1.2",


### PR DESCRIPTION
Reverts guardian/facia-tool#351.

There was a logic error that did not correctly respect switches when accessed via `Acl.scala`. This essentially meant anyone could edit a front or send a breaking news alert.

Luckily it didn't make it to production!