### PR TITLE
Revert "Remove Google group checker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ $ feria cmsFronts && feria --access sqs-consumer frontend
 You can run the fronts tool without frontend credentials, but you will not be able to check how your changes to fronts appear on frontend without
 these credentials. You will need to test your changes on `CODE` to see these changes.
 
-You will also need to have `fronts_access` permission in `CODE` from https://permissions.code.dev-gutools.co.uk.
+You will also need to be a member of the Editorial Tools Google Group in order to authenticate.
 
 ### Code Dependencies
 

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -179,6 +179,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     lazy val domain = getMandatoryString("pandomain.domain")
     lazy val service = getMandatoryString("pandomain.service")
     lazy val roleArn = getMandatoryString("pandomain.roleArn")
+    lazy val userGroups = getMandatoryStringPropertiesSplitByComma("pandomain.user.groups")
   }
 
   object permission {

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -14,6 +14,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{BaseController, ControllerComponents, RequestHeader, Result}
 import play.api.{BuiltInComponentsFromContext, Logger}
 import play.filters.cors.CORSComponents
+import switchboard.SwitchManager
 
 abstract class BaseFaciaControllerComponents(context: Context) extends BuiltInComponentsFromContext(context) with AhcWSComponents with AssetsComponents with CORSComponents {
 
@@ -45,11 +46,22 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
   final def AccessAuthAction = AuthAction andThen accessPermissionCheck
   final def AccessAPIAuthAction = APIAuthAction andThen accessPermissionCheck
 
-  private def userHasAccess(authedUser: AuthenticatedUser): Boolean = {
-    deps.permissions.hasPermission(Permissions.FrontsAccess, authedUser.user.email)
+  private def userInGroups(authedUser: AuthenticatedUser): Boolean = {
+    if(SwitchManager.getStatus("facia-tool-permissions-access")) {
+      deps.permissions.hasPermission(Permissions.FrontsAccess, authedUser.user.email)
+    } else {
+      // TODO MRB: remove this when we have switched over to the permission
+      groupChecker.exists(checker =>
+        checker.checkGroups(authedUser, config.pandomain.userGroups).fold(
+          error => {
+            Logger.warn(error)
+            false
+          }, identity)
+      )
+    }
   }
 
-  override def validateUser(authedUser: AuthenticatedUser): Boolean = PanDomain.guardianValidation(authedUser) && userHasAccess(authedUser)
+  override def validateUser(authedUser: AuthenticatedUser): Boolean = PanDomain.guardianValidation(authedUser) && userInGroups(authedUser)
 
   override lazy val panDomainSettings: PanDomainAuthSettingsRefresher = deps.panDomainSettings
 
@@ -62,7 +74,7 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
     if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor)
       s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to have two factor authentication enabled and be granted permission." +
         s" Please contact Central Production by emailing core.central.production@guardian.co.uk and request access to The Fronts Tool."
-    else if (!userHasAccess(claimedAuth)) s"${claimedAuth.user.email} does not have permission to access the Fronts tool. Please contact Central Production by emailing core.central.production@guardian.co.uk"
+    else if (!userInGroups(claimedAuth)) s"${claimedAuth.user.email} does not have permission to access the Fronts tool. Please contact Central Production by emailing core.central.production@guardian.co.uk"
 
     else s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
 

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -3,10 +3,11 @@ package permissions
 import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionsProvider
 import controllers.BaseFaciaController
-import logging.Logging
 import play.api.mvc._
 import services.ConfigAgent
 import util.{AccessDenied, AccessGranted, Acl, Authorization}
+import logging.Logging
+import switchboard.SwitchManager
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -31,8 +32,14 @@ class AccessPermissionCheck(client: PermissionsProvider)(implicit ec: ExecutionC
   val executionContext = ec
   val restrictedAction = "access fronts"
   val testAccess: String => Authorization = (email: String) => {
+    val switchEnabled = SwitchManager.getStatus("facia-tool-permissions-access")
+    val hasPermission = client.hasPermission(Permissions.FrontsAccess, email)
 
-    if(client.hasPermission(Permissions.FrontsAccess, email)) { AccessGranted } else { AccessDenied }
+    if(switchEnabled) {
+      if(hasPermission) { AccessGranted } else { AccessDenied }
+    } else {
+      AccessGranted
+    }
   }
 }
 


### PR DESCRIPTION
Reverts guardian/facia-tool#360.

We are seeing problems with people have various email aliases (casual, freelance, guardian.co.uk etc)