### PR TITLE
Increase max uri length in dev

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,9 @@ resolvers ++= Seq(
     "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend"
 )
 
+
+PlayKeys.devSettings := Seq("play.akka.dev-mode.akka.http.parsing.max-uri-length" -> "20480")
+
 libraryDependencies ++= Seq(
     ws,
     filters,


### PR DESCRIPTION
Sometimes I get errors complaining capi query is too long in dev, this fixes it.