### PR TITLE
remove logging if permissions denied

### DIFF
--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -37,7 +37,6 @@ class Acl(permissions: PermissionsProvider) extends Logging {
         AccessGranted
 
       case false =>
-        logger.warn(s"User $email denied ${permission.name}")
         AccessDenied
     }
   }


### PR DESCRIPTION
We are a user's testing permissions all the time and sending them back to the client - having this warning here just creates unnecessary noise in the logs.