### PR TITLE
Press alerts

### DIFF
--- a/client-v2/src/actions/Fronts.js
+++ b/client-v2/src/actions/Fronts.js
@@ -6,10 +6,12 @@ import { batchActions } from 'redux-batched-actions';
 import {
   fetchFrontsConfig,
   fetchLastPressed as fetchLastPressedApi,
-  publishCollection as publishCollectionApi
+  publishCollection as publishCollectionApi,
+  getCollection
 } from 'services/faciaApi';
 import { actions as frontsConfigActions } from 'bundles/frontsConfigBundle';
 import { recordUnpublishedChanges } from 'actions/UnpublishedChanges';
+import { isFrontStale } from 'util/frontsUtils';
 
 function fetchLastPressedSuccess(frontId: string, datePressed: string): Action {
   return {
@@ -31,11 +33,11 @@ function publishCollectionSuccess(collectionId: string): Action {
   };
 }
 
-function recordStaleFronts(frontId: string, isFrontStale: boolean): Action {
+function recordStaleFronts(frontId: string, frontIsStale: boolean): Action {
   return {
     type: 'RECORD_STALE_FRONTS',
     payload: {
-      frontId: isFrontStale
+      [frontId]: frontIsStale
     }
   };
 }
@@ -45,24 +47,35 @@ function fetchLastPressed(frontId: string): ThunkAction {
     fetchLastPressedApi(frontId)
       .then(datePressed =>
         dispatch(fetchLastPressedSuccess(frontId, datePressed))
-        dispatch(recordStaleFronts(frontId, isFrontStale(datePressed)))
       )
       .catch(() => {
         // @todo: implement once error handling is done
       });
 }
 
-function publishCollection(collectionId: string): ThunkAction {
+function publishCollection(collectionId: string, frontId: string): ThunkAction {
   return (dispatch: Dispatch) =>
     publishCollectionApi(collectionId)
-      .then(() =>
+      .then(() => {
         dispatch(
           batchActions([
             publishCollectionSuccess(collectionId),
             recordUnpublishedChanges(collectionId, false)
           ])
-        )
-      )
+        );
+        return Promise.all([
+          getCollection(collectionId),
+          fetchLastPressedApi(frontId)
+        ]).then(([collection, lastPressed]) => {
+          const lastPressedInMilliseconds = new Date(lastPressed).getTime();
+          dispatch(
+            recordStaleFronts(
+              frontId,
+              isFrontStale(collection.lastUpdated, lastPressedInMilliseconds)
+            )
+          );
+        });
+      })
       .catch(() => {
         // @todo: implement once error handling is done
       });

--- a/client-v2/src/actions/Fronts.js
+++ b/client-v2/src/actions/Fronts.js
@@ -31,11 +31,21 @@ function publishCollectionSuccess(collectionId: string): Action {
   };
 }
 
+function recordStaleFronts(frontId: string, isFrontStale: boolean): Action {
+  return {
+    type: 'RECORD_STALE_FRONTS',
+    payload: {
+      frontId: isFrontStale
+    }
+  };
+}
+
 function fetchLastPressed(frontId: string): ThunkAction {
   return (dispatch: Dispatch) =>
     fetchLastPressedApi(frontId)
       .then(datePressed =>
         dispatch(fetchLastPressedSuccess(frontId, datePressed))
+        dispatch(recordStaleFronts(frontId, isFrontStale(datePressed)))
       )
       .catch(() => {
         // @todo: implement once error handling is done

--- a/client-v2/src/actions/Fronts.js
+++ b/client-v2/src/actions/Fronts.js
@@ -63,18 +63,23 @@ function publishCollection(collectionId: string, frontId: string): ThunkAction {
             recordUnpublishedChanges(collectionId, false)
           ])
         );
-        return Promise.all([
-          getCollection(collectionId),
-          fetchLastPressedApi(frontId)
-        ]).then(([collection, lastPressed]) => {
-          const lastPressedInMilliseconds = new Date(lastPressed).getTime();
-          dispatch(
-            recordStaleFronts(
-              frontId,
-              isFrontStale(collection.lastUpdated, lastPressedInMilliseconds)
-            )
-          );
-        });
+
+        return new Promise(resolve => setTimeout(resolve, 10000))
+          .then(() =>
+            Promise.all([
+              getCollection(collectionId),
+              fetchLastPressedApi(frontId)
+            ])
+          )
+          .then(([collection, lastPressed]) => {
+            const lastPressedInMilliseconds = new Date(lastPressed).getTime();
+            dispatch(
+              recordStaleFronts(
+                frontId,
+                isFrontStale(collection.lastUpdated, lastPressedInMilliseconds)
+              )
+            );
+          });
       })
       .catch(() => {
         // @todo: implement once error handling is done

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.js
@@ -16,10 +16,12 @@ type CollectionPropsBeforeState = {
   id: string,
   groups: *,
   children: *,
-  alsoOn: { [string]: AlsoOnDetail }
+  alsoOn: { [string]: AlsoOnDetail },
+  frontId: string
 };
+
 type CollectionProps = CollectionPropsBeforeState & {
-  publishCollection: (collectionId: string) => Promise<void>,
+  publishCollection: (collectionId: string, frontId: string) => Promise<void>,
   hasUnpublishedChanges: boolean
 };
 
@@ -29,13 +31,14 @@ const Collection = ({
   children,
   alsoOn,
   hasUnpublishedChanges,
-  publishCollection: publish
+  publishCollection: publish,
+  frontId
 }: CollectionProps) => (
   <CollectionDisplay
     id={id}
     headlineContent={
       hasUnpublishedChanges && (
-        <Button dark onClick={() => publish(id)}>
+        <Button dark onClick={() => publish(id, frontId)}>
           Launch
         </Button>
       )

--- a/client-v2/src/components/FrontsEdit/Edit.js
+++ b/client-v2/src/components/FrontsEdit/Edit.js
@@ -9,12 +9,14 @@ import FrontsLayout from '../FrontsLayout';
 import FrontsContainer from './FrontsContainer';
 import Feed from '../Feed';
 import ErrorBannner from '../ErrorBanner';
+import PressFailAlert from '../PressFailAlert';
 import Clipboard from '../Clipboard';
 
 type Props = {
   match: Match,
   error: ActionError,
-  history: RouterHistory
+  history: RouterHistory,
+  staleFronts: { string: boolean }
 };
 
 const getFrontId = (frontId: ?string): string =>
@@ -23,6 +25,7 @@ const getFrontId = (frontId: ?string): string =>
 const FrontsEdit = (props: Props) => (
   <React.Fragment>
     <ErrorBannner error={props.error} />
+    <PressFailAlert staleFronts={props.staleFronts} />
     <FrontsLayout
       left={<Feed />}
       middle={<Clipboard />}
@@ -38,7 +41,8 @@ const FrontsEdit = (props: Props) => (
 );
 
 const mapStateToProps = (state: State) => ({
-  error: state.error
+  error: state.error,
+  staleFronts: state.staleFronts
 });
 
 export default connect(mapStateToProps)(FrontsEdit);

--- a/client-v2/src/components/FrontsEdit/Front.js
+++ b/client-v2/src/components/FrontsEdit/Front.js
@@ -33,7 +33,8 @@ type FrontPropsBeforeState = {
   browsingStage: string,
   collections: string[],
   alsoOn: { [string]: AlsoOnDetail },
-  handleEdits: (edits: Edit[]) => void
+  handleEdits: (edits: Edit[]) => void,
+  frontId: string
 };
 
 type FrontProps = FrontPropsBeforeState & {
@@ -120,7 +121,11 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         >
           <Front {...this.props.tree}>
             {collection => (
-              <Collection {...collection} alsoOn={this.props.alsoOn}>
+              <Collection
+                {...collection}
+                alsoOn={this.props.alsoOn}
+                frontId={this.props.frontId}
+              >
                 {group => (
                   <Group {...group}>
                     {(articleFragment, afDragProps) => (

--- a/client-v2/src/components/FrontsEdit/Fronts.js
+++ b/client-v2/src/components/FrontsEdit/Fronts.js
@@ -107,6 +107,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
             alsoOn={this.props.alsoOn}
             collectionIds={this.props.selectedFront.collections}
             browsingStage={this.state.browsingStage}
+            frontId={this.props.frontId}
           />
         )}
       </ScrollContainer>

--- a/client-v2/src/components/PressFailAlert.js
+++ b/client-v2/src/components/PressFailAlert.js
@@ -1,0 +1,40 @@
+// @flow
+
+import React from 'react';
+import styled from 'styled-components';
+import { error } from '../styleConstants';
+
+type Props = {
+  staleFronts: { string: boolean }
+};
+
+const AlertContainer = styled('div')`
+  background-color: ${error.primary};
+  font-weight: 50;
+  padding: 5px;
+`;
+
+const PressFailAlert = (props: Props) => {
+  const failedFronts: Array<string> =
+    props.staleFronts &&
+    Object.keys(props.staleFronts).reduce((fronts, frontId) => {
+      if (props.staleFronts[frontId]) {
+        fronts.push(frontId);
+      }
+      return fronts;
+    }, []);
+
+  const getErrorString = () => {
+    const usePlural = failedFronts.length > 1;
+    return `Sorry, the latest edit to the front${
+      usePlural ? 's' : ''
+    } ${failedFronts.join(',')} ${usePlural ? 'have' : 'has'} not gone live.`;
+  };
+
+  if (failedFronts && failedFronts.length > 0) {
+    return <AlertContainer>{getErrorString()}</AlertContainer>;
+  }
+  return null;
+};
+
+export default PressFailAlert;

--- a/client-v2/src/components/PressFailAlert.js
+++ b/client-v2/src/components/PressFailAlert.js
@@ -26,7 +26,7 @@ const PressFailAlert = (props: Props) => {
 
   const getErrorString = () => {
     const usePlural = failedFronts.length > 1;
-    return `Sorry, the latest edit to the front${
+    return `Sorry, the latest edit${usePlural ? 's' : ''} to the front${
       usePlural ? 's' : ''
     } ${failedFronts.join(',')} ${usePlural ? 'have' : 'has'} not gone live.`;
   };

--- a/client-v2/src/constants/fronts.js
+++ b/client-v2/src/constants/fronts.js
@@ -6,3 +6,5 @@ export const frontStages = {
   draft: 'draft',
   live: 'live'
 };
+
+export const detectPressFailureMs = 10000;

--- a/client-v2/src/reducers/rootReducer.js
+++ b/client-v2/src/reducers/rootReducer.js
@@ -9,7 +9,7 @@ import error from './errorReducer';
 import path from './pathReducer';
 import unpublishedChanges from './unpublishedChangesReducer';
 import clipboard from './clipboardReducer';
-import staleFrons from './staleFrontsReducer';
+import staleFronts from './staleFrontsReducer';
 
 const reducers = {
   config,

--- a/client-v2/src/reducers/rootReducer.js
+++ b/client-v2/src/reducers/rootReducer.js
@@ -9,6 +9,7 @@ import error from './errorReducer';
 import path from './pathReducer';
 import unpublishedChanges from './unpublishedChangesReducer';
 import clipboard from './clipboardReducer';
+import staleFrons from './staleFrontsReducer';
 
 const reducers = {
   config,
@@ -17,7 +18,8 @@ const reducers = {
   path,
   shared,
   unpublishedChanges,
-  clipboard
+  clipboard,
+  staleFronts
 };
 
 export type Reducers = typeof reducers;

--- a/client-v2/src/reducers/staleFrontsReducer.js
+++ b/client-v2/src/reducers/staleFrontsReducer.js
@@ -1,0 +1,21 @@
+// @flow
+
+import type { Action } from 'types/Action';
+
+type State = {
+  [string]: boolean
+};
+
+const staleFronts = (state: State = {}, action: Action): State => {
+  switch (action.type) {
+    case 'RECORD_STALE_FRONTS': {
+      const { payload } = action;
+      return { ...state, ...payload };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default staleFronts;

--- a/client-v2/src/types/Action.js
+++ b/client-v2/src/types/Action.js
@@ -123,6 +123,11 @@ type RemoveClipboardArticleFragment = {|
   payload: { articleFragmentId: string }
 |};
 
+type RecordStaleFronts = {|
+  type: 'RECORD_STALE_FRONTS',
+  payload: { [string]: boolean }
+|};
+
 type Action =
   | ConfigReceivedAction
   | FrontsConfigReceivedAction
@@ -143,7 +148,8 @@ type Action =
   | FetchClipboardContentSuccess
   | AddClipboardArticleFragment
   | RemoveClipboardArticleFragment
-  | AddClipboardContent;
+  | AddClipboardContent
+  | RecordStaleFronts;
 
 type BatchedAction = {|
   type: 'BATCHING_REDUCER.BATCH',

--- a/client-v2/src/util/frontsUtils.js
+++ b/client-v2/src/util/frontsUtils.js
@@ -43,7 +43,7 @@ const isFrontStale = (lastUpdated?: number, lastPressed?: number) => {
     return lastUpdated - lastPressed > detectPressFailureMs;
   }
   return false;
-}
+};
 
 export {
   getFrontCollections,

--- a/client-v2/src/util/frontsUtils.js
+++ b/client-v2/src/util/frontsUtils.js
@@ -38,8 +38,12 @@ const combineCollectionWithConfig = (
 const populateDraftArticles = (collection: CollectionWithNestedArticles) =>
   !collection.draft ? collection.live : collection.draft;
 
-const isFrontStale = (lastUpdated: number, lastPressed: number) =>
-  lastUpdated - lastPressed > detectPressFailureMs;
+const isFrontStale = (lastUpdated?: number, lastPressed?: number) => {
+  if (lastUpdated && lastPressed) {
+    return lastUpdated - lastPressed > detectPressFailureMs;
+  }
+  return false;
+}
 
 export {
   getFrontCollections,

--- a/client-v2/src/util/frontsUtils.js
+++ b/client-v2/src/util/frontsUtils.js
@@ -2,6 +2,7 @@
 
 import type { FrontConfig, CollectionConfig } from 'types/FaciaApi';
 import type { CollectionWithNestedArticles } from 'shared/types/Collection';
+import { detectPressFailureMs } from 'constants/fronts';
 
 const getFrontCollections = (
   frontId: ?string,
@@ -37,8 +38,12 @@ const combineCollectionWithConfig = (
 const populateDraftArticles = (collection: CollectionWithNestedArticles) =>
   !collection.draft ? collection.live : collection.draft;
 
+const isFrontStale = (lastUpdated: number, lastPressed: number) =>
+  lastUpdated - lastPressed > detectPressFailureMs;
+
 export {
   getFrontCollections,
   combineCollectionWithConfig,
-  populateDraftArticles
+  populateDraftArticles,
+  isFrontStale
 };


### PR DESCRIPTION
Replicates the fronts failing to press alert behaviour with some changes: 
- Because we don't allow edits on live content we only need to check if a front was pressed on launch
- Because users can have multiple fronts open at once, we show them a list of all the fronts which are failed to press after publish.

The beautifully styled alert banner can we restyled and integrated with the app error banner once we get input from ux. For now, this should central prod to start using the application. 