### PR TITLE
Persist front ids

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -64,7 +64,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val pressController = new PressController(dynamo, this)
   val v2App = new V2App(isDev, acl, dynamo, this)
   val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, this)
-  val clipboardController = new ClipboardController(dynamo, this)
+  val userDataController = new UserDataController(dynamo, this)
   val gridProxy = new GridProxy(this)
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
@@ -74,7 +74,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   override lazy val assets: Assets = new controllers.Assets(httpErrorHandler, assetsMetadata)
 
   val router: Router = new Routes(httpErrorHandler, status, pandaAuth, v2Assets, uncachedAssets, views, faciaTool,
-    pressController, faciaToolV2, defaults, clipboardController, faciaCapiProxy, thumbnail, front, collection, storiesVisible, vanityRedirects, troubleshoot, v2App, gridProxy)
+    pressController, faciaToolV2, defaults, userDataController, faciaCapiProxy, thumbnail, front, collection, storiesVisible, vanityRedirects, troubleshoot, v2App, gridProxy)
 
 
   override lazy val httpFilters = Seq(

--- a/app/Components.scala
+++ b/app/Components.scala
@@ -62,7 +62,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val vanityRedirects = new VanityRedirects(acl, this)
   val views = new ViewsController(acl, assetsManager, isDev, encryption, this)
   val pressController = new PressController(dynamo, this)
-  val v2App = new V2App(isDev, acl, this)
+  val v2App = new V2App(isDev, acl, dynamo, this)
   val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, this)
   val clipboardController = new ClipboardController(dynamo, this)
   val gridProxy = new GridProxy(this)

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -28,7 +28,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
   private val stageFromProperties = properties.getOrElse("STAGE", "CODE")
   private val stsRoleToAssumeFromProperties = properties.getOrElse("STS_ROLE", "unknown")
   private val frontPressedDynamoTable = properties.getOrElse("FRONT_PRESSED_TABLE", "unknown")
-  private val frontsClipboardTable = properties.getOrElse("CLIPBOARD_TABLE", "unknown")
+  private val userTable = properties.getOrElse("USER_DATA_TABLE", "unknown")
 
   private def getString(property: String): Option[String] =
     playConfiguration.getOptional[String](stageFromProperties + "." + property)
@@ -162,7 +162,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     lazy val showTestContainers = getBoolean("faciatool.show_test_containers").getOrElse(false)
     lazy val stsRoleToAssume = getString("faciatool.sts.role.to.assume").getOrElse(stsRoleToAssumeFromProperties)
     lazy val frontPressUpdateTable = frontPressedDynamoTable
-    lazy val clipboardTable = frontsClipboardTable
+    lazy val userDataTable = userTable
   }
 
   object media {

--- a/app/controllers/ClipboardController.scala
+++ b/app/controllers/ClipboardController.scala
@@ -3,40 +3,27 @@ package controllers
 import com.gu.facia.api.NotFound
 import com.gu.facia.client.models.Trail
 import com.gu.scanamo._
-import com.gu.scanamo.error.TypeCoercionError
 import com.gu.scanamo.syntax._
 import play.api.libs.json._
 import services.Dynamo
+import model.UserData
 
 import scala.util.{Failure, Success, Try}
 
-object ClipboardData {
-  implicit val jsonFormat = Json.format[ClipboardData]
-
-  implicit val jsValueFormat: DynamoFormat[JsValue] = DynamoFormat.xmap[JsValue, String](
-    x => Try(Json.parse(x)) match {
-      case Success(y) => Right(y)
-      case Failure(f) => Left(TypeCoercionError(f))
-    }
-  )(Json.stringify(_))
-}
-case class ClipboardData(email: String, articles: List[Trail])
-
 
 class ClipboardController(dynamo: Dynamo, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  import ClipboardData._
+  import model.UserData._
 
-  private lazy val clipboardTable = Table[ClipboardData](config.faciatool.clipboardTable)
+  private lazy val userDataTable = Table[UserData](config.faciatool.userDataTable)
 
   def getClipboardContent() = APIAuthAction { request =>
 
-    val userEmail = request.user.email
-    val value = Scanamo.exec(dynamo.client)(clipboardTable.get('email -> userEmail))
+    val userEmail: String = request.user.email
 
-    val record: Option[ClipboardData] = Scanamo.exec(dynamo.client)(
-      clipboardTable.get('email -> userEmail)).flatMap(_.right.toOption)
+    val record: Option[UserData] = Scanamo.exec(dynamo.client)(
+      userDataTable.get('email -> userEmail)).flatMap(_.right.toOption)
 
-    record.map(clipboardContent => Ok(Json.toJson(clipboardContent.articles))).getOrElse(NotFound)
+    record.map(clipboardContent => Ok(Json.toJson(clipboardContent.clipboardArticles))).getOrElse(NotFound)
   }
 
   def putClipboardContent() = APIAuthAction { request =>
@@ -47,8 +34,8 @@ class ClipboardController(dynamo: Dynamo, val deps: BaseFaciaControllerComponent
     clipboardContent match {
       case Some(articles) => {
         val userEmail = request.user.email
-        val item = ClipboardData(request.user.email, articles)
-        val result = Scanamo.put(dynamo.client)(config.faciatool.clipboardTable)(item)
+        val item = UserData(request.user.email, articles, List())
+        val result = Scanamo.put(dynamo.client)(config.faciatool.userDataTable)(item)
         Ok
       }
       case None => BadRequest

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.facia.client.models.Metadata
+import com.gu.facia.client.models.{Trail, Metadata}
 import model.Cached
 import permissions.Permissions
 import play.api.libs.json.{JsValue, Json}
@@ -28,6 +28,8 @@ case class Defaults(
   navListCap: Int,
   navListType: String,
   collectionMetadata: Iterable[Metadata],
+  clipboardArticles: Option[List[Trail]],
+  frontIds: Option[List[String]],
   capiLiveUrl: String = "",
   capiPreviewUrl: String = ""
 )
@@ -61,7 +63,9 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
         config.facia.navListType,
         Metadata.tags.map{
           case (_, meta) => meta
-        }
+        },
+        None,
+        None
       )))
     }
   }

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -1,8 +1,10 @@
 package controllers
 
+import com.gu.scanamo.Table
 import frontsapi.model.UpdateActions
 import logging.Logging
 import metrics.FaciaToolMetrics
+import model.UserData
 import play.api.libs.json.Json
 import services._
 import updates._
@@ -20,8 +22,8 @@ class FaciaToolV2Controller(
                          )(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with Logging {
 
-
   def collectionEdits() = AccessAPIAuthAction { implicit request =>
+
 
     FaciaToolMetrics.ApiUsageCount.increment()
 

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -1,10 +1,8 @@
 package controllers
 
-import com.gu.scanamo.Table
 import frontsapi.model.UpdateActions
 import logging.Logging
 import metrics.FaciaToolMetrics
-import model.UserData
 import play.api.libs.json.Json
 import services._
 import updates._
@@ -22,8 +20,8 @@ class FaciaToolV2Controller(
                          )(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with Logging {
 
-  def collectionEdits() = AccessAPIAuthAction { implicit request =>
 
+  def collectionEdits() = AccessAPIAuthAction { implicit request =>
 
     FaciaToolMetrics.ApiUsageCount.increment()
 

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -1,17 +1,12 @@
 package controllers
 
-import com.gu.facia.api.NotFound
 import com.gu.facia.client.models.Trail
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
-import play.api.libs.json._
 import services.Dynamo
 import model.UserData
 
-import scala.util.{Failure, Success, Try}
-
-
-class ClipboardController(dynamo: Dynamo, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
+class UserDataController(dynamo: Dynamo, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
   import model.UserData._
 
   private lazy val userDataTable = Table[UserData](config.faciatool.userDataTable)
@@ -26,8 +21,21 @@ class ClipboardController(dynamo: Dynamo, val deps: BaseFaciaControllerComponent
       case Some(articles) => {
         val userEmail = request.user.email
         Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('clipboardArticles -> articles)))
-        //val item = UserData(request.user.email, articles, List())
-        //val result = Scanamo.put(dynamo.client)(config.faciatool.userDataTable)(item)
+        Ok
+      }
+      case None => BadRequest
+    }
+  }
+
+  def putFrontIds() = APIAuthAction { request =>
+
+    val frontIds: Option[List[String]] = request.body.asJson.flatMap(jsValue =>
+      jsValue.asOpt[List[String]])
+
+    frontIds match {
+      case Some(ids) => {
+        val userEmail = request.user.email
+        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('frontIds -> ids)))
         Ok
       }
       case None => BadRequest

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -1,0 +1,20 @@
+package model
+
+import com.gu.facia.client.models.Trail
+import com.gu.scanamo.DynamoFormat
+import com.gu.scanamo.error.TypeCoercionError
+import play.api.libs.json.{JsValue, Json}
+
+import scala.util.{Failure, Success, Try}
+
+object UserData {
+  implicit val jsonFormat = Json.format[UserData]
+
+  implicit val jsValueFormat: DynamoFormat[JsValue] = DynamoFormat.xmap[JsValue, String](
+    x => Try(Json.parse(x)) match {
+      case Success(y) => Right(y)
+      case Failure(f) => Left(TypeCoercionError(f))
+    }
+  )(Json.stringify(_))
+}
+case class UserData(email: String, clipboardArticles: List[Trail], frontIds: List[String])

--- a/client-v2/src/components/Clipboard.js
+++ b/client-v2/src/components/Clipboard.js
@@ -1,9 +1,9 @@
 // @flow
 
+import { bindActionCreators } from 'redux';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as Guration from '@guardian/guration';
-import { bindActionCreators } from 'redux';
 import { type Dispatch } from 'types/Store';
 import styled from 'styled-components';
 import { batchActions } from 'redux-batched-actions';
@@ -16,12 +16,10 @@ import ArticleFragment from 'components/FrontsEdit/CollectionComponents/ArticleF
 import Supporting from 'components/FrontsEdit/CollectionComponents/Supporting';
 import DropZone from 'components/DropZone';
 import { addArticleFragment } from 'shared/actions/ArticleFragments';
-import { fetchClipboardContent } from 'actions/Clipboard';
 
 type ClipboardPropsBeforeState = {};
 
 type ClipboardProps = ClipboardPropsBeforeState & {
-  fetchClipboardContent: () => Promise<Array<String>>,
   addArticleFragment: string => Promise<string>,
   tree: Object, // TODO add typing,
   dispatch: Dispatch
@@ -38,10 +36,6 @@ const ClipboardContainer = styled(`div`)`
 `;
 
 class Clipboard extends React.Component<ClipboardProps> {
-  componentDidMount() {
-    this.props.fetchClipboardContent();
-  }
-
   handleChange = edits => {
     const futureActions = edits.reduce((acc, edit) => {
       switch (edit.type) {
@@ -117,10 +111,7 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = (dispatch: *) => ({
-  ...bindActionCreators(
-    { fetchClipboardContent, addArticleFragment },
-    dispatch
-  ),
+  ...bindActionCreators({ addArticleFragment }, dispatch),
   dispatch
 });
 

--- a/client-v2/src/index.js
+++ b/client-v2/src/index.js
@@ -10,6 +10,7 @@ import configureStore from 'util/configureStore';
 import extractConfigFromPage from 'util/extractConfigFromPage';
 import App from 'components/App';
 import { configReceived } from 'actions/Config';
+import { storeClipboardContent } from 'actions/Clipboard';
 
 const store = configureStore();
 const config = extractConfigFromPage();
@@ -19,6 +20,7 @@ if (config.stage === 'PROD' && config.ravenUrl)
   Raven.config(config.ravenUrl).install();
 
 store.dispatch(configReceived(config));
+storeClipboardContent(config.clipboardArticles)(store.dispatch);
 
 const reactMount = document.getElementById('react-mount');
 

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -109,26 +109,6 @@ async function updateCollection(
   }
 }
 
-async function getClipboard(): Promise<Array<NestedArticleFragment>> {
-  // The server does not respond with JSON
-  try {
-    const response = await pandaFetch(`/clipboard`, {
-      method: 'get',
-      credentials: 'same-origin'
-    });
-    return await response.json();
-  } catch (response) {
-    if (response.status === '404') {
-      return [];
-    }
-    throw new Error(
-      `Tried to fetch a clipboard but the server responded with ${
-        response.status
-      }: ${response.body}`
-    );
-  }
-}
-
 async function saveClipboard(
   clipboardContent: Array<NestedArticleFragment>
 ): Promise<Array<NestedArticleFragment>> {
@@ -211,6 +191,5 @@ export {
   fetchLastPressed,
   publishCollection,
   updateCollection,
-  getClipboard,
   saveClipboard
 };

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -114,8 +114,8 @@ async function saveClipboard(
 ): Promise<Array<NestedArticleFragment>> {
   // The server does not respond with JSON
   try {
-    const response = await pandaFetch(`/clipboard`, {
-      method: 'post',
+    const response = await pandaFetch(`/userdata/clipboard`, {
+      method: 'put',
       credentials: 'same-origin',
       body: JSON.stringify(clipboardContent),
       headers: {

--- a/client-v2/src/types/Config.js
+++ b/client-v2/src/types/Config.js
@@ -1,4 +1,6 @@
 // @flow
+//
+import type { NestedArticleFragment } from 'shared/types/Collection';
 
 type Permission = {
   [string]: boolean
@@ -33,7 +35,9 @@ type Config = {
   collectionMetadata: Array<Metadata>,
   capiLiveUrl: string,
   capiPreviewUrl: string,
-  ravenUrl?: string
+  ravenUrl?: string,
+  frontIds: Array<string>,
+  clipboardArticles: Array<NestedArticleFragment>
 };
 
 export type { Config };

--- a/conf/routes
+++ b/conf/routes
@@ -51,8 +51,6 @@ GET         /metadata                                controllers.FaciaToolContro
 
 POST        /treats/*collectionId                    controllers.FaciaToolController.treatEdits(collectionId)
 
-GET         /clipboard                               controllers.ClipboardController.getClipboardContent()
-
 POST        /clipboard                               controllers.ClipboardController.putClipboardContent()
 
 # endpoints for proxying https

--- a/conf/routes
+++ b/conf/routes
@@ -51,7 +51,9 @@ GET         /metadata                                controllers.FaciaToolContro
 
 POST        /treats/*collectionId                    controllers.FaciaToolController.treatEdits(collectionId)
 
-POST        /clipboard                               controllers.ClipboardController.putClipboardContent()
+PUT        /userdata/clipboard                       controllers.UserDataController.putClipboardContent()
+
+PUT        /userdata/frontIds                        controllers.UserDataController.putFrontIds()
 
 # endpoints for proxying https
 GET         /api/preview/*path                       controllers.FaciaContentApiProxy.capiPreview(path)


### PR DESCRIPTION
Instead of just storing clipboard data in dynamo, we want to store both front ids in there as well. This userdata is sent to the client when the app loads. In the future, other kinds of settings could be added to this store as well. 

Cloudformation changes for this here: https://github.com/guardian/editorial-tools-platform/pull/229

