### PR TITLE
Disable preview

### DIFF
--- a/client-v2/src/components/Feed.js
+++ b/client-v2/src/components/Feed.js
@@ -12,7 +12,6 @@ import FeedItem from './FeedItem';
 import SearchInput from './FrontsCAPIInterface/SearchInput';
 import Loader from './Loader';
 import { capiFeedSpecsSelector } from '../selectors/configSelectors';
-import { RadioButton, RadioGroup } from './inputs/RadioButtons';
 
 type ErrorDisplayProps = {
   error: ?(Error | string),
@@ -51,10 +50,6 @@ const FeedContainer = styled('div')`
   height: 100%;
 `;
 
-const StageSelectionContainer = styled('div')`
-  margin-left: auto;
-`;
-
 const ResultsHeadingContainer = styled('div')`
   display: flex;
 `;
@@ -81,19 +76,6 @@ class Feed extends React.Component<FeedProps, FeedState> {
   renderFixedContent = () => (
     <ResultsHeadingContainer>
       <ContainerHeading>Results</ContainerHeading>
-      <StageSelectionContainer>
-        <RadioGroup>
-          {this.props.capiFeedSpecs.map(({ name }, i) => (
-            <RadioButton
-              key={name}
-              checked={i === this.state.capiFeedIndex}
-              onChange={() => this.handleFeedClick(i)}
-              label={name}
-              inline
-            />
-          ))}
-        </RadioGroup>
-      </StageSelectionContainer>
     </ResultsHeadingContainer>
   );
 

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -189,7 +189,7 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     .join(',');
 
   const articlePromise = pandaFetch(
-    `/api/preview/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,
+    `/api/live/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,
     {
       method: 'get',
       credentials: 'same-origin'


### PR DESCRIPTION
Only show live articles and capi feed and always fetch articles from live capi until we've added proper support for preview articles.