### PR TITLE
clipboard content and frontids should be options

### DIFF
--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -56,8 +56,8 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
       Metadata.tags.map {
         case (_, meta) => meta
       },
-      record.map(record => record.clipboardArticles),
-      record.map(record => record.frontIds),
+      record.map(record => record.clipboardArticles.getOrElse(List())),
+      record.map(record => record.frontIds.getOrElse(List())),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
     )

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -17,4 +17,4 @@ object UserData {
     }
   )(Json.stringify(_))
 }
-case class UserData(email: String, clipboardArticles: List[Trail], frontIds: List[String])
+case class UserData(email: String, clipboardArticles: Option[List[Trail]], frontIds: Option[List[String]])


### PR DESCRIPTION
Clipboard and frontids are now options. This is means we are able to fetch clipboard content if either one is empty. We are also able to create a new entry if user does not have any data stored yet. 

The user data table key is still the user's email. I couldn't find an easy way of getting hold of the user's id but I had a chat with central production about this and they don't think it is a problem. User's emails change rarely, they shouldn't be storing content on the clipboard long term and if there is some kind of an emergency, we can fix it for them.