### PR TITLE
Add more granular permissions

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -63,7 +63,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val views = new ViewsController(acl, assetsManager, isDev, encryption, this)
   val pressController = new PressController(dynamo, this)
   val v2App = new V2App(isDev, acl, dynamo, this)
-  val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, this)
+  val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, configAgent, this)
   val userDataController = new UserDataController(dynamo, this)
   val gridProxy = new GridProxy(this)
 

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -2,19 +2,21 @@ package controllers
 
 import java.util.Locale
 
-import com.gu.pandomainauth.action.AuthActions
+import com.gu.pandomainauth.action.{AuthActions, UserRequest}
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
 import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import conf.ApplicationConfiguration
-import permissions.{AccessPermissionCheck, Permissions}
+import permissions._
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
-import play.api.mvc.{BaseController, ControllerComponents, RequestHeader, Result}
+import play.api.mvc._
 import play.api.{BuiltInComponentsFromContext, Logger}
 import play.filters.cors.CORSComponents
 import switchboard.SwitchManager
+import util.Acl
+import scala.concurrent.ExecutionContext
 
 abstract class BaseFaciaControllerComponents(context: Context) extends BuiltInComponentsFromContext(context) with AhcWSComponents with AssetsComponents with CORSComponents {
 
@@ -45,6 +47,16 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
   private val accessPermissionCheck = new AccessPermissionCheck(deps.permissions)(deps.executionContext)
   final def AccessAuthAction = AuthAction andThen accessPermissionCheck
   final def AccessAPIAuthAction = APIAuthAction andThen accessPermissionCheck
+
+  def getCollectionPermissionFilterByPriority(priority: String, acl: Acl)(implicit ec: ExecutionContext): ActionBuilder[UserRequest, AnyContent] = {
+    val permissionsPriority = PermissionsPriority.stringToPermissionPriority(priority)
+    permissionsPriority match {
+      case Some(EditorialPermission) => AccessAuthAction andThen new EditEditorialFrontsPermissionCheck(acl)
+      case Some(CommercialPermission) => AccessAuthAction andThen new LaunchCommercialFrontsPermissionCheck(acl)
+      case Some(EmailPermission) => AccessAuthAction andThen new EditEditorialFrontsPermissionCheck(acl)
+      case _ => AccessAuthAction
+    }
+  }
 
   private def userInGroups(authedUser: AuthenticatedUser): Boolean = {
     if(SwitchManager.getStatus("facia-tool-permissions-access")) {

--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -42,7 +42,7 @@ class FaciaToolController(
 
   def getCollection(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
 
-    val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
+    val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
 
@@ -61,16 +61,11 @@ class FaciaToolController(
     }
   }
 
-  def getPriorityFilterFromCollectionId(collectionId: String) = {
-    val result: Set[PermissionsPriority] = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
-    result
-  }
-
   def publishCollection(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
 
     withModifyPermissionForCollections(Set(collectionId)) {
 
-      val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
+      val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
 
       withModifyGroupPermissionForCollections(collectionPriorities, Set(), true) {
         val identity = request.user
@@ -120,7 +115,7 @@ class FaciaToolController(
 
   def treatEdits(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
 
-    val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
+    val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
 
@@ -167,7 +162,7 @@ class FaciaToolController(
         case update: Update =>
           withModifyPermissionForCollections(Set(update.update.id)) {
 
-            val collectionPriorities = getPriorityFilterFromCollectionId(update.update.id)
+            val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(update.update.id)
 
             withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
 
@@ -198,7 +193,7 @@ class FaciaToolController(
         case remove: Remove =>
           withModifyPermissionForCollections(Set(remove.remove.id)) {
 
-            val collectionPriorities = getPriorityFilterFromCollectionId(remove.remove.id)
+            val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(remove.remove.id)
 
             withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
 
@@ -220,8 +215,8 @@ class FaciaToolController(
         case updateAndRemove: UpdateAndRemove =>
           withModifyPermissionForCollections(Set(updateAndRemove.update.id, updateAndRemove.remove.id)) {
 
-            val fromCollectionPriorities = getPriorityFilterFromCollectionId(updateAndRemove.update.id)
-            val toCollectionPriorities = getPriorityFilterFromCollectionId(updateAndRemove.remove.id)
+            val fromCollectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(updateAndRemove.update.id)
+            val toCollectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(updateAndRemove.remove.id)
 
             withModifyGroupPermissionForCollections(fromCollectionPriorities, toCollectionPriorities) {
               val identity = request.user

--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -40,30 +40,39 @@ class FaciaToolController(
       NoCache {
         Ok(Json.toJson(configJson)).as("application/json")}}}
 
-  def getCollection(collectionId: String) = AccessAPIAuthAction.async { request =>
+  def getCollection(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
 
-    FaciaToolMetrics.ApiUsageCount.increment()
-    val collection = frontsApi.amazonClient.collection(collectionId).flatMap{ collectionJson =>
-      collectionJson.map(json => mediaServiceClient.addThumbnailsToCollection(json, collectionId)) match {
-        case Some(f) => f.map(Some(_))
-        case None    => Future.successful(None)
+    val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
+
+    withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
+
+      FaciaToolMetrics.ApiUsageCount.increment()
+      val collection = frontsApi.amazonClient.collection(collectionId).flatMap { collectionJson =>
+        collectionJson.map(json => mediaServiceClient.addThumbnailsToCollection(json, collectionId)) match {
+          case Some(f) => f.map(Some(_))
+          case None => Future.successful(None)
+
+        }
       }
+      collection.map(c => NoCache {
+        Ok(Json.toJson(c)).as("application/json")
+      })
+
     }
-    collection.map(c => NoCache {
-      Ok(Json.toJson(c)).as("application/json")})
   }
 
   def getPriorityFilterFromCollectionId(collectionId: String) = {
-    println(collectionId)
     val result: Set[PermissionsPriority] = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
     result
   }
 
   def publishCollection(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
 
-    val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
     withModifyPermissionForCollections(Set(collectionId)) {
-      withModifyGroupPermissionForCollections(collectionPriorities, true) {
+
+      val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
+
+      withModifyGroupPermissionForCollections(collectionPriorities, Set(), true) {
         val identity = request.user
         FaciaToolMetrics.DraftPublishCount.increment()
         val futureCollectionJson = faciaApiIO.publishCollectionJson(collectionId, identity)
@@ -109,41 +118,47 @@ class FaciaToolController(
       }
       NoCache(Ok)}}
 
-  def treatEdits(collectionId: String) = AccessAPIAuthAction.async { request =>
-    request.body.asJson.flatMap(_.asOpt[UpdateMessage]).map {
-      case update: Update =>
-        val identity = request.user
-        updateActions.updateTreats(collectionId, update.update, identity).map(_.map{ updatedCollectionJson =>
-          s3FrontsApi.putCollectionJson(collectionId, Json.prettyPrint(Json.toJson(updatedCollectionJson)))
-          structuredLogger.putLog(LogUpdate(update, identity.email))
-          faciaPress.press(PressCommand.forOneId(collectionId).withPressLive())
-          Ok(Json.toJson(Map(collectionId -> updatedCollectionJson))).as("application/json")
-        }.getOrElse(NotFound))
+  def treatEdits(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
 
-      case remove: Remove =>
-        val identity = request.user
-        updateActions.removeTreats(collectionId, remove.remove, identity).map(_.map{ updatedCollectionJson =>
-          s3FrontsApi.putCollectionJson(collectionId, Json.prettyPrint(Json.toJson(updatedCollectionJson)))
-          structuredLogger.putLog(LogUpdate(remove, identity.email))
-          faciaPress.press(PressCommand.forOneId(collectionId).withPressLive())
-          Ok(Json.toJson(Map(collectionId -> updatedCollectionJson))).as("application/json")
-      }.getOrElse(NotFound))
-      case updateAndRemove: UpdateAndRemove =>
-        val identity = request.user
-        val futureUpdatedCollections =
-          Future.sequence(
-            List(updateActions.updateTreats(updateAndRemove.update.id, updateAndRemove.update, identity).map(_.map(updateAndRemove.update.id -> _)),
-              updateActions.removeTreats(updateAndRemove.remove.id, updateAndRemove.remove, identity).map(_.map(updateAndRemove.remove.id -> _))
-            )).map(_.flatten.toMap)
+    val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
 
-        futureUpdatedCollections.map { updatedCollections =>
-          val collectionIds = updatedCollections.keySet
-          structuredLogger.putLog(LogUpdate(updateAndRemove, identity.email))
-          faciaPress.press(PressCommand(collectionIds).withPressLive())
-          Ok(Json.toJson(updatedCollections)).as("application/json")
-        }
-      case _ => Future.successful(NotAcceptable)
-    }.getOrElse(Future.successful(NotAcceptable))
+    withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
+
+      request.body.asJson.flatMap(_.asOpt[UpdateMessage]).map {
+        case update: Update =>
+          val identity = request.user
+          updateActions.updateTreats(collectionId, update.update, identity).map(_.map { updatedCollectionJson =>
+            s3FrontsApi.putCollectionJson(collectionId, Json.prettyPrint(Json.toJson(updatedCollectionJson)))
+            structuredLogger.putLog(LogUpdate(update, identity.email))
+            faciaPress.press(PressCommand.forOneId(collectionId).withPressLive())
+            Ok(Json.toJson(Map(collectionId -> updatedCollectionJson))).as("application/json")
+          }.getOrElse(NotFound))
+
+        case remove: Remove =>
+          val identity = request.user
+          updateActions.removeTreats(collectionId, remove.remove, identity).map(_.map { updatedCollectionJson =>
+            s3FrontsApi.putCollectionJson(collectionId, Json.prettyPrint(Json.toJson(updatedCollectionJson)))
+            structuredLogger.putLog(LogUpdate(remove, identity.email))
+            faciaPress.press(PressCommand.forOneId(collectionId).withPressLive())
+            Ok(Json.toJson(Map(collectionId -> updatedCollectionJson))).as("application/json")
+          }.getOrElse(NotFound))
+        case updateAndRemove: UpdateAndRemove =>
+          val identity = request.user
+          val futureUpdatedCollections =
+            Future.sequence(
+              List(updateActions.updateTreats(updateAndRemove.update.id, updateAndRemove.update, identity).map(_.map(updateAndRemove.update.id -> _)),
+                updateActions.removeTreats(updateAndRemove.remove.id, updateAndRemove.remove, identity).map(_.map(updateAndRemove.remove.id -> _))
+              )).map(_.flatten.toMap)
+
+          futureUpdatedCollections.map { updatedCollections =>
+            val collectionIds = updatedCollections.keySet
+            structuredLogger.putLog(LogUpdate(updateAndRemove, identity.email))
+            faciaPress.press(PressCommand(collectionIds).withPressLive())
+            Ok(Json.toJson(updatedCollections)).as("application/json")
+          }
+        case _ => Future.successful(NotAcceptable)
+      }.getOrElse(Future.successful(NotAcceptable))
+    }
   }
 
   def collectionEdits(): Action[AnyContent] = AccessAPIAuthAction.async { implicit request =>
@@ -151,66 +166,84 @@ class FaciaToolController(
       request.body.asJson.flatMap (_.asOpt[UpdateMessage]).map {
         case update: Update =>
           withModifyPermissionForCollections(Set(update.update.id)) {
-            val identity = request.user
 
-            val futureCollectionJson = updateActions.updateCollectionList(update.update.id, update.update, identity)
-            futureCollectionJson.map { maybeCollectionJson =>
-              val updatedCollections = maybeCollectionJson.map(update.update.id -> _).toMap
+            val collectionPriorities = getPriorityFilterFromCollectionId(update.update.id)
 
-              val shouldUpdateLive: Boolean = update.update.live
+            withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
 
-              val collectionIds = updatedCollections.keySet
+              val identity = request.user
 
-              faciaPress.press(PressCommand(
-                collectionIds,
-                live = shouldUpdateLive,
-                draft = (updatedCollections.values.exists(_.draft.isEmpty) && shouldUpdateLive) || update.update.draft)
-              )
+              val futureCollectionJson = updateActions.updateCollectionList(update.update.id, update.update, identity)
+              futureCollectionJson.map { maybeCollectionJson =>
+                val updatedCollections = maybeCollectionJson.map(update.update.id -> _).toMap
 
-              if (updatedCollections.nonEmpty) {
-                structuredLogger.putLog(LogUpdate(update, identity.email))
-                Ok(Json.toJson(updatedCollections)).as("application/json")
-              } else
-                NotFound
+                val shouldUpdateLive: Boolean = update.update.live
+
+                val collectionIds = updatedCollections.keySet
+
+                faciaPress.press(PressCommand(
+                  collectionIds,
+                  live = shouldUpdateLive,
+                  draft = (updatedCollections.values.exists(_.draft.isEmpty) && shouldUpdateLive) || update.update.draft)
+                )
+
+                if (updatedCollections.nonEmpty) {
+                  structuredLogger.putLog(LogUpdate(update, identity.email))
+                  Ok(Json.toJson(updatedCollections)).as("application/json")
+                } else
+                  NotFound
+              }
             }
           }
         case remove: Remove =>
           withModifyPermissionForCollections(Set(remove.remove.id)) {
-            val identity = request.user
-            updateActions.updateCollectionFilter(remove.remove.id, remove.remove, identity).map { maybeCollectionJson =>
-              val updatedCollections = maybeCollectionJson.map(remove.remove.id -> _).toMap
-              val shouldUpdateLive: Boolean = remove.remove.live
-              val collectionIds = updatedCollections.keySet
-              faciaPress.press(PressCommand(
-                collectionIds,
-                live = shouldUpdateLive,
-                draft = (updatedCollections.values.exists(_.draft.isEmpty) && shouldUpdateLive) || remove.remove.draft)
-              )
-              structuredLogger.putLog(LogUpdate(remove, identity.email))
-              Ok(Json.toJson(updatedCollections)).as("application/json")
+
+            val collectionPriorities = getPriorityFilterFromCollectionId(remove.remove.id)
+
+            withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
+
+              val identity = request.user
+              updateActions.updateCollectionFilter(remove.remove.id, remove.remove, identity).map { maybeCollectionJson =>
+                val updatedCollections = maybeCollectionJson.map(remove.remove.id -> _).toMap
+                val shouldUpdateLive: Boolean = remove.remove.live
+                val collectionIds = updatedCollections.keySet
+                faciaPress.press(PressCommand(
+                  collectionIds,
+                  live = shouldUpdateLive,
+                  draft = (updatedCollections.values.exists(_.draft.isEmpty) && shouldUpdateLive) || remove.remove.draft)
+                )
+                structuredLogger.putLog(LogUpdate(remove, identity.email))
+                Ok(Json.toJson(updatedCollections)).as("application/json")
+              }
             }
           }
         case updateAndRemove: UpdateAndRemove =>
           withModifyPermissionForCollections(Set(updateAndRemove.update.id, updateAndRemove.remove.id)) {
-            val identity = request.user
-            val futureUpdatedCollections =
-              Future.sequence(
-                List(updateActions.updateCollectionList(updateAndRemove.update.id, updateAndRemove.update, identity).map(_.map(updateAndRemove.update.id -> _)),
-                  updateActions.updateCollectionFilter(updateAndRemove.remove.id, updateAndRemove.remove, identity).map(_.map(updateAndRemove.remove.id -> _))
-                )).map(_.flatten.toMap)
 
-            futureUpdatedCollections.map { updatedCollections =>
+            val fromCollectionPriorities = getPriorityFilterFromCollectionId(updateAndRemove.update.id)
+            val toCollectionPriorities = getPriorityFilterFromCollectionId(updateAndRemove.remove.id)
 
-              val shouldUpdateLive: Boolean = updateAndRemove.remove.live || updateAndRemove.update.live
-              val shouldUpdateDraft: Boolean = updateAndRemove.remove.draft || updateAndRemove.update.draft
-              val collectionIds = updatedCollections.keySet
-              faciaPress.press(PressCommand(
-                collectionIds,
-                live = shouldUpdateLive,
-                draft = (updatedCollections.values.exists(_.draft.isEmpty) && shouldUpdateLive) || shouldUpdateDraft)
-              )
-              structuredLogger.putLog(LogUpdate(updateAndRemove, identity.email))
-              Ok(Json.toJson(updatedCollections)).as("application/json")
+            withModifyGroupPermissionForCollections(fromCollectionPriorities, toCollectionPriorities) {
+              val identity = request.user
+              val futureUpdatedCollections =
+                Future.sequence(
+                  List(updateActions.updateCollectionList(updateAndRemove.update.id, updateAndRemove.update, identity).map(_.map(updateAndRemove.update.id -> _)),
+                    updateActions.updateCollectionFilter(updateAndRemove.remove.id, updateAndRemove.remove, identity).map(_.map(updateAndRemove.remove.id -> _))
+                  )).map(_.flatten.toMap)
+
+              futureUpdatedCollections.map { updatedCollections =>
+
+                val shouldUpdateLive: Boolean = updateAndRemove.remove.live || updateAndRemove.update.live
+                val shouldUpdateDraft: Boolean = updateAndRemove.remove.draft || updateAndRemove.update.draft
+                val collectionIds = updatedCollections.keySet
+                faciaPress.press(PressCommand(
+                  collectionIds,
+                  live = shouldUpdateLive,
+                  draft = (updatedCollections.values.exists(_.draft.isEmpty) && shouldUpdateLive) || shouldUpdateDraft)
+                )
+                structuredLogger.putLog(LogUpdate(updateAndRemove, identity.email))
+                Ok(Json.toJson(updatedCollections)).as("application/json")
+              }
             }
           }
         case _ => Future.successful(NotAcceptable)

--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -63,7 +63,7 @@ class FaciaToolController(
 
     val collectionPriorities = getPriorityFilterFromCollectionId(collectionId)
     withModifyPermissionForCollections(Set(collectionId)) {
-      withLaunchGroupPermissionForCollections(collectionPriorities) {
+      withModifyGroupPermissionForCollections(collectionPriorities, true) {
         val identity = request.user
         FaciaToolMetrics.DraftPublishCount.increment()
         val futureCollectionJson = faciaApiIO.publishCollectionJson(collectionId, identity)

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -16,7 +16,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
 
   import model.UserData._
 
-  def index(priority: String = "", frontId: String = "") = AccessAuthAction { implicit req =>
+  def index(priority: String = "", frontId: String = "") = getCollectionPermissionFilterByPriority(priority, acl)(ec) { implicit req =>
 
     val userDataTable = Table[UserData](config.faciatool.userDataTable)
 

--- a/app/controllers/ViewsController.scala
+++ b/app/controllers/ViewsController.scala
@@ -18,7 +18,7 @@ class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean
     }
   }
 
-  def collectionEditor() = AccessAuthAction { request =>
+  def collectionEditor(priority: String) = getCollectionPermissionFilterByPriority(priority, acl)(ec) { request =>
     val identity = request.user
     Cached(60) {
       Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -6,7 +6,7 @@ object Permissions {
   val FrontsAccess = PermissionDefinition("fronts_access", "fronts")
   val ConfigureFronts = PermissionDefinition("configure_fronts", "fronts")
   val BreakingNewsAlert = PermissionDefinition("breaking_news_alert", "fronts")
-  val LaunchCommercialFrontsAlert = PermissionDefinition("launch_commercial_fronts", "fronts")
-  val LaunchEditorialFrontsAlert = PermissionDefinition("launch_editorial_fronts", "fronts")
-  val EditEditorialFrontsAlert = PermissionDefinition("edit_editorial_fronts", "fronts")
+  val LaunchCommercialFronts = PermissionDefinition("launch_commercial_fronts", "fronts")
+  val LaunchEditorialFronts = PermissionDefinition("launch_editorial_fronts", "fronts")
+  val EditEditorialFronts = PermissionDefinition("edit_editorial_fronts", "fronts")
 }

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -6,4 +6,7 @@ object Permissions {
   val FrontsAccess = PermissionDefinition("fronts_access", "fronts")
   val ConfigureFronts = PermissionDefinition("configure_fronts", "fronts")
   val BreakingNewsAlert = PermissionDefinition("breaking_news_alert", "fronts")
+  val LaunchCommercialFrontsAlert = PermissionDefinition("launch_commercial_fronts", "fronts")
+  val LaunchEditorialFrontsAlert = PermissionDefinition("launch_editorial_fronts", "fronts")
+  val EditEditorialFrontsAlert = PermissionDefinition("edit_editorial_fronts", "fronts")
 }

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -62,19 +62,19 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
 
 class LaunchCommercialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
-  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchCommercialFrontsAlert, "facia-tool-allow-access-for-all")
+  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchCommercialFrontsAlert, "facia-tool-allow-launch-commercial-fronts-for-all")
   override val restrictedAction: String = "Launch commercial fronts."
 }
 
 class LaunchEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
-  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchEditorialFrontsAlert, "facia-tool-allow-access-for-all")
+  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchEditorialFrontsAlert, "facia-tool-allow-launch-editorial-fronts-for-all")
   override val restrictedAction: String = "Launch editorial fronts."
 }
 
 class EditEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
-  override val testAccess: String => Authorization = acl.testUser(Permissions.EditEditorialFrontsAlert, "facia-tool-allow-access-for-all")
+  override val testAccess: String => Authorization = acl.testUser(Permissions.EditEditorialFrontsAlert, "facia-tool-allow-edit-editorial-fronts-for-all")
   override val restrictedAction: String = "Edit editorial fronts."
 }
 

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -37,11 +37,11 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
     if (priorities.isEmpty) AccessGranted
     else if (isLaunch)
       acl.testUserGroupsAndCollections(
-        Permissions.LaunchEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert, Permissions.EditEditorialFrontsAlert,
+        Permissions.LaunchEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert,
         Permissions.FrontsAccess, "facia-tool-allow-access-for-all")(email, priorities)
     else
       acl.testUserGroupsAndCollections(
-        Permissions.EditEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert, Permissions.EditEditorialFrontsAlert,
+        Permissions.EditEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert,
         Permissions.FrontsAccess, "facia-tool-allow-access-for-all")(email, priorities)
   }
 

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -38,11 +38,11 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
     else if (isLaunch)
       acl.testUserGroupsAndCollections(
         Permissions.LaunchEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert,
-        Permissions.FrontsAccess, "facia-tool-allow-access-for-all")(email, priorities)
+        Permissions.FrontsAccess, "facia-tool-allow-launch-editorial-fronts-for-all")(email, priorities)
     else
       acl.testUserGroupsAndCollections(
         Permissions.EditEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert,
-        Permissions.FrontsAccess, "facia-tool-allow-access-for-all")(email, priorities)
+        Permissions.FrontsAccess, "facia-tool-allow-edit-editorial-fronts-for-all")(email, priorities)
   }
 
   def withModifyGroupPermissionForCollections[A](priorities: Set[PermissionsPriority], secondaryPriorities: Set[PermissionsPriority],

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -37,11 +37,11 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
     if (priorities.isEmpty) AccessGranted
     else if (isLaunch)
       acl.testUserGroupsAndCollections(
-        Permissions.LaunchEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert,
+        Permissions.LaunchEditorialFronts, Permissions.LaunchCommercialFronts,
         Permissions.FrontsAccess, "facia-tool-allow-launch-editorial-fronts-for-all")(email, priorities)
     else
       acl.testUserGroupsAndCollections(
-        Permissions.EditEditorialFrontsAlert, Permissions.LaunchCommercialFrontsAlert,
+        Permissions.EditEditorialFronts, Permissions.LaunchCommercialFronts,
         Permissions.FrontsAccess, "facia-tool-allow-edit-editorial-fronts-for-all")(email, priorities)
   }
 
@@ -62,19 +62,19 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
 
 class LaunchCommercialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
-  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchCommercialFrontsAlert, "facia-tool-allow-launch-commercial-fronts-for-all")
+  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchCommercialFronts, "facia-tool-allow-launch-commercial-fronts-for-all")
   override val restrictedAction: String = "Launch commercial fronts."
 }
 
 class LaunchEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
-  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchEditorialFrontsAlert, "facia-tool-allow-launch-editorial-fronts-for-all")
+  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchEditorialFronts, "facia-tool-allow-launch-editorial-fronts-for-all")
   override val restrictedAction: String = "Launch editorial fronts."
 }
 
 class EditEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
-  override val testAccess: String => Authorization = acl.testUser(Permissions.EditEditorialFrontsAlert, "facia-tool-allow-edit-editorial-fronts-for-all")
+  override val testAccess: String => Authorization = acl.testUser(Permissions.EditEditorialFronts, "facia-tool-allow-edit-editorial-fronts-for-all")
   override val restrictedAction: String = "Edit editorial fronts."
 }
 

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -28,6 +28,36 @@ trait PermissionActionFilter extends ActionFilter[UserRequest] with Logging {
   }
 }
 
+//I think that this might be a better place to put the logic than in the FaciaToolController class. In both places the logic will be quite ugly I think
+//My vision is that there would be a modify and a view to take into account editorial priority having the concept of both view and launch. Whether should deny permission
+//is based on the endpoint i.e. is it GET or POST so which filter you want would need to be decided in the controller.
+class ModifyCollectionsPermissionsCheck(val acl: Acl, val priorityPermissions: Set[PermissionsPriority])(implicit ec: ExecutionContext) extends PermissionActionFilter {
+  override implicit val executionContext: ExecutionContext = ec
+  override val testAccess: String => Authorization = { email =>
+    if(priorityPermissions.size > 1) {
+
+    }
+
+
+
+
+
+
+
+
+
+    val commercialTest = acl.testUser(Permissions.LaunchCommercialFrontsAlert, "facia-tool-allow-access-for-all")(email)
+    val editorialTest = acl.testUser(Permissions.LaunchEditorialFrontsAlert, "facia-tool-allow-access-for-all")(email)
+    if(commercialTest == AccessGranted) commercialTest else {
+      if(editorialTest == AccessGranted) editorialTest else {
+        //The user does not have permission to edit a collection on a editorial or a commercial front which 'testUser' function get's returned doesn't matter
+        commercialTest
+      }
+    }
+  }
+  override val restrictedAction: String = "Modify a collection"
+}
+
 class LaunchCommercialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   override implicit val executionContext: ExecutionContext = ec
   override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchCommercialFrontsAlert, "facia-tool-allow-access-for-all")

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -28,6 +28,24 @@ trait PermissionActionFilter extends ActionFilter[UserRequest] with Logging {
   }
 }
 
+class LaunchCommercialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
+  override implicit val executionContext: ExecutionContext = ec
+  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchCommercialFrontsAlert, "facia-tool-allow-access-for-all")
+  override val restrictedAction: String = "Launch commercial fronts."
+}
+
+class LaunchEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
+  override implicit val executionContext: ExecutionContext = ec
+  override val testAccess: String => Authorization = acl.testUser(Permissions.LaunchEditorialFrontsAlert, "facia-tool-allow-access-for-all")
+  override val restrictedAction: String = "Launch editorial fronts."
+}
+
+class EditEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
+  override implicit val executionContext: ExecutionContext = ec
+  override val testAccess: String => Authorization = acl.testUser(Permissions.EditEditorialFrontsAlert, "facia-tool-allow-access-for-all")
+  override val restrictedAction: String = "Edit editorial fronts."
+}
+
 class AccessPermissionCheck(client: PermissionsProvider)(implicit ec: ExecutionContext) extends PermissionActionFilter {
   val executionContext = ec
   val restrictedAction = "access fronts"

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -53,7 +53,7 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
     (testAccess(request.user.email, priorities, isLaunch), testAccess(request.user.email, secondaryPriorities, isLaunch)) match {
       case (AccessGranted, AccessGranted) => block
       case _ => {
-        logger.info(s"User with e-mail ${request.user.email} not authorized to modify collection")
+        logger.warn(s"User with e-mail ${request.user.email} not authorized to modify collection with priorities $priorities")
         Future.successful(Results.Unauthorized)
       }
     }

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -52,10 +52,7 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
 
     (testAccess(request.user.email, priorities, isLaunch), testAccess(request.user.email, secondaryPriorities, isLaunch)) match {
       case (AccessGranted, AccessGranted) => block
-      case _ => {
-        logger.warn(s"User with e-mail ${request.user.email} not authorized to modify collection with priorities $priorities")
-        Future.successful(Results.Unauthorized)
-      }
+      case _ => Future.successful(Results.Unauthorized)
     }
   }
 }

--- a/app/permissions/PermissionsPriority.scala
+++ b/app/permissions/PermissionsPriority.scala
@@ -1,0 +1,20 @@
+package permissions
+
+sealed trait PermissionsPriority
+case object EditorialPermission extends PermissionsPriority
+case object CommercialPermission extends PermissionsPriority
+case object EmailPermission extends PermissionsPriority
+case object TrainingPermission extends PermissionsPriority
+
+
+object PermissionsPriority {
+  def stringToPermissionPriority(s: String) = {
+    s.toLowerCase match {
+      case "editorial" => Some(EditorialPermission)
+      case "commercial" => Some(CommercialPermission)
+      case "email" => Some(EmailPermission)
+      case "training" => Some(TrainingPermission)
+      case _ => None
+    }
+  }
+}

--- a/app/permissions/PermissionsPriority.scala
+++ b/app/permissions/PermissionsPriority.scala
@@ -8,7 +8,7 @@ case object TrainingPermission extends PermissionsPriority
 
 
 object PermissionsPriority {
-  def stringToPermissionPriority(s: String) = {
+  def stringToPermissionPriority(s: String): Option[PermissionsPriority] = {
     s.toLowerCase match {
       case "editorial" => Some(EditorialPermission)
       case "commercial" => Some(CommercialPermission)

--- a/app/services/ConfigAgentTrait.scala
+++ b/app/services/ConfigAgentTrait.scala
@@ -5,6 +5,7 @@ import com.gu.facia.api.models.CollectionConfig
 import com.gu.facia.client.models.{ConfigJson => Config}
 import conf.ApplicationConfiguration
 import logging.Logging
+import permissions.PermissionsPriority
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -53,5 +54,18 @@ class ConfigAgent(val config: ApplicationConfiguration, val frontsApi: FrontsApi
   }
 
   def getConfig(id: String): Option[CollectionConfig] = configAgent.get().flatMap(_.collections.get(id).map(CollectionConfig.fromCollectionJson))
+
+  def getFrontsPermissionsPriorityByCollectionId(id: String): Set[PermissionsPriority] = configAgent.get().map(config => {
+    val fronts = config.fronts
+    fronts.foldLeft(Set[PermissionsPriority]())((acc, front) => {
+      if (front._2.collections.contains(id)) {
+        val priority = PermissionsPriority.stringToPermissionPriority(front._2.priority.getOrElse("editorial"))
+        priority match {
+          case Some(p) => acc + p
+          case _ => acc
+        }
+      } else acc
+    })
+  }).getOrElse(Set.empty)
 
 }

--- a/app/services/ConfigAgentTrait.scala
+++ b/app/services/ConfigAgentTrait.scala
@@ -57,15 +57,15 @@ class ConfigAgent(val config: ApplicationConfiguration, val frontsApi: FrontsApi
 
   def getFrontsPermissionsPriorityByCollectionId(id: String): Set[PermissionsPriority] = configAgent.get().map(config => {
     val fronts = config.fronts
-    fronts.foldLeft(Set[PermissionsPriority]())((acc, front) => {
-      if (front._2.collections.contains(id)) {
-        val priority = PermissionsPriority.stringToPermissionPriority(front._2.priority.getOrElse("editorial"))
+    fronts.foldLeft(Set.empty[PermissionsPriority]) { case (acc, (_, front)) => {
+      if (front.collections.contains(id)) {
+        val priority = PermissionsPriority.stringToPermissionPriority(front.priority.getOrElse("editorial"))
         priority match {
           case Some(p) => acc + p
           case _ => acc
         }
       } else acc
-    })
+    }}
   }).getOrElse(Set.empty)
 
 }

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -57,7 +57,16 @@ class Acl(permissions: PermissionsProvider) extends Logging {
     val hasEditorialPermissions = testUser(editorialPermission, editorialSwitch)(email)
     val hasTrainingPermissions = testUser(trainingPermission, "facia-tool-permissions-access")(email)
 
-    PermissionsChecker.check(hasCommercialPermissions, hasEditorialPermissions, hasTrainingPermissions, priorities)
+    PermissionsChecker.check(hasCommercialPermissions, hasEditorialPermissions, hasTrainingPermissions, priorities) match {
+      case AccessGranted => AccessGranted
+      case AccessDenied => {
+        logger.warn(s"User with e-mail ${email} and with the following permissions commercial: $hasCommercialPermissions, " +
+          s"editorial: $hasEditorialPermissions and training: $hasTrainingPermissions is not authorized to modify " +
+          s"collection with priorities " +
+          s"$priorities")
+        AccessDenied
+      }
+    }
   }
 }
 

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -50,12 +50,12 @@ class Acl(permissions: PermissionsProvider) extends Logging {
   }
 
   def testUserGroupsAndCollections(editorialPermission: PermissionDefinition, commercialPermission: PermissionDefinition,
-                                   trainingPermission: PermissionDefinition, switch: String)
+                                   trainingPermission: PermissionDefinition, editorialSwitch: String)
                                   (email: String, priorities: Set[PermissionsPriority]): Authorization = {
 
-    val hasCommercialPermissions = testUser(commercialPermission, switch)(email)
-    val hasEditorialPermissions = testUser(editorialPermission, switch)(email)
-    val hasTrainingPermissions = testUser(trainingPermission, switch)(email)
+    val hasCommercialPermissions = testUser(commercialPermission, "facia-tool-allow-launch-commercial-fronts-for-all")(email)
+    val hasEditorialPermissions = testUser(editorialPermission, editorialSwitch)(email)
+    val hasTrainingPermissions = testUser(trainingPermission, "facia-tool-permissions-access")(email)
 
     PermissionsChecker.check(hasCommercialPermissions, hasEditorialPermissions, hasTrainingPermissions, priorities)
   }

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -64,13 +64,17 @@ class Acl(permissions: PermissionsProvider) extends Logging {
     if (priorities.contains(TrainingPermission))
       hasTrainingPermissions
     else {
-      if (editorialPermissionIsValid && commercialPermissionIsValid)
-        if (List(hasCommercialPermissions, hasEditorialPermissions).contains(AccessGranted))
+      if (editorialPermissionIsValid && commercialPermissionIsValid) {
+        if (List(hasCommercialPermissions, hasEditorialPermissions).contains(AccessGranted)) {
           AccessGranted
+        }
         else
           AccessDenied
-      else if (commercialPermissionIsValid)
+      }
+
+      else if (commercialPermissionIsValid) {
         hasCommercialPermissions
+      }
       else if (editorialPermissionIsValid)
         hasEditorialPermissions
       else AccessDenied

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -51,17 +51,31 @@ class Acl(permissions: PermissionsProvider) extends Logging {
   }
 
   def testUserGroupsAndCollections(editorialPermission: PermissionDefinition, commercialPermission: PermissionDefinition,
-                                   emailPermission: PermissionDefinition, trainingPermission: PermissionDefinition, switch: String)
+                                   trainingPermission: PermissionDefinition, switch: String)
                                   (email: String, priorities: Set[PermissionsPriority]): Authorization = {
 
-    val hasCommercialPermissions =  testUser(commercialPermission, switch)(email)
+    val hasCommercialPermissions = testUser(commercialPermission, switch)(email)
     val hasEditorialPermissions = testUser(editorialPermission, switch)(email)
     val hasTrainingPermissions = testUser(trainingPermission, switch)(email)
 
+    PermissionsChecker.check(hasCommercialPermissions, hasEditorialPermissions, hasTrainingPermissions, priorities)
+  }
+}
+
+object PermissionsChecker {
+
+  def check(
+             hasCommercialPermissions: Authorization,
+             hasEditorialPermissions: Authorization,
+             hasTrainingPermissions: Authorization,
+             priorities: Set[PermissionsPriority]
+           ): Authorization =  {
+
+    val trainingPermissionIsValid = priorities.contains(TrainingPermission)
     val editorialPermissionIsValid = priorities.contains(EditorialPermission) || priorities.contains(EmailPermission)
     val commercialPermissionIsValid = priorities.contains(CommercialPermission)
 
-    if (priorities.contains(TrainingPermission))
+    if (trainingPermissionIsValid)
       hasTrainingPermissions
     else {
       if (editorialPermissionIsValid && commercialPermissionIsValid) {

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -1,7 +1,6 @@
 package util
 
 import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
-import com.sun.xml.internal.fastinfoset.CommonResourceBundle
 import logging.Logging
 import permissions._
 import play.api.libs.json.{JsBoolean, JsValue, Json, Writes}

--- a/conf/routes
+++ b/conf/routes
@@ -23,10 +23,10 @@ GET         /assets/*file                            controllers.UncachedAssets.
 
 # Fronts
 GET         /                                        controllers.ViewsController.priorities()
-GET         /editorial                               controllers.ViewsController.collectionEditor()
-GET         /commercial                              controllers.ViewsController.collectionEditor()
-GET         /training                                controllers.ViewsController.collectionEditor()
-GET         /email                                   controllers.ViewsController.collectionEditor()
+GET         /editorial                               controllers.ViewsController.collectionEditor(priority="editorial")
+GET         /commercial                              controllers.ViewsController.collectionEditor(priority="commercial")
+GET         /training                                controllers.ViewsController.collectionEditor(priority="training")
+GET         /email                                   controllers.ViewsController.collectionEditor(priority="email")
 
 GET         /editorial/config                        controllers.ViewsController.configEditor()
 GET         /commercial/config                       controllers.ViewsController.configEditor()

--- a/test/package.scala
+++ b/test/package.scala
@@ -1,9 +1,11 @@
 package test
 
 import org.scalatest.Suites
+import util.AclTest
 
 class FaciaToolTestSuite extends Suites (
   new config.TransformationsSpec,
   new metrics.DurationMetricTest,
   new util.SanitizeInputTest,
+  new AclTest,
   new tools.FaciaApiTest) {}

--- a/test/util/AclTest.scala
+++ b/test/util/AclTest.scala
@@ -9,38 +9,71 @@ import permissions.{TrainingPermission, EmailPermission, EditorialPermission, Co
 
     "Allow access to commercial fronts if commercial permissions" in {
 
-      PermissionsChecker.check(AccessGranted, AccessDenied, AccessDenied, Set(CommercialPermission)) should be(AccessGranted)
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessGranted,
+        hasEditorialPermissions = AccessDenied,
+        hasTrainingPermissions = AccessDenied,
+        Set(CommercialPermission)
+      ) should be(AccessGranted)
     }
 
     "Allow access to editorial fronts if editorial permissions" in {
 
-      PermissionsChecker.check(AccessDenied, AccessGranted, AccessDenied, Set(EditorialPermission)) should be(AccessGranted)
-
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessDenied,
+        hasEditorialPermissions = AccessGranted,
+        hasTrainingPermissions = AccessDenied,
+        Set(EditorialPermission)
+      ) should be(AccessGranted)
     }
 
     "Allow access to email fronts if editorial permissions"  in {
-      PermissionsChecker.check(AccessDenied, AccessGranted, AccessDenied, Set(EmailPermission)) should be(AccessGranted)
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessDenied,
+        hasEditorialPermissions = AccessGranted,
+        hasTrainingPermissions = AccessDenied,
+        Set(EmailPermission)
+      ) should be(AccessGranted)
     }
 
     "Allow access to training fronts if training permissions" in {
 
-      PermissionsChecker.check(AccessDenied, AccessDenied, AccessGranted, Set(TrainingPermission)) should be(AccessGranted)
-
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessDenied,
+        hasEditorialPermissions = AccessDenied,
+        hasTrainingPermissions = AccessGranted,
+        Set(TrainingPermission)
+      ) should be(AccessGranted)
     }
 
     "Allow access to fronts shared between editorial and commercial if commercial permissions " in {
 
-      PermissionsChecker.check(AccessGranted, AccessDenied, AccessDenied, Set(EditorialPermission, CommercialPermission)) should be(AccessGranted)
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessGranted,
+        hasEditorialPermissions = AccessDenied,
+        hasTrainingPermissions = AccessDenied,
+        Set(EditorialPermission, CommercialPermission)
+      ) should be(AccessGranted)
     }
 
     "Allow access to fronts shared between editorial and commercial if editorial permissions " in {
 
-      PermissionsChecker.check(AccessDenied, AccessGranted, AccessDenied, Set(EditorialPermission, CommercialPermission)) should be(AccessGranted)
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessDenied,
+        hasEditorialPermissions = AccessGranted,
+        hasTrainingPermissions = AccessDenied,
+        Set(EditorialPermission, CommercialPermission)
+      ) should be(AccessGranted)
   }
 
     "Do not allow access if not access to any of the priorities " in {
 
-      PermissionsChecker.check(AccessDenied, AccessDenied, AccessGranted, Set(EditorialPermission, CommercialPermission)) should be(AccessDenied)
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessDenied,
+        hasEditorialPermissions = AccessDenied,
+        hasTrainingPermissions = AccessGranted,
+        Set(EditorialPermission, CommercialPermission)
+      ) should be(AccessDenied)
 
     }
 

--- a/test/util/AclTest.scala
+++ b/test/util/AclTest.scala
@@ -1,0 +1,48 @@
+package util
+
+import org.scalatest.{DoNotDiscover, FreeSpec, Matchers}
+import permissions.{TrainingPermission, EmailPermission, EditorialPermission, CommercialPermission}
+
+@DoNotDiscover class AclTest extends FreeSpec with Matchers {
+
+  "Grant access according to collection priorities" - {
+
+    "Allow access to commercial fronts if commercial permissions" in {
+
+      PermissionsChecker.check(AccessGranted, AccessDenied, AccessDenied, Set(CommercialPermission)) should be(AccessGranted)
+    }
+
+    "Allow access to editorial fronts if editorial permissions" in {
+
+      PermissionsChecker.check(AccessDenied, AccessGranted, AccessDenied, Set(EditorialPermission)) should be(AccessGranted)
+
+    }
+
+    "Allow access to email fronts if editorial permissions"  in {
+      PermissionsChecker.check(AccessDenied, AccessGranted, AccessDenied, Set(EmailPermission)) should be(AccessGranted)
+    }
+
+    "Allow access to training fronts if training permissions" in {
+
+      PermissionsChecker.check(AccessDenied, AccessDenied, AccessGranted, Set(TrainingPermission)) should be(AccessGranted)
+
+    }
+
+    "Allow access to fronts shared between editorial and commercial if commercial permissions " in {
+
+      PermissionsChecker.check(AccessGranted, AccessDenied, AccessDenied, Set(EditorialPermission, CommercialPermission)) should be(AccessGranted)
+    }
+
+    "Allow access to fronts shared between editorial and commercial if editorial permissions " in {
+
+      PermissionsChecker.check(AccessDenied, AccessGranted, AccessDenied, Set(EditorialPermission, CommercialPermission)) should be(AccessGranted)
+  }
+
+    "Do not allow access if not access to any of the priorities " in {
+
+      PermissionsChecker.check(AccessDenied, AccessDenied, AccessGranted, Set(EditorialPermission, CommercialPermission)) should be(AccessDenied)
+
+    }
+
+  }
+}


### PR DESCRIPTION
Add permissions to the fronts tool to lock to the tool down by front priority (commercial, training, editorial). We lock down the front edit endpoints and collection edit endpoints. Because collections can be shared between fronts of different priorities, the user will be allowed to edit a collection if they have the permission to edit at least one of the front priorities that the collection belongs to.

These new permissions will initially be behind switches and will not immediately be operational when we merge the pr. Wanting to have new permissions behind switches has meant a little bit of code repetition here because we've had to keep old permissions (breaking news and config permissions) separate from the new ones.