### PR TITLE
Update dnd

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -55,7 +55,7 @@
     "webpack-dev-server": "^3.1.3"
   },
   "dependencies": {
-    "@guardian/guration": "^1.0.0",
+    "@guardian/guration": "^3.0.1",
     "babel-polyfill": "^6.26.0",
     "date-fns": "^1.29.0",
     "downshift": "^1.31.6",

--- a/client-v2/src/components/Clipboard.js
+++ b/client-v2/src/components/Clipboard.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as Guration from '@guardian/guration';
+import type { Edit } from '@guardian/guration';
 import { type Dispatch } from 'types/Store';
 import { batchActions } from 'redux-batched-actions';
 import { type State } from 'types/State';
@@ -23,10 +24,6 @@ type ClipboardProps = ClipboardPropsBeforeState & {
 };
 
 class Clipboard extends React.Component<ClipboardProps> {
-  componentDidMount() {
-    this.props.fetchClipboardContent();
-  }
-
   // TODO: this code is repeated in src/components/FrontsEdit/Front.js
   // refactor
   runEdit = edit => {
@@ -51,7 +48,7 @@ class Clipboard extends React.Component<ClipboardProps> {
     }
   };
 
-  handleChange = edit => {
+  handleChange = (edit: Edit) => {
     const futureActions = this.runEdit(edit);
     if (!futureActions) {
       return;

--- a/client-v2/src/components/Clipboard.js
+++ b/client-v2/src/components/Clipboard.js
@@ -62,47 +62,43 @@ class Clipboard extends React.Component<ClipboardProps> {
 
   render() {
     const { tree } = this.props;
-    const treeKeysExist = Object.keys(tree).length > 0;
     return (
       <div>
-        {treeKeysExist && (
-          <Guration.Root
-            id="clipboard"
-            type="clipboard"
-            onChange={this.handleChange}
-            mapIn={{
-              text: text => urlToArticle(text),
-              capi: capi => ({ type: 'articleFragment', id: capi }),
-              collection: str => JSON.parse(str)
-            }}
-            mapOut={{
-              clipboard: (el, type) =>
-                JSON.stringify({
-                  type,
-                  id: el.id
-                })
-            }}
+        <Guration.Root
+          id="clipboard"
+          type="clipboard"
+          dedupeType="articleFragment"
+          onChange={this.handleChange}
+          mapIn={{
+            text: text => urlToArticle(text),
+            capi: capi => ({ type: 'articleFragment', id: capi }),
+            collection: str => JSON.parse(str)
+          }}
+          mapOut={{
+            clipboard: (el, type) =>
+              JSON.stringify({
+                type,
+                id: el.id
+              })
+          }}
+        >
+          <Guration.Level
+            arr={tree.articleFragments || []}
+            type="articleFragment"
+            getKey={({ uuid }) => uuid}
+            getDedupeKey={({ id }) => id}
+            renderDrop={(getDropProps, { canDrop, isTarget }) => (
+              <DropZone
+                {...getDropProps()}
+                override={!!canDrop && !!isTarget}
+              />
+            )}
           >
-            <Guration.Level
-              arr={tree.articleFragments}
-              type="articleFragment"
-              getKey={({ uuid }) => uuid}
-              renderDrop={(getDropProps, { canDrop, isTarget }) => (
-                <DropZone
-                  {...getDropProps()}
-                  override={!!canDrop && !!isTarget}
-                />
-              )}
-            >
-              {(articleFragment, getNodeProps) => (
-                <ArticlePolaroid
-                  id={articleFragment.uuid}
-                  {...getNodeProps()}
-                />
-              )}
-            </Guration.Level>
-          </Guration.Root>
-        )}
+            {(articleFragment, getNodeProps) => (
+              <ArticlePolaroid id={articleFragment.uuid} {...getNodeProps()} />
+            )}
+          </Guration.Level>
+        </Guration.Root>
       </div>
     );
   }

--- a/client-v2/src/components/Clipboard.js
+++ b/client-v2/src/components/Clipboard.js
@@ -18,7 +18,7 @@ import { addArticleFragment } from 'shared/actions/ArticleFragments';
 type ClipboardPropsBeforeState = {};
 
 type ClipboardProps = ClipboardPropsBeforeState & {
-  addArticleFragment: string => Promise<string>,
+  addArticleFragment: (id: string, supporting: string[]) => Promise<string>,
   tree: Object, // TODO add typing,
   dispatch: Dispatch
 };
@@ -33,14 +33,17 @@ class Clipboard extends React.Component<ClipboardProps> {
       }
 
       case 'INSERT': {
-        const editsPromise = this.props
-          .addArticleFragment(edit.payload.id)
-          .then(uuid => {
-            const payloadWithUuid = { ...edit.payload, id: uuid };
-            const insertWithUuid = { ...edit, payload: payloadWithUuid };
-            return getInsertActions(insertWithUuid);
-          });
-        return editsPromise;
+        return this.props
+          .addArticleFragment(edit.payload.id, edit.meta.supporting)
+          .then(uuid =>
+            getInsertActions({
+              ...edit,
+              payload: {
+                ...edit.payload,
+                id: uuid
+              }
+            })
+          );
       }
       default: {
         return null;

--- a/client-v2/src/components/DropZone.js
+++ b/client-v2/src/components/DropZone.js
@@ -18,7 +18,8 @@ class DropZone extends React.Component<
     onDrop: (e: DragEvent) => void,
     onDragOver: (e: DragEvent) => void,
     style: Object,
-    indicatorStyle: Object
+    indicatorStyle: Object,
+    override?: boolean
   },
   { isHoveredOver: boolean }
 > {
@@ -43,6 +44,12 @@ class DropZone extends React.Component<
     return this.props.onDrop(e);
   };
 
+  get isActive() {
+    return typeof this.props.override === 'boolean'
+      ? this.props.override
+      : this.state.isHoveredOver;
+  }
+
   render() {
     const { onDragOver, style } = this.props;
     return (
@@ -57,8 +64,8 @@ class DropZone extends React.Component<
         <DropIndicator
           style={{
             ...this.props.indicatorStyle,
-            zIndex: this.state.isHoveredOver ? 1 : null,
-            backgroundColor: this.state.isHoveredOver ? 'rgba(199, 0, 0)' : null
+            zIndex: this.isActive ? 1 : null,
+            backgroundColor: this.isActive ? 'rgba(199, 0, 0)' : null
           }}
         />
       </DropContainer>

--- a/client-v2/src/components/DropZone.js
+++ b/client-v2/src/components/DropZone.js
@@ -15,8 +15,8 @@ const DropIndicator = styled('div')`
 
 class DropZone extends React.Component<
   {
-    onDrop: (e: DragEvent) => void,
-    onDragOver: (e: DragEvent) => void,
+    onDrop: (e: SyntheticDragEvent<HTMLElement>) => void,
+    onDragOver: (e: SyntheticDragEvent<HTMLElement>) => void,
     style: Object,
     indicatorStyle: Object,
     override?: boolean
@@ -31,6 +31,12 @@ class DropZone extends React.Component<
     isHoveredOver: false
   };
 
+  get isActive() {
+    return typeof this.props.override === 'boolean'
+      ? this.props.override
+      : this.state.isHoveredOver;
+  }
+
   handleDragEnter = () => {
     this.setState({ isHoveredOver: true });
   };
@@ -39,16 +45,10 @@ class DropZone extends React.Component<
     this.setState({ isHoveredOver: false });
   };
 
-  handleDrop = (e: DragEvent) => {
+  handleDrop = (e: SyntheticDragEvent<HTMLElement>) => {
     this.setState({ isHoveredOver: false });
     return this.props.onDrop(e);
   };
-
-  get isActive() {
-    return typeof this.props.override === 'boolean'
-      ? this.props.override
-      : this.state.isHoveredOver;
-  }
 
   render() {
     const { onDragOver, style } = this.props;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.js
@@ -14,7 +14,7 @@ type ArticleFragmentProps = {
     supporting: *
   },
   children: *,
-  getDragProps: () => Object,
+  getNodeProps: () => Object,
   onSelect: (uuid: string) => void
 };
 
@@ -43,21 +43,22 @@ const ArticleFragment = ({
   isSelected,
   meta: { supporting = [] } = {},
   children,
-  getDragProps,
+  getNodeProps,
   onSelect
 }: ArticleFragmentProps) => (
   <ArticleFragmentContainer
     isSelected={isSelected}
     {...optionize(() => onSelect(uuid))}
   >
-    <Article id={uuid} {...getDragProps()}>
+    <Article id={uuid} {...getNodeProps()}>
       <Guration.Level
         arr={supporting}
         type="articleFragment"
         getKey={({ uuid: key }) => key}
-        renderDrop={props => (
+        renderDrop={(getDropProps, { canDrop, isTarget }) => (
           <DropZone
-            {...props}
+            {...getDropProps()}
+            override={!!canDrop && !!isTarget}
             style={dropZoneStyle}
             indicatorStyle={dropIndicatorStyle}
           />

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.js
@@ -55,6 +55,7 @@ const ArticleFragment = ({
         arr={supporting}
         type="articleFragment"
         getKey={({ uuid: key }) => key}
+        getDedupeKey={({ id }) => id}
         renderDrop={(getDropProps, { canDrop, isTarget }) => (
           <DropZone
             {...getDropProps()}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Group.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Group.js
@@ -22,7 +22,13 @@ const Group = ({ id, articleFragments, children }: GroupProps) => (
       arr={articleFragments}
       type="articleFragment"
       getKey={({ uuid }) => uuid}
-      renderDrop={props => <DropZone {...props} style={dropZoneStyle} />}
+      renderDrop={(getDropProps, { canDrop, isTarget }) => (
+        <DropZone
+          {...getDropProps()}
+          override={!!canDrop && !!isTarget}
+          style={dropZoneStyle}
+        />
+      )}
     >
       {children}
     </Guration.Level>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Group.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Group.js
@@ -22,6 +22,7 @@ const Group = ({ id, articleFragments, children }: GroupProps) => (
       arr={articleFragments}
       type="articleFragment"
       getKey={({ uuid }) => uuid}
+      getDedupeKey={({ id: key }) => key}
       renderDrop={(getDropProps, { canDrop, isTarget }) => (
         <DropZone
           {...getDropProps()}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.js
@@ -5,11 +5,11 @@ import Article from 'shared/components/Article';
 
 type SupportingProps = {
   uuid: string,
-  getDragProps: *
+  getNodeProps: *
 };
 
-const Supporting = ({ uuid, getDragProps }: SupportingProps) => (
-  <Article id={uuid} {...getDragProps()} size="small" />
+const Supporting = ({ uuid, getNodeProps }: SupportingProps) => (
+  <Article id={uuid} {...getNodeProps()} size="small" />
 );
 
 export default Supporting;

--- a/client-v2/src/components/FrontsEdit/Front.js
+++ b/client-v2/src/components/FrontsEdit/Front.js
@@ -127,7 +127,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         <FrontContainer>
           <FrontContentContainer>
             <Guration.Root
-              id={'frontId' /* Do we need this? */}
+              // do we need frontId?
+              id="frontId"
               type="front"
               onChange={this.handleChange}
               mapIn={{

--- a/client-v2/src/components/FrontsEdit/Front.js
+++ b/client-v2/src/components/FrontsEdit/Front.js
@@ -133,6 +133,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
               onChange={this.handleChange}
               mapIn={{
                 text: text => urlToArticle(text),
+                // TODO: the below will not dedupe properly
                 capi: capi => ({ type: 'articleFragment', id: capi }),
                 clipboard: str => JSON.parse(str)
               }}
@@ -140,7 +141,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                 collection: (el, type) =>
                   JSON.stringify({
                     type,
-                    id: el.id
+                    id: el.id,
+                    meta: {
+                      supporting: (el.meta.supporting || []).map(({ id }) => id)
+                    }
                   })
               }}
             >

--- a/client-v2/src/shared/components/Article.js
+++ b/client-v2/src/shared/components/Article.js
@@ -21,6 +21,8 @@ type ContainerProps = {
   id: string, // eslint-disable-line react/no-unused-prop-types
   draggable: boolean,
   onDragStart?: DragEvent => void,
+  onDragOver?: DragEvent => void,
+  onDrop?: DragEvent => void,
   selectSharedState: (state: any) => State // eslint-disable-line react/no-unused-prop-types
 };
 
@@ -110,6 +112,8 @@ const ArticleComponent = ({
   size = 'default',
   draggable = false,
   onDragStart = noop,
+  onDragOver = noop,
+  onDrop = noop,
   children
 }: ComponentProps) => {
   if (!article) {
@@ -118,15 +122,18 @@ const ArticleComponent = ({
   const ArticleHeadingContainer =
     size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
   return (
-    <ArticleContainer>
+    <ArticleContainer
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
       <ArticleBodyContainer
         key={article.headline}
         style={{
           borderTopColor:
             size === 'default' ? toneColorMap[article.tone] : '#c9c9c9'
         }}
-        draggable={draggable}
-        onDragStart={onDragStart}
       >
         <ArticleMetaContainer>
           {size === 'default' && <Tone>{startCase(article.tone)}</Tone>}

--- a/client-v2/src/shared/components/ArticlePolaroid.js
+++ b/client-v2/src/shared/components/ArticlePolaroid.js
@@ -18,6 +18,8 @@ type ContainerProps = {
   id: string, // eslint-disable-line react/no-unused-prop-types
   draggable: boolean,
   onDragStart?: DragEvent => void,
+  onDragOver?: DragEvent => void,
+  onDrop?: DragEvent => void,
   selectSharedState: (state: any) => State // eslint-disable-line react/no-unused-prop-types
 };
 
@@ -37,14 +39,21 @@ const Thumbnail = styled('img')`
 const ArticleComponent = ({
   article,
   draggable = false,
-  onDragStart = noop
+  onDragStart = noop,
+  onDragOver = noop,
+  onDrop = noop
 }: ComponentProps) => {
   if (!article) {
     return null;
   }
 
   return (
-    <BodyContainer draggable={draggable} onDragStart={onDragStart}>
+    <BodyContainer
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
       {article.elements && (
         <Thumbnail src={getThumbnail(article.elements)} alt="" />
       )}

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -703,13 +703,15 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@guardian/guration@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-1.0.0.tgz#6d2396732d3dda10bb94746fd705d33c896f2012"
+"@guardian/guration@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.0.1.tgz#faffc7fa80e29bc04f4a1478ee42c2927daf7b8d"
   dependencies:
-    lodash "^4.17.10"
+    lodash.throttle "^4.1.1"
+    prop-types "^15.6.2"
     react "^16.3.0"
     react-dom "^16.3.0"
+    uuid "^3.3.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -5851,6 +5853,10 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
@@ -8733,7 +8739,7 @@ uuid@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
-uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -186,6 +186,10 @@
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.55.tgz#31f40777efd6b961da8496a923c22d2b062b3f73"
 
+"@babel/helper-plugin-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+
 "@babel/helper-regex@7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.55.tgz#74e6c063d1ef9f7e58b7a84c06e6ee4a5bb5a5da"
@@ -310,6 +314,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.55"
 
+"@babel/plugin-syntax-flow@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz#70638aeaad9ee426bc532e51523cff8ff02f6f17"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-jsx@7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.55.tgz#3c16cc972b31c27d4c2e6388e834f146463263a4"
@@ -407,6 +417,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.55"
     "@babel/plugin-syntax-flow" "7.0.0-beta.55"
+
+"@babel/plugin-transform-flow-strip-types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz#c40ced34c2783985d90d9f9ac77a13e6fb396a01"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.0.0"
 
 "@babel/plugin-transform-for-of@7.0.0-beta.55":
   version "7.0.0-beta.55"
@@ -603,6 +620,13 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/preset-flow@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0.tgz#afd764835d9535ec63d8c7d4caf1c06457263da2"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+
 "@babel/preset-flow@^7.0.0-beta.44":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0-beta.55.tgz#76c2a8987a79a29d4c462f10ad3c05245dcb95e2"
@@ -704,13 +728,15 @@
     to-fast-properties "^2.0.0"
 
 "@guardian/guration@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.0.1.tgz#faffc7fa80e29bc04f4a1478ee42c2927daf7b8d"
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.1.2.tgz#32b21bf46e7accf6b4d6fd0cb7dccc8998064787"
   dependencies:
+    "@babel/preset-flow" "^7.0.0"
     lodash.throttle "^4.1.1"
     prop-types "^15.6.2"
     react "^16.3.0"
     react-dom "^16.3.0"
+    rollup-plugin-flow-defs "^1.0.2"
     uuid "^3.3.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -6147,7 +6173,7 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch
 
 minimist@0.0.8:
   version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^0.1.0:
   version "0.1.0"
@@ -7690,6 +7716,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup-plugin-flow-defs@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-flow-defs/-/rollup-plugin-flow-defs-1.0.2.tgz#a04447dcba34c6708681468a670b52a99c111073"
+  dependencies:
+    mkdirp "^0.5.1"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -728,8 +728,8 @@
     to-fast-properties "^2.0.0"
 
 "@guardian/guration@^3.0.1":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.1.2.tgz#32b21bf46e7accf6b4d6fd0cb7dccc8998064787"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.2.0.tgz#676493f755af5e876c99decb7082ca8e63a47ef6"
   dependencies:
     "@babel/preset-flow" "^7.0.0"
     lodash.throttle "^4.1.1"

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -728,8 +728,8 @@
     to-fast-properties "^2.0.0"
 
 "@guardian/guration@^3.0.1":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.2.0.tgz#676493f755af5e876c99decb7082ca8e63a47ef6"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/guration/-/guration-3.3.0.tgz#f43998b77d4cf3a1683ec2e2e5fba6c8e9b4b8e6"
   dependencies:
     "@babel/preset-flow" "^7.0.0"
     lodash.throttle "^4.1.1"


### PR DESCRIPTION
This fixes most aspects of drag and drop that have been implemented. The main additions are:
- Drag and drop articles with supporting between Guration contexts
- Add in some missing dedupeProps to ensure deduping works as expected
- Add in the ability to drag over a node in order to drop either side of it
- Add in some hover states for clipboard
- Allow dropping into empty contexts

There seems to be an issue with JSON serialisation  / deserialisation when adding supporting articles to a clipboard article.

This is what makes it Dynamo
```json
{
      "frontPublicationDate": 1536073954684,
      "id": "internal-code/page/4969585",
      "meta": {
        "json": {
          "supporting": "[{\"id\":\"internal-code/page/4969003\",\"frontPublicationDate\":1536073954684,\"meta\":{}}]"
        }
      }
    }
```