### PR TITLE
use preview capi to get articles

### DIFF
--- a/client-v2/src/components/Feed.js
+++ b/client-v2/src/components/Feed.js
@@ -12,6 +12,7 @@ import FeedItem from './FeedItem';
 import SearchInput from './FrontsCAPIInterface/SearchInput';
 import Loader from './Loader';
 import { capiFeedSpecsSelector } from '../selectors/configSelectors';
+import { RadioButton, RadioGroup } from './inputs/RadioButtons';
 
 type ErrorDisplayProps = {
   error: ?(Error | string),
@@ -50,6 +51,10 @@ const FeedContainer = styled('div')`
   height: 100%;
 `;
 
+const StageSelectionContainer = styled('div')`
+  margin-left: auto;
+`;
+
 const ResultsHeadingContainer = styled('div')`
   display: flex;
 `;
@@ -76,6 +81,19 @@ class Feed extends React.Component<FeedProps, FeedState> {
   renderFixedContent = () => (
     <ResultsHeadingContainer>
       <ContainerHeading>Results</ContainerHeading>
+      <StageSelectionContainer>
+        <RadioGroup>
+          {this.props.capiFeedSpecs.map(({ name }, i) => (
+            <RadioButton
+              key={name}
+              checked={i === this.state.capiFeedIndex}
+              onChange={() => this.handleFeedClick(i)}
+              label={name}
+              inline
+            />
+          ))}
+        </RadioGroup>
+      </StageSelectionContainer>
     </ResultsHeadingContainer>
   );
 
@@ -99,31 +117,33 @@ class Feed extends React.Component<FeedProps, FeedState> {
                     <LoaderDisplay loading={!value && pending}>
                       <div>
                         {value &&
-                          value.response.results.map(
-                            ({
-                              webTitle,
-                              webUrl,
-                              webPublicationDate,
-                              elements,
-                              fields,
-                              frontsMeta: { tone }
-                            }) => (
-                              <FeedItem
-                                key={webUrl}
-                                title={webTitle}
-                                href={webUrl}
-                                publicationDate={webPublicationDate}
-                                tone={tone}
-                                trailText={fields && fields.trailText}
-                                thumbnailUrl={
-                                  elements && getThumbnail(elements)
-                                }
-                                internalPageCode={
-                                  fields && getId(fields.internalPageCode)
-                                }
-                              />
-                            )
-                          )}
+                          value.response.results
+                            .filter(result => result.webTitle)
+                            .map(
+                              ({
+                                webTitle,
+                                webUrl,
+                                webPublicationDate,
+                                elements,
+                                fields,
+                                frontsMeta: { tone }
+                              }) => (
+                                <FeedItem
+                                  key={webUrl}
+                                  title={webTitle}
+                                  href={webUrl}
+                                  publicationDate={webPublicationDate}
+                                  tone={tone}
+                                  trailText={fields && fields.trailText}
+                                  thumbnailUrl={
+                                    elements && getThumbnail(elements)
+                                  }
+                                  internalPageCode={
+                                    fields && getId(fields.internalPageCode)
+                                  }
+                                />
+                              )
+                            )}
                       </div>
                     </LoaderDisplay>
                   </ErrorDisplay>

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -189,7 +189,7 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     .join(',');
 
   const articlePromise = pandaFetch(
-    `/api/live/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,
+    `/api/preview/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,
     {
       method: 'get',
       credentials: 'same-origin'


### PR DESCRIPTION
While trying to figure out where the 'Taken Down' text is coming from in the fronts tool, I've had to remind myself how the old fronts tool deals with draft articles and as a consequence I am reverting the changes to remove draft articles because it is quite easy to replicate the behaviour of the old fronts tool (I'm not sure if this 100% correct behaviour but we've never had any complaints so...). 

This is how it works: 

- We always requests articles from preview capi. 
- If the article we have fetched from preview has not been launched or has been taken down, we let the user know because this means it will not appear on the front
- Otherwise we show the user the article from capi preview, the article from live capi will appear on the front itself. 
- This means that there is a chance that what the user sees in the fronts tool is different than what appears on the website but once these changes are launched differences will disappear. 

I've made a small additional change - removing articles without headlines from capi search results. Some draft articles were lacking this, it looks a bit funny on the search page and is not useful to these to our users at all. 

One last change we will probably want to make is to add some additional preview colours to articles but we can save this for later. Will mention to Josh. 