### PR TITLE
Import image validation from v1

### DIFF
--- a/client-v2/jest.config.js
+++ b/client-v2/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  transformIgnorePatterns: ['/node_modules/(?!panda-session).+\\.js$'],
+  transformIgnorePatterns: [
+    '/node_modules/(?!panda-session|grid-util-js).+\\.js$'
+  ],
   setupTestFrameworkScriptFile: './node_modules/jest-enzyme/lib/index.js',
   setupFiles: ['./src/setupTest.js'],
   moduleDirectories: ['<rootDir>/src', 'node_modules'],

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -63,6 +63,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "fetch": "^1.1.0",
     "flow-coverage-report": "^0.5.0",
+    "grid-util-js": "^1.1.0",
     "history": "^4.7.2",
     "jest-enzyme": "^6.0.0",
     "lodash": "^4.17.5",

--- a/client-v2/src/shared/constants/images.js
+++ b/client-v2/src/shared/constants/images.js
@@ -1,0 +1,11 @@
+// @flow
+
+export default {
+  apiBaseUrl: '/api.grid',
+  mediaBaseUrl: 'http://media',
+  usageBaseUrl: '/api/usage',
+  imgIXDomainExpr: /^https:\/\/i\.guim\.co\.uk\/img\/static\//,
+  imageCdnDomain: '.guim.co.uk',
+  staticImageCdnDomain: 'https://static.guim.co.uk/',
+  imageCdnDomainExpr: /^https:\/\/(.*)\.guim\.co\.uk\//,
+};

--- a/client-v2/src/shared/constants/images.js
+++ b/client-v2/src/shared/constants/images.js
@@ -7,5 +7,5 @@ export default {
   imgIXDomainExpr: /^https:\/\/i\.guim\.co\.uk\/img\/static\//,
   imageCdnDomain: '.guim.co.uk',
   staticImageCdnDomain: 'https://static.guim.co.uk/',
-  imageCdnDomainExpr: /^https:\/\/(.*)\.guim\.co\.uk\//,
+  imageCdnDomainExpr: /^https:\/\/(.*)\.guim\.co\.uk\//
 };

--- a/client-v2/src/shared/util/ImageMock.js
+++ b/client-v2/src/shared/util/ImageMock.js
@@ -1,0 +1,27 @@
+// @flow
+
+export default class ImageMock {
+  static defaultLoadDelay = 100;
+  static defaultWidth: number = 100;
+  static defaultHeight: number = 100;
+  static shouldError: boolean = false;
+  width: void | number = undefined;
+  height: void | number = undefined;
+  src: void | string = undefined;
+  constructor() {
+    this.width = ImageMock.defaultWidth;
+    this.height = ImageMock.defaultHeight;
+    setTimeout(
+      () => (ImageMock.shouldError ? this.onerror() : this.onload()),
+      ImageMock.defaultLoadDelay
+    );
+  }
+  static restoreDefaults() {
+    ImageMock.defaultWidth = 100;
+    ImageMock.defaultHeight = 100;
+    ImageMock.defaultLoadDelay = 100;
+    ImageMock.shouldError = false;
+  }
+  onload = () => {};
+  onerror = () => {};
+}

--- a/client-v2/src/shared/util/__tests__/deepGet.spec.js
+++ b/client-v2/src/shared/util/__tests__/deepGet.spec.js
@@ -10,16 +10,24 @@ const object = {
       }
     }
   }
-}
+};
 
 describe('deepGet', () => {
   it('gets properties from objects', () => {
-    expect(deepGet(object, ['a'])).toEqual({ really: {deeply: { nested: 'string' }}})
-    expect(deepGet(object, ['a', 'really'])).toEqual({ deeply: { nested: 'string' }})
-    expect(deepGet(object, ['a', 'really', 'deeply'])).toEqual({ nested: 'string' })
-    expect(deepGet(object, ['a', 'really', 'deeply', 'nested'])).toEqual('string')
+    expect(deepGet(object, ['a'])).toEqual({
+      really: { deeply: { nested: 'string' } }
+    });
+    expect(deepGet(object, ['a', 'really'])).toEqual({
+      deeply: { nested: 'string' }
+    });
+    expect(deepGet(object, ['a', 'really', 'deeply'])).toEqual({
+      nested: 'string'
+    });
+    expect(deepGet(object, ['a', 'really', 'deeply', 'nested'])).toEqual(
+      'string'
+    );
   });
-  it('handles cases where the property doesn\'t exist', () => {
+  it("handles cases where the property doesn't exist", () => {
     expect(deepGet(object, ['not', 'legit'])).toEqual(null);
   });
 });

--- a/client-v2/src/shared/util/__tests__/deepGet.spec.js
+++ b/client-v2/src/shared/util/__tests__/deepGet.spec.js
@@ -1,0 +1,25 @@
+// @flow
+
+import deepGet from '../deepGet';
+
+const object = {
+  a: {
+    really: {
+      deeply: {
+        nested: 'string'
+      }
+    }
+  }
+}
+
+describe('deepGet', () => {
+  it('gets properties from objects', () => {
+    expect(deepGet(object, ['a'])).toEqual({ really: {deeply: { nested: 'string' }}})
+    expect(deepGet(object, ['a', 'really'])).toEqual({ deeply: { nested: 'string' }})
+    expect(deepGet(object, ['a', 'really', 'deeply'])).toEqual({ nested: 'string' })
+    expect(deepGet(object, ['a', 'really', 'deeply', 'nested'])).toEqual('string')
+  });
+  it('handles cases where the property doesn\'t exist', () => {
+    expect(deepGet(object, ['not', 'legit'])).toEqual(null);
+  });
+});

--- a/client-v2/src/shared/util/__tests__/validateImageSrc.spec.js
+++ b/client-v2/src/shared/util/__tests__/validateImageSrc.spec.js
@@ -1,0 +1,566 @@
+// @flow
+
+import GridUtil from 'grid-util-js';
+import fetchMock from 'fetch-mock';
+import { validateImageSrc, validateImageEvent } from '../validateImageSrc';
+import ImageMock from '../ImageMock';
+import grid from '../grid';
+
+global.Image = ImageMock;
+
+jest.mock('../../constants/images', () => ({
+  imageCdnDomainExpr: new RegExp(`http://localhost`),
+  imgIXDomainExpr: /http:\/\/imgix\//,
+  staticImageCdnDomain: `http://localhost/base/public/test/fixtures/`,
+  imageCdnDomain: 'localhost',
+  mediaBaseUrl: 'http://media',
+  apiBaseUrl: '/api.grid',
+  usageBaseUrl: '/api/usage'
+}));
+
+function getPath(image) {
+  return `http://localhost/base/public/test/fixtures/${image}`;
+}
+
+function getImgIXPath(image) {
+  return `http://imgix/${image}`;
+}
+
+describe('Validate images', () => {
+  beforeEach(() => {
+    grid.setGridInstance(
+      new GridUtil({
+        apiBaseUrl: '/api.grid'
+      })
+    );
+
+    fetchMock.once(
+      '/api/usage',
+      {
+        method: 'post'
+      },
+      {
+        overwriteRoutes: true
+      }
+    );
+
+    ImageMock.restoreDefaults();
+  });
+
+  describe('- invalid', () => {
+    it('missing images', done => {
+      // $FlowFixMe -- this code is ported from v1, and we can't call validateImageSrc() without arguments in flow.
+      validateImageSrc().then(
+        err => done.fail(err),
+        (err: Error) => {
+          expect(err.message).toMatch(/missing/i);
+          done();
+        }
+      );
+    });
+
+    it('unknown domain', done => {
+      validateImageSrc('http://another-host/image.png').then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/images must come/i);
+          done();
+        }
+      );
+    });
+  });
+
+  describe('- from image CDN', () => {
+    it("fails if the image can't be found", done => {
+      ImageMock.shouldError = true;
+      validateImageSrc(getPath('this_image_doesnt_exists__promised.png')).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/could not be found/i);
+          done();
+        }
+      );
+    });
+
+    it('fails if the image is too big', done => {
+      const criteria = {
+        maxWidth: 50
+      };
+      const path = getPath('square.png');
+      validateImageSrc(path, 'front', criteria).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/cannot be more/i);
+          done();
+        }
+      );
+    });
+
+    it('fails if the image is too small', done => {
+      const criteria = {
+        minWidth: 200
+      };
+      validateImageSrc(getPath('square.png'), 'front', criteria).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/cannot be less/i);
+          done();
+        }
+      );
+    });
+
+    it('fails if the aspect ratio is wrong', done => {
+      const criteria = {
+        widthAspectRatio: 5,
+        heightAspectRatio: 3
+      };
+
+      validateImageSrc(getPath('square.png'), 'front', criteria).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/aspect ratio/i);
+          done();
+        }
+      );
+    });
+
+    it('works with no criteria', done => {
+      validateImageSrc(getPath('square.png'), 'front').then(
+        image => {
+          expect(image.width).toBe(100);
+          expect(image.height).toBe(100);
+          expect(image.src).toMatch(/square\.png/);
+          expect(image.origin).toMatch(/square\.png/);
+          done();
+        },
+        err => done.fail(err)
+      );
+    });
+
+    it('works with if all criteria are met', done => {
+      const criteria = {
+        minWidth: 100,
+        maxWidth: 200,
+        widthAspectRatio: 1,
+        heightAspectRatio: 1
+      };
+
+      validateImageSrc(getPath('square.png'), 'front', criteria).then(
+        image => {
+          expect(image.width).toBe(100);
+          expect(image.height).toBe(100);
+          expect(image.src).toMatch(/square\.png/);
+          expect(image.origin).toMatch(/square\.png/);
+          done();
+        },
+        err => done.fail(err)
+      );
+    });
+  });
+
+  describe('- from imgIX', () => {
+    it('strips unnecessary parameters', done => {
+      validateImageSrc(
+        getImgIXPath(
+          'square.png?s=82a57a91afadd159bb4639d6b798f6c5&other=params'
+        )
+      ).then(
+        image => {
+          expect(image.width).toBe(100);
+          expect(image.height).toBe(100);
+          expect(image.src).toMatch(/square\.png$/);
+          expect(image.origin).toMatch(/square\.png$/);
+          done();
+        },
+        err => done.fail(err)
+      );
+    });
+  });
+
+  describe('- from the Grid', () => {
+    it('fails if media is not accessible', done => {
+      grid.gridInstance.getImage = () =>
+        Promise.reject(new Error('error while loading'));
+      validateImageSrc(
+        'http://grid.co.uk/1234567890123456789012345678901234567890'
+      ).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/unable to locate/i);
+          done();
+        }
+      );
+    });
+
+    describe('- link include crop id', () => {
+      it('fails if crop id is invalid', done => {
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: {
+              exports: [{ id: 'nice_crop_id' }]
+            }
+          });
+
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop',
+          'front'
+        ).then(
+          err => done.fail(err),
+          err => {
+            expect(err.message).toMatch(/does not have a valid crop/i);
+            done();
+          }
+        );
+      });
+
+      it("fails if crop doesn't respect criteria", done => {
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: {
+              exports: [
+                {
+                  id: 'image_crop',
+                  assets: [
+                    { dimensions: { width: 5000, height: 100 } },
+                    { dimensions: { width: 500, height: 10 } },
+                    { dimensions: { width: 50, height: 1 } }
+                  ]
+                }
+              ]
+            }
+          });
+
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop',
+          'front',
+          {
+            minWidth: 100,
+            maxWidth: 1000,
+            widthAspectRatio: 5,
+            heightAspectRatio: 4
+          }
+        ).then(
+          err => done.fail(err),
+          err => {
+            expect(err.message).toMatch(/does not have a valid crop/i);
+            done();
+          }
+        );
+      });
+
+      it('gets the specified asset', done => {
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: {
+              exports: [
+                {
+                  id: 'image_crop',
+                  assets: [
+                    { dimensions: { width: 1400, height: 1400 } },
+                    {
+                      secureUrl: getPath('square.png'),
+                      dimensions: { width: 140, height: 140 }
+                    }
+                  ]
+                }
+              ]
+            }
+          });
+        ImageMock.defaultWidth = 140;
+        ImageMock.defaultHeight = 140;
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop',
+          'front',
+          {
+            minWidth: 100,
+            maxWidth: 1000,
+            widthAspectRatio: 1,
+            heightAspectRatio: 1
+          }
+        )
+          .then(image => {
+            expect(image.width).toBe(140);
+            expect(image.height).toBe(140);
+            expect(image.src).toMatch(/square\.png$/);
+            expect(image.origin).toBe(
+              'http://media/image/1234567890123456789012345678901234567890'
+            );
+          })
+          .then(done)
+          .catch(err => done.fail(err));
+      });
+    });
+
+    describe('- link does not include crop id', () => {
+      it('fails if there are no crops', done => {
+        ImageMock.defaultWidth = 140;
+        ImageMock.defaultHeight = 140;
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: { exports: [] }
+          });
+
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890'
+        ).then(
+          err => done.fail(err),
+          err => {
+            expect(err.message).toMatch(/does not have a valid crop/i);
+            done();
+          }
+        );
+      });
+
+      it("fails if crops don't respect criteria", done => {
+        ImageMock.defaultWidth = 140;
+        ImageMock.defaultHeight = 140;
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: {
+              exports: [
+                {
+                  id: 'image_crop',
+                  assets: [
+                    { dimensions: { width: 5000, height: 100 } },
+                    { dimensions: { width: 500, height: 10 } },
+                    { dimensions: { width: 50, height: 1 } }
+                  ]
+                }
+              ]
+            }
+          });
+
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890',
+          'front',
+          {
+            minWidth: 100,
+            maxWidth: 1000,
+            widthAspectRatio: 5,
+            heightAspectRatio: 4
+          }
+        ).then(
+          err => done.fail(err),
+          err => {
+            expect(err.message).toMatch(/does not have a valid crop/i);
+            done();
+          }
+        );
+      });
+
+      it('gets the first valid asset', done => {
+        ImageMock.defaultWidth = 140;
+        ImageMock.defaultHeight = 140;
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: {
+              exports: [
+                {
+                  id: 'image_crop',
+                  assets: [
+                    { dimensions: { width: 1400, height: 1400 } },
+                    {
+                      secureUrl: getPath('square.png'),
+                      dimensions: { width: 140, height: 140 }
+                    }
+                  ]
+                }
+              ]
+            }
+          });
+
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890',
+          'front',
+          {
+            minWidth: 100,
+            maxWidth: 1000,
+            widthAspectRatio: 1,
+            heightAspectRatio: 1
+          }
+        )
+          .then(image => {
+            expect(image.width).toBe(140);
+            expect(image.height).toBe(140);
+            expect(image.src).toMatch(/square\.png$/);
+            expect(image.origin).toBe(
+              'http://media/image/1234567890123456789012345678901234567890'
+            );
+          })
+          .then(done)
+          .catch(err => done.fail(err));
+      });
+
+      it('gets the first asset when no criteria', done => {
+        ImageMock.defaultWidth = 140;
+        ImageMock.defaultHeight = 140;
+        grid.gridInstance.getImage = () =>
+          Promise.resolve({
+            data: {
+              exports: [
+                {
+                  id: 'image_crop',
+                  assets: [
+                    {
+                      secureUrl: getPath('square.png'),
+                      dimensions: { width: 800, height: 800 }
+                    },
+                    {
+                      secureUrl: 'thumbnail',
+                      dimensions: { width: 140, height: 140 }
+                    }
+                  ]
+                }
+              ]
+            }
+          });
+
+        validateImageSrc(
+          'http://grid.co.uk/1234567890123456789012345678901234567890'
+        )
+          .then(image => {
+            expect(image.width).toBe(140);
+            expect(image.height).toBe(140);
+            expect(image.src).toMatch(/square\.png$/);
+            expect(image.origin).toBe(
+              'http://media/image/1234567890123456789012345678901234567890'
+            );
+            expect(image.thumb).toBe('thumbnail');
+          })
+          .then(done)
+          .catch(err => done.fail(err));
+      });
+    });
+  });
+
+  describe('- from copy paste event', () => {
+    it('fails with invalid item', done => {
+      grid.gridInstance.getCropFromEvent = () => null;
+
+      validateImageEvent('front', {}).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/invalid image/i);
+          done();
+        }
+      );
+    });
+
+    it('fails when no suitable assets', done => {
+      grid.gridInstance.getCropFromEvent = () => ({
+        assets: [
+          {
+            secureUrl: getPath('square.png'),
+            dimensions: { width: 800, height: 800 }
+          }
+        ]
+      });
+
+      const dragEvent: any = {};
+      validateImageEvent(dragEvent, 'front', {
+        maxWidth: 500
+      }).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/does not have a valid asset/i);
+          done();
+        }
+      );
+    });
+
+    it("fails when the actual image doesn't validate", done => {
+      grid.gridInstance.getCropFromEvent = () => ({
+        assets: [
+          {
+            secureUrl: getPath('square.png'),
+            dimensions: { width: 800, height: 800 }
+          }
+        ]
+      });
+      validateImageEvent({}, 'front', {
+        widthAspectRatio: 4,
+        heightAspectRatio: 1
+      }).then(
+        err => done.fail(err),
+        err => {
+          expect(err.message).toMatch(/aspect ratio/i);
+          done();
+        }
+      );
+    });
+
+    it('resolves correctly', done => {
+      grid.gridInstance.getCropFromEvent = () => ({
+        assets: [
+          {
+            secureUrl: getPath('square.png'),
+            dimensions: { width: 140, height: 140 }
+          },
+          {
+            secureUrl: getPath('thumb.png'),
+            dimensions: { width: 140, height: 140 }
+          }
+        ],
+        id: 'mediaID'
+      });
+      grid.gridInstance.getGridUrlFromEvent = () =>
+        'http://media/image/mediaID';
+
+      validateImageEvent({}, 'front', {
+        widthAspectRatio: 1,
+        heightAspectRatio: 1
+      })
+        .then(image => {
+          expect(image.width).toBe(140);
+          expect(image.height).toBe(140);
+          expect(image.src).toMatch(/square\.png$/);
+          expect(image.origin).toBe('http://media/image/mediaID');
+          expect(image.thumb).toMatch(/thumb\.png$/);
+        })
+        .then(done)
+        .catch(err => done.fail(err));
+    });
+
+    it('resolves correctly when it contains a URL', done => {
+      grid.gridInstance.getCropFromEvent = () => {};
+      grid.gridInstance.getGridUrlFromEvent = () =>
+        'http://grid.co.uk/1234567890123456789012345678901234567890';
+      grid.gridInstance.getImage = () =>
+        Promise.resolve({
+          data: {
+            exports: [
+              {
+                id: 'crop_id',
+                assets: [
+                  {
+                    secureUrl: getPath('square.png'),
+                    dimensions: { width: 800, height: 800 }
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      ImageMock.defaultWidth = 140;
+      ImageMock.defaultHeight = 140;
+      validateImageEvent(
+        {},
+        {
+          widthAspectRatio: 1,
+          heightAspectRatio: 1
+        }
+      )
+        .then(image => {
+          expect(image.width).toBe(140);
+          expect(image.height).toBe(140);
+          expect(image.src).toMatch(/square\.png$/);
+          expect(image.origin).toBe(
+            'http://media/image/1234567890123456789012345678901234567890'
+          );
+          expect(image.thumb).toMatch(/square\.png$/);
+        })
+        .then(done)
+        .catch(err => done.fail(err));
+    });
+  });
+});

--- a/client-v2/src/shared/util/deepGet.js
+++ b/client-v2/src/shared/util/deepGet.js
@@ -1,19 +1,20 @@
 // @flow
 
+/**
+ * Safely get a nested property from an object.
+ *
+ * @param {Object} obj
+ * @param {string[]} properties
+ */
 export default function deepGet(obj: Object, properties: string[]) {
-  // If we have reached an undefined/null property
-  // then stop executing and return undefined.
   if (obj === undefined || obj === null) {
     return null;
   }
 
-  // If the path array has no more elements, we've reached
-  // the intended property and return its value.
   if (properties.length === 0) {
     return obj;
   }
 
-  // Prepare our found property and path array for recursion
   const foundSoFar = obj[properties[0]];
   const remainingProperties = properties.slice(1);
 

--- a/client-v2/src/shared/util/deepGet.js
+++ b/client-v2/src/shared/util/deepGet.js
@@ -1,0 +1,21 @@
+// @flow
+
+export default function deepGet(obj: Object, properties: string[]) {
+  // If we have reached an undefined/null property
+  // then stop executing and return undefined.
+  if (obj === undefined || obj === null) {
+    return null;
+  }
+
+  // If the path array has no more elements, we've reached
+  // the intended property and return its value.
+  if (properties.length === 0) {
+    return obj;
+  }
+
+  // Prepare our found property and path array for recursion
+  const foundSoFar = obj[properties[0]];
+  const remainingProperties = properties.slice(1);
+
+  return deepGet(foundSoFar, remainingProperties);
+}

--- a/client-v2/src/shared/util/fetchImage.js
+++ b/client-v2/src/shared/util/fetchImage.js
@@ -1,8 +1,8 @@
 // @flow
 
-import type { Description, Asset } from './validateImageSrc';
+import type { ImageDescription } from './validateImageSrc';
 
-function fetchImage(description: Description): Promise<Asset> {
+function fetchImage(description: ImageDescription): Promise<ImageDescription> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.onerror = () => {
@@ -14,7 +14,7 @@ function fetchImage(description: Description): Promise<Asset> {
         height: img.height,
         ratio: img.width / img.height
       };
-      const asset: Asset = {
+      const asset: ImageDescription = {
         ...description,
         ...size
       };

--- a/client-v2/src/shared/util/fetchImage.js
+++ b/client-v2/src/shared/util/fetchImage.js
@@ -1,0 +1,27 @@
+// @flow
+
+import type { Description, Asset } from './validateImageSrc';
+
+function fetchImage(description: Description): Promise<Asset> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onerror = () => {
+      reject(new Error('That image could not be found'));
+    };
+    img.onload = () => {
+      const size = {
+        width: img.width,
+        height: img.height,
+        ratio: img.width / img.height
+      };
+      const asset: Asset = {
+        ...description,
+        ...size
+      };
+      resolve(asset);
+    };
+    img.src = description.path;
+  });
+}
+
+export default fetchImage;

--- a/client-v2/src/shared/util/grid.js
+++ b/client-v2/src/shared/util/grid.js
@@ -1,0 +1,38 @@
+// @flow
+
+import GridUtil from 'grid-util-js';
+import imageConstants from '../constants/images';
+
+class Grid {
+  instance = new GridUtil({
+    apiBaseUrl: imageConstants.apiBaseUrl,
+    fetchInit: {
+      credentials: 'include',
+      mode: 'cors'
+    }
+  });
+
+  get gridInstance() {
+    return this.instance;
+  }
+
+  setGridInstance(instance: GridUtil) {
+    this.instance = instance;
+  }
+}
+
+const grid = new Grid();
+
+export function recordUsage(mediaId: string, frontId?: string) {
+  const usageData = {
+    mediaId,
+    front: frontId
+  };
+
+  return fetch(imageConstants.usageBaseUrl, {
+    method: 'POST',
+    data: JSON.stringify(usageData)
+  });
+}
+
+export default grid;

--- a/client-v2/src/shared/util/validateImageSrc.js
+++ b/client-v2/src/shared/util/validateImageSrc.js
@@ -1,0 +1,289 @@
+// @flow
+
+import { find, chain } from 'lodash';
+import imageConstants from '../constants/images';
+import deepGet from './deepGet';
+import grid, { recordUsage } from './grid';
+import fetchImage from './fetchImage';
+
+type Criteria = {|
+  maxWidth?: number,
+  minWidth?: number,
+  widthAspectRatio?: number,
+  heightAspectRatio?: number
+|};
+
+type Description = {|
+  path: string,
+  criteria?: Criteria
+|};
+
+type Asset = {|
+  height?: number,
+  width?: number,
+  thumb?: string,
+  origin?: string,
+  ratio?: number,
+  path: string,
+  criteria?: Criteria
+|};
+
+type ValidationResponse = {|
+  src: string,
+  thumb: string,
+  origin: string,
+  height: number,
+  width: number
+|};
+
+function filterGridCrops(
+  json,
+  desired,
+  { minWidth, maxWidth, widthAspectRatio, heightAspectRatio }: Criteria = {}
+) {
+  return grid.gridInstance.filterCrops(json, crop => {
+    if (desired.crop && crop.id !== desired.crop) {
+      return false;
+    }
+
+    const ratio =
+      widthAspectRatio && heightAspectRatio
+        ? widthAspectRatio / heightAspectRatio
+        : NaN;
+
+    return !!find([crop.master].concat(crop.assets).filter(Boolean), asset => {
+      const { width, height } = asset.dimensions;
+      const actualRatio = width / height;
+      if (maxWidth && maxWidth < width) {
+        return false;
+      } else if (minWidth && minWidth > width) {
+        return false;
+      } else if (ratio && Math.abs(ratio - actualRatio) > 0.01) {
+        return false;
+      }
+      return true;
+    });
+  });
+}
+
+function getSuitableAsset(crops, id, desired): Promise<Asset> {
+  if (crops.length === 0) {
+    return Promise.reject(
+      new Error('The image does not have a valid crop on the Grid')
+    );
+  }
+  const { maxWidth, minWidth } = desired;
+  const assets = chain([crops[0].master].concat(crops[0].assets))
+    .filter(Boolean)
+    .filter(
+      asset =>
+        maxWidth
+          ? parseInt(deepGet(asset, ['dimensions', 'width']), 10) <= maxWidth
+          : true
+    )
+    .filter(
+      asset =>
+        minWidth
+          ? parseInt(deepGet(asset, ['dimensions', 'width']), 10) >= minWidth
+          : true
+    )
+    .sortBy(
+      asset => parseInt(deepGet(asset, ['dimensions', 'width']), 10) * -1
+    );
+
+  if (assets.value().length) {
+    const mainAsset = assets.first().value();
+    const path = mainAsset.secureUrl;
+    const { height, width } = mainAsset.dimensions;
+    return Promise.resolve({
+      path,
+      thumb: assets.last().value().secureUrl,
+      origin: `${imageConstants.mediaBaseUrl}/image/${id}`,
+      height,
+      width,
+      ratio: width / height
+    });
+  }
+  return Promise.reject(
+    new Error('The crop does not have a valid asset on the Grid')
+  );
+}
+
+function validateActualImage(image: Asset, frontId?: string) {
+  return new Promise((resolve, reject) => {
+    const {
+      width = 0,
+      height = 0,
+      ratio = 0,
+      criteria,
+      path,
+      origin,
+      thumb
+    } = image;
+    const { maxWidth, minWidth, widthAspectRatio, heightAspectRatio } =
+      criteria || {};
+    const criteriaRatio =
+      widthAspectRatio && heightAspectRatio
+        ? widthAspectRatio / heightAspectRatio
+        : NaN;
+
+    if (maxWidth && maxWidth < width) {
+      return reject(
+        new Error(`Images cannot be more than ${maxWidth} pixels wide`)
+      );
+    } else if (minWidth && minWidth > width) {
+      return reject(
+        new Error(`Images cannot be less than ${minWidth} pixels wide`)
+      );
+    } else if (criteriaRatio && criteriaRatio - ratio > 0.01) {
+      return reject(
+        new Error(
+          `Images must have a ${widthAspectRatio || ''}:${heightAspectRatio ||
+            ''} aspect ratio`
+        )
+      );
+    }
+    if (image.origin) {
+      return recordUsage(image.origin.split('/').slice(-1)[0], frontId).then(
+        () => {
+          resolve({ path, origin, thumb, width, height });
+        }
+      );
+    }
+    return resolve({ path, origin, thumb, width, height });
+  });
+}
+
+function stripImplementationDetails(src, criteria): Promise<Asset> {
+  return new Promise((resolve, reject) => {
+    const maybeFromGrid = grid.gridInstance.excractMediaId(src);
+    if (src && imageConstants.imgIXDomainExpr.test(src)) {
+      const localSource = src
+        .substring(0, src.indexOf('?'))
+        .replace(
+          imageConstants.imgIXDomainExpr,
+          imageConstants.staticImageCdnDomain
+        );
+      resolve({
+        path: localSource,
+        criteria
+      });
+    } else if (maybeFromGrid) {
+      grid.gridInstance
+        .getImage(maybeFromGrid.id)
+        .catch(() =>
+          reject(new Error('Unable to locate the image on the Grid'))
+        )
+        .then(gridImageJson =>
+          filterGridCrops(gridImageJson, maybeFromGrid, criteria)
+        )
+        .then(crops =>
+          getSuitableAsset(crops, maybeFromGrid.id, criteria || {})
+        )
+        .then(asset =>
+          resolve({
+            ...asset,
+            criteria
+          })
+        )
+        .catch(reject);
+    } else if (!imageConstants.imageCdnDomainExpr.test(src)) {
+      reject(
+        new Error(
+          `Images must come from ${imageConstants.imageCdnDomain} or the Grid`
+        )
+      );
+    } else {
+      resolve({
+        path: src,
+        criteria
+      });
+    }
+  });
+}
+
+/**
+ * Asserts if the given image URL is on The Guardian domain, is proper size and aspect ratio.
+ * @param {string} src image source
+ * @param criteria. validation criteria object. defines: maxWidth, minWidth, widthAspectRatio, heightAspectRatio
+ * @returns Promise object: rejects with (error) OR resolves with (width, height, src)
+ */
+function validateImageSrc(
+  src: string,
+  frontId?: string,
+  criteria?: Criteria
+): Promise<ValidationResponse> {
+  if (!src) {
+    return Promise.reject(new Error('Missing image'));
+  }
+
+  return stripImplementationDetails(src, criteria)
+    .then(fetchImage)
+    .then(image => validateActualImage(image, frontId))
+    .then(({ path, origin, thumb, width, height }) => ({
+      src: path,
+      origin: origin || path,
+      thumb: thumb || path,
+      width,
+      height
+    }));
+}
+
+function getData(
+  event: DragEvent | SyntheticDragEvent<HTMLElement>,
+  identifier
+) {
+  const dataTransfer = event.nativeEvent
+    ? (event.nativeEvent: any).dataTransfer
+    : event.dataTransfer;
+  return dataTransfer && dataTransfer.getData
+    ? dataTransfer.getData(identifier)
+    : null;
+}
+
+function validateImageEvent(
+  event: DragEvent | SyntheticDragEvent<HTMLElement>,
+  frontId: string,
+  criteria?: Criteria
+): Promise<ValidationResponse> {
+  const mediaItem = grid.gridInstance.getCropFromEvent(event);
+
+  if (mediaItem) {
+    return getSuitableAsset(
+      [
+        {
+          assets: mediaItem.assets,
+          master: mediaItem.master
+        }
+      ],
+      mediaItem.id,
+      criteria || {}
+    )
+      .then(asset => {
+        const newAsset = asset;
+        newAsset.origin = grid.gridInstance.getGridUrlFromEvent(event);
+        newAsset.criteria = criteria;
+        return asset;
+      })
+      .then(image => validateActualImage(image, frontId))
+      .then(({ path, origin, thumb, width, height }) => ({
+        src: path,
+        origin: origin || path,
+        thumb: thumb || path,
+        width,
+        height
+      }));
+  }
+  const url =
+    grid.gridInstance.getGridUrlFromEvent(event) || getData(event, 'Url');
+
+  if (url) {
+    return validateImageSrc(url, frontId, criteria);
+  }
+  return Promise.reject(
+    new Error('Invalid image source, are you dragging from the grid?')
+  );
+}
+
+export type { Description, Asset };
+export { validateImageSrc, validateImageEvent };

--- a/client-v2/src/shared/util/validateImageSrc.js
+++ b/client-v2/src/shared/util/validateImageSrc.js
@@ -1,6 +1,7 @@
 // @flow
 
-import { find, chain } from 'lodash';
+import find from 'lodash/find';
+import sortBy from 'lodash/sortBy';
 import imageConstants from '../constants/images';
 import deepGet from './deepGet';
 import grid, { recordUsage } from './grid';
@@ -68,31 +69,32 @@ function getSuitableAsset(crops, id, desired): Promise<ImageDescription> {
     );
   }
   const { maxWidth, minWidth } = desired;
-  const assets = chain([crops[0].master].concat(crops[0].assets))
-    .filter(Boolean)
-    .filter(
-      asset =>
-        maxWidth
-          ? parseInt(deepGet(asset, ['dimensions', 'width']), 10) <= maxWidth
-          : true
-    )
-    .filter(
-      asset =>
-        minWidth
-          ? parseInt(deepGet(asset, ['dimensions', 'width']), 10) >= minWidth
-          : true
-    )
-    .sortBy(
-      asset => parseInt(deepGet(asset, ['dimensions', 'width']), 10) * -1
-    );
+  const assets = sortBy(
+    [crops[0].master]
+      .concat(crops[0].assets)
+      .filter(Boolean)
+      .filter(
+        asset =>
+          maxWidth
+            ? parseInt(deepGet(asset, ['dimensions', 'width']), 10) <= maxWidth
+            : true
+      )
+      .filter(
+        asset =>
+          minWidth
+            ? parseInt(deepGet(asset, ['dimensions', 'width']), 10) >= minWidth
+            : true
+      ),
+    asset => parseInt(deepGet(asset, ['dimensions', 'width']), 10) * -1
+  );
 
-  if (assets.value().length) {
-    const mainAsset = assets.first().value();
+  if (assets.length) {
+    const mainAsset = assets[0];
     const path = mainAsset.secureUrl;
     const { height, width } = mainAsset.dimensions;
     return Promise.resolve({
       path,
-      thumb: assets.last().value().secureUrl,
+      thumb: assets[assets.length - 1].secureUrl,
       origin: `${imageConstants.mediaBaseUrl}/image/${id}`,
       height,
       width,

--- a/client-v2/src/shared/util/validateImageSrc.js
+++ b/client-v2/src/shared/util/validateImageSrc.js
@@ -13,12 +13,7 @@ type Criteria = {|
   heightAspectRatio?: number
 |};
 
-type Description = {|
-  path: string,
-  criteria?: Criteria
-|};
-
-type Asset = {|
+type ImageDescription = {|
   height?: number,
   width?: number,
   thumb?: string,
@@ -66,7 +61,7 @@ function filterGridCrops(
   });
 }
 
-function getSuitableAsset(crops, id, desired): Promise<Asset> {
+function getSuitableAsset(crops, id, desired): Promise<ImageDescription> {
   if (crops.length === 0) {
     return Promise.reject(
       new Error('The image does not have a valid crop on the Grid')
@@ -109,7 +104,7 @@ function getSuitableAsset(crops, id, desired): Promise<Asset> {
   );
 }
 
-function validateActualImage(image: Asset, frontId?: string) {
+function validateActualImage(image: ImageDescription, frontId?: string) {
   return new Promise((resolve, reject) => {
     const {
       width = 0,
@@ -154,7 +149,7 @@ function validateActualImage(image: Asset, frontId?: string) {
   });
 }
 
-function stripImplementationDetails(src, criteria): Promise<Asset> {
+function stripImplementationDetails(src, criteria): Promise<ImageDescription> {
   return new Promise((resolve, reject) => {
     const maybeFromGrid = grid.gridInstance.excractMediaId(src);
     if (src && imageConstants.imgIXDomainExpr.test(src)) {
@@ -285,5 +280,5 @@ function validateImageEvent(
   );
 }
 
-export type { Description, Asset };
+export type { ImageDescription };
 export { validateImageSrc, validateImageEvent };

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -4364,6 +4364,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+grid-util-js@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/grid-util-js/-/grid-util-js-1.1.0.tgz#e7e9224eb2753b82a6c6319e7726d8272e56d08d"
+
 grouped-queue@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/grouped-queue/-/grouped-queue-0.3.3.tgz#c167d2a5319c5a0e0964ef6a25b7c2df8996c85c"


### PR DESCRIPTION
This imports the image validation code from Fronts V1, including the test suite.

The only major change - the V1 suite used actual images as fixtures that the browser test environment would parse. Our test runs in Node, so in the absence of an Image() global in Node I've written a basic mock.