### PR TITLE
Search articles

### DIFF
--- a/client-v2/src/components/CAPI/TagQuery.js
+++ b/client-v2/src/components/CAPI/TagQuery.js
@@ -12,11 +12,12 @@ type CAPITagQueryProps = {
   baseURL?: string,
   fetch?: Fetch,
   children: *,
-  params: Object
+  params: Object,
+  tagType: 'sections' | 'tags'
 };
 
 type CAPITagQueryState = {
-  capi?: $ElementType<$Call<typeof capiQuery, string>, 'tags'>,
+  capi?: $ElementType<$Call<typeof capiQuery, 'sections' | 'tags'>, string>,
   baseURL?: string,
   fetch?: Fetch
 };
@@ -29,7 +30,7 @@ class TagQuery extends React.Component<CAPITagQueryProps, CAPITagQueryState> {
   state = {};
 
   static getDerivedStateFromProps(
-    { baseURL, fetch }: CAPITagQueryProps,
+    { baseURL, fetch, tagType }: CAPITagQueryProps,
     prevState: CAPITagQueryState
   ) {
     if (
@@ -37,7 +38,7 @@ class TagQuery extends React.Component<CAPITagQueryProps, CAPITagQueryState> {
       (fetch && prevState.fetch !== fetch)
     ) {
       return {
-        capi: capiQuery(baseURL, fetch).tags,
+        capi: capiQuery(baseURL, fetch)[tagType],
         baseURL,
         fetch
       };

--- a/client-v2/src/components/Feed.js
+++ b/client-v2/src/components/Feed.js
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import ContainerHeading from 'shared/components/typography/ContainerHeading';
 import pandaFetch from 'services/pandaFetch';
 import { getThumbnail } from 'util/CAPIUtils';
 import * as CAPIParamsContext from './CAPI/CAPIParamsContext';
@@ -80,7 +79,6 @@ class Feed extends React.Component<FeedProps, FeedState> {
 
   renderFixedContent = () => (
     <ResultsHeadingContainer>
-      <ContainerHeading>Results</ContainerHeading>
       <StageSelectionContainer>
         <RadioGroup>
           {this.props.capiFeedSpecs.map(({ name }, i) => (

--- a/client-v2/src/components/Feed.js
+++ b/client-v2/src/components/Feed.js
@@ -51,6 +51,10 @@ const FeedContainer = styled('div')`
   height: 100%;
 `;
 
+const NoResults = styled('div')`
+  margin: 4px;
+`;
+
 const StageSelectionContainer = styled('div')`
   margin-left: auto;
 `;
@@ -157,6 +161,10 @@ class Feed extends React.Component<FeedProps, FeedState> {
                                 />
                               )
                             )}
+                        {value &&
+                          value.response.results.length === 0 && (
+                            <NoResults>No results found</NoResults>
+                          )}
                       </div>
                     </LoaderDisplay>
                   </ErrorDisplay>

--- a/client-v2/src/components/Feed.js
+++ b/client-v2/src/components/Feed.js
@@ -43,7 +43,8 @@ type FeedProps = {
 };
 
 type FeedState = {
-  capiFeedIndex: number
+  capiFeedIndex: number,
+  displaySearchFilters: boolean
 };
 
 const FeedContainer = styled('div')`
@@ -64,36 +65,46 @@ class Feed extends React.Component<FeedProps, FeedState> {
   };
 
   state = {
-    capiFeedIndex: 0
+    capiFeedIndex: 0,
+    displaySearchFilters: false
   };
 
   get capiFeedSpec() {
     return this.props.capiFeedSpecs[this.state.capiFeedIndex];
   }
 
-  handleFeedClick(index: number) {
+  updateDisplaySearchFilters = (newValue: boolean) =>
+    this.setState({
+      displaySearchFilters: newValue
+    });
+
+  handleFeedClick = (index: number) =>
     this.setState({
       capiFeedIndex: index
     });
-  }
 
-  renderFixedContent = () => (
-    <ResultsHeadingContainer>
-      <StageSelectionContainer>
-        <RadioGroup>
-          {this.props.capiFeedSpecs.map(({ name }, i) => (
-            <RadioButton
-              key={name}
-              checked={i === this.state.capiFeedIndex}
-              onChange={() => this.handleFeedClick(i)}
-              label={name}
-              inline
-            />
-          ))}
-        </RadioGroup>
-      </StageSelectionContainer>
-    </ResultsHeadingContainer>
-  );
+  renderFixedContent = () => {
+    if (!this.state.displaySearchFilters) {
+      return (
+        <ResultsHeadingContainer>
+          <StageSelectionContainer>
+            <RadioGroup>
+              {this.props.capiFeedSpecs.map(({ name }, i) => (
+                <RadioButton
+                  key={name}
+                  checked={i === this.state.capiFeedIndex}
+                  onChange={() => this.handleFeedClick(i)}
+                  label={name}
+                  inline
+                />
+              ))}
+            </RadioGroup>
+          </StageSelectionContainer>
+        </ResultsHeadingContainer>
+      );
+    }
+    return null;
+  };
 
   render() {
     const { capiFeedSpec } = this;
@@ -108,7 +119,11 @@ class Feed extends React.Component<FeedProps, FeedState> {
             fetch={pandaFetch}
             debounce={500}
           >
-            <SearchInput additionalFixedContent={this.renderFixedContent}>
+            <SearchInput
+              updateDisplaySearchFilters={this.updateDisplaySearchFilters}
+              displaySearchFilters={this.state.displaySearchFilters}
+              additionalFixedContent={this.renderFixedContent}
+            >
               {({ pending, error, value }) => (
                 <React.Fragment>
                   <ErrorDisplay error={error}>

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -14,7 +14,8 @@ type FrontsCAPISearchInputProps = {
 
 type FrontsCAPISearchInputState = {
   q: ?string,
-  tag: ?string
+  tag: ?string,
+  section: ?string
 };
 
 const InputContainer = styled('div')`
@@ -27,7 +28,8 @@ class FrontsCAPISearchInput extends React.Component<
 > {
   state = {
     q: null,
-    tag: null
+    tag: null,
+    section: null
   };
 
   clearInput = () => {
@@ -48,12 +50,18 @@ class FrontsCAPISearchInput extends React.Component<
     });
   };
 
+  handleSectionInput = (item: any) => {
+    this.setState({
+      section: item ? item.id : null
+    });
+  };
+
   render() {
     const {
       children,
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
-    const { tag, q } = this.state;
+    const { tag, section, q } = this.state;
 
     return (
       <ScrollContainer
@@ -74,6 +82,7 @@ class FrontsCAPISearchInput extends React.Component<
         <SearchQuery
           params={{
             tag,
+            section,
             q,
             'show-elements': 'image',
             'show-fields': 'internalPageCode,trailText'

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -10,49 +10,54 @@ import CAPITagInput from '../FrontsCAPIInterface/TagInput';
 
 type FrontsCAPISearchInputProps = {
   children: *,
-  additionalFixedContent?: React.ComponentType<any>,
-  displaySearchFilters: boolean
+  additionalFixedContent?: React.ComponentType<any>
 };
 
 type FrontsCAPISearchInputState = {
   q: ?string,
   tags: Array<string>,
   sections: Array<string>,
-  dislaySearchFilters: boolean
+  dislaySearchFilters: boolean,
+  tagsSearchTerm: '',
+  sectionsSearchTerm: ''
 };
 
 const InputContainer = styled('div')`
   margin-bottom: 20px;
 `;
 
+const emptyState = {
+  q: null,
+  tags: [],
+  sections: [],
+  displaySearchFilters: true,
+  tagsSearchTerm: '',
+  sectionsSearchTerm: ''
+};
+
 class FrontsCAPISearchInput extends React.Component<
   FrontsCAPISearchInputProps,
   FrontsCAPISearchInputState
 > {
-  state = {
-    q: null,
-    tags: [],
-    sections: [],
-    displaySearchFilters: true,
-    tagSearchTerm: ''
-  };
+  state = emptyState;
 
   clearInput = () => {
     this.setState({
-      q: '',
+      q: null,
       tags: [],
       sections: [],
-      displaySearchFilters: false
+      displaySearchFilters: true,
+      tagsSearchTerm: '',
+      sectionsSearchTerm: ''
     });
   };
 
-  clearIndividualSearchTerm = (
-    type: 'tags' | 'sections',
-    searchTerm: string
-  ) => {
-    const oldTerms = this.state[type];
-    const newTerms = oldTerms.filter(term => term !== searchTerm);
-    this.setState({ [type]: newTerms });
+  clearIndividualSearchTerm = (searchTerm: string) => {
+    const oldTags = this.state.tags;
+    const newTags = oldTags.filter(term => term !== searchTerm);
+    const oldSections = this.state.sections;
+    const newSections = oldSections.filter(term => term !== searchTerm);
+    this.setState({ tags: newTags, sections: newSections });
   };
 
   handleSearchInput = ({ currentTarget }: SyntheticEvent<HTMLInputElement>) => {
@@ -61,26 +66,25 @@ class FrontsCAPISearchInput extends React.Component<
     });
   };
 
-  handleTagSearchInput = ({ currentTarget }: SyntheticEvent<HTMLInputElement>) => {
+  handleTagSearchInput = (
+    { currentTarget }: SyntheticEvent<HTMLInputElement>,
+    type: string
+  ) => {
+    const termInState = `${type}SearchTerm`;
     this.setState({
-      tagSearchTerm: currentTarget.value
+      [termInState]: currentTarget.value
     });
   };
 
-  handleTagInput = (item: any) => {
-    const newTags = this.state.tags;
+  handleTagInput = (item: any, type: string) => {
+    const searchTerm = `${type}SearchTerm`;
+    const newTags = this.state[type];
     if (item && newTags.indexOf(item.id) === -1) {
       newTags.push(item.id);
     }
     this.setState({
-      tags: newTags,
-      tagSearchTerm: ''
-    });
-  };
-
-  handleSectionInput = (item: any) => {
-    this.setState({
-      sections: item ? item.id : []
+      [type]: newTags,
+      [searchTerm]: ''
     });
   };
 
@@ -95,7 +99,14 @@ class FrontsCAPISearchInput extends React.Component<
       children,
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
-    const { tags, sections, q, displaySearchFilters, tagSearchTerm } = this.state;
+    const {
+      tags,
+      sections,
+      q,
+      displaySearchFilters,
+      tagsSearchTerm,
+      sectionsSearchTerm
+    } = this.state;
 
     const displayClear = !!tags || !!sections || !!q;
     const tagQuery = tags ? tags.join(',') : '';
@@ -136,7 +147,22 @@ class FrontsCAPISearchInput extends React.Component<
           </SearchQuery>
         )}
         {displaySearchFilters && (
-          <CAPITagInput onSearchChange={this.handleTagSearchInput} tagSearchTerm={tagSearchTerm} onChange={this.handleTagInput} />
+          <React.Fragment>
+            <CAPITagInput
+              placeholder="Type tag name"
+              onSearchChange={this.handleTagSearchInput}
+              tagsSearchTerm={tagsSearchTerm}
+              onChange={this.handleTagInput}
+              searchType="tags"
+            />
+            <CAPITagInput
+              placeholder="Type section name"
+              onSearchChange={this.handleTagSearchInput}
+              tagsSearchTerm={sectionsSearchTerm}
+              onChange={this.handleTagInput}
+              searchType="sections"
+            />
+          </React.Fragment>
         )}
       </ScrollContainer>
     );

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -69,7 +69,7 @@ class FrontsCAPISearchInput extends React.Component<
 
   handleTagInput = (item: any) => {
     const newTags = this.state.tags;
-    if (item) {
+    if (item && newTags.indexOf(item.id) === -1) {
       newTags.push(item.id);
     }
     this.setState({

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -101,9 +101,10 @@ class FrontsCAPISearchInput extends React.Component<
 
   handleTagInput = (item: any, type: string) => {
     const searchTerm = `${type}SearchTerm`;
-    const newTags = this.state[type];
-    if (item && newTags.indexOf(item.id) === -1) {
-      newTags.push(item.id);
+    let newTags;
+    const oldTags = this.state[type];
+    if (item && oldTags.indexOf(item.id) === -1) {
+      newTags = oldTags.concat([item.id]);
     }
     this.setState({
       [type]: newTags,

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -2,7 +2,8 @@
 
 import * as React from 'react';
 import styled from 'styled-components';
-
+import moreImage from 'shared/images/icons/more.svg';
+import { SmallRoundButton, ClearButtonIcon } from 'util/sharedStyles/buttons';
 import SearchQuery from '../CAPI/SearchQuery';
 import ScrollContainer from '../ScrollContainer';
 import TextInput from '../TextInput';
@@ -26,6 +27,19 @@ type FrontsCAPISearchInputState = {
 const InputContainer = styled('div')`
   margin-bottom: 20px;
   background: #ffffff;
+`;
+
+const TagItem = styled('div')`
+  color: #121212;
+  font-weight: bold;
+  border: solid 1px #c4c4c4;
+  font-size: 14px;
+  background-color: #ffffff;
+  padding: 7px 15px 7px 15px;
+  margin-bottom: 10px;
+  :hover {
+    color: #c4c4c4;
+  }
 `;
 
 const emptyState = {
@@ -101,6 +115,25 @@ class FrontsCAPISearchInput extends React.Component<
     this.props.updateDisplaySearchFilters(!this.props.displaySearchFilters);
   };
 
+  renderSelectedTags = (selectedTags: Array<string>) =>
+    selectedTags.map(searchTerm => (
+      <TagItem key={searchTerm}>
+        <span>{searchTerm}</span>
+        <SmallRoundButton
+          onClick={() => this.clearIndividualSearchTerm(searchTerm)}
+          title="Clear search"
+        >
+          <ClearButtonIcon
+            src={moreImage}
+            onClick={() => this.clearIndividualSearchTerm(searchTerm)}
+            alt=""
+            height="22px"
+            width="22px"
+          />
+        </SmallRoundButton>
+      </TagItem>
+    ));
+
   render() {
     const {
       children,
@@ -127,7 +160,6 @@ class FrontsCAPISearchInput extends React.Component<
             <React.Fragment>
               <InputContainer>
                 <TextInput
-                  searchTerms={tags.concat(sections)}
                   placeholder="Search content"
                   value={this.state.q || ''}
                   onChange={this.handleSearchInput}
@@ -138,6 +170,7 @@ class FrontsCAPISearchInput extends React.Component<
                   onDisplaySearchFilters={this.handleDisplaySearchFilters}
                 />
               </InputContainer>
+              {this.renderSelectedTags(tags.concat(sections))}
               {AdditionalFixedContent && <AdditionalFixedContent />}
             </React.Fragment>
           }
@@ -174,6 +207,7 @@ class FrontsCAPISearchInput extends React.Component<
             onDisplaySearchFilters={this.handleDisplaySearchFilters}
           />
         </InputContainer>
+        {this.renderSelectedTags(tags.concat(sections))}
         <CAPITagInput
           placeholder="Type tag name"
           onSearchChange={this.handleTagSearchInput}

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -20,8 +20,10 @@ type FrontsCAPISearchInputState = {
   q: ?string,
   tags: Array<string>,
   sections: Array<string>,
-  tagsSearchTerm: '',
-  sectionsSearchTerm: ''
+  searchTerms: {
+    tags: string,
+    sections: string
+  }
 };
 
 const InputContainer = styled('div')`
@@ -42,12 +44,16 @@ const TagItem = styled('div')`
   }
 `;
 
+const emptySearchTerms = {
+  tags: '',
+  sections: ''
+};
+
 const emptyState = {
   q: null,
   tags: [],
   sections: [],
-  tagsSearchTerm: '',
-  sectionsSearchTerm: ''
+  searchTerms: emptySearchTerms
 };
 
 class FrontsCAPISearchInput extends React.Component<
@@ -61,16 +67,14 @@ class FrontsCAPISearchInput extends React.Component<
       q: null,
       tags: [],
       sections: [],
-      tagsSearchTerm: '',
-      sectionsSearchTerm: ''
+      searchTerms: emptySearchTerms
     });
     this.props.updateDisplaySearchFilters(false);
   };
 
   searchInput = () => {
     this.setState({
-      tagsSearchTerm: '',
-      sectionsSearchTerm: ''
+      searchTerms: emptySearchTerms
     });
     this.props.updateDisplaySearchFilters(false);
   };
@@ -93,22 +97,25 @@ class FrontsCAPISearchInput extends React.Component<
     { currentTarget }: SyntheticEvent<HTMLInputElement>,
     type: string
   ) => {
-    const termInState = `${type}SearchTerm`;
+    const newSearchTerms = {
+      ...this.state.searchTerms,
+      ...{ [type]: currentTarget.value }
+    };
     this.setState({
-      [termInState]: currentTarget.value
+      searchTerms: newSearchTerms
     });
   };
 
   handleTagInput = (item: any, type: string) => {
-    const searchTerm = `${type}SearchTerm`;
     let newTags;
     const oldTags = this.state[type];
     if (item && oldTags.indexOf(item.id) === -1) {
       newTags = oldTags.concat([item.id]);
     }
+    const newSearchTerms = { ...this.state.searchTerms, ...{ [type]: '' } };
     this.setState({
       [type]: newTags,
-      [searchTerm]: ''
+      searchTerms: newSearchTerms
     });
   };
 
@@ -142,13 +149,7 @@ class FrontsCAPISearchInput extends React.Component<
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
 
-    const {
-      tags,
-      sections,
-      q,
-      tagsSearchTerm,
-      sectionsSearchTerm
-    } = this.state;
+    const { tags, sections, q, searchTerms } = this.state;
 
     const searchTermsExist = tags.length !== 0 || sections.length !== 0 || !!q;
     const tagQuery = tags ? tags.join(',') : '';
@@ -191,6 +192,9 @@ class FrontsCAPISearchInput extends React.Component<
         </ScrollContainer>
       );
     }
+
+    const tagType = 'tags';
+    const sectionType = 'sections';
     return (
       <React.Fragment>
         <InputContainer>
@@ -210,16 +214,16 @@ class FrontsCAPISearchInput extends React.Component<
         <CAPITagInput
           placeholder="Type tag name"
           onSearchChange={this.handleTagSearchInput}
-          tagsSearchTerm={tagsSearchTerm}
+          tagsSearchTerm={searchTerms[tagType]}
           onChange={this.handleTagInput}
-          searchType="tags"
+          searchType={tagType}
         />
         <CAPITagInput
           placeholder="Type section name"
           onSearchChange={this.handleTagSearchInput}
-          tagsSearchTerm={sectionsSearchTerm}
+          tagsSearchTerm={searchTerms[sectionType]}
           onChange={this.handleTagInput}
-          searchType="sections"
+          searchType={sectionType}
         />
       </React.Fragment>
     );

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -46,7 +46,15 @@ class FrontsCAPISearchInput extends React.Component<
       q: null,
       tags: [],
       sections: [],
-      displaySearchFilters: true,
+      displaySearchFilters: false,
+      tagsSearchTerm: '',
+      sectionsSearchTerm: ''
+    });
+  };
+
+  searchInput = () => {
+    this.setState({
+      displaySearchFilters: false,
       tagsSearchTerm: '',
       sectionsSearchTerm: ''
     });
@@ -86,6 +94,7 @@ class FrontsCAPISearchInput extends React.Component<
       [type]: newTags,
       [searchTerm]: ''
     });
+
   };
 
   handleDisplaySearchFilters = () => {
@@ -123,6 +132,7 @@ class FrontsCAPISearchInput extends React.Component<
                 value={this.state.q || ''}
                 onChange={this.handleSearchInput}
                 onClear={this.clearInput}
+                onSearch={this.searchInput}
                 onClearTag={this.clearIndividualSearchTerm}
                 displayClear={displayClear}
                 onDisplaySearchFilters={this.handleDisplaySearchFilters}
@@ -135,8 +145,8 @@ class FrontsCAPISearchInput extends React.Component<
         {!displaySearchFilters && (
           <SearchQuery
             params={{
-              tagQuery,
-              sectionQuery,
+              tag: tagQuery,
+              section: sectionQuery,
               q,
               'show-elements': 'image',
               'show-fields': 'internalPageCode,trailText'

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -16,8 +16,8 @@ type FrontsCAPISearchInputProps = {
 
 type FrontsCAPISearchInputState = {
   q: ?string,
-  tag: ?string,
-  section: ?string,
+  tags: ?Array<string>,
+  sections: ?Array<string>,
   dislaySearchFilters: boolean
 };
 
@@ -31,16 +31,16 @@ class FrontsCAPISearchInput extends React.Component<
 > {
   state = {
     q: null,
-    tag: null,
-    section: null,
-    displaySearchFilters: false
+    tags: [],
+    sections: [],
+    displaySearchFilters: true
   };
 
   clearInput = () => {
     this.setState({
       q: '',
-      tag: null,
-      section: null,
+      tags: [],
+      sections: [],
       displaySearchFilters: false
     });
   };
@@ -52,14 +52,18 @@ class FrontsCAPISearchInput extends React.Component<
   };
 
   handleTagInput = (item: any) => {
+    const newTags = this.state.tags;
+    if (item) {
+      newTags.push(item.id)
+    }
     this.setState({
-      tag: item ? item.id : null
+      tags: newTags
     });
   };
 
   handleSectionInput = (item: any) => {
     this.setState({
-      section: item ? item.id : null
+      sections: item ? item.id : []
     });
   };
 
@@ -74,9 +78,10 @@ class FrontsCAPISearchInput extends React.Component<
       children,
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
-    const { tag, section, q, displaySearchFilters } = this.state;
+    const { tags, sections, q, displaySearchFilters } = this.state;
+    console.log({tags});
 
-    const displayClear = !!tag || !!section || !!q;
+    const displayClear = !!tags || !!sections || !!q;
 
     return (
       <ScrollContainer
@@ -96,11 +101,12 @@ class FrontsCAPISearchInput extends React.Component<
           </React.Fragment>
         }
       >
+        {tags.map(tag => <div>{tag}</div>)}
         {!displaySearchFilters && (
           <SearchQuery
             params={{
-              tag,
-              section,
+              tags,
+              sections,
               q,
               'show-elements': 'image',
               'show-fields': 'internalPageCode,trailText'

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -33,7 +33,8 @@ class FrontsCAPISearchInput extends React.Component<
     q: null,
     tags: [],
     sections: [],
-    displaySearchFilters: true
+    displaySearchFilters: true,
+    tagSearchTerm: ''
   };
 
   clearInput = () => {
@@ -60,13 +61,20 @@ class FrontsCAPISearchInput extends React.Component<
     });
   };
 
+  handleTagSearchInput = ({ currentTarget }: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({
+      tagSearchTerm: currentTarget.value
+    });
+  };
+
   handleTagInput = (item: any) => {
     const newTags = this.state.tags;
     if (item) {
       newTags.push(item.id);
     }
     this.setState({
-      tags: newTags
+      tags: newTags,
+      tagSearchTerm: ''
     });
   };
 
@@ -87,7 +95,7 @@ class FrontsCAPISearchInput extends React.Component<
       children,
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
-    const { tags, sections, q, displaySearchFilters } = this.state;
+    const { tags, sections, q, displaySearchFilters, tagSearchTerm } = this.state;
 
     const displayClear = !!tags || !!sections || !!q;
     const tagQuery = tags ? tags.join(',') : '';
@@ -128,7 +136,7 @@ class FrontsCAPISearchInput extends React.Component<
           </SearchQuery>
         )}
         {displaySearchFilters && (
-          <CAPITagInput onChange={this.handleTagInput} />
+          <CAPITagInput onSearchChange={this.handleTagSearchInput} tagSearchTerm={tagSearchTerm} onChange={this.handleTagInput} />
         )}
       </ScrollContainer>
     );

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -16,8 +16,8 @@ type FrontsCAPISearchInputProps = {
 
 type FrontsCAPISearchInputState = {
   q: ?string,
-  tags: ?Array<string>,
-  sections: ?Array<string>,
+  tags: Array<string>,
+  sections: Array<string>,
   dislaySearchFilters: boolean
 };
 
@@ -45,6 +45,15 @@ class FrontsCAPISearchInput extends React.Component<
     });
   };
 
+  clearIndividualSearchTerm = (
+    type: 'tags' | 'sections',
+    searchTerm: string
+  ) => {
+    const oldTerms = this.state[type];
+    const newTerms = oldTerms.filter(term => term !== searchTerm);
+    this.setState({ [type]: newTerms });
+  };
+
   handleSearchInput = ({ currentTarget }: SyntheticEvent<HTMLInputElement>) => {
     this.setState({
       q: currentTarget.value
@@ -54,7 +63,7 @@ class FrontsCAPISearchInput extends React.Component<
   handleTagInput = (item: any) => {
     const newTags = this.state.tags;
     if (item) {
-      newTags.push(item.id)
+      newTags.push(item.id);
     }
     this.setState({
       tags: newTags
@@ -79,9 +88,10 @@ class FrontsCAPISearchInput extends React.Component<
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
     const { tags, sections, q, displaySearchFilters } = this.state;
-    console.log({tags});
 
     const displayClear = !!tags || !!sections || !!q;
+    const tagQuery = tags ? tags.join(',') : '';
+    const sectionQuery = sections ? sections.join(',') : '';
 
     return (
       <ScrollContainer
@@ -89,10 +99,12 @@ class FrontsCAPISearchInput extends React.Component<
           <React.Fragment>
             <InputContainer>
               <TextInput
+                searchTerms={tags.concat(sections)}
                 placeholder="Search"
                 value={this.state.q || ''}
                 onChange={this.handleSearchInput}
                 onClear={this.clearInput}
+                onClearTag={this.clearIndividualSearchTerm}
                 displayClear={displayClear}
                 onDisplaySearchFilters={this.handleDisplaySearchFilters}
               />
@@ -101,12 +113,11 @@ class FrontsCAPISearchInput extends React.Component<
           </React.Fragment>
         }
       >
-        {tags.map(tag => <div>{tag}</div>)}
         {!displaySearchFilters && (
           <SearchQuery
             params={{
-              tags,
-              sections,
+              tagQuery,
+              sectionQuery,
               q,
               'show-elements': 'image',
               'show-fields': 'internalPageCode,trailText'

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -6,16 +6,19 @@ import styled from 'styled-components';
 import SearchQuery from '../CAPI/SearchQuery';
 import ScrollContainer from '../ScrollContainer';
 import TextInput from '../TextInput';
+import CAPITagInput from '../FrontsCAPIInterface/TagInput';
 
 type FrontsCAPISearchInputProps = {
   children: *,
-  additionalFixedContent?: React.ComponentType<any>
+  additionalFixedContent?: React.ComponentType<any>,
+  displaySearchFilters: boolean
 };
 
 type FrontsCAPISearchInputState = {
   q: ?string,
   tag: ?string,
-  section: ?string
+  section: ?string,
+  dislaySearchFilters: boolean
 };
 
 const InputContainer = styled('div')`
@@ -29,12 +32,16 @@ class FrontsCAPISearchInput extends React.Component<
   state = {
     q: null,
     tag: null,
-    section: null
+    section: null,
+    displaySearchFilters: false
   };
 
   clearInput = () => {
     this.setState({
-      q: ''
+      q: '',
+      tag: null,
+      section: null,
+      displaySearchFilters: false
     });
   };
 
@@ -56,12 +63,20 @@ class FrontsCAPISearchInput extends React.Component<
     });
   };
 
+  handleDisplaySearchFilters = () => {
+    this.setState({
+      displaySearchFilters: !this.state.displaySearchFilters
+    });
+  };
+
   render() {
     const {
       children,
       additionalFixedContent: AdditionalFixedContent
     } = this.props;
-    const { tag, section, q } = this.state;
+    const { tag, section, q, displaySearchFilters } = this.state;
+
+    const displayClear = !!tag || !!section || !!q;
 
     return (
       <ScrollContainer
@@ -73,24 +88,31 @@ class FrontsCAPISearchInput extends React.Component<
                 value={this.state.q || ''}
                 onChange={this.handleSearchInput}
                 onClear={this.clearInput}
+                displayClear={displayClear}
+                onDisplaySearchFilters={this.handleDisplaySearchFilters}
               />
             </InputContainer>
             {AdditionalFixedContent && <AdditionalFixedContent />}
           </React.Fragment>
         }
       >
-        <SearchQuery
-          params={{
-            tag,
-            section,
-            q,
-            'show-elements': 'image',
-            'show-fields': 'internalPageCode,trailText'
-          }}
-          poll={30000}
-        >
-          {children}
-        </SearchQuery>
+        {!displaySearchFilters && (
+          <SearchQuery
+            params={{
+              tag,
+              section,
+              q,
+              'show-elements': 'image',
+              'show-fields': 'internalPageCode,trailText'
+            }}
+            poll={30000}
+          >
+            {children}
+          </SearchQuery>
+        )}
+        {displaySearchFilters && (
+          <CAPITagInput onChange={this.handleTagInput} />
+        )}
       </ScrollContainer>
     );
   }

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -176,20 +176,18 @@ class FrontsCAPISearchInput extends React.Component<
             </React.Fragment>
           }
         >
-          {!displaySearchFilters && (
-            <SearchQuery
-              params={{
-                tag: tagQuery,
-                section: sectionQuery,
-                q,
-                'show-elements': 'image',
-                'show-fields': 'internalPageCode,trailText'
-              }}
-              poll={30000}
-            >
-              {children}
-            </SearchQuery>
-          )}
+          <SearchQuery
+            params={{
+              tag: tagQuery,
+              section: sectionQuery,
+              q,
+              'show-elements': 'image',
+              'show-fields': 'internalPageCode,trailText'
+            }}
+            poll={30000}
+          >
+            {children}
+          </SearchQuery>
         </ScrollContainer>
       );
     }

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.js
@@ -11,11 +11,10 @@ type CAPITagInputProps<T> = {
 };
 
 const DragContainer = styled('div')`
-  width: 100%
+  width: 100%;
 `;
 
-const TagDropdown = styled('div')`
-`;
+const TagDropdown = styled('div')``;
 
 const DropdownItem = styled('div')`
   background-color: ${({ selected }) => (selected ? '#dcdcdc' : 'white')};
@@ -68,7 +67,7 @@ const SearchContainer = styled('div')`
 const CAPITagInput = <T>({ onChange, placeholder }: CAPITagInputProps<T>) => (
   <Downshift
     itemToString={item => (item ? item.id : '')}
-    onChange={(value) => {
+    onChange={value => {
       onChange(value);
       value = null;
     }}

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.js
@@ -106,7 +106,7 @@ const CAPITagInput = <T>({
               /**
                * Filter tags based on ids
                * think this is only for the test/test tag but sometime tags
-               * come
+               * come through more than once
                */
               const seenIds = [];
 

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.js
@@ -7,14 +7,16 @@ import TagQuery from '../CAPI/TagQuery';
 
 type CAPITagInputProps<T> = {
   onChange: (value: T) => void,
-  placeholder?: string
+  placeholder?: string,
+  tagSearchTerm: string
 };
 
 const DragContainer = styled('div')`
-  width: 100%;
+  width: 100%
 `;
 
-const TagDropdown = styled('div')``;
+const TagDropdown = styled('div')`
+`;
 
 const DropdownItem = styled('div')`
   background-color: ${({ selected }) => (selected ? '#dcdcdc' : 'white')};
@@ -64,12 +66,11 @@ const SearchContainer = styled('div')`
   padding: 2px;
 `;
 
-const CAPITagInput = <T>({ onChange, placeholder }: CAPITagInputProps<T>) => (
+const CAPITagInput = <T>({ onChange, onSearchChange, placeholder, tagSearchTerm }: CAPITagInputProps<T>) => (
   <Downshift
     itemToString={item => (item ? item.id : '')}
-    onChange={value => {
+    onChange={(value) => {
       onChange(value);
-      value = null;
     }}
     render={({
       getInputProps,
@@ -87,7 +88,9 @@ const CAPITagInput = <T>({ onChange, placeholder }: CAPITagInputProps<T>) => (
             {...getInputProps({
               placeholder,
               onClear: clearSelection,
-              width: '100%'
+              width: '100%',
+              value: tagSearchTerm,
+              onChange: onSearchChange
             })}
           />
         </SearchContainer>

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.js
@@ -4,43 +4,74 @@ import * as React from 'react';
 import Downshift from 'downshift';
 import styled from 'styled-components';
 import TagQuery from '../CAPI/TagQuery';
-import TextInput from '../TextInput';
 
 type CAPITagInputProps<T> = {
   onChange: (value: T) => void,
   placeholder?: string
 };
 
-const TagWrapper = styled('div')`
-  position: relative;
+const DragContainer = styled('div')`
+  width: 100%
 `;
 
 const TagDropdown = styled('div')`
-  background-color: #213;
-  position: absolute;
 `;
 
 const DropdownItem = styled('div')`
-  background-color: ${({ selected }) => (selected ? 'white' : 'transparent')};
-  border-left: 1px solid #fff;
-  border-right: 1px solid #fff;
-  color: ${({ selected }) => (selected ? '#213' : 'white')};
-  font-weight: ${({ highlighted }) => (highlighted ? '700' : '300')};
-  padding: 0.5em;
-
-  &:first-child {
-    border-top: 1px solid #fff;
+  background-color: ${({ selected }) => (selected ? '#dcdcdc' : 'white')};
+  :hover {
+    background-color: #dcdcdc
   }
+  font-size: 14px;
+  front-weight: bold;
+  padding: 7px; 15px; 7px; 15px;
+  border-left: 1px solid #c4c4c4;
+  color: #121212;
+`;
 
-  &:last-child {
-    border-bottom: 1px solid #fff;
+const SearchTitle = styled('span')`
+  width: 39px;
+  height: 20px;
+  font-family: TS3TextSans;
+  font-size: 16px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #121212;
+  margin-right: 3px;
+`;
+
+const SearchInput = styled('input')`
+  type: 'text';
+  background-color: transparent;
+  border: none;
+  width: 109px;
+  height: 20px;
+  &::-webkit-input-placeholder {
+    font-family: TS3TextSans;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    font-stretch: normal;
+    line-height: normal;
+    letter-spacing: normal;
   }
+`;
+
+const SearchContainer = styled('div')`
+  border-bottom: solid 2px #c4c4c4;
+  padding: 2px;
 `;
 
 const CAPITagInput = <T>({ onChange, placeholder }: CAPITagInputProps<T>) => (
   <Downshift
     itemToString={item => (item ? item.id : '')}
-    onChange={onChange}
+    onChange={(value) => {
+      onChange(value);
+      value = null;
+    }}
     render={({
       getInputProps,
       getItemProps,
@@ -51,57 +82,58 @@ const CAPITagInput = <T>({ onChange, placeholder }: CAPITagInputProps<T>) => (
       clearSelection
     }) => (
       <div>
-        <TagWrapper>
-          <TextInput
+        <SearchContainer>
+          <SearchTitle>Tags:</SearchTitle>
+          <SearchInput
             {...getInputProps({
               placeholder,
               onClear: clearSelection,
               width: '100%'
             })}
           />
-          <TagDropdown>
-            <TagQuery params={{ q: inputValue }}>
-              {({ value }) => {
-                if (!value || !isOpen) {
-                  return false;
-                }
+        </SearchContainer>
+        <TagDropdown>
+          <TagQuery params={{ q: inputValue }}>
+            {({ value }) => {
+              if (!value || !isOpen) {
+                return false;
+              }
 
-                /**
-                 * Filter tags based on ids
-                 * think this is only for the test/test tag but sometime tags
-                 * come
-                 */
-                const seenIds = [];
+              /**
+               * Filter tags based on ids
+               * think this is only for the test/test tag but sometime tags
+               * come
+               */
+              const seenIds = [];
 
-                return value.response.results.map((tag, index) => {
-                  const wasSeen = seenIds.indexOf(tag.id);
-                  seenIds.push();
-                  return (
-                    wasSeen && (
-                      <DropdownItem
-                        {...getItemProps({
-                          item: tag,
-                          highlighted: highlightedIndex === index,
-                          selected: selectedItem === tag
-                        })}
-                        key={tag.id}
-                      >
-                        {tag.id}
-                      </DropdownItem>
-                    )
-                  );
-                });
-              }}
-            </TagQuery>
-          </TagDropdown>
-        </TagWrapper>
+              return value.response.results.map((tag, index) => {
+                const wasSeen = seenIds.indexOf(tag.id);
+                seenIds.push();
+                return (
+                  wasSeen && (
+                    <DropdownItem
+                      {...getItemProps({
+                        item: tag,
+                        highlighted: highlightedIndex === index,
+                        selected: selectedItem === tag
+                      })}
+                      key={tag.id}
+                    >
+                      {tag.id}
+                    </DropdownItem>
+                  )
+                );
+              });
+            }}
+          </TagQuery>
+        </TagDropdown>
       </div>
     )}
   />
 );
 
 CAPITagInput.defaultProps = {
-  placeholder: ''
+  placeholder: 'Type tag name'
 };
 
 export default CAPITagInput;

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.js
@@ -2,21 +2,19 @@
 
 import * as React from 'react';
 import Downshift from 'downshift';
+import capitalize from 'lodash/capitalize';
 import styled from 'styled-components';
 import TagQuery from '../CAPI/TagQuery';
 
 type CAPITagInputProps<T> = {
   onChange: (value: T) => void,
+  onSearchChange: (value: T, type: string) => void,
   placeholder?: string,
-  tagSearchTerm: string
+  tagsSearchTerm: string,
+  searchType: string
 };
 
-const DragContainer = styled('div')`
-  width: 100%
-`;
-
-const TagDropdown = styled('div')`
-`;
+const TagDropdown = styled('div')``;
 
 const DropdownItem = styled('div')`
   background-color: ${({ selected }) => (selected ? '#dcdcdc' : 'white')};
@@ -66,11 +64,17 @@ const SearchContainer = styled('div')`
   padding: 2px;
 `;
 
-const CAPITagInput = <T>({ onChange, onSearchChange, placeholder, tagSearchTerm }: CAPITagInputProps<T>) => (
+const CAPITagInput = <T>({
+  onChange,
+  onSearchChange,
+  placeholder,
+  tagsSearchTerm,
+  searchType
+}: CAPITagInputProps<T>) => (
   <Downshift
     itemToString={item => (item ? item.id : '')}
-    onChange={(value) => {
-      onChange(value);
+    onChange={value => {
+      onChange(value, searchType);
     }}
     render={({
       getInputProps,
@@ -83,19 +87,21 @@ const CAPITagInput = <T>({ onChange, onSearchChange, placeholder, tagSearchTerm 
     }) => (
       <div>
         <SearchContainer>
-          <SearchTitle>Tags:</SearchTitle>
+          <SearchTitle>{capitalize(searchType)}:</SearchTitle>
           <SearchInput
             {...getInputProps({
               placeholder,
               onClear: clearSelection,
               width: '100%',
-              value: tagSearchTerm,
-              onChange: onSearchChange
+              value: tagsSearchTerm,
+              onChange: input => {
+                onSearchChange(input, searchType);
+              }
             })}
           />
         </SearchContainer>
         <TagDropdown>
-          <TagQuery params={{ q: inputValue }}>
+          <TagQuery tagType={searchType} params={{ q: inputValue }}>
             {({ value }) => {
               if (!value || !isOpen) {
                 return false;

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.js
@@ -7,14 +7,16 @@ import styled from 'styled-components';
 import TagQuery from '../CAPI/TagQuery';
 
 type CAPITagInputProps<T> = {
-  onChange: (value: T) => void,
+  onChange: (value: T, type: string) => void,
   onSearchChange: (value: T, type: string) => void,
   placeholder?: string,
   tagsSearchTerm: string,
-  searchType: string
+  searchType: 'tags' | 'sections'
 };
 
-const TagDropdown = styled('div')``;
+const TagDropdown = styled('div')`
+  margin-right: 19px;
+`;
 
 const DropdownItem = styled('div')`
   background-color: ${({ selected }) => (selected ? '#dcdcdc' : 'white')};
@@ -29,39 +31,33 @@ const DropdownItem = styled('div')`
 `;
 
 const SearchTitle = styled('span')`
-  width: 39px;
-  height: 20px;
-  font-family: TS3TextSans;
   font-size: 16px;
   font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: normal;
   color: #121212;
   margin-right: 3px;
 `;
 
 const SearchInput = styled('input')`
-  type: 'text';
   background-color: transparent;
   border: none;
   width: 109px;
-  height: 20px;
-  &::-webkit-input-placeholder {
-    font-family: TS3TextSans;
+  padding-left: 5px;
+  font-size: 16px;
+  flex: 1;
+  :focus {
+    outline: none;
+  }
+  &::placeholder {
     font-size: 16px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
   }
 `;
 
 const SearchContainer = styled('div')`
   border-bottom: solid 2px #c4c4c4;
   padding: 2px;
+  padding-top: 24px;
+  margin-right: 19px;
+  display: flex;
 `;
 
 const CAPITagInput = <T>({

--- a/client-v2/src/components/ScrollContainer.js
+++ b/client-v2/src/components/ScrollContainer.js
@@ -24,7 +24,7 @@ const ScrollTitle = styled(`div`)`
 
 const ScrollInner = styled(`div`)`
   overflow-y: scroll;
-  display: flex;
+  display: block;
   height: 100%;
 `;
 

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -9,6 +9,19 @@ import searchImage from 'shared/images/icons/search.svg';
 const InputWrapper = styled('div')`
   position: relative;
   width: ${({ width }) => width || 'auto'};
+  display: flex;
+`;
+
+const TagItem = styled('div')`
+  color: #121212;
+  font-weight: bold;
+  border: solid 1px #c4c4c4;
+  font-size: 14px;
+  background-color: #ffffff;
+  padding: 7px 15px 7px 15px;
+  :hover {
+    color: #c4c4c4;
+  }
 `;
 
 const Input = styled(`input`)`
@@ -56,6 +69,8 @@ const SmallRoundButton = styled('button')`
   }
 `;
 
+const RemoveButton = SmallRoundButton.extend``;
+
 const SmallRoundButtonOrange = SmallRoundButton.extend`
   background-color: #ff7f0f;
   margin-right: 4px;
@@ -90,16 +105,37 @@ type TextInputProps = {
   onClear?: () => void,
   onDisplaySearchFilters?: () => void,
   width?: string,
-  displayClear: boolean
+  displayClear: boolean,
+  searchTerms: Array<string>,
+  onClearTag: (string, string) => void
 };
 
 const TextInput = ({
   onClear,
   displayClear,
   onDisplaySearchFilters,
+  searchTerms,
+  onClearTag,
   ...props
 }: TextInputProps) => (
   <InputWrapper>
+    {searchTerms.map(searchTerm => (
+      <TagItem key={searchTerm}>
+        {searchTerm}
+        <RemoveButton
+          onClick={() => onClearTag('tags', searchTerm)}
+          title="Clear search"
+        >
+          <ClearButtonIcon
+            src={moreImage}
+            onClick={() => onClearTag('tags', searchTerm)}
+            alt=""
+            height="22px"
+            width="22px"
+          />
+        </RemoveButton>
+      </TagItem>
+    ))})
     <Input {...props} />
     <ButtonsContainer>
       {onClear &&

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -10,15 +10,19 @@ const InputWrapper = styled('div')`
   position: relative;
   width: ${({ width }) => width || 'auto'};
   display: flex;
+  border: solid 1px #c9c9c9;
+  backgroud: #fffff;
 `;
 
 const TagItem = styled('div')`
   color: #121212;
   font-weight: bold;
   border: solid 1px #c4c4c4;
-  font-size: 14px;
+  font-size: 12px;
   background-color: #ffffff;
   padding: 7px 15px 7px 15px;
+  border-top: solid 1px #121212;
+  margin: 5px;
   :hover {
     color: #c4c4c4;
   }
@@ -27,20 +31,18 @@ const TagItem = styled('div')`
 const Input = styled(`input`)`
   appearance: none;
   background: #fff;
-  border: solid 1px #c9c9c9;
+  border: none;
   width: 100%;
   height: 50px;
   padding: 9px 85px 9px 9px;
   font-size: 16px;
 
   :focus {
-    border: solid 1px #a9a9a9;
     outline: none;
   }
 
-  ::placeholder {
+  &::placeholder
     color: rgba(255, 255, 255, 0.75);
-    font-style: italic;
   }
 `;
 
@@ -69,11 +71,10 @@ const SmallRoundButton = styled('button')`
   }
 `;
 
-const RemoveButton = SmallRoundButton.extend``;
-
 const SmallRoundButtonOrange = SmallRoundButton.extend`
   background-color: #ff7f0f;
   margin-right: 4px;
+  padding: 4px;
   :hover {
     background-color: #ff983f;
   }
@@ -106,15 +107,15 @@ type TextInputProps = {
   onSearch?: () => void,
   onDisplaySearchFilters?: () => void,
   width?: string,
-  displayClear: boolean,
+  searchTermsExist: boolean,
   searchTerms: Array<string>,
-  onClearTag: (string, string) => void
+  onClearTag: string => void
 };
 
 const TextInput = ({
   onClear,
   onSearch,
-  displayClear,
+  searchTermsExist,
   onDisplaySearchFilters,
   searchTerms,
   onClearTag,
@@ -123,8 +124,8 @@ const TextInput = ({
   <InputWrapper>
     {searchTerms.map(searchTerm => (
       <TagItem key={searchTerm}>
-        {searchTerm}
-        <RemoveButton
+        <span>{searchTerm}</span>
+        <SmallRoundButton
           onClick={() => onClearTag(searchTerm)}
           title="Clear search"
         >
@@ -135,17 +136,17 @@ const TextInput = ({
             height="22px"
             width="22px"
           />
-        </RemoveButton>
+        </SmallRoundButton>
       </TagItem>
     ))}
     <Input {...props} />
     <ButtonsContainer>
       {onClear &&
-        displayClear && (
-          <SmallRoundButtonOrange onClick={onClear} title="Search">
+        searchTermsExist && (
+          <SmallRoundButtonOrange onClick={onSearch} title="Clear search">
             <ClearButtonIcon
               src={moreImage}
-              onClick={onSearch}
+              onClick={onClear}
               alt=""
               height="22px"
               width="22px"
@@ -153,10 +154,7 @@ const TextInput = ({
           </SmallRoundButtonOrange>
         )}
       {onDisplaySearchFilters && (
-        <SmallRoundButtonBlack
-          onClick={onDisplaySearchFilters}
-          title="Clear Search"
-        >
+        <SmallRoundButtonBlack onClick={onDisplaySearchFilters} title="Search">
           <SearchButtonIcon
             src={searchImage}
             onClick={onSearch}

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -123,12 +123,12 @@ const TextInput = ({
       <TagItem key={searchTerm}>
         {searchTerm}
         <RemoveButton
-          onClick={() => onClearTag('tags', searchTerm)}
+          onClick={() => onClearTag(searchTerm)}
           title="Clear search"
         >
           <ClearButtonIcon
             src={moreImage}
-            onClick={() => onClearTag('tags', searchTerm)}
+            onClick={() => onClearTag(searchTerm)}
             alt=""
             height="22px"
             width="22px"

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import moreImage from 'shared/images/icons/more.svg';
+import searchImage from 'shared/images/icons/search.svg';
 
 const InputWrapper = styled('div')`
   position: relative;
@@ -57,9 +58,16 @@ const SmallRoundButton = styled('button')`
 
 const SmallRoundButtonOrange = SmallRoundButton.extend`
   background-color: #ff7f0f;
+  margin-right: 4px;
   :hover {
     background-color: #ff983f;
   }
+`;
+
+const SmallRoundButtonBlack = SmallRoundButton.extend`
+  background-color: #333333;
+  :hover {
+    background-color: #505050;
 `;
 
 const ButtonsContainer = styled('div')`
@@ -71,29 +79,53 @@ const ButtonsContainer = styled('div')`
 const ClearButtonIcon = styled('img')`
   transform: rotate(45deg);
   vertical-align: middle;
+  margin-right: 4px;
+`;
+
+const SearchButtonIcon = styled('img')`
+  vertical-align: middle;
 `;
 
 type TextInputProps = {
   onClear?: () => void,
-  width?: string
+  onDisplaySearchFilters?: () => void,
+  width?: string,
+  displayClear: boolean
 };
 
-const TextInput = ({ onClear, ...props }: TextInputProps) => (
+const TextInput = ({
+  onClear,
+  displayClear,
+  onDisplaySearchFilters,
+  ...props
+}: TextInputProps) => (
   <InputWrapper>
     <Input {...props} />
-    {onClear && (
-      <ButtonsContainer>
-        <SmallRoundButtonOrange onClick={onClear} title="Clear search">
-          <ClearButtonIcon
-            src={moreImage}
+    <ButtonsContainer>
+      {onClear &&
+        displayClear && (
+          <SmallRoundButtonOrange onClick={onClear} title="Clear search">
+            <ClearButtonIcon
+              src={moreImage}
+              onClick={onClear}
+              alt=""
+              height="22px"
+              width="22px"
+            />
+          </SmallRoundButtonOrange>
+        )}
+      {onDisplaySearchFilters && (
+        <SmallRoundButtonBlack onClick={onDisplaySearchFilters} title="Search">
+          <SearchButtonIcon
+            src={searchImage}
             onClick={onClear}
             alt=""
             height="22px"
             width="22px"
           />
-        </SmallRoundButtonOrange>
-      </ButtonsContainer>
-    )}
+        </SmallRoundButtonBlack>
+      )}
+    </ButtonsContainer>
   </InputWrapper>
 );
 

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -135,7 +135,7 @@ const TextInput = ({
           />
         </RemoveButton>
       </TagItem>
-    ))})
+    ))}
     <Input {...props} />
     <ButtonsContainer>
       {onClear &&

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -103,6 +103,7 @@ const SearchButtonIcon = styled('img')`
 
 type TextInputProps = {
   onClear?: () => void,
+  onSearch?: () => void,
   onDisplaySearchFilters?: () => void,
   width?: string,
   displayClear: boolean,
@@ -112,6 +113,7 @@ type TextInputProps = {
 
 const TextInput = ({
   onClear,
+  onSearch,
   displayClear,
   onDisplaySearchFilters,
   searchTerms,
@@ -140,10 +142,10 @@ const TextInput = ({
     <ButtonsContainer>
       {onClear &&
         displayClear && (
-          <SmallRoundButtonOrange onClick={onClear} title="Clear search">
+          <SmallRoundButtonOrange onClick={onClear} title="Search">
             <ClearButtonIcon
               src={moreImage}
-              onClick={onClear}
+              onClick={onSearch}
               alt=""
               height="22px"
               width="22px"
@@ -151,10 +153,13 @@ const TextInput = ({
           </SmallRoundButtonOrange>
         )}
       {onDisplaySearchFilters && (
-        <SmallRoundButtonBlack onClick={onDisplaySearchFilters} title="Search">
+        <SmallRoundButtonBlack
+          onClick={onDisplaySearchFilters}
+          title="Clear Search"
+        >
           <SearchButtonIcon
             src={searchImage}
-            onClick={onClear}
+            onClick={onSearch}
             alt=""
             height="22px"
             width="22px"

--- a/client-v2/src/components/TextInput.js
+++ b/client-v2/src/components/TextInput.js
@@ -2,9 +2,9 @@
 
 import * as React from 'react';
 import styled from 'styled-components';
-
 import moreImage from 'shared/images/icons/more.svg';
 import searchImage from 'shared/images/icons/search.svg';
+import { SmallRoundButton, ClearButtonIcon } from 'util/sharedStyles/buttons';
 
 const InputWrapper = styled('div')`
   position: relative;
@@ -12,20 +12,6 @@ const InputWrapper = styled('div')`
   display: flex;
   border: solid 1px #c9c9c9;
   backgroud: #fffff;
-`;
-
-const TagItem = styled('div')`
-  color: #121212;
-  font-weight: bold;
-  border: solid 1px #c4c4c4;
-  font-size: 12px;
-  background-color: #ffffff;
-  padding: 7px 15px 7px 15px;
-  border-top: solid 1px #121212;
-  margin: 5px;
-  :hover {
-    color: #c4c4c4;
-  }
 `;
 
 const Input = styled(`input`)`
@@ -43,31 +29,6 @@ const Input = styled(`input`)`
 
   &::placeholder
     color: rgba(255, 255, 255, 0.75);
-  }
-`;
-
-const SmallRoundButton = styled('button')`
-  appearance: none;
-  display: inline-block;
-  vertical-align: middle;
-  text-align: center;
-  width: 32px;
-  height: 32px;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  padding: 0;
-  border-radius: 100%;
-  transition: background-color 0.15s;
-
-  ::before {
-    font-size: 1em;
-    line-height: 1;
-  }
-
-  :focus {
-    outline: none;
-    font-weight: bold;
   }
 `;
 
@@ -92,12 +53,6 @@ const ButtonsContainer = styled('div')`
   right: 8px;
 `;
 
-const ClearButtonIcon = styled('img')`
-  transform: rotate(45deg);
-  vertical-align: middle;
-  margin-right: 4px;
-`;
-
 const SearchButtonIcon = styled('img')`
   vertical-align: middle;
 `;
@@ -107,9 +62,7 @@ type TextInputProps = {
   onSearch?: () => void,
   onDisplaySearchFilters?: () => void,
   width?: string,
-  searchTermsExist: boolean,
-  searchTerms: Array<string>,
-  onClearTag: string => void
+  searchTermsExist: boolean
 };
 
 const TextInput = ({
@@ -117,28 +70,9 @@ const TextInput = ({
   onSearch,
   searchTermsExist,
   onDisplaySearchFilters,
-  searchTerms,
-  onClearTag,
   ...props
 }: TextInputProps) => (
   <InputWrapper>
-    {searchTerms.map(searchTerm => (
-      <TagItem key={searchTerm}>
-        <span>{searchTerm}</span>
-        <SmallRoundButton
-          onClick={() => onClearTag(searchTerm)}
-          title="Clear search"
-        >
-          <ClearButtonIcon
-            src={moreImage}
-            onClick={() => onClearTag(searchTerm)}
-            alt=""
-            height="22px"
-            width="22px"
-          />
-        </SmallRoundButton>
-      </TagItem>
-    ))}
     <Input {...props} />
     <ButtonsContainer>
       {onClear &&

--- a/client-v2/src/services/capiQuery.js
+++ b/client-v2/src/services/capiQuery.js
@@ -78,6 +78,15 @@ const capiQuery = (
     );
 
     return response.json();
+  },
+  sections: async (params: Object): Promise<CAPITagQueryReponse> => {
+    const response = await fetch(
+      `${baseURL}sections${qs({
+        ...params
+      })}`
+    );
+
+    return response.json();
   }
 });
 

--- a/client-v2/src/util/sharedStyles/buttons.js
+++ b/client-v2/src/util/sharedStyles/buttons.js
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const SmallRoundButton = styled('button')`
+  appearance: none;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  border-radius: 100%;
+  transition: background-color 0.15s;
+
+  ::before {
+    font-size: 1em;
+    line-height: 1;
+  }
+
+  :focus {
+    outline: none;
+    font-weight: bold;
+  }
+`;
+
+export const ClearButtonIcon = styled('img')`
+  transform: rotate(45deg);
+  vertical-align: middle;
+  margin-right: 4px;
+`;


### PR DESCRIPTION
@jonathonherbert @RichieAHB This is now done and ready for review!

Allows for searching capi by tag and by section. It's missing pagination still but I'm going to add that in a separate pr. The menu icons in the bottom are also missing but those are not urgent and I have a card on trello for adding those later.

It looks a bit different from @Joshua-David's designs, we've had a chat about this and decided that having chosen tags displayed in the input field is not going to work. Josh is going to continue working on the designs for the tags but this should be enough for now to roll it out to central prod. 

![screen shot 2018-10-03 at 09 25 21](https://user-images.githubusercontent.com/3066534/46398983-7b6c2080-c6ee-11e8-8366-3a018c74b6fd.png)
![screen shot 2018-10-03 at 09 25 39](https://user-images.githubusercontent.com/3066534/46398990-7effa780-c6ee-11e8-9ad5-c587329743d6.png)
