### PR TITLE
Add logging to show latency and status of request

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -8,6 +8,7 @@ import play.api.Mode
 import play.api.routing.Router
 import play.filters.cors.CORSConfig
 import play.filters.cors.CORSConfig.Origins
+import filters._
 import router.Routes
 import services._
 import slices.{Containers, FixedContainers}
@@ -66,6 +67,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, configAgent, this)
   val userDataController = new UserDataController(dynamo, this)
   val gridProxy = new GridProxy(this)
+  val loggingFilter = new LoggingFilter
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
     allowedOrigins = Origins.Matching(Set(config.environment.applicationUrl))
@@ -79,6 +81,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
 
   override lazy val httpFilters = Seq(
     new CustomGzipFilter()(materializer),
-    corsFilter
+    corsFilter,
+    loggingFilter
   )
 }

--- a/app/filters/LoggingFilter.scala
+++ b/app/filters/LoggingFilter.scala
@@ -1,0 +1,35 @@
+package filters
+
+import javax.inject.Inject
+import scala.collection.JavaConverters._
+import akka.stream.Materializer
+import play.api.MarkerContext
+import play.api.mvc._
+import scala.concurrent.{ExecutionContext, Future}
+import logging.Logging
+import net.logstash.logback.marker.Markers.appendEntries
+
+class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext) extends Filter with Logging {
+  def apply(nextFilter: RequestHeader => Future[Result])
+           (requestHeader: RequestHeader): Future[Result] = {
+
+    val startTime = System.currentTimeMillis
+
+    nextFilter(requestHeader).map { result =>
+
+      val endTime = System.currentTimeMillis
+      val requestTime = endTime - startTime
+
+      val logMarker = MarkerContext(appendEntries(Map(
+        "method" -> requestHeader.method,
+        "url" -> requestHeader.uri,
+        "requestTime" -> requestTime,
+        "status" -> result.header.status
+      ).asJava))
+
+      logger.info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")(logMarker)
+
+      result.withHeaders("Request-Time" -> requestTime.toString)
+    }
+  }
+}


### PR DESCRIPTION
Add some structured logging to show the latency and status of requests as they complete. This may help us debug the latency issues we've experienced recently.