### PR TITLE
Add drag rendering

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.js
@@ -1,0 +1,49 @@
+// @flow
+
+import React from 'react';
+import { connect } from 'react-redux';
+import {
+  externalArticleFromArticleFragmentSelector,
+  selectSharedState
+} from 'shared/selectors/shared';
+import type { State } from 'types/State';
+import type { Article } from 'shared/types/Article';
+
+type ContainerProps = {
+  id: string // eslint-disable-line react/no-unused-prop-types
+};
+
+type ComponentProps = {
+  article: ?Article
+} & ContainerProps;
+
+const ArticleDrag = ({ article }: ComponentProps) =>
+  article && (
+    <div
+      style={{
+        background: '#eee',
+        borderRadius: '4px',
+        dropShadow: '-2px -2px 5px 0 rgba(0, 0, 0, 0.5)',
+        overflow: 'hidden',
+        padding: '8px',
+        textOverflow: 'ellipsis',
+        width: '300px',
+        whiteSpace: 'nowrap'
+      }}
+    >
+      {article.headline}
+    </div>
+  );
+
+// $FlowFixMe
+const createMapStateToProps = () => (
+  state: State,
+  props: ContainerProps
+): { article: ?Article } => ({
+  article: externalArticleFromArticleFragmentSelector(
+    selectSharedState(state),
+    props.id
+  )
+});
+
+export default connect(createMapStateToProps)(ArticleDrag);

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Group.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Group.js
@@ -4,6 +4,7 @@ import React from 'react';
 import * as Guration from 'lib/guration';
 import GroupDisplay from 'shared/components/GroupDisplay';
 import DropZone from 'components/DropZone';
+import ArticleDrag from './ArticleDrag';
 
 type GroupProps = {
   id: string,
@@ -29,6 +30,7 @@ const Group = ({ id, articleFragments, children }: GroupProps) => (
           style={dropZoneStyle}
         />
       )}
+      renderDrag={e => <ArticleDrag id={e.uuid} />}
     >
       {children}
     </Guration.Level>

--- a/client-v2/src/lib/guration/Level.js
+++ b/client-v2/src/lib/guration/Level.js
@@ -60,6 +60,7 @@ type LevelProps<T> = {|
   arr: T[],
   type: string,
   children: NodeChildren<T>,
+  renderDrag?: (el: T) => ReactNode,
   renderDrop?: DropRenderer,
   getKey: (node: T) => string,
   dropOnNode: boolean,
@@ -77,7 +78,15 @@ class Level<T> extends React.Component<LevelProps<T>> {
   }
 
   render() {
-    const { arr, type, children, renderDrop, getKey, dropOnNode } = this.props;
+    const {
+      arr,
+      type,
+      children,
+      renderDrag,
+      renderDrop,
+      getKey,
+      dropOnNode
+    } = this.props;
 
     let didWarnKey = false;
 
@@ -126,6 +135,7 @@ class Level<T> extends React.Component<LevelProps<T>> {
                     id={getKey(item)}
                     type={type}
                     index={i}
+                    renderDrag={renderDrag}
                     childrenField={this.childrenField}
                     // TODO: maybe move this into Node?
                     handleDragStart={handleDragStart}


### PR DESCRIPTION
There is now a `renderDrag` prop on a `Guration.Level` that allows custom rendering of dragged components instead of using the HTMLElement that is being dragged.

![drag-render](https://user-images.githubusercontent.com/1652187/46418489-c7858800-c723-11e8-855d-690bc8b0481b.gif)
