### PR TITLE
  Update facia-tool README.md - New developers quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-Facia Tool [![Build Status](https://travis-ci.org/guardian/facia-tool.svg?branch=master)](https://travis-ci.org/guardian/facia-tool)
-==========
+# Facia Tool [![Build Status](https://travis-ci.org/guardian/facia-tool.svg?branch=master)](https://travis-ci.org/guardian/facia-tool)
+
 The Guardian front pages editor.
 
 [![Build Status](https://travis-ci.org/guardian/facia-tool.svg?branch=master)](https://travis-ci.org/guardian/facia-tool)
 
-New developers quick-start
-===========================
+# New developers quick-start
 
 1. [Application dependencies](#application-dependencies)
 1. [Clone repository](#clone-repository)
@@ -14,7 +13,6 @@ New developers quick-start
 1. [Run the App](#run-the-app)
 1. [Unit tests](#unit-tests)
 
-
 ### Application dependencies
 
 Install each of the things listed:
@@ -22,6 +20,7 @@ Install each of the things listed:
 #### Git
 
 Mac:
+
 ```bash
 brew install git
 echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
@@ -30,6 +29,7 @@ echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
 #### [Homebrew](http://brew.sh/)
 
 This is needed on Mac only:
+
 ```bash
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
@@ -37,15 +37,45 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 #### JDK 8
 
 Ubuntu:
+
 ```bash
 sudo apt-get install openjdk-8-jdk
 ```
 
 Mac: Install from [Oracle web site](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 
-#### Node.JS
+If you have more than one JDK version running, ensure you run JDK 8 by adding the below to `.bash_profile`:
+
+```
+export JAVA_HOME=`/usr/libexec/java_home -v 1.8
+```
+
+#### Node.JS with NVM
+
+Installation with [NVM](https://github.com/creationix/nvm) is highly recommended to ensure correct Node version is used and project setup scripts run correctly.
+
+Ubuntu/Mac:
+
+```bash
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+```
+
+Verify installation:
+
+```bash
+command -v nvm
+```
+
+Install Node.JS:
+
+```bash
+nvm install node
+```
+
+#### Node.JS without NVM
 
 Ubuntu:
+
 ```bash
 sudo apt-get install nodejs
 sudo apt-get install npm
@@ -53,16 +83,15 @@ sudo ln -s /usr/bin/nodejs /usr/bin/node
 ```
 
 Mac:
+
 ```bash
 brew install node
 ```
 
-#### NVM
-Optional: Install nvm to manage your node versions
-
 #### Grunt (build tool)
 
 Ubuntu/Mac:
+
 ```bash
 sudo npm -g install grunt-cli
 ```
@@ -70,6 +99,7 @@ sudo npm -g install grunt-cli
 #### JSPM (package management)
 
 Ubuntu/Mac:
+
 ```bash
 sudo npm -g install jspm
 jspm registry config github
@@ -80,6 +110,7 @@ It'll ask for a GitHub access token. Go to GitHub Settings -> Applications and [
 #### nginx
 
 Mac:
+
 ```bash
 brew install nginx
 ```
@@ -87,18 +118,21 @@ brew install nginx
 #### sbt
 
 Mac:
+
 ```bash
 brew install sbt
 ```
 
 #### aws cli
+
+You must have [Python](https://www.python.org/) installed on your system first.
+
 ```bash
-pip install awscli
+brew install awscli
 ```
 
-
-
 ### Clone repository
+
 1. [Generate and add an SSH key](https://help.github.com/articles/generating-ssh-keys) to your GitHub account.
 1. Check out the repository:
 
@@ -107,20 +141,23 @@ pip install awscli
     cd facia-tool
     ```
 
-
-
 ### Local test server
 
-Clone and follows the instructions to set up [dev-nginx](https://github.com/guardian/dev-nginx). The steps to follow are 'Install SSL certificates' and 'Install config for an application'. The path for nginx mapping is `nginx/nginx-mapping.yml`.
+Clone and follows the instructions to set up [dev-nginx](https://github.com/guardian/dev-nginx) (private repo - request access). The steps to follow are 'Install SSL certificates' and 'Install config for an application'. The path for nginx mapping is `nginx/nginx-mapping.yml`.
+
+Also add the root certificate `digital-ca.crt` file to your System Keychain and trust it for SSL connections:
+
+```
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <certificate>
+```
 
 Modify the files
 
-* `/usr/local/etc/nginx/nginx.conf` and add this line at the bottom, inside the main block
+-   `/usr/local/etc/nginx/nginx.conf` and add this line at the bottom, inside the main block
 
-   > include sites-enabled/*.conf;
+    > include sites-enabled/\*.conf;
 
 Run `sudo nginx -s reload` to restart nginx with the new configuration.
-
 
 #### Config Files
 
@@ -129,18 +166,19 @@ To get the config files run `./fetch-config.sh`. This requires CMS front credent
 ### Credentials
 
 You need the following credentials:
-- cmsFronts - developer
-- capi - API Gateway invocation
-- frontend - AWS console access
-You can get keys temporary keys from `janus`. You can copy these credentials manually from `janus`
 
-You can also get credentials for *facia-tool* by using [feria](https://github.com/guardian/feria):
+-   cmsFronts - developer
+-   capi - API Gateway invocation
+-   frontend - AWS console access
+    You can get keys temporary keys from `janus`. You can copy these credentials manually from `janus`
+
+You can also get credentials for _facia-tool_ by using [feria](https://github.com/guardian/feria):
 
 ```
 $ feria cmsFronts && feria --access sqs-consumer frontend
 ```
-(You should first checkout the repository and follow the install instructions for [*feria*](https://github.com/guardian/feria).)
 
+(You should first checkout the repository and follow the install instructions for [_feria_](https://github.com/guardian/feria).)
 
 You can run the fronts tool without frontend credentials, but you will not be able to check how your changes to fronts appear on frontend without
 these credentials. You will need to test your changes on `CODE` to see these changes.
@@ -165,6 +203,7 @@ sbt
 Wait for SBT to be up and running. This may take a while the first time, you'll know it's done when you get a prompt.
 
 If it is your first time, compile the project.
+
 ```
 compile
 ```
@@ -173,15 +212,16 @@ Ensure that you are running to correct version of node (4.1 or higher).
 You can get this by running `nvm use`
 
 Run the project locally by typing
+
 ```
 run
 ```
+
 This also can take a while the first time.
 
 Now check that you are up and running by hitting the following URL
 
 [https://fronts.local.dev-gutools.co.uk](https://fronts.local.dev-gutools.co.uk)
-
 
 ### Unit tests
 
@@ -196,11 +236,13 @@ Unit tests on the client are run with `grunt`, `karma` and `jasmine`.
 ```bash
 grunt test
 ```
+
 Runs the tests once in PhantomJS and exits with an error if tests fails
 
 ```bash
 grunt test --no-single-run
 ```
+
 Runs the tests on the browserm, starts `karma` in debug mode. You can connect your browser at [http://localhost:9876?debug.html](http://localhost:9876?debug.html)
 
 You can run a single test going to [http://localhost:9876/debug.html?test=collections](http://localhost:9876/debug.html?test=collections), spec files are inside `facia-tool/test/public/spec`.
@@ -219,4 +261,5 @@ More detailed instructions of how to develop fronts tool available [here](./GUID
 Enjoy!
 
 ### Get Fronts Editors
+
 There is a script to get a list of the fronts editors in the `get-editors-script`. See the [script README](./get-editors-script/README.md) for more details.


### PR DESCRIPTION
- Add instructions to switch JDK version if necessary
- Add install Node.js via nvm instructions
- Update awscli install instructions to use homebrew not pip
- Flag dev-nginx is a private repo 
- Add instruction to add root certificate to system keychain (this is not very clear in the dev-nginx README)

Note: VSCode made some other format changes to the markdown such as adding new lines and changing bullet point characters. Will try to turn this off for future markdown edits. 

 