### PR TITLE
Improved feed

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -182,6 +182,7 @@ class FrontsCAPISearchInput extends React.Component<
               tag: tagQuery,
               section: sectionQuery,
               q,
+              'page-size': '20',
               'show-elements': 'image',
               'show-fields': 'internalPageCode,trailText'
             }}

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.js
@@ -183,6 +183,7 @@ class FrontsCAPISearchInput extends React.Component<
               section: sectionQuery,
               q,
               'page-size': '20',
+              'use-date': 'first-publication',
               'show-elements': 'image',
               'show-fields': 'internalPageCode,trailText'
             }}


### PR DESCRIPTION
Talked about infinite scroll to Rich and realised that it doesn't make any sense for the fronts tool which doesn't currently have a search, it has a feed. So instead of adding infinite scroll I thought I should focus making the feed more useful. So this pr 

- Increases page size to 20
- Sorts search results by first publication date so that we don't put republished pieces to the top. I would be interested in giving this to central production to try out and ask them if this iteration of the fronts feed would actually be useful and prevent users from using ophan. 

I will implement pagination if it  is requested, my suspicion is it might not be needed for a feed. 