### PR TITLE
Add missing drag leave listener

### DIFF
--- a/client-v2/src/lib/guration/Root.js
+++ b/client-v2/src/lib/guration/Root.js
@@ -344,6 +344,7 @@ class Root<T: Object> extends React.Component<RootProps<T>, RootState> {
         onDragOver={this.handleRootDragOver}
         onDrop={this.handleRootDrop}
         onDragEnd={this.handleRootDrop}
+        onDragLeave={this.handleRootDrop}
       >
         <RootContext.Provider
           value={{


### PR DESCRIPTION
This fixes an issue where dragging over a drag zone and then leaving the drag zone wouldn't remove the highlight from the drag zone.