### PR TITLE
Calls to fetch collection articles from CAPI no longer include duplicate article ids

### DIFF
--- a/client-v2/src/actions/Collections.js
+++ b/client-v2/src/actions/Collections.js
@@ -1,5 +1,6 @@
 // @flow
 
+import uniq from 'lodash/uniq';
 import { batchActions } from 'redux-batched-actions';
 import {
   getArticles,
@@ -60,8 +61,11 @@ function getCollection(collectionId: string) {
             groupsReceived(groups)
           ])
         );
-        return Object.keys(articleFragments).map(
-          afId => articleFragments[afId].id
+
+        // We dedupe ids here to ensure that articles aren't requested twice,
+        // e.g. multiple articles containing the same supporting article.
+        return uniq(
+          Object.keys(articleFragments).map(afId => articleFragments[afId].id)
         );
       })
       .catch((error: string) => {

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -1,6 +1,5 @@
 // @flow
 
-import uniq from 'lodash/uniq';
 import isValid from 'date-fns/is_valid';
 import type {
   FrontsConfig,
@@ -185,9 +184,9 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     return [];
   };
 
-  const articleIdsWithoutSnaps = uniq(
-    articleIds.filter(id => !id.match(/^snap/))
-  ).join(',');
+  const articleIdsWithoutSnaps = articleIds
+    .filter(id => !id.match(/^snap/))
+    .join(',');
 
   const articlePromise = pandaFetch(
     `/api/preview/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -1,5 +1,6 @@
 // @flow
 
+import uniq from 'lodash/uniq';
 import isValid from 'date-fns/is_valid';
 import type {
   FrontsConfig,
@@ -184,9 +185,9 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     return [];
   };
 
-  const articleIdsWithoutSnaps = articleIds
-    .filter(id => !id.match(/^snap/))
-    .join(',');
+  const articleIdsWithoutSnaps = uniq(
+    articleIds.filter(id => !id.match(/^snap/))
+  ).join(',');
 
   const articlePromise = pandaFetch(
     `/api/preview/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,


### PR DESCRIPTION
... which is one of the reasons certain collections couldn't load articles (very long query strings).
