### PR TITLE
Add HTML flow coverage report

### DIFF
--- a/client-v2/.gitignore
+++ b/client-v2/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+flow-coverage
 *.log

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -15,7 +15,7 @@
     "dev-server": "yarn compileWithBabel $(yarn bin)/webpack-dev-server --config config/webpack.config.dev.js",
     "dev": "yarn install && yarn dev-server --open",
     "test": "yarn jest",
-    "flow-coverage": "yarn run flow-coverage-report -i \"src/**/*.js\" --threshold 90 --strict-coverage",
+    "flow-coverage": "yarn run flow-coverage-report -i \"src/**/*.js\" -t text -t html --threshold 90 --strict-coverage",
     "run-checks": "yarn test && yarn flow && yarn lint && yarn flow-coverage"
   },
   "devDependencies": {


### PR DESCRIPTION
Add `-text -html` flags to `flow-coverage` script. 

This will produce the default terminal report, as well as now a folder with an HTML report, to view more information about uncovered types in the code. I found this report a bit more helpful to understanding using types. 

The html output folder has also been added to the `.gitignore`. 