### PR TITLE
Derive article correctly from CAPI article and ArticleFragment meta

### DIFF
--- a/client-v2/src/components/Feed.js
+++ b/client-v2/src/components/Feed.js
@@ -112,7 +112,7 @@ class Feed extends React.Component<FeedProps, FeedState> {
 
   render() {
     const { capiFeedSpec } = this;
-    const getId = (internalPageCode: string) =>
+    const getId = (internalPageCode: string | number) =>
       `internal-code/page/${internalPageCode}`;
 
     return (

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.js
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.js
@@ -23,7 +23,7 @@ import {
   articleFromArticleFragmentSelector,
   selectSharedState
 } from 'shared/selectors/shared';
-import type { Article } from 'shared/types/Article';
+import type { DerivedArticle } from 'shared/types/Article';
 import type {
   ArticleFragment,
   ArticleFragmentMeta
@@ -263,7 +263,7 @@ const formComponent = ({
 
 const defaultMeta = {};
 
-const getInitialValuesForArticleFragmentForm = (article: ?Article) => {
+const getInitialValuesForArticleFragmentForm = (article: ?DerivedArticle) => {
   if (!article) {
     return {};
   }
@@ -304,26 +304,29 @@ const getInitialValuesForArticleFragmentForm = (article: ?Article) => {
     : defaultMeta;
 };
 
-const getArticleFragmentMetaFromFormValues = (values): Article =>
-  omit(
+const getArticleFragmentMetaFromFormValues = (values): DerivedArticle => {
+  const primaryImage = values.primaryImage || {};
+  const cutoutImage = values.cutoutImage || {};
+  return omit(
     {
       ...values,
       imageReplace: !values.hideMedia,
       showKickerCustom: !!values.customKicker,
-      imageSrc: values.primaryImage.src,
-      imageSrcThumb: values.primaryImage.thumb,
-      imageSrcWidth: values.primaryImage.width,
-      imageSrcHeight: values.primaryImage.height,
-      imageSrcOrigin: values.primaryImage.origin,
-      imageCutoutSrc: values.cutoutImage.src,
-      imageCutoutSrcWidth: values.cutoutImage.width,
-      imageCutoutSrcHeight: values.cutoutImage.height,
-      imageCutoutSrcOrigin: values.cutoutImage.origin,
+      imageSrc: primaryImage.src,
+      imageSrcThumb: primaryImage.thumb,
+      imageSrcWidth: primaryImage.width,
+      imageSrcHeight: primaryImage.height,
+      imageSrcOrigin: primaryImage.origin,
+      imageCutoutSrc: cutoutImage.src,
+      imageCutoutSrcWidth: cutoutImage.width,
+      imageCutoutSrcHeight: cutoutImage.height,
+      imageCutoutSrcOrigin: cutoutImage.origin,
       slideshow: compact(values.slideshow)
     },
     'primaryImage',
     'cutoutImage'
   );
+};
 
 const articleFragmentForm = reduxForm({
   destroyOnUnmount: false,

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.js
@@ -7,14 +7,14 @@ import {
   selectSharedState
 } from 'shared/selectors/shared';
 import type { State } from 'types/State';
-import type { Article } from 'shared/types/Article';
+import type { DerivedArticle } from 'shared/types/Article';
 
 type ContainerProps = {
   id: string // eslint-disable-line react/no-unused-prop-types
 };
 
 type ComponentProps = {
-  article: ?Article
+  article: ?DerivedArticle
 } & ContainerProps;
 
 const ArticleDrag = ({ article }: ComponentProps) =>
@@ -39,7 +39,7 @@ const ArticleDrag = ({ article }: ComponentProps) =>
 const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
-): { article: ?Article } => ({
+): { article: ?DerivedArticle } => ({
   article: articleFromArticleFragmentSelector(
     selectSharedState(state),
     props.id

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.js
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-  externalArticleFromArticleFragmentSelector,
+  articleFromArticleFragmentSelector,
   selectSharedState
 } from 'shared/selectors/shared';
 import type { State } from 'types/State';
@@ -40,7 +40,7 @@ const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
 ): { article: ?Article } => ({
-  article: externalArticleFromArticleFragmentSelector(
+  article: articleFromArticleFragmentSelector(
     selectSharedState(state),
     props.id
   )

--- a/client-v2/src/components/FrontsEdit/Edit.js
+++ b/client-v2/src/components/FrontsEdit/Edit.js
@@ -1,4 +1,5 @@
 // @flow
+
 import { type Dispatch } from 'types/Store';
 import * as React from 'react';
 import { connect } from 'react-redux';

--- a/client-v2/src/components/FrontsEdit/Front.js
+++ b/client-v2/src/components/FrontsEdit/Front.js
@@ -3,16 +3,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
-/* eslint-disable import/no-duplicates */
 import * as Guration from 'lib/guration';
-/* eslint-enable import/no-duplicates */
 import { type State } from 'types/State';
 import { type Dispatch } from 'types/Store';
 import {
   selectSharedState,
   createCollectionsAsTreeSelector
 } from 'shared/selectors/shared';
-// import { externalArticlesReceived } from 'shared/actions/ExternalArticles';
 import { bindActionCreators } from 'redux';
 import { addArticleFragment } from 'shared/actions/ArticleFragments';
 import {

--- a/client-v2/src/fixtures/articleFragment.js
+++ b/client-v2/src/fixtures/articleFragment.js
@@ -1,0 +1,38 @@
+// @flow
+
+const articleFragmentWithElementsThumbnail = {
+  id: 'internal-code/page/5158391',
+  frontPublicationDate: 1539180309305,
+  meta: {},
+  uuid: '36a2fa8e-0e77-4f53-98d2-271282b5db70'
+};
+
+const articleFragmentWithSlideshowThumbnail = {
+  id: 'internal-code/page/5158391',
+  frontPublicationDate: 1539180309305,
+  meta: {
+    imageSlideshowReplace: true,
+    slideshow: [
+      {
+        src: 'exampleSrc1',
+        thumb: 'exampleThumbnail1',
+        width: 100,
+        height: 100,
+        origin: 'exampleOrigin1'
+      },
+      {
+        src: 'exampleSrc2',
+        thumb: 'exampleThumbnail2',
+        width: 100,
+        height: 100,
+        origin: 'exampleOrigin2'
+      }
+    ]
+  },
+  uuid: '36a2fa8e-0e77-4f53-98d2-271282b5db70'
+};
+
+export {
+  articleFragmentWithElementsThumbnail,
+  articleFragmentWithSlideshowThumbnail
+};

--- a/client-v2/src/fixtures/capiArticle.js
+++ b/client-v2/src/fixtures/capiArticle.js
@@ -1,0 +1,281 @@
+// @flow
+
+const capiArticleWithElementsThumbnail = {
+  id:
+    'world/2018/oct/10/alleged-saudi-hit-squad-linked-to-jamal-khashoggi-disappearance',
+  type: 'article',
+  sectionId: 'world',
+  sectionName: 'World news',
+  webPublicationDate: '2018-10-10T17:44:11Z',
+  webTitle: 'Jamal Khashoggi: details of alleged Saudi hit squad emerge',
+  webUrl:
+    'https://www.theguardian.com/world/2018/oct/10/alleged-saudi-hit-squad-linked-to-jamal-khashoggi-disappearance',
+  apiUrl:
+    'https://preview.content.guardianapis.com/world/2018/oct/10/alleged-saudi-hit-squad-linked-to-jamal-khashoggi-disappearance',
+  fields: {
+    trailText:
+      'Fifteen-person team linked to disappearance of dissident, Turkish media report',
+    firstPublicationDate: '2018-10-10T10:33:45Z',
+    internalPageCode: '5158739',
+    isLive: 'true'
+  },
+  elements: [
+    {
+      id: 'b901bb680b236bc377d02d2ec24434558186fa65',
+      relation: 'body',
+      type: 'image',
+      assets: [
+        {
+          type: 'image',
+          mimeType: 'image/jpeg',
+          file:
+            'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/4000.jpg',
+          typeData: {
+            altText:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            caption:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            credit: 'Photograph: Ozan Köse/AFP/Getty Images',
+            photographer: 'Ozan Köse',
+            source: 'AFP/Getty Images',
+            width: '4000',
+            height: '2400',
+            secureFile:
+              'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/4000.jpg',
+            displayCredit: 'true',
+            mediaId: 'b901bb680b236bc377d02d2ec24434558186fa65',
+            imageType: 'Photograph',
+            suppliersReference: 'AFP_19W5G0',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/b901bb680b236bc377d02d2ec24434558186fa65',
+            copyright: 'AFP or licensors'
+          }
+        },
+        {
+          type: 'image',
+          mimeType: 'image/jpeg',
+          file:
+            'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/master/4000.jpg',
+          typeData: {
+            altText:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            caption:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            credit: 'Photograph: Ozan Köse/AFP/Getty Images',
+            photographer: 'Ozan Köse',
+            source: 'AFP/Getty Images',
+            width: '4000',
+            height: '2400',
+            secureFile:
+              'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/master/4000.jpg',
+            isMaster: 'true',
+            displayCredit: 'true',
+            mediaId: 'b901bb680b236bc377d02d2ec24434558186fa65',
+            imageType: 'Photograph',
+            suppliersReference: 'AFP_19W5G0',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/b901bb680b236bc377d02d2ec24434558186fa65',
+            copyright: 'AFP or licensors'
+          }
+        },
+        {
+          type: 'image',
+          mimeType: 'image/jpeg',
+          file:
+            'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/2000.jpg',
+          typeData: {
+            altText:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            caption:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            credit: 'Photograph: Ozan Köse/AFP/Getty Images',
+            photographer: 'Ozan Köse',
+            source: 'AFP/Getty Images',
+            width: '2000',
+            height: '1200',
+            secureFile:
+              'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/2000.jpg',
+            displayCredit: 'true',
+            mediaId: 'b901bb680b236bc377d02d2ec24434558186fa65',
+            imageType: 'Photograph',
+            suppliersReference: 'AFP_19W5G0',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/b901bb680b236bc377d02d2ec24434558186fa65',
+            copyright: 'AFP or licensors'
+          }
+        },
+        {
+          type: 'image',
+          mimeType: 'image/jpeg',
+          file:
+            'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/1000.jpg',
+          typeData: {
+            altText:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            caption:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            credit: 'Photograph: Ozan Köse/AFP/Getty Images',
+            photographer: 'Ozan Köse',
+            source: 'AFP/Getty Images',
+            width: '1000',
+            height: '600',
+            secureFile:
+              'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/1000.jpg',
+            displayCredit: 'true',
+            mediaId: 'b901bb680b236bc377d02d2ec24434558186fa65',
+            imageType: 'Photograph',
+            suppliersReference: 'AFP_19W5G0',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/b901bb680b236bc377d02d2ec24434558186fa65',
+            copyright: 'AFP or licensors'
+          }
+        },
+        {
+          type: 'image',
+          mimeType: 'image/jpeg',
+          file:
+            'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/500.jpg',
+          typeData: {
+            altText:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            caption:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            credit: 'Photograph: Ozan Köse/AFP/Getty Images',
+            photographer: 'Ozan Köse',
+            source: 'AFP/Getty Images',
+            width: '500',
+            height: '300',
+            secureFile:
+              'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/500.jpg',
+            displayCredit: 'true',
+            mediaId: 'b901bb680b236bc377d02d2ec24434558186fa65',
+            imageType: 'Photograph',
+            suppliersReference: 'AFP_19W5G0',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/b901bb680b236bc377d02d2ec24434558186fa65',
+            copyright: 'AFP or licensors'
+          }
+        },
+        {
+          type: 'image',
+          mimeType: 'image/jpeg',
+          file:
+            'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/140.jpg',
+          typeData: {
+            altText:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            caption:
+              'Protesters in Istanbul hold pictures of missing journalist Jamal Khashoggi on Monday.',
+            credit: 'Photograph: Ozan Köse/AFP/Getty Images',
+            photographer: 'Ozan Köse',
+            source: 'AFP/Getty Images',
+            width: '140',
+            height: '84',
+            secureFile:
+              'https://media.guim.co.uk/b901bb680b236bc377d02d2ec24434558186fa65/0_225_4000_2400/140.jpg',
+            displayCredit: 'true',
+            mediaId: 'b901bb680b236bc377d02d2ec24434558186fa65',
+            imageType: 'Photograph',
+            suppliersReference: 'AFP_19W5G0',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/b901bb680b236bc377d02d2ec24434558186fa65',
+            copyright: 'AFP or licensors'
+          }
+        }
+      ]
+    },
+    {
+      id: '6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556',
+      relation: 'thumbnail',
+      type: 'image',
+      assets: [
+        {
+          type: 'image',
+          file:
+            'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/master/1313.jpg',
+          typeData: {
+            altText: 'Image taken from CCTV footage',
+            credit: 'Photograph: AP',
+            source: 'AP',
+            width: '1313',
+            height: '788',
+            secureFile:
+              'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/master/1313.jpg',
+            isMaster: 'true',
+            displayCredit: 'true',
+            mediaId: '6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556',
+            imageType: 'Photograph',
+            suppliersReference: 'TH101',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556'
+          }
+        },
+        {
+          type: 'image',
+          file:
+            'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/1313.jpg',
+          typeData: {
+            altText: 'Image taken from CCTV footage',
+            credit: 'Photograph: AP',
+            source: 'AP',
+            width: '1313',
+            height: '788',
+            secureFile:
+              'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/1313.jpg',
+            displayCredit: 'true',
+            mediaId: '6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556',
+            imageType: 'Photograph',
+            suppliersReference: 'TH101',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556'
+          }
+        },
+        {
+          type: 'image',
+          file:
+            'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/500.jpg',
+          typeData: {
+            altText: 'Image taken from CCTV footage',
+            credit: 'Photograph: AP',
+            source: 'AP',
+            width: '500',
+            height: '300',
+            secureFile:
+              'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/500.jpg',
+            displayCredit: 'true',
+            mediaId: '6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556',
+            imageType: 'Photograph',
+            suppliersReference: 'TH101',
+            mediaApiUri:
+              'https://api.media.gutools.co.uk/images/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556'
+          }
+        }
+      ]
+    }
+  ],
+  isGone: false,
+  isHosted: false,
+  pillarId: 'pillar/news',
+  pillarName: 'News',
+  frontsMeta: {
+    defaults: {
+      isBreaking: false,
+      isBoosted: false,
+      showMainVideo: false,
+      imageHide: false,
+      showKickerCustom: false,
+      showByline: false,
+      showQuotedHeadline: false,
+      imageSlideshowReplace: false,
+      showKickerTag: false,
+      showLivePlayable: false,
+      imageReplace: false,
+      imageCutoutReplace: false,
+      showKickerSection: false,
+      showBoostedHeadline: false
+    },
+    tone: 'news'
+  }
+};
+
+export { capiArticleWithElementsThumbnail };

--- a/client-v2/src/index.js
+++ b/client-v2/src/index.js
@@ -24,6 +24,8 @@ store.dispatch(configReceived(config));
 if (config.frontIds) {
   store.dispatch(editorSetOpenFronts(config.frontIds));
 }
+
+// $FlowFixMe
 store.dispatch(storeClipboardContent(config.clipboardArticles));
 
 const reactMount = document.getElementById('react-mount');

--- a/client-v2/src/services/capiQuery.js
+++ b/client-v2/src/services/capiQuery.js
@@ -1,54 +1,16 @@
 // @flow
 
 import { qs } from 'util/qs';
+import type { CapiArticle, Tag } from 'types/Capi';
 
 const API_BASE = 'https://content.guardianapis.com/';
 
 type Fetch = (path: string) => Promise<Response>;
 
-type ImageAsset = {
-  type: 'image',
-  mimeType: string,
-  file: string,
-  typeData: {
-    width: string,
-    number: string
-  }
-};
-
-type ImageElement = {
-  id: string,
-  relation: string,
-  type: 'image',
-  assets: ImageAsset[]
-};
-
-type Element = ImageElement;
-
-type Article = {
-  webTitle: string,
-  webUrl: string,
-  webPublicationDate?: string,
-  elements?: Element[],
-  fields?: {
-    trailText?: string,
-    internalPageCode: string
-  },
-  frontsMeta: {
-    tone: string
-  }
-};
-
 type CAPISearchQueryReponse = {
   response: {
-    results: Article[]
+    results: CapiArticle[]
   }
-};
-
-type Tag = {
-  id: string,
-  webTitle: string,
-  webUrl: string
 };
 
 type CAPITagQueryReponse = {
@@ -90,5 +52,5 @@ const capiQuery = (
   }
 });
 
-export type { Fetch, Element };
+export type { Fetch, Element, CapiArticle };
 export default capiQuery;

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -171,7 +171,7 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
   ): Array<ExternalArticle> => {
     if (text) {
       return JSON.parse(text).response.results.map(result => ({
-        headline: result.webTitle,
+        headline: result.fields.headline,
         id: `internal-code/page/${result.fields.internalPageCode}`,
         isLive: result.fields.isLive === 'true',
         urlPath: result.id,
@@ -179,6 +179,8 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
         tone: result.frontsMeta && result.frontsMeta.tone,
         sectionName: result.sectionName,
         trailText: result.fields.trailText,
+        byline: result.fields.byline,
+        thumbnail: result.fields.thumbnail,
         elements: result.elements
       }));
     }
@@ -190,7 +192,7 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     .join(',');
 
   const articlePromise = pandaFetch(
-    `/api/preview/search?ids=${articleIdsWithoutSnaps}&show-fields=internalPageCode,isLive,firstPublicationDate&show-elements=image&show-fields=trailText`,
+    `/api/preview/search?ids=${articleIdsWithoutSnaps}?show-elements=video,main&show-blocks=main&show-tags=all&show-atoms=media&show-fields=internalPageCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,secureThumbnail,liveBloggingNow,membershipAccess,shortUrl`,
     {
       method: 'get',
       credentials: 'same-origin'

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -1,11 +1,13 @@
 // @flow
 
 import isValid from 'date-fns/is_valid';
+import uniq from 'lodash/uniq';
 import type {
   FrontsConfig,
   FrontsConfigResponse,
   FrontConfigMap
 } from 'types/FaciaApi';
+import type { CapiArticle } from 'types/Capi';
 import type { ExternalArticle } from 'shared/types/ExternalArticle';
 import type {
   CollectionResponse,

--- a/client-v2/src/shared/components/Article.js
+++ b/client-v2/src/shared/components/Article.js
@@ -10,7 +10,6 @@ import startCase from 'lodash/startCase';
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
 import toneColorMap from 'shared/util/toneColorMap';
 import ButtonHoverAction from 'shared/components/input/ButtonHoverAction';
-import { getThumbnailFromElements } from 'util/CAPIUtils';
 import { getPaths } from '../../util/paths';
 
 import {
@@ -242,9 +241,7 @@ const ArticleComponent = ({
         {size === 'default' && (
           <Thumbnail
             style={{
-              backgroundImage:
-                article.elements &&
-                `url('${getThumbnailFromElements(article.elements) || ''}')`
+              backgroundImage: `url('${article.thumbnail}')`
             }}
           />
         )}

--- a/client-v2/src/shared/components/Article.js
+++ b/client-v2/src/shared/components/Article.js
@@ -222,7 +222,7 @@ const ArticleComponent = ({
         <ArticleContentContainer>
           <ArticleHeadingContainer>
             <KickerHeading style={{ color: toneColorMap[article.tone] }}>
-              {article.sectionName}
+              {article.kicker}
             </KickerHeading>
             &nbsp;
             {size === 'default' ? (

--- a/client-v2/src/shared/components/Article.js
+++ b/client-v2/src/shared/components/Article.js
@@ -17,7 +17,7 @@ import {
   selectSharedState
 } from '../selectors/shared';
 import type { State } from '../types/State';
-import type { Article } from '../types/Article';
+import type { DerivedArticle } from '../types/Article';
 
 type ContainerProps = {
   id: string, // eslint-disable-line react/no-unused-prop-types
@@ -30,7 +30,7 @@ type ContainerProps = {
 };
 
 type ComponentProps = {
-  article: ?Article,
+  article: ?DerivedArticle,
   size: 'default' | 'small',
   children: ReactNode
 } & ContainerProps;
@@ -290,7 +290,7 @@ const ArticleComponent = ({
 const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
-): { article: ?Article } => ({
+): { article: ?DerivedArticle } => ({
   article: articleFromArticleFragmentSelector(
     props.selectSharedState
       ? props.selectSharedState(state)

--- a/client-v2/src/shared/components/Article.js
+++ b/client-v2/src/shared/components/Article.js
@@ -14,7 +14,7 @@ import { getThumbnailFromElements } from 'util/CAPIUtils';
 import { getPaths } from '../../util/paths';
 
 import {
-  externalArticleFromArticleFragmentSelector,
+  articleFromArticleFragmentSelector,
   selectSharedState
 } from '../selectors/shared';
 import type { State } from '../types/State';
@@ -294,7 +294,7 @@ const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
 ): { article: ?Article } => ({
-  article: externalArticleFromArticleFragmentSelector(
+  article: articleFromArticleFragmentSelector(
     props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state),

--- a/client-v2/src/shared/components/ArticlePolaroid.js
+++ b/client-v2/src/shared/components/ArticlePolaroid.js
@@ -6,9 +6,8 @@ import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import truncate from 'lodash/truncate';
 
-import { getThumbnailFromElements } from 'util/CAPIUtils';
 import {
-  externalArticleFromArticleFragmentSelector,
+  articleFromArticleFragmentSelector,
   selectSharedState
 } from '../selectors/shared';
 import type { State } from '../types/State';
@@ -57,9 +56,7 @@ const ArticleComponent = ({
       onDragOver={onDragOver}
       onDrop={onDrop}
     >
-      {article.elements && (
-        <Thumbnail src={getThumbnailFromElements(article.elements)} alt="" />
-      )}
+      <Thumbnail src={article.thumbnail} alt="" />
       {truncate(article.headline, { length: 45 })}
       {children}
     </BodyContainer>
@@ -71,7 +68,7 @@ const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
 ): { article: ?Article } => ({
-  article: externalArticleFromArticleFragmentSelector(
+  article: articleFromArticleFragmentSelector(
     props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state),

--- a/client-v2/src/shared/components/ArticlePolaroid.js
+++ b/client-v2/src/shared/components/ArticlePolaroid.js
@@ -11,7 +11,7 @@ import {
   selectSharedState
 } from '../selectors/shared';
 import type { State } from '../types/State';
-import type { Article } from '../types/Article';
+import type { DerivedArticle } from '../types/Article';
 
 type ContainerProps = {
   id: string, // eslint-disable-line react/no-unused-prop-types
@@ -23,7 +23,7 @@ type ContainerProps = {
 };
 
 type ComponentProps = {
-  article: ?Article,
+  article: ?DerivedArticle,
   children?: ReactNode
 } & ContainerProps;
 
@@ -67,7 +67,7 @@ const ArticleComponent = ({
 const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
-): { article: ?Article } => ({
+): { article: ?DerivedArticle } => ({
   article: articleFromArticleFragmentSelector(
     props.selectSharedState
       ? props.selectSharedState(state)

--- a/client-v2/src/shared/components/ArticlePolaroidSub.js
+++ b/client-v2/src/shared/components/ArticlePolaroidSub.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import truncate from 'lodash/truncate';
 import {
-  externalArticleFromArticleFragmentSelector,
+  articleFromArticleFragmentSelector,
   selectSharedState
 } from '../selectors/shared';
 import type { State } from '../types/State';
@@ -72,7 +72,7 @@ const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
 ): { article: ?Article } => ({
-  article: externalArticleFromArticleFragmentSelector(
+  article: articleFromArticleFragmentSelector(
     props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state),

--- a/client-v2/src/shared/components/ArticlePolaroidSub.js
+++ b/client-v2/src/shared/components/ArticlePolaroidSub.js
@@ -10,7 +10,7 @@ import {
   selectSharedState
 } from '../selectors/shared';
 import type { State } from '../types/State';
-import type { Article } from '../types/Article';
+import type { DerivedArticle } from '../types/Article';
 import toneColorMap from '../util/toneColorMap';
 
 type ContainerProps = {
@@ -23,7 +23,7 @@ type ContainerProps = {
 };
 
 type ComponentProps = {
-  article: ?Article,
+  article: ?DerivedArticle,
   children?: ReactNode
 } & ContainerProps;
 
@@ -71,7 +71,7 @@ const ArticleComponent = ({
 const createMapStateToProps = () => (
   state: State,
   props: ContainerProps
-): { article: ?Article } => ({
+): { article: ?DerivedArticle } => ({
   article: articleFromArticleFragmentSelector(
     props.selectSharedState
       ? props.selectSharedState(state)

--- a/client-v2/src/shared/components/input/InputContainer.js
+++ b/client-v2/src/shared/components/input/InputContainer.js
@@ -1,3 +1,5 @@
+// @flow
+
 import styled from 'styled-components';
 
 // This component has no styles - we don't have a style for input containers,

--- a/client-v2/src/shared/components/layout/ShortVerticalPinline.js
+++ b/client-v2/src/shared/components/layout/ShortVerticalPinline.js
@@ -1,3 +1,5 @@
+// @flow
+
 import styled from 'styled-components';
 
 export default styled('div')`

--- a/client-v2/src/shared/constants/theme.js
+++ b/client-v2/src/shared/constants/theme.js
@@ -1,3 +1,5 @@
+// @flow
+
 const base = {
   colors: {
     text: '#333',

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.js
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.js
@@ -63,7 +63,15 @@ const state = {
     data: {
       ea1: {
         id: 'ea1',
-        headline: 'Example external article'
+        pillarName: 'external-pillar',
+        fields: {
+          headline: 'external-headline',
+          trailText: 'external-trailText',
+          byline: 'external-byline'
+        },
+        frontsMeta: {
+          tone: 'external-tone'
+        }
       }
     }
   },
@@ -73,8 +81,18 @@ const state = {
       id: 'ea1',
       frontPublicationDate: 1,
       publishedBy: 'A. N. Author',
+      meta: {}
+    },
+    af1WithOverrides: {
+      uuid: 'af1',
+      id: 'ea1',
+      frontPublicationDate: 1,
+      publishedBy: 'A. N. Author',
       meta: {
-        headline: 'Replaced headline'
+        headline: 'fragment-headline',
+        trailText: 'fragment-trailText',
+        byline: 'fragment-byline',
+        customKicker: 'fragment-kicker'
       }
     },
     afWithInvalidReference: {
@@ -176,7 +194,7 @@ describe('Shared selectors', () => {
     });
   });
 
-  describe('createExternalArticleFromArticleFragmentSelector', () => {
+  describe('externalArticleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an external article referenced by the given article fragment', () => {
       expect(externalArticleFromArticleFragmentSelector(state, 'af1')).toEqual(
         state.externalArticles.data.ea1
@@ -187,14 +205,36 @@ describe('Shared selectors', () => {
     });
   });
 
-  describe('createArticleFromArticleFragmentSelector', () => {
+  describe('articleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an article (externalArticle + articleFragment) referenced by the given article fragment', () => {
       expect(articleFromArticleFragmentSelector(state, 'af1')).toEqual({
-        ...state.externalArticles.data.ea1,
+        id: 'ea1',
+        pillarName: 'external-pillar',
         frontPublicationDate: 1,
         publishedBy: 'A. N. Author',
         uuid: 'af1',
-        headline: 'Replaced headline'
+        headline: 'external-headline',
+        thumbnail: undefined,
+        tone: 'external-tone',
+        trailText: 'external-trailText',
+        kicker: 'external-pillar',
+        byline: 'external-byline'
+      });
+      expect(
+        articleFromArticleFragmentSelector(state, 'af1WithOverrides')
+      ).toEqual({
+        id: 'ea1',
+        customKicker: 'fragment-kicker',
+        pillarName: 'external-pillar',
+        frontPublicationDate: 1,
+        publishedBy: 'A. N. Author',
+        uuid: 'af1',
+        headline: 'fragment-headline',
+        thumbnail: undefined,
+        tone: 'external-tone',
+        trailText: 'fragment-trailText',
+        kicker: 'fragment-kicker',
+        byline: 'fragment-byline'
       });
       expect(articleFromArticleFragmentSelector(state, 'invalid')).toEqual(
         null

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.js
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.js
@@ -73,7 +73,9 @@ const state = {
       id: 'ea1',
       frontPublicationDate: 1,
       publishedBy: 'A. N. Author',
-      meta: {}
+      meta: {
+        headline: 'Replaced headline'
+      }
     },
     afWithInvalidReference: {
       uuid: 'afWithInvalidReference',
@@ -176,16 +178,12 @@ describe('Shared selectors', () => {
 
   describe('createExternalArticleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an external article referenced by the given article fragment', () => {
-      expect(externalArticleFromArticleFragmentSelector(state, 'af1')).toEqual({
-        ...state.externalArticles.data.ea1,
-        meta: {},
-        frontPublicationDate: 1,
-        publishedBy: 'A. N. Author',
-        uuid: 'af1'
-      });
-      expect(externalArticleFromArticleFragmentSelector(state, 'invalid')).toEqual(
-        null
+      expect(externalArticleFromArticleFragmentSelector(state, 'af1')).toEqual(
+        state.externalArticles.data.ea1
       );
+      expect(
+        externalArticleFromArticleFragmentSelector(state, 'invalid')
+      ).toEqual(null);
     });
   });
 
@@ -193,10 +191,10 @@ describe('Shared selectors', () => {
     it('should create a selector that returns an article (externalArticle + articleFragment) referenced by the given article fragment', () => {
       expect(articleFromArticleFragmentSelector(state, 'af1')).toEqual({
         ...state.externalArticles.data.ea1,
-        meta: {},
         frontPublicationDate: 1,
         publishedBy: 'A. N. Author',
-        uuid: 'af1'
+        uuid: 'af1',
+        headline: 'Replaced headline'
       });
       expect(articleFromArticleFragmentSelector(state, 'invalid')).toEqual(
         null
@@ -305,15 +303,7 @@ describe('Shared selectors', () => {
                 {
                   id: 'group2',
                   uuid: 'g2',
-                  articleFragments: [
-                    {
-                      uuid: 'af1',
-                      id: 'ea1',
-                      frontPublicationDate: 1,
-                      publishedBy: 'A. N. Author',
-                      meta: {}
-                    }
-                  ]
+                  articleFragments: [state.articleFragments.af1]
                 }
               ]
             }

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.js
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.js
@@ -2,6 +2,7 @@
 
 import {
   externalArticleFromArticleFragmentSelector,
+  articleFromArticleFragmentSelector,
   createArticlesInCollectionGroupSelector,
   createArticlesInCollectionSelector,
   createCollectionsAsTreeSelector,
@@ -174,13 +175,32 @@ describe('Shared selectors', () => {
   });
 
   describe('createExternalArticleFromArticleFragmentSelector', () => {
-    it('should create a selector that returns an external article referenced by the given article', () => {
-      expect(externalArticleFromArticleFragmentSelector(state, 'af1')).toEqual(
-        state.externalArticles.data.ea1
+    it('should create a selector that returns an external article referenced by the given article fragment', () => {
+      expect(externalArticleFromArticleFragmentSelector(state, 'af1')).toEqual({
+        ...state.externalArticles.data.ea1,
+        meta: {},
+        frontPublicationDate: 1,
+        publishedBy: 'A. N. Author',
+        uuid: 'af1'
+      });
+      expect(externalArticleFromArticleFragmentSelector(state, 'invalid')).toEqual(
+        null
       );
-      expect(
-        externalArticleFromArticleFragmentSelector(state, 'invalid')
-      ).toEqual(null);
+    });
+  });
+
+  describe('createArticleFromArticleFragmentSelector', () => {
+    it('should create a selector that returns an article (externalArticle + articleFragment) referenced by the given article fragment', () => {
+      expect(articleFromArticleFragmentSelector(state, 'af1')).toEqual({
+        ...state.externalArticles.data.ea1,
+        meta: {},
+        frontPublicationDate: 1,
+        publishedBy: 'A. N. Author',
+        uuid: 'af1'
+      });
+      expect(articleFromArticleFragmentSelector(state, 'invalid')).toEqual(
+        null
+      );
     });
   });
 

--- a/client-v2/src/shared/selectors/shared.js
+++ b/client-v2/src/shared/selectors/shared.js
@@ -2,9 +2,10 @@
 
 import omit from 'lodash/omit';
 import { createSelector } from 'reselect';
+
+import { getThumbnail } from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
-
 import type { ExternalArticle } from '../types/ExternalArticle';
 import type { Article } from '../types/Article';
 import type { ArticleFragment } from '../types/Collection';
@@ -53,16 +54,18 @@ const articleFromArticleFragmentSelector = (
 
   return {
     ...omit(externalArticle, 'fields'),
-    ...omit(articleFragment, 'meta'),
     ...externalArticle.fields,
+    ...omit(articleFragment, 'meta'),
+    ...articleFragment.meta,
     headline: articleFragment.meta.headline || externalArticle.fields.headline,
-    trailText: articleFragment.meta.trailText || externalArticle.fields.trailText,
+    trailText:
+      articleFragment.meta.trailText || externalArticle.fields.trailText,
     byline: articleFragment.meta.byline || externalArticle.fields.byline,
     kicker: articleFragment.meta.customKicker || externalArticle.pillarName,
-    tone: externalArticle.frontsMeta.tone
+    tone: externalArticle.frontsMeta.tone,
+    thumbnail: getThumbnail(articleFragment, externalArticle)
   };
 };
-
 const collectionIdSelector = (_, { collectionId }: { collectionId: string }) =>
   collectionId;
 

--- a/client-v2/src/shared/selectors/shared.js
+++ b/client-v2/src/shared/selectors/shared.js
@@ -53,7 +53,7 @@ const articleFromArticleFragmentSelector = (
   }
 
   return {
-    ...omit(externalArticle, 'fields'),
+    ...omit(externalArticle, 'fields', 'frontsMeta'),
     ...externalArticle.fields,
     ...omit(articleFragment, 'meta'),
     ...articleFragment.meta,

--- a/client-v2/src/shared/selectors/shared.js
+++ b/client-v2/src/shared/selectors/shared.js
@@ -41,7 +41,10 @@ const externalArticleFromArticleFragmentSelector = (
   return externalArticles[articleFragment.id];
 };
 
-const articleFromArticleFragmentSelector = (state: State, id: string): ?Article => {
+const articleFromArticleFragmentSelector = (
+  state: State,
+  id: string
+): ?Article => {
   const externalArticle = externalArticleFromArticleFragmentSelector(state, id);
   const articleFragment = articleFragmentSelector(state, id);
   if (!externalArticle || !articleFragment) {
@@ -49,13 +52,16 @@ const articleFromArticleFragmentSelector = (state: State, id: string): ?Article 
   }
 
   return {
-    ...externalArticle,
+    ...omit(externalArticle, 'fields'),
     ...omit(articleFragment, 'meta'),
-    headline: articleFragment.meta.headline || externalArticle.headline,
-    thumbnail: getArticleThumbnail(externalArticle),
-
-  }
-}
+    ...externalArticle.fields,
+    headline: articleFragment.meta.headline || externalArticle.fields.headline,
+    trailText: articleFragment.meta.trailText || externalArticle.fields.trailText,
+    byline: articleFragment.meta.byline || externalArticle.fields.byline,
+    kicker: articleFragment.meta.customKicker || externalArticle.pillarName,
+    tone: externalArticle.frontsMeta.tone
+  };
+};
 
 const collectionIdSelector = (_, { collectionId }: { collectionId: string }) =>
   collectionId;
@@ -219,6 +225,7 @@ const createCollectionsAsTreeSelector = () =>
 
 export {
   externalArticleFromArticleFragmentSelector,
+  articleFromArticleFragmentSelector,
   createArticlesInCollectionGroupSelector,
   createArticlesInCollectionSelector,
   groupArticlesSelector,

--- a/client-v2/src/shared/selectors/shared.js
+++ b/client-v2/src/shared/selectors/shared.js
@@ -7,7 +7,7 @@ import { getThumbnail } from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import type { ExternalArticle } from '../types/ExternalArticle';
-import type { Article } from '../types/Article';
+import type { DerivedArticle } from '../types/Article';
 import type { ArticleFragment } from '../types/Collection';
 import type { State } from '../types/State';
 
@@ -45,7 +45,7 @@ const externalArticleFromArticleFragmentSelector = (
 const articleFromArticleFragmentSelector = (
   state: State,
   id: string
-): ?Article => {
+): ?DerivedArticle => {
   const externalArticle = externalArticleFromArticleFragmentSelector(state, id);
   const articleFragment = articleFragmentSelector(state, id);
   if (!externalArticle || !articleFragment) {

--- a/client-v2/src/shared/selectors/shared.js
+++ b/client-v2/src/shared/selectors/shared.js
@@ -1,9 +1,12 @@
 // @flow
 
+import omit from 'lodash/omit';
 import { createSelector } from 'reselect';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 
+import type { ExternalArticle } from '../types/ExternalArticle';
+import type { Article } from '../types/Article';
 import type { ArticleFragment } from '../types/Collection';
 import type { State } from '../types/State';
 
@@ -29,14 +32,30 @@ const articleFragmentSelector = (state: State, id: string): ArticleFragment =>
 const externalArticleFromArticleFragmentSelector = (
   state: State,
   id: string
-) => {
+): ?ExternalArticle => {
   const articleFragment = articleFragmentSelector(state, id);
   const externalArticles = externalArticleSelectors.selectAll(state);
   if (!articleFragment) {
     return null;
   }
-  return externalArticles[articleFragment.id] || null;
+  return externalArticles[articleFragment.id];
 };
+
+const articleFromArticleFragmentSelector = (state: State, id: string): ?Article => {
+  const externalArticle = externalArticleFromArticleFragmentSelector(state, id);
+  const articleFragment = articleFragmentSelector(state, id);
+  if (!externalArticle || !articleFragment) {
+    return null;
+  }
+
+  return {
+    ...externalArticle,
+    ...omit(articleFragment, 'meta'),
+    headline: articleFragment.meta.headline || externalArticle.headline,
+    thumbnail: getArticleThumbnail(externalArticle),
+
+  }
+}
 
 const collectionIdSelector = (_, { collectionId }: { collectionId: string }) =>
   collectionId;

--- a/client-v2/src/shared/types/Article.js
+++ b/client-v2/src/shared/types/Article.js
@@ -1,13 +1,20 @@
 // @flow
 
+import type { CapiArticleFields } from 'types/Capi';
 import type { ExternalArticle } from './ExternalArticle';
 import type {
   ArticleFragmentRootFields,
   ArticleFragmentMeta
 } from './Collection';
 
-type Article = ExternalArticle &
+type Article = $Diff<
+  ExternalArticle,
+  { fields: any, blocks: any, tags: any, elements: any, frontsMeta: any }
+> &
+  CapiArticleFields &
   ArticleFragmentRootFields &
-  ArticleFragmentMeta;
+  ArticleFragmentMeta & {
+    tone: string
+  };
 
 export type { Article };

--- a/client-v2/src/shared/types/Article.js
+++ b/client-v2/src/shared/types/Article.js
@@ -14,7 +14,8 @@ type Article = $Diff<
   CapiArticleFields &
   ArticleFragmentRootFields &
   ArticleFragmentMeta & {
-    tone: string
+    tone: string,
+    thumbnail: string
   };
 
 export type { Article };

--- a/client-v2/src/shared/types/Article.js
+++ b/client-v2/src/shared/types/Article.js
@@ -15,7 +15,8 @@ type Article = $Diff<
   ArticleFragmentRootFields &
   ArticleFragmentMeta & {
     tone: string,
-    thumbnail: string
+    thumbnail: string,
+    kicker: string
   };
 
 export type { Article };

--- a/client-v2/src/shared/types/Article.js
+++ b/client-v2/src/shared/types/Article.js
@@ -7,7 +7,7 @@ import type {
   ArticleFragmentMeta
 } from './Collection';
 
-type Article = $Diff<
+type DerivedArticle = $Diff<
   ExternalArticle,
   { fields: any, blocks: any, tags: any, elements: any, frontsMeta: any }
 > &
@@ -19,4 +19,4 @@ type Article = $Diff<
     kicker: string
   };
 
-export type { Article };
+export type { DerivedArticle };

--- a/client-v2/src/shared/types/Article.js
+++ b/client-v2/src/shared/types/Article.js
@@ -1,15 +1,13 @@
 // @flow
 
 import type { ExternalArticle } from './ExternalArticle';
+import type {
+  ArticleFragmentRootFields,
+  ArticleFragmentMeta
+} from './Collection';
 
-type Article = ExternalArticle & {
-  uuid: string,
-  id: string,
-  frontPublicationDate: number,
-  publishedBy?: string,
-  group?: number,
-  supporting: string[],
-  trailText: string
-};
+type Article = ExternalArticle &
+  ArticleFragmentRootFields &
+  ArticleFragmentMeta;
 
 export type { Article };

--- a/client-v2/src/shared/types/Collection.js
+++ b/client-v2/src/shared/types/Collection.js
@@ -5,10 +5,13 @@ type Group = {
   articleFragments: string[]
 };
 
-type NestedArticleFragment = {
+type NestedArticleFragmentRootFields = {
   id: string,
   frontPublicationDate: number,
-  publishedBy?: string,
+  publishedBy?: string
+};
+
+type NestedArticleFragment = NestedArticleFragmentRootFields & {
   meta: {
     supporting?: $Diff<NestedArticleFragment, { supporting: any }>[]
   }
@@ -55,11 +58,11 @@ type ArticleFragmentMeta = {|
   }[]
 |};
 
-type ArticleFragment = $Diff<NestedArticleFragment, { meta: any }> & {
-  uuid: string,
-  // We strip the path from the id when the articleFragment enters
-  // the application state. 'idWithPath' preserves this path + id,
-  // so we can reassemble the original id for persist operations.
+type ArticleFragmentRootFields = NestedArticleFragmentRootFields & {
+  uuid: string
+};
+
+type ArticleFragment = ArticleFragmentRootFields & {
   meta: {
     supporting?: string[]
   } & ArticleFragmentMeta
@@ -97,6 +100,7 @@ type Collection = {|
 export type {
   NestedArticleFragment,
   ArticleFragment,
+  ArticleFragmentRootFields,
   ArticleFragmentMeta,
   CollectionWithNestedArticles,
   CollectionResponse,

--- a/client-v2/src/shared/types/Collection.js
+++ b/client-v2/src/shared/types/Collection.js
@@ -58,15 +58,15 @@ type ArticleFragmentMeta = {|
   }[]
 |};
 
-type ArticleFragmentRootFields = NestedArticleFragmentRootFields & {
+type ArticleFragmentRootFields = NestedArticleFragmentRootFields & {|
   uuid: string
-};
+|};
 
-type ArticleFragment = ArticleFragmentRootFields & {
+type ArticleFragment = ArticleFragmentRootFields & {|
   meta: {
     supporting?: string[]
   } & ArticleFragmentMeta
-};
+|};
 
 type CollectionResponse = {
   live: NestedArticleFragment[],

--- a/client-v2/src/shared/types/ExternalArticle.js
+++ b/client-v2/src/shared/types/ExternalArticle.js
@@ -1,16 +1,7 @@
 // @flow
 
-import type { Element } from 'services/capiQuery';
+import type { CapiArticle } from 'types/Capi';
 
-type ExternalArticle = {
-  id: string,
-  headline: string,
-  isLive: boolean,
-  urlPath: string,
-  firstPublicationDate?: string,
-  tone: string,
-  sectionName: string,
-  elements?: Element[]
-};
+type ExternalArticle = CapiArticle;
 
 export type { ExternalArticle };

--- a/client-v2/src/types/Capi.js
+++ b/client-v2/src/types/Capi.js
@@ -1,10 +1,107 @@
 // @flow
 
-type CapiArticle = {
+type ImageAsset = {|
+  type: 'image',
+  mimeType: string,
+  file: string,
+  typeData: {
+    width: string,
+    number: string
+  }
+|};
+
+type ImageElement = {|
   id: string,
-  headline: string
+  relation: string,
+  type: 'image',
+  assets: ImageAsset[]
+|};
+
+type Element = ImageElement;
+
+type CapiDate = {|
+  // Unix epoch
+  dateTime: number,
+  // yyyy-MM-dd`T`HH:mm:ss.SSSZZ
+  iso8601: string
+|};
+
+type User = {|
+  email: string,
+  firstName?: string,
+  lastName?: string
+|};
+
+type Block = {|
+  id: string,
+  bodyHtml: string,
+  bodyTextSummary: string,
+  title?: string,
+  attributes: any[],
+  published: boolean,
+  createdDate?: CAPIDate,
+  firstPublishedDate?: CAPIDate,
+  publishedDate: ?CAPIDate,
+  lastModifiedDate?: CAPIDate,
+  contributors: string[],
+  createdBy?: User,
+  lastModifiedBy?: User,
+  elements: Element[]
+|};
+
+type Blocks = {|
+  main: Block,
+  body: Block[]
+|};
+
+type Tag = {
+  id: string,
+  webTitle: string,
+  webUrl: string
 };
+
+type CapiArticleFields = {
+  headline: string,
+  standfirst: string,
+  trailText: string,
+  byline: string,
+  internalPageCode: number,
+  isLive: boolean,
+  firstPublicationDate: CapiDate,
+  scheduledPublicationDate: CapiDate,
+  secureThumbnail: string,
+  thumbnail: string,
+  liveBloggingNow: boolean,
+  shortUrl: string,
+  membershipUrl: string
+};
+
+// See https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift#L1431
+// for the canonical thrift definition.
+type CapiArticle = {|
+  webTitle: string,
+  webUrl: string,
+  urlPath: string,
+  webPublicationDate?: string,
+  elements?: Element[],
+  pillarId: string,
+  pillarName: string,
+  sectionId: string,
+  sectionName: string,
+  fields: CapiArticleFields,
+  frontsMeta: {
+    tone: string
+  },
+  tags?: Tag[],
+  blocks: Blocks
+|};
 
 type CapiArticleWithMetadata = CapiArticle & { group?: number };
 
-export type { CapiArticle, CapiArticleWithMetadata };
+export type {
+  CapiArticle,
+  CapiArticleFields,
+  CapiArticleWithMetadata,
+  Tag,
+  Element
+};

--- a/client-v2/src/types/Capi.js
+++ b/client-v2/src/types/Capi.js
@@ -19,12 +19,7 @@ type ImageElement = {|
 
 type Element = ImageElement;
 
-type CapiDate = {|
-  // Unix epoch
-  dateTime: number,
-  // yyyy-MM-dd`T`HH:mm:ss.SSSZZ
-  iso8601: string
-|};
+type CapiDate = string;
 
 type User = {|
   email: string,
@@ -39,10 +34,10 @@ type Block = {|
   title?: string,
   attributes: any[],
   published: boolean,
-  createdDate?: CAPIDate,
-  firstPublishedDate?: CAPIDate,
-  publishedDate: ?CAPIDate,
-  lastModifiedDate?: CAPIDate,
+  createdDate?: CapiDate,
+  firstPublishedDate?: CapiDate,
+  publishedDate?: CapiDate,
+  lastModifiedDate?: CapiDate,
   contributors: string[],
   createdBy?: User,
   lastModifiedBy?: User,
@@ -56,8 +51,11 @@ type Blocks = {|
 
 type Tag = {
   id: string,
+  type: string,
   webTitle: string,
-  webUrl: string
+  webUrl: string,
+  bylineImageUrl?: string,
+  bylineLargeImageUrl?: string
 };
 
 type CapiArticleFields = {
@@ -83,7 +81,7 @@ type CapiArticle = {|
   webUrl: string,
   urlPath: string,
   webPublicationDate?: string,
-  elements?: Element[],
+  elements: Element[],
   pillarId: string,
   pillarName: string,
   sectionId: string,

--- a/client-v2/src/util/CAPIUtils.js
+++ b/client-v2/src/util/CAPIUtils.js
@@ -1,6 +1,5 @@
 // @flow
 
-import get from 'lodash/get';
 import { getArticles } from 'services/faciaApi';
 import type { Element } from 'types/Capi';
 import type { ExternalArticle } from '../shared/types/ExternalArticle';

--- a/client-v2/src/util/CAPIUtils.js
+++ b/client-v2/src/util/CAPIUtils.js
@@ -17,6 +17,9 @@ const getURLInternalPageCode = async (url: string): Promise<string | null> => {
 
 // TODO: get apiKey from context (or speak directly to FrontsAPI)
 const getThumbnailFromElements = (_elements: Element[]) => {
+  if (!_elements || !_elements.length) {
+    return undefined;
+  }
   const elements = _elements.filter(
     element => element.type === 'image' && element.relation === 'thumbnail'
   );
@@ -79,7 +82,17 @@ function getThumbnail(
   ) {
     return meta.slideshow[0].src;
   }
-  return fields.secureThumbnail || fields.thumbnail;
+
+  return (
+    fields.secureThumbnail ||
+    fields.thumbnail ||
+    getThumbnailFromElements(externalArticle.elements)
+  );
 }
 
-export { getURLInternalPageCode, getThumbnailFromElements, getThumbnail };
+export {
+  getURLInternalPageCode,
+  getThumbnailFromElements,
+  getThumbnail,
+  getContributorImage
+};

--- a/client-v2/src/util/CAPIUtils.js
+++ b/client-v2/src/util/CAPIUtils.js
@@ -1,7 +1,10 @@
 // @flow
 
+import get from 'lodash/get';
 import { getArticles } from 'services/faciaApi';
-import type { Element } from 'services/capiQuery';
+import type { Element } from 'types/Capi';
+import type { ExternalArticle } from '../shared/types/ExternalArticle';
+import type { ArticleFragment } from '../shared/types/Collection';
 
 const getInternalPageCode = async (id: string) =>
   ((await getArticles([id]))[0] || {}).id || null;

--- a/client-v2/src/util/CAPIUtils.js
+++ b/client-v2/src/util/CAPIUtils.js
@@ -43,4 +43,44 @@ const getThumbnailFromElements = (_elements: Element[]) => {
   return smallestAsset && smallestAsset.file;
 };
 
-export { getURLInternalPageCode, getThumbnailFromElements };
+function getContributorImage(externalArticle: ExternalArticle) {
+  const contributor =
+    externalArticle.tags &&
+    externalArticle.tags.find(tag => tag.type === 'contributor');
+
+  return contributor && contributor.bylineLargeImageUrl;
+}
+
+function getThumbnail(
+  articleFragment: ArticleFragment,
+  externalArticle: ExternalArticle
+) {
+  const { meta } = articleFragment;
+  const { fields } = externalArticle;
+  const isReplacingImage = meta.imageReplace;
+  const metaImageSrcThumb = isReplacingImage && meta.imageSrcThumb;
+  const imageSrc = isReplacingImage && meta.imageSrc;
+
+  if (metaImageSrcThumb && metaImageSrcThumb !== '') {
+    return metaImageSrcThumb;
+  } else if (imageSrc) {
+    return imageSrc;
+  } else if (meta.imageCutoutReplace) {
+    return (
+      meta.imageCutoutSrc ||
+      getContributorImage(externalArticle) ||
+      fields.secureThumbnail ||
+      fields.thumbnail
+    );
+  } else if (
+    meta.imageSlideshowReplace &&
+    meta.imageSlideshowReplace &&
+    meta.slideshow &&
+    meta.slideshow[0]
+  ) {
+    return meta.slideshow[0].src;
+  }
+  return fields.secureThumbnail || fields.thumbnail;
+}
+
+export { getURLInternalPageCode, getThumbnailFromElements, getThumbnail };

--- a/client-v2/src/util/__tests__/CAPIUtils.spec.js
+++ b/client-v2/src/util/__tests__/CAPIUtils.spec.js
@@ -1,0 +1,202 @@
+// @flow
+
+import { capiArticleWithElementsThumbnail } from 'fixtures/capiArticle';
+import {
+  articleFragmentWithElementsThumbnail,
+  articleFragmentWithSlideshowThumbnail
+} from 'fixtures/articleFragment';
+import { getContributorImage, getThumbnail } from 'util/CAPIUtils';
+
+describe('CAPIUtils', () => {
+  describe('getContributorImage', () => {
+    it('should get a contributor image from an external article', () => {
+      expect(getContributorImage(capiArticleWithElementsThumbnail)).toEqual(
+        undefined
+      );
+    });
+  });
+  describe('getThumbnail', () => {
+    it('should get a thumbnail from article elements', () => {
+      expect(
+        getThumbnail(
+          articleFragmentWithElementsThumbnail,
+          capiArticleWithElementsThumbnail
+        )
+      ).toEqual(
+        'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/500.jpg'
+      );
+    });
+    it('should get a thumbnail from articleFragmentMeta slideshows if imageSlideshowReplace is true', () => {
+      expect(
+        getThumbnail(
+          articleFragmentWithSlideshowThumbnail,
+          capiArticleWithElementsThumbnail
+        )
+      ).toEqual('exampleSrc1');
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageSlideshowReplace: false
+            }
+          },
+          capiArticleWithElementsThumbnail
+        )
+      ).toEqual(
+        'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/500.jpg'
+      );
+    });
+    it('should get a thumbnail from the fields thumbnail/secureThumbnail if meta.imageCutoutReplace is true', () => {
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageCutoutReplace: true
+            }
+          },
+          {
+            ...capiArticleWithElementsThumbnail,
+            fields: {
+              ...capiArticleWithElementsThumbnail.fields,
+              thumbnail: 'fieldSrc'
+            }
+          }
+        )
+      ).toEqual('fieldSrc');
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageCutoutReplace: true
+            }
+          },
+          {
+            ...capiArticleWithElementsThumbnail,
+            fields: {
+              ...capiArticleWithElementsThumbnail.fields,
+              thumbnail: 'fieldSrc',
+              secureThumbnail: 'fieldSrcSecure'
+            }
+          }
+        )
+      ).toEqual('fieldSrcSecure');
+    });
+    it('should get a thumbnail from the contributor image if meta.imageCutoutReplace is true', () => {
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageCutoutReplace: true
+            }
+          },
+          {
+            ...capiArticleWithElementsThumbnail,
+            tags: [
+              {
+                type: 'contributor',
+                bylineLargeImageUrl: 'contributorSrc'
+              }
+            ]
+          }
+        )
+      ).toEqual('contributorSrc');
+    });
+    it('should get a thumbnail from the meta cutout if meta.imageCutoutReplace is true', () => {
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageCutoutReplace: true,
+              imageCutoutSrc: 'imageCutoutSrc'
+            }
+          },
+          {
+            ...capiArticleWithElementsThumbnail,
+            tags: [
+              {
+                type: 'contributor',
+                bylineLargeImageUrl: 'contributorSrc'
+              }
+            ],
+            fields: {
+              ...capiArticleWithElementsThumbnail.fields,
+              thumbnail: 'fieldSrc',
+              secureThumbnail: 'fieldSrcSecure'
+            }
+          }
+        )
+      ).toEqual('imageCutoutSrc');
+    });
+    it('should get a thumbnail from the meta imageSrc if isReplacingImage is true', () => {
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageReplace: true,
+              imageCutoutReplace: true,
+              imageCutoutSrc: 'imageCutoutSrc',
+              imageSrc: 'imageSrc'
+            }
+          },
+          {
+            ...capiArticleWithElementsThumbnail,
+            tags: [
+              {
+                type: 'contributor',
+                bylineLargeImageUrl: 'contributorSrc'
+              }
+            ],
+            fields: {
+              ...capiArticleWithElementsThumbnail.fields,
+              thumbnail: 'fieldSrc',
+              secureThumbnail: 'fieldSrcSecure'
+            }
+          }
+        )
+      ).toEqual('imageSrc');
+    });
+    it('should get a thumbnail from the meta imageSrc if isReplacingImage is true', () => {
+      expect(
+        getThumbnail(
+          {
+            ...articleFragmentWithSlideshowThumbnail,
+            meta: {
+              ...articleFragmentWithSlideshowThumbnail.meta,
+              imageReplace: true,
+              imageCutoutReplace: true,
+              imageCutoutSrc: 'imageCutoutSrc',
+              imageSrc: 'imageSrc',
+              imageSrcThumb: 'imageSrcThumb'
+            }
+          },
+          {
+            ...capiArticleWithElementsThumbnail,
+            tags: [
+              {
+                type: 'contributor',
+                bylineLargeImageUrl: 'contributorSrc'
+              }
+            ],
+            fields: {
+              ...capiArticleWithElementsThumbnail.fields,
+              thumbnail: 'fieldSrc',
+              secureThumbnail: 'fieldSrcSecure'
+            }
+          }
+        )
+      ).toEqual('imageSrcThumb');
+    });
+  });
+});

--- a/client-v2/src/util/sharedStyles/buttons.js
+++ b/client-v2/src/util/sharedStyles/buttons.js
@@ -1,3 +1,5 @@
+// @flow
+
 import styled from 'styled-components';
 
 export const SmallRoundButton = styled('button')`


### PR DESCRIPTION
This PR rounds out the Article type and selector result to contain the information necessary to represent itself properly, both in the article meta form and when displaying Articles in collections.

In doing this it was necessary to expand the CAPI definition and import a few utility functions from V1 to correctly derive thumbnails.

There'll be more to do here as we expand the number of things we edit in Fronts.