### PR TITLE
Fronts now hold themselves open when articles aren't being edited

### DIFF
--- a/client-v2/src/components/FrontsEdit/Edit.js
+++ b/client-v2/src/components/FrontsEdit/Edit.js
@@ -37,7 +37,7 @@ const FrontsEditContainer = styled('div')`
 
 const SingleFrontContainer = styled('div')`
   height: 100%;
-  width: 1011px;
+  min-width: 1011px;
 `;
 
 const FeedContainer = SectionContainer.extend`


### PR DESCRIPTION
... rather than collapsing, which isn't desirable.