### PR TITLE
Better error reporting when fetching articles

### DIFF
--- a/client-v2/src/actions/Collections.js
+++ b/client-v2/src/actions/Collections.js
@@ -52,6 +52,7 @@ function getCollection(collectionId: string) {
           articleFragments,
           groups
         } = normaliseCollectionWithNestedArticles(collectionWithDraftArticles);
+
         dispatch(
           batchActions([
             collectionActions.fetchSuccess(collection),
@@ -75,35 +76,32 @@ function getCollection(collectionId: string) {
 }
 
 function updateCollection(collection: Collection) {
-  return async (
-  dispatch: Dispatch,
-  getState: () => State
-) => {
-  const state = getState();
-  dispatch(
-    batchActions([
-      collectionActions.updateStart({
-        ...collection,
-        updatedEmail: selectUserEmail(getState()),
-        updatedBy: `${selectFirstName(state)} ${selectLastName(state)}`,
-        lastUpdated: Date.now()
-      }),
-      recordUnpublishedChanges(collection.id, true)
-    ])
-  );
-  try {
-    const denormalisedCollection = denormaliseCollection(
-      getState(),
-      collection.id
+  return async (dispatch: Dispatch, getState: () => State) => {
+    const state = getState();
+    dispatch(
+      batchActions([
+        collectionActions.updateStart({
+          ...collection,
+          updatedEmail: selectUserEmail(getState()),
+          updatedBy: `${selectFirstName(state)} ${selectLastName(state)}`,
+          lastUpdated: Date.now()
+        }),
+        recordUnpublishedChanges(collection.id, true)
+      ])
     );
-    await updateCollectionFromApi(collection.id, denormalisedCollection);
-    dispatch(collectionActions.updateSuccess(collection.id));
-  } catch (e) {
-    dispatch(collectionActions.updateError(e, collection.id));
-    throw e;
-  }
-};
-};
+    try {
+      const denormalisedCollection = denormaliseCollection(
+        getState(),
+        collection.id
+      );
+      await updateCollectionFromApi(collection.id, denormalisedCollection);
+      dispatch(collectionActions.updateSuccess(collection.id));
+    } catch (e) {
+      dispatch(collectionActions.updateError(e, collection.id));
+      throw e;
+    }
+  };
+}
 
 const getCollectionsAndArticles = (
   collectionIds: Array<string>,
@@ -124,7 +122,4 @@ const getCollectionsAndArticles = (
     })
   );
 
-export const lib = {
-  getCollection
-};
 export { getCollection, getCollectionsAndArticles, updateCollection };

--- a/client-v2/src/actions/Collections.js
+++ b/client-v2/src/actions/Collections.js
@@ -30,52 +30,52 @@ import type { Dispatch } from 'types/Store';
 import type { Collection } from 'shared/types/Collection';
 import { recordUnpublishedChanges } from 'actions/UnpublishedChanges';
 
-const getCollection = (collectionId: string) => (
-  dispatch: Dispatch,
-  getState: () => State
-) => {
-  dispatch(collectionActions.fetchStart(collectionId));
-  return fetchCollection(collectionId)
-    .then((res: Object) => {
-      const collectionConfig = getCollectionConfig(getState(), collectionId);
-      const collectionWithNestedArticles = combineCollectionWithConfig(
-        collectionConfig,
-        res
-      );
-      const hasUnpublishedChanges =
-        collectionWithNestedArticles.draft !== undefined;
+function getCollection(collectionId: string) {
+  return (dispatch: Dispatch, getState: () => State) => {
+    dispatch(collectionActions.fetchStart(collectionId));
+    return fetchCollection(collectionId)
+      .then((res: Object) => {
+        const collectionConfig = getCollectionConfig(getState(), collectionId);
+        const collectionWithNestedArticles = combineCollectionWithConfig(
+          collectionConfig,
+          res
+        );
+        const hasUnpublishedChanges =
+          collectionWithNestedArticles.draft !== undefined;
 
-      const collectionWithDraftArticles = {
-        ...collectionWithNestedArticles,
-        draft: populateDraftArticles(collectionWithNestedArticles)
-      };
-      const {
-        collection,
-        articleFragments,
-        groups
-      } = normaliseCollectionWithNestedArticles(collectionWithDraftArticles);
-      dispatch(
-        batchActions([
-          collectionActions.fetchSuccess(collection),
-          articleFragmentsReceived(articleFragments),
-          recordUnpublishedChanges(collectionId, hasUnpublishedChanges),
-          groupsReceived(groups)
-        ])
-      );
+        const collectionWithDraftArticles = {
+          ...collectionWithNestedArticles,
+          draft: populateDraftArticles(collectionWithNestedArticles)
+        };
+        const {
+          collection,
+          articleFragments,
+          groups
+        } = normaliseCollectionWithNestedArticles(collectionWithDraftArticles);
+        dispatch(
+          batchActions([
+            collectionActions.fetchSuccess(collection),
+            articleFragmentsReceived(articleFragments),
+            recordUnpublishedChanges(collectionId, hasUnpublishedChanges),
+            groupsReceived(groups)
+          ])
+        );
 
-      // We dedupe ids here to ensure that articles aren't requested twice,
-      // e.g. multiple articles containing the same supporting article.
-      return uniq(
-        Object.keys(articleFragments).map(afId => articleFragments[afId].id)
-      );
-    })
-    .catch((error: string) => {
-      dispatch(collectionActions.fetchError(error, collectionId));
-      return [];
-    });
-};
+        // We dedupe ids here to ensure that articles aren't requested twice,
+        // e.g. multiple articles containing the same supporting article.
+        return uniq(
+          Object.keys(articleFragments).map(afId => articleFragments[afId].id)
+        );
+      })
+      .catch((error: string) => {
+        dispatch(collectionActions.fetchError(error, collectionId));
+        return [];
+      });
+  };
+}
 
-const updateCollection = (collection: Collection) => async (
+function updateCollection(collection: Collection) {
+  return async (
   dispatch: Dispatch,
   getState: () => State
 ) => {
@@ -102,6 +102,7 @@ const updateCollection = (collection: Collection) => async (
     dispatch(collectionActions.updateError(e, collection.id));
     throw e;
   }
+};
 };
 
 const getCollectionsAndArticles = (

--- a/client-v2/src/actions/Collections.js
+++ b/client-v2/src/actions/Collections.js
@@ -107,18 +107,16 @@ const getCollectionsAndArticles = (collectionIds: Array<string>) => (
   dispatch: Dispatch
 ) =>
   Promise.all(
-    collectionIds.map(collectionId =>
-      dispatch(getCollection(collectionId))
-        .then(articleIds => {
-          dispatch(externalArticleActions.fetchStart(articleIds));
-          return getArticles(articleIds).catch(error =>
-            dispatch(externalArticleActions.fetchError(error, articleIds))
-          );
-        })
-        .then(articles => {
-          dispatch(externalArticleActions.fetchSuccess(articles));
-        })
-    )
+    collectionIds.map(async collectionId => {
+      const articleIds = await dispatch(getCollection(collectionId));
+      dispatch(externalArticleActions.fetchStart(articleIds));
+      try {
+        const articles = getArticles(articleIds);
+        dispatch(externalArticleActions.fetchSuccess(articles));
+      } catch (e) {
+        dispatch(externalArticleActions.fetchError(e, articleIds));
+      }
+    })
   );
 
 export { getCollection, getCollectionsAndArticles, updateCollection };

--- a/client-v2/src/services/faciaApi.js
+++ b/client-v2/src/services/faciaApi.js
@@ -176,7 +176,7 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
         isLive: result.fields.isLive === 'true',
         urlPath: result.id,
         firstPublicationDate: result.fields.firstPublicationDate,
-        tone: result.frontsMeta.tone,
+        tone: result.frontsMeta && result.frontsMeta.tone,
         sectionName: result.sectionName,
         trailText: result.fields.trailText,
         elements: result.elements
@@ -201,7 +201,14 @@ function getArticles(articleIds: string[]): Promise<Array<ExternalArticle>> {
     .then(response => response.text())
     .then(articles =>
       Promise.resolve([...parseArticleListFromResponse(articles)])
-    );
+    )
+    .catch(response => {
+      throw new Error(
+        `Error fetching articles - the server returned ${response.status}: ${
+          response.statusText
+        }`
+      );
+    });
 }
 
 export {

--- a/client-v2/src/shared/fixtures/shared.js
+++ b/client-v2/src/shared/fixtures/shared.js
@@ -1,5 +1,367 @@
 // @flow
 
+const capiArticle = {
+  id:
+    'world/live/2018/sep/13/florence-hurricane-latest-live-news-updates-weather-path-storm-surge-north-carolina',
+  type: 'liveblog',
+  sectionId: 'world',
+  sectionName: 'World news',
+  webPublicationDate: '2018-09-15T05:54:07Z',
+  webTitle:
+    'Five dead in tropical storm as flooding and surges continue – as it happened',
+  webUrl:
+    'https://www.theguardian.com/world/live/2018/sep/13/florence-hurricane-latest-live-news-updates-weather-path-storm-surge-north-carolina',
+  apiUrl:
+    'https://content.guardianapis.com/world/live/2018/sep/13/florence-hurricane-latest-live-news-updates-weather-path-storm-surge-north-carolina',
+  fields: {
+    headline:
+      'Five dead in tropical storm as flooding and surges continue – as it happened',
+    trailText:
+      'More than 600,000 people without power as Florence, downgraded to tropical storm, continues to lash Carolinas',
+    byline:
+      'Kate Lyons (now),  Sam Levin, Matthew Weaver and Jamiles Lartey (earlier)',
+    firstPublicationDate: '2018-09-13T20:18:37Z',
+    internalPageCode: '5029528',
+    liveBloggingNow: 'false',
+    shortUrl: 'https://gu.com/p/9ce5m',
+    thumbnail:
+      'https://media.guim.co.uk/35b940fe70bfa86b82c45f6c7a8c3b342028a3be/0_2_3000_1800/500.jpg'
+  },
+  tags: [
+    {
+      id: 'world/hurricane-florence',
+      type: 'keyword',
+      sectionId: 'world',
+      sectionName: 'World news',
+      webTitle: 'Hurricane Florence',
+      webUrl: 'https://www.theguardian.com/world/hurricane-florence',
+      apiUrl: 'https://content.guardianapis.com/world/hurricane-florence',
+      references: []
+    }
+  ],
+  blocks: {
+    main: {
+      id: '5b9ad6b2e4b0543ecbf2c7d8',
+      bodyHtml:
+        '<figure class="element element-atom"> <gu-atom data-atom-id="06666fe2-10f1-468f-b4de-91f5653931ac"         data-atom-type="media"    > </gu-atom> </figure>',
+      bodyTextSummary: '',
+      attributes: {},
+      published: true,
+      createdDate: '2018-09-13T21:29:22Z',
+      firstPublishedDate: '2018-09-13T20:01:47Z',
+      publishedDate: '2018-09-13T21:29:25Z',
+      lastModifiedDate: '2018-09-13T21:29:22Z',
+      contributors: [],
+      createdBy: {
+        email: 'akshata.rao.casual@guardian.co.uk',
+        firstName: 'Akshata',
+        lastName: 'Rao'
+      },
+      lastModifiedBy: {
+        email: 'akshata.rao.casual@guardian.co.uk',
+        firstName: 'Akshata',
+        lastName: 'Rao'
+      },
+      elements: [
+        {
+          type: 'contentatom',
+          assets: [],
+          contentAtomTypeData: {
+            atomId: '06666fe2-10f1-468f-b4de-91f5653931ac',
+            atomType: 'media'
+          }
+        }
+      ]
+    }
+  },
+  atoms: {
+    media: [
+      {
+        id: '06666fe2-10f1-468f-b4de-91f5653931ac',
+        atomType: 'media',
+        labels: [],
+        defaultHtml:
+          '<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/Vg4dddBmukI?showinfo=0&rel=0"></iframe>',
+        data: {
+          media: {
+            assets: [
+              {
+                assetType: 'video',
+                version: 4,
+                id: 'Vg4dddBmukI',
+                platform: 'youtube'
+              },
+              {
+                assetType: 'video',
+                version: 3,
+                id: 'jBNmcz6rlTo',
+                platform: 'youtube'
+              },
+              {
+                assetType: 'video',
+                version: 2,
+                id: 'WQKiwLaMRjc',
+                platform: 'youtube'
+              },
+              {
+                assetType: 'video',
+                version: 1,
+                id: 'RyvXK7X2zg8',
+                platform: 'youtube'
+              }
+            ],
+            activeVersion: 4,
+            title:
+              'Life-threatening Hurricane Florence makes landfall in North Carolina – video report ',
+            category: 'news',
+            duration: 88,
+            source: 'As credited',
+            posterUrl:
+              'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/master/3000.jpg',
+            description:
+              "<p><a href=\"https://www.theguardian.com/world/hurricane-florence\">Hurricane Florence</a>&nbsp;has made landfall near Wrightsville Beach, North Carolina, with winds of nearly 90mph. Although downgraded to a category 1 storm, the National Hurricane Center has warned of 'catastrophic' freshwater flooding. A Fema spokesperson has said 'this is only the beginning' of the storm's effects</p><ul><li><a href=\"https://www.theguardian.com/world/live/2018/sep/13/florence-hurricane-latest-live-news-updates-weather-path-storm-surge-north-carolina\">Hurricane Florence makes landfall in North Carolina – live updates</a></li></ul>",
+            metadata: {
+              tags: [
+                'world',
+                'hurricane',
+                'hurriance Florence',
+                'natural disasters',
+                'extreme weather',
+                'US extreme weather',
+                'US braces for hurricane Florence',
+                'giant waves',
+                'US east coast',
+                'central Atlantic seaboard',
+                'North Carolina',
+                'South Carolina',
+                'damaging winds',
+                'storm surge',
+                'carolinas',
+                'us',
+                'weather',
+                '2018',
+                'news',
+                'flood',
+                'floods',
+                'flooding',
+                'rain',
+                'rains',
+                'record rainfall',
+                'rainfall',
+                'storm',
+                'florence',
+                'florence path',
+                'florence map',
+                'florence wind',
+                'florence aftermath'
+              ],
+              categoryId: '25',
+              channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
+              pluto: {
+                commissionId: 'KP-22289',
+                projectId: 'KP-22321'
+              }
+            },
+            posterImage: {
+              assets: [
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/2000.jpg',
+                  dimensions: {
+                    height: 1125,
+                    width: 2000
+                  },
+                  size: 322318,
+                  aspectRatio: '16:9'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/1000.jpg',
+                  dimensions: {
+                    height: 563,
+                    width: 1000
+                  },
+                  size: 97135,
+                  aspectRatio: '16:9'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/500.jpg',
+                  dimensions: {
+                    height: 281,
+                    width: 500
+                  },
+                  size: 28827,
+                  aspectRatio: '16:9'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/140.jpg',
+                  dimensions: {
+                    height: 79,
+                    width: 140
+                  },
+                  size: 6055,
+                  aspectRatio: '16:9'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/3000.jpg',
+                  dimensions: {
+                    height: 1688,
+                    width: 3000
+                  },
+                  size: 673897,
+                  aspectRatio: '16:9'
+                }
+              ],
+              master: {
+                mimeType: 'image/jpeg',
+                file:
+                  'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_35_3000_1688/master/3000.jpg',
+                dimensions: {
+                  height: 1688,
+                  width: 3000
+                },
+                size: 1696693,
+                aspectRatio: '16:9'
+              },
+              mediaId:
+                'https://api.media.gutools.co.uk/images/e43df93d3022d27100292b233fabcab9c22ac163',
+              source: 'Getty Images'
+            },
+            trailText:
+              '<p><a href="https://www.theguardian.com/world/hurricane-florence">Hurricane Florence</a>&nbsp;has made landfall in North Carolina with winds near 90mph and warnings of catastrophic flooding&nbsp;</p>',
+            byline: [],
+            commissioningDesks: ['tracking/commissioningdesk/uk-video'],
+            keywords: [
+              'world/hurricane-florence',
+              'world/natural-disasters',
+              'us-news/us-news',
+              'tone/news',
+              'us-news/northcarolina'
+            ],
+            trailImage: {
+              assets: [
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_15_3000_1800/2000.jpg',
+                  dimensions: {
+                    height: 1200,
+                    width: 2000
+                  },
+                  size: 341405,
+                  aspectRatio: '5:3'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_15_3000_1800/1000.jpg',
+                  dimensions: {
+                    height: 600,
+                    width: 1000
+                  },
+                  size: 103236,
+                  aspectRatio: '5:3'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_15_3000_1800/500.jpg',
+                  dimensions: {
+                    height: 300,
+                    width: 500
+                  },
+                  size: 30814,
+                  aspectRatio: '5:3'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_15_3000_1800/140.jpg',
+                  dimensions: {
+                    height: 84,
+                    width: 140
+                  },
+                  size: 6312,
+                  aspectRatio: '5:3'
+                },
+                {
+                  mimeType: 'image/jpeg',
+                  file:
+                    'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_15_3000_1800/3000.jpg',
+                  dimensions: {
+                    height: 1800,
+                    width: 3000
+                  },
+                  size: 712250,
+                  aspectRatio: '5:3'
+                }
+              ],
+              master: {
+                mimeType: 'image/jpeg',
+                file:
+                  'https://media.guim.co.uk/e43df93d3022d27100292b233fabcab9c22ac163/0_15_3000_1800/master/3000.jpg',
+                dimensions: {
+                  height: 1800,
+                  width: 3000
+                },
+                size: 1775031,
+                aspectRatio: '5:3'
+              },
+              mediaId:
+                'https://api.media.gutools.co.uk/images/e43df93d3022d27100292b233fabcab9c22ac163',
+              source: 'Getty Images'
+            }
+          }
+        },
+        contentChangeDetails: {
+          lastModified: {
+            date: 1537175465000,
+            user: {
+              email: 'adam.sich@guardian.co.uk',
+              firstName: 'Adam',
+              lastName: 'Sich'
+            }
+          },
+          created: {
+            date: 1536873965000,
+            user: {
+              email: 'akshata.rao.casual@guardian.co.uk',
+              firstName: 'Akshata',
+              lastName: 'Rao'
+            }
+          },
+          published: {
+            date: 1537175465000,
+            user: {
+              email: 'adam.sich@guardian.co.uk',
+              firstName: 'Adam',
+              lastName: 'Sich'
+            }
+          },
+          revision: 45
+        },
+        flags: {
+          blockAds: true
+        },
+        title:
+          'Life-threatening Hurricane Florence makes landfall in North Carolina – video report ',
+        commissioningDesks: []
+      }
+    ]
+  },
+  isHosted: false,
+  pillarId: 'pillar/news',
+  pillarName: 'News'
+};
+
 const liveArticle = {
   id: 'article/live/0',
   frontPublicationDate: 1,
@@ -64,6 +426,18 @@ const collectionWithSupportingArticles = {
 };
 
 const stateWithCollection = {
+  fronts: {
+    frontsConfig: {
+      data: {
+        fronts: {},
+        collections: {
+          exampleCollection: {
+            displayName: 'Example Collection'
+          }
+        }
+      }
+    }
+  },
   shared: {
     collections: {
       data: {
@@ -175,6 +549,7 @@ const stateWithCollectionAndSupporting = {
 };
 
 export {
+  capiArticle,
   collection,
   collectionWithSupportingArticles,
   stateWithCollection,

--- a/client-v2/src/shared/util/createAsyncResourceBundle.js
+++ b/client-v2/src/shared/util/createAsyncResourceBundle.js
@@ -109,7 +109,8 @@ const createSelectAll = selectLocalState => (state: any) =>
 
 function applyNewData<Resource: BaseResource>(
   data: { [id: string]: Resource } | {},
-  newData: Resource | Resource[]
+  newData: Resource | Resource[],
+  resourceName: string
 ): Resource | { [id: string]: Resource } {
   if (newData instanceof Array) {
     const result: { [id: string]: Resource } = {
@@ -117,7 +118,7 @@ function applyNewData<Resource: BaseResource>(
       ...newData.reduce((acc, model: BaseResource, index) => {
         if (!model.id) {
           throw new Error(
-            `[asyncResourceBundle]: Cannot apply new data - model is missing ID at index ${index}.`
+            `[asyncResourceBundle]: Cannot apply new data - incoming resource ${resourceName} is missing ID at index ${index}.`
           );
         }
         return {
@@ -131,7 +132,7 @@ function applyNewData<Resource: BaseResource>(
 
   if (!newData.id) {
     throw new Error(
-      `[asyncResourceBundle]: Cannot apply new data - model with keys ${Object.keys(
+      `[asyncResourceBundle]: Cannot apply new data - incoming resource ${resourceName} with keys ${Object.keys(
         newData
       ).join(', ')} is missing id.`
     );
@@ -267,7 +268,7 @@ function createAsyncResourceBundle<Resource: any>(
             ...state,
             data: !indexById
               ? action.payload.data
-              : applyNewData(state.data, action.payload.data),
+              : applyNewData(state.data, action.payload.data, entityName),
             lastFetch: action.payload.time,
             error: null,
             loadingIds: indexById
@@ -303,7 +304,7 @@ function createAsyncResourceBundle<Resource: any>(
             ...state,
             data: !indexById
               ? action.payload.data
-              : applyNewData(state.data, action.payload.data),
+              : applyNewData(state.data, action.payload.data, entityName),
             updatingIds: applyStatusIds(
               state.updatingIds,
               indexById ? action.payload.data.id : undefined
@@ -315,7 +316,7 @@ function createAsyncResourceBundle<Resource: any>(
           if (action.payload.data) {
             data = !indexById
               ? action.payload.data
-              : applyNewData(state.data, action.payload.data);
+              : applyNewData(state.data, action.payload.data, entityName);
           } else {
             data = state.data; // eslint-disable-line prefer-destructuring
           }


### PR DESCRIPTION
A few changes to error handling re: external articles -

- asyncBundleResource is more verbose when reporting problems with incoming models
- getCollectionsAndArticles no longer swallows errors 😄 