### PR TITLE
Remove slideshow array from form values if empty

### DIFF
--- a/client-v2/src/components/Feed.tsx
+++ b/client-v2/src/components/Feed.tsx
@@ -112,7 +112,7 @@ class Feed extends React.Component<FeedProps, FeedState> {
 
   public render() {
     const { capiFeedSpec } = this;
-    const getId = (internalPageCode: string | number) =>
+    const getId = (internalPageCode: string | number | undefined) =>
       `internal-code/page/${internalPageCode}`;
 
     return (

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -67,7 +67,7 @@ interface ArticleFragmentFormData {
   cutoutImage: ImageData;
   imageCutoutReplace: boolean;
   imageSlideshowReplace: boolean;
-  slideshow: Array<ImageData | void>;
+  slideshow: Array<ImageData | void> | void;
 }
 
 const FormContainer = ContentContainer.withComponent('form').extend`
@@ -153,12 +153,7 @@ const formComponent: React.StatelessComponent<Props> = ({
     <CollectionHeadingPinline>
       Edit
       <ButtonContainer>
-        <Button
-          priority="primary"
-          onClick={onCancel}
-          type="button"
-          size="l"
-        >
+        <Button priority="primary" onClick={onCancel} type="button" size="l">
           Cancel
         </Button>
         <Button onClick={handleSubmit} disabled={pristine} size="l">
@@ -335,7 +330,7 @@ const getInitialValuesForArticleFragmentForm = (
         showByline: article.showByline || false,
         trailText: article.trailText || '',
         imageCutoutReplace: article.imageCutoutReplace || false,
-        imageHide: !article.imageReplace || false,
+        imageHide: article.imageHide || false,
         imageSlideshowReplace: article.imageSlideshowReplace || false,
         primaryImage: {
           src: article.imageSrc,
@@ -365,7 +360,7 @@ const getArticleFragmentMetaFromFormValues = (
   return omit(
     {
       ...values,
-      imageReplace: !values.imageHide,
+      imageReplace: !!primaryImage.src && !values.imageHide,
       showKickerCustom: !!values.customKicker,
       imageSrc: primaryImage.src,
       imageSrcThumb: primaryImage.thumb,
@@ -376,7 +371,7 @@ const getArticleFragmentMetaFromFormValues = (
       imageCutoutSrcWidth: cutoutImage.width,
       imageCutoutSrcHeight: cutoutImage.height,
       imageCutoutSrcOrigin: cutoutImage.origin,
-      slideshow: slideshow.length ? slideshow : []
+      slideshow: slideshow.length ? slideshow : undefined
     },
     'primaryImage',
     'cutoutImage'
@@ -438,4 +433,8 @@ const mapStateToProps = (state: State, props: InterfaceProps) => {
   };
 };
 
+export {
+  getArticleFragmentMetaFromFormValues,
+  getInitialValuesForArticleFragmentForm
+};
 export default connect(mapStateToProps)(formContainer);

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -1,0 +1,118 @@
+import {
+  getArticleFragmentMetaFromFormValues,
+  getInitialValuesForArticleFragmentForm
+} from '../ArticleFragmentForm';
+import derivedArticle from 'fixtures/derivedArticle';
+
+const formValues = {
+  byline: 'Caroline Davies',
+  customKicker: '',
+  cutoutImage: {
+    height: undefined,
+    origin: undefined,
+    src: undefined,
+    width: undefined
+  },
+  headline: "Sister of academic's killer warned police he was mentally ill",
+  imageCutoutReplace: false,
+  imageHide: false,
+  imageSlideshowReplace: false,
+  isBoosted: false,
+  isBreaking: false,
+  primaryImage: {
+    height: undefined,
+    origin: undefined,
+    src: undefined,
+    thumb: undefined,
+    width: undefined
+  },
+  showBoostedHeadline: false,
+  showByline: false,
+  showQuotedHeadline: false,
+  slideshow: [undefined, undefined, undefined, undefined],
+  trailText:
+    'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+};
+
+describe('ArticleFragmentForm transform functions', () => {
+  describe('Derive form values from a derived article', () => {
+    it('should derive values', () => {
+      expect(getInitialValuesForArticleFragmentForm(derivedArticle)).toEqual(
+        formValues
+      );
+    });
+  });
+  describe('Derive articleFragment meta from form values', () => {
+    it('should derive values, removing the slideshow array if empty', () => {
+      expect(getArticleFragmentMetaFromFormValues(formValues)).toEqual({
+        byline: 'Caroline Davies',
+        customKicker: '',
+        headline:
+          "Sister of academic's killer warned police he was mentally ill",
+        imageCutoutReplace: false,
+        imageCutoutSrc: undefined,
+        imageCutoutSrcHeight: undefined,
+        imageCutoutSrcOrigin: undefined,
+        imageCutoutSrcWidth: undefined,
+        imageHide: false,
+        imageReplace: false,
+        imageSlideshowReplace: false,
+        imageSrc: undefined,
+        imageSrcHeight: undefined,
+        imageSrcOrigin: undefined,
+        imageSrcThumb: undefined,
+        imageSrcWidth: undefined,
+        isBoosted: false,
+        isBreaking: false,
+        showBoostedHeadline: false,
+        showByline: false,
+        showKickerCustom: false,
+        showQuotedHeadline: false,
+        slideshow: undefined,
+        trailText:
+          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+      });
+    });
+    it('should derive values, setting the imageReplace value if necessary', () => {
+      expect(
+        getArticleFragmentMetaFromFormValues({
+          ...formValues,
+          primaryImage: {
+            src: 'exampleSrc',
+            width: '100',
+            height: '100',
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          }
+        })
+      ).toEqual({
+        byline: 'Caroline Davies',
+        customKicker: '',
+        headline:
+          "Sister of academic's killer warned police he was mentally ill",
+        imageCutoutReplace: false,
+        imageCutoutSrc: undefined,
+        imageCutoutSrcHeight: undefined,
+        imageCutoutSrcOrigin: undefined,
+        imageCutoutSrcWidth: undefined,
+        imageHide: false,
+        imageReplace: true,
+        imageSlideshowReplace: false,
+        imageSrc: 'exampleSrc',
+        imageSrcHeight: '100',
+        imageSrcOrigin: 'exampleOrigin',
+        imageSrcThumb: 'exampleThumb',
+        imageSrcWidth: '100',
+        isBoosted: false,
+        isBreaking: false,
+        showBoostedHeadline: false,
+        showByline: false,
+        showKickerCustom: false,
+        showQuotedHeadline: false,
+        slideshow: undefined,
+        trailText:
+          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+      });
+    });
+  });
+});

--- a/client-v2/src/fixtures/derivedArticle.ts
+++ b/client-v2/src/fixtures/derivedArticle.ts
@@ -25,7 +25,7 @@ export default {
   shortUrl: 'https://gu.com/p/9vxyd',
   thumbnail:
     'https://media.guim.co.uk/d49141dab560d0a37c99911f373d1d5f7f4706d0/0_356_1245_746/500.jpg',
-  isLive: 'true',
+  isLive: true,
   frontPublicationDate: 1535551228444,
   publishedBy: 'Philip McMahon',
   uuid: 'fc87955e-fa51-4994-b6cb-bf1c55e0a212',

--- a/client-v2/src/fixtures/derivedArticle.ts
+++ b/client-v2/src/fixtures/derivedArticle.ts
@@ -1,0 +1,35 @@
+import { DerivedArticle } from "shared/types/Article";
+
+export default {
+  id: 'internal-code/page/4784278',
+  type: 'article',
+  sectionId: 'uk-news',
+  sectionName: 'UK news',
+  webPublicationDate: '2018-07-03T14:37:48Z',
+  webTitle: "Sister of academic's killer warned police he was mentally ill",
+  webUrl:
+    'https://www.theguardian.com/uk-news/2018/jul/03/sister-of-academics-killer-warned-police-he-was-mentally-ill',
+  tags: [],
+  elements: [],
+  blocks: {},
+  pillarId: 'pillar/news',
+  pillarName: 'News',
+  urlPath:
+    'uk-news/2018/jul/03/sister-of-academics-killer-warned-police-he-was-mentally-ill',
+  headline: "Sister of academic's killer warned police he was mentally ill",
+  trailText:
+    'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him',
+  byline: 'Caroline Davies',
+  firstPublicationDate: '2018-07-03T14:37:48Z',
+  internalPageCode: '4784278',
+  shortUrl: 'https://gu.com/p/9vxyd',
+  thumbnail:
+    'https://media.guim.co.uk/d49141dab560d0a37c99911f373d1d5f7f4706d0/0_356_1245_746/500.jpg',
+  isLive: 'true',
+  frontPublicationDate: 1535551228444,
+  publishedBy: 'Philip McMahon',
+  uuid: 'fc87955e-fa51-4994-b6cb-bf1c55e0a212',
+  supporting: [],
+  kicker: 'News',
+  tone: 'news'
+} as DerivedArticle;

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -43,8 +43,8 @@ interface Block {
 }
 
 interface Blocks {
-  main: Block;
-  body: Block[];
+  main?: Block;
+  body?: Block[];
 }
 
 interface Tag {
@@ -59,25 +59,26 @@ interface Tag {
 }
 
 interface CapiArticleFields {
-  headline: string;
-  standfirst: string;
-  trailText: string;
-  byline: string;
-  internalPageCode: number;
-  isLive: boolean;
-  firstPublicationDate: CapiDate;
-  scheduledPublicationDate: CapiDate;
-  secureThumbnail: string;
-  thumbnail: string | void;
-  liveBloggingNow: boolean;
-  shortUrl: string;
-  membershipUrl: string;
+  headline?: string;
+  standfirst?: string;
+  trailText?: string;
+  byline?: string;
+  internalPageCode?: string;
+  isLive?: boolean;
+  firstPublicationDate?: CapiDate;
+  scheduledPublicationDate?: CapiDate;
+  secureThumbnail?: string;
+  thumbnail?: string | void;
+  liveBloggingNow?: boolean;
+  shortUrl?: string;
+  membershipUrl?: string;
 }
 
 // See https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift#L1431
 // for the canonical thrift definition.
 interface CapiArticle {
   id: string;
+  type: string;
   webTitle: string;
   webUrl: string;
   urlPath: string;


### PR DESCRIPTION
... and add tests, as there's more and more logic here.

In adding fixtures for the tests, I also noticed some discrepancies between the incoming models and, with reference to https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift, adjusted the CapiArticle type to fit.