### PR TITLE
Don't remove supporting article fragments when updating meta

### DIFF
--- a/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
+++ b/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
@@ -1,0 +1,21 @@
+import reducer from '../articleFragmentsReducer';
+import { updateArticleFragmentMeta } from '../../actions/ArticleFragments';
+import { stateWithClipboard } from 'fixtures/clipboard';
+
+describe('articleFragmentsReducer', () => {
+  it('should update the article fragment meta', () => {
+    expect(reducer(stateWithClipboard.shared.articleFragments as any, updateArticleFragmentMeta('article', {
+      headline: 'headline'
+    })).article.meta).toEqual({
+      headline: 'headline'
+    });
+  });
+  it('shouldn\'t overwrite properties', () => {
+    expect(reducer(stateWithClipboard.shared.articleFragments as any, updateArticleFragmentMeta('article2', {
+      headline: 'headline'
+    })).article2.meta).toEqual({
+      headline: 'headline',
+      supporting: ['article3']
+    });
+  });
+})

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -8,11 +8,15 @@ interface State {
 const articleFragments = (state: State = {}, action: Action) => {
   switch (action.type) {
     case 'SHARED/UPDATE_ARTICLE_FRAGMENT_META': {
+      const { id } = action.payload;
       return {
         ...state,
-        [action.payload.id]: {
-          ...state[action.payload.id],
-          meta: action.payload.meta
+        [id]: {
+          ...state[id],
+          meta: {
+            ...(state[id].meta || {}),
+            ...action.payload.meta
+          }
         }
       };
     }


### PR DESCRIPTION
We ... shouldn't do that.

Updates to article fragment meta are now spread over the old meta, so unless we explicitly overwrite fields they remain.

