### PR TITLE
Image width and height overrides are now strings

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -47,8 +47,8 @@ type Props = ComponentProps &
 
 interface ImageData {
   src?: string;
-  width?: string;
-  height?: string;
+  width?: number;
+  height?: number;
   origin?: string;
   thumb?: string;
 }
@@ -308,6 +308,9 @@ const formComponent: React.StatelessComponent<Props> = ({
   </FormContainer>
 );
 
+const strToInt = (str: string | void) => (str ? parseInt(str, 10) : undefined);
+const intToStr = (int: number | void) => (int ? int.toString() : undefined);
+
 const getInitialValuesForArticleFragmentForm = (
   article: DerivedArticle | void
 ): ArticleFragmentFormData | void => {
@@ -315,7 +318,13 @@ const getInitialValuesForArticleFragmentForm = (
     return undefined;
   }
   const slideshowBackfill: Array<ImageData | void> = [];
-  const slideshow: Array<ImageData | void> = article.slideshow || [];
+  const slideshow: Array<ImageData | void> = (article.slideshow || []).map(
+    image => ({
+      ...image,
+      width: strToInt(image.width),
+      height: strToInt(image.height)
+    })
+  );
   slideshowBackfill.length = 4 - slideshow.length;
   slideshowBackfill.fill(undefined);
   return article
@@ -334,15 +343,15 @@ const getInitialValuesForArticleFragmentForm = (
         imageSlideshowReplace: article.imageSlideshowReplace || false,
         primaryImage: {
           src: article.imageSrc,
-          width: article.imageSrcWidth,
-          height: article.imageSrcHeight,
+          width: strToInt(article.imageSrcWidth),
+          height: strToInt(article.imageSrcHeight),
           origin: article.imageSrcOrigin,
           thumb: article.imageSrcThumb
         },
         cutoutImage: {
           src: article.imageCutoutSrc,
-          width: article.imageCutoutSrcWidth,
-          height: article.imageCutoutSrcHeight,
+          width: strToInt(article.imageCutoutSrcWidth),
+          height: strToInt(article.imageCutoutSrcHeight),
           origin: article.imageCutoutSrcOrigin
         },
         slideshow: slideshow.concat(slideshowBackfill)
@@ -356,7 +365,13 @@ const getArticleFragmentMetaFromFormValues = (
   const primaryImage = values.primaryImage || {};
   const cutoutImage = values.cutoutImage || {};
   // Lodash doesn't remove undefined in the type settings here, hence the any.
-  const slideshow: ImageData[] = compact(values.slideshow as any);
+  const slideshow = compact(values.slideshow as any).map(
+    (image: ImageData) => ({
+      ...image,
+      width: intToStr(image.width),
+      height: intToStr(image.height)
+    })
+  );
   return omit(
     {
       ...values,
@@ -364,12 +379,12 @@ const getArticleFragmentMetaFromFormValues = (
       showKickerCustom: !!values.customKicker,
       imageSrc: primaryImage.src,
       imageSrcThumb: primaryImage.thumb,
-      imageSrcWidth: primaryImage.width,
-      imageSrcHeight: primaryImage.height,
+      imageSrcWidth: intToStr(primaryImage.width),
+      imageSrcHeight: intToStr(primaryImage.height),
       imageSrcOrigin: primaryImage.origin,
       imageCutoutSrc: cutoutImage.src,
-      imageCutoutSrcWidth: cutoutImage.width,
-      imageCutoutSrcHeight: cutoutImage.height,
+      imageCutoutSrcWidth: intToStr(cutoutImage.width),
+      imageCutoutSrcHeight: intToStr(cutoutImage.height),
       imageCutoutSrcOrigin: cutoutImage.origin,
       slideshow: slideshow.length ? slideshow : undefined
     },

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -41,6 +41,71 @@ describe('ArticleFragmentForm transform functions', () => {
         formValues
       );
     });
+    it('should get number values for all image widths and heights', () => {
+      expect(
+        getInitialValuesForArticleFragmentForm({
+          ...derivedArticle,
+          imageSrc: 'exampleSrc1',
+          imageSrcHeight: '100',
+          imageSrcWidth: '100',
+          imageSrcOrigin: 'exampleOrigin',
+          imageSrcThumb: 'exampleThumb',
+          imageCutoutSrc: 'exampleSrc2',
+          imageCutoutSrcHeight: '200',
+          imageCutoutSrcWidth: '200',
+          imageCutoutSrcOrigin: 'exampleOrigin',
+          slideshow: [
+            {
+              src: 'exampleSrc3',
+              height: '300',
+              width: '300',
+              thumb: 'exampleThumb',
+              origin: 'exampleOrigin'
+            },
+            {
+              src: 'exampleSrc4',
+              height: '400',
+              width: '400',
+              thumb: 'exampleThumb',
+              origin: 'exampleOrigin'
+            }
+          ]
+        })
+      ).toEqual({
+        ...formValues,
+        primaryImage: {
+          src: 'exampleSrc1',
+          width: 100,
+          height: 100,
+          origin: 'exampleOrigin',
+          thumb: 'exampleThumb'
+        },
+        cutoutImage: {
+          src: 'exampleSrc2',
+          width: 200,
+          height: 200,
+          origin: 'exampleOrigin'
+        },
+        slideshow: [
+          {
+            src: 'exampleSrc3',
+            width: 300,
+            height: 300,
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          },
+          {
+            src: 'exampleSrc4',
+            width: 400,
+            height: 400,
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          },
+          undefined,
+          undefined
+        ]
+      });
+    });
   });
   describe('Derive articleFragment meta from form values', () => {
     it('should derive values, removing the slideshow array if empty', () => {
@@ -79,8 +144,8 @@ describe('ArticleFragmentForm transform functions', () => {
           ...formValues,
           primaryImage: {
             src: 'exampleSrc',
-            width: '100',
-            height: '100',
+            width: 100,
+            height: 100,
             origin: 'exampleOrigin',
             thumb: 'exampleThumb'
           }
@@ -110,6 +175,78 @@ describe('ArticleFragmentForm transform functions', () => {
         showKickerCustom: false,
         showQuotedHeadline: false,
         slideshow: undefined,
+        trailText:
+          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+      });
+    });
+    it('should handle conversion of string values for images', () => {
+      expect(
+        getArticleFragmentMetaFromFormValues({
+          ...formValues,
+          primaryImage: {
+            src: 'exampleSrc',
+            width: 100,
+            height: 100,
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          },
+          slideshow: [
+            {
+              src: 'exampleSrc',
+              width: 100,
+              height: 100,
+              origin: 'exampleOrigin',
+              thumb: 'exampleThumb'
+            },
+            {
+              src: 'exampleSrc',
+              width: 100,
+              height: 100,
+              origin: 'exampleOrigin',
+              thumb: 'exampleThumb'
+            }
+          ]
+        })
+      ).toEqual({
+        byline: 'Caroline Davies',
+        customKicker: '',
+        headline:
+          "Sister of academic's killer warned police he was mentally ill",
+        imageCutoutReplace: false,
+        imageCutoutSrc: undefined,
+        imageCutoutSrcHeight: undefined,
+        imageCutoutSrcOrigin: undefined,
+        imageCutoutSrcWidth: undefined,
+        imageHide: false,
+        imageReplace: true,
+        imageSlideshowReplace: false,
+        imageSrc: 'exampleSrc',
+        imageSrcHeight: '100',
+        imageSrcOrigin: 'exampleOrigin',
+        imageSrcThumb: 'exampleThumb',
+        imageSrcWidth: '100',
+        isBoosted: false,
+        isBreaking: false,
+        showBoostedHeadline: false,
+        showByline: false,
+        showKickerCustom: false,
+        showQuotedHeadline: false,
+        slideshow: [
+          {
+            src: 'exampleSrc',
+            width: '100',
+            height: '100',
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          },
+          {
+            src: 'exampleSrc',
+            width: '100',
+            height: '100',
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          }
+        ],
         trailText:
           'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
       });


### PR DESCRIPTION
... as they are in the old tool.