### PR TITLE
Search for scheduled content when searching for preview

### DIFF
--- a/client-v2/src/components/CAPI/SearchQuery.tsx
+++ b/client-v2/src/components/CAPI/SearchQuery.tsx
@@ -13,6 +13,7 @@ interface CAPISearchQueryProps {
   children: AsyncChild<SearchReturn>;
   params: object;
   poll?: number;
+  isPreview: boolean;
 }
 
 interface CAPISearchQueryState {
@@ -30,7 +31,7 @@ class SearchQuery extends React.Component<
   };
 
   public static getDerivedStateFromProps(
-    { baseURL, fetch }: CAPISearchQueryProps,
+    { baseURL, fetch, isPreview }: CAPISearchQueryProps,
     prevState: CAPISearchQueryState
   ) {
     if (
@@ -38,7 +39,7 @@ class SearchQuery extends React.Component<
       (fetch && prevState.fetch !== fetch)
     ) {
       return {
-        capi: capiQuery(baseURL, fetch).search,
+        capi: isPreview ? capiQuery(baseURL, fetch).scheduled : capiQuery(baseURL, fetch).search,
         baseURL,
         fetch
       };

--- a/client-v2/src/components/CAPI/__tests__/SearchQuery.spec.tsx
+++ b/client-v2/src/components/CAPI/__tests__/SearchQuery.spec.tsx
@@ -28,7 +28,7 @@ describe('SearchQuery', () => {
     let e;
     const baseURL = 'https://www.example.com';
     mount(
-      <SearchQuery baseURL={baseURL}>
+      <SearchQuery baseURL={baseURL} isPreview={false}>
         {({ value, pending, error }: ChildrenParams) => {
           v = value;
           p = pending;
@@ -46,7 +46,7 @@ describe('SearchQuery', () => {
     let e;
     const baseURL = 'https://www.example.com';
     mount(
-      <SearchQuery baseURL={baseURL}>
+      <SearchQuery baseURL={baseURL} isPreview={false}>
         {({ value, pending, error }: ChildrenParams) => {
           v = value;
           p = pending;
@@ -57,6 +57,28 @@ describe('SearchQuery', () => {
     );
     await flushPromises();
     expect((global as any).fetch.mock.calls[0][0].includes(baseURL)).toBe(true);
+    expect((global as any).fetch.mock.calls[0][0].includes('search')).toBe(true);
+    expect([v, p, e]).toEqual([succesfulReturn, false, undefined]);
+  });
+
+  it('seaches for scheduled content when preview is set to true', async () => {
+    let v;
+    let p;
+    let e;
+    const baseURL = 'https://www.example.com';
+    mount(
+      <SearchQuery baseURL={baseURL} isPreview={true}>
+        {({ value, pending, error }: ChildrenParams) => {
+          v = value;
+          p = pending;
+          e = error;
+          return null;
+        }}
+      </SearchQuery>
+    );
+    await flushPromises();
+    expect((global as any).fetch.mock.calls[0][0].includes(baseURL)).toBe(true);
+    expect((global as any).fetch.mock.calls[0][0].includes('scheduled')).toBe(true);
     expect([v, p, e]).toEqual([succesfulReturn, false, undefined]);
   });
 });

--- a/client-v2/src/components/Feed.tsx
+++ b/client-v2/src/components/Feed.tsx
@@ -127,6 +127,7 @@ class Feed extends React.Component<FeedProps, FeedState> {
               updateDisplaySearchFilters={this.updateDisplaySearchFilters}
               displaySearchFilters={this.state.displaySearchFilters}
               additionalFixedContent={this.renderFixedContent}
+              isPreview={this.state.capiFeedIndex !== 0}
             >
               {({
                 pending,

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -15,6 +15,7 @@ interface FrontsCAPISearchInputProps {
   additionalFixedContent?: React.ComponentType<any>;
   displaySearchFilters: boolean;
   updateDisplaySearchFilters: (value: boolean) => void;
+  isPreview: boolean;
 }
 
 type SearchTypeMap<T> = { [K in SearchTypes]: T };
@@ -154,7 +155,8 @@ class FrontsCAPISearchInput extends React.Component<
     const {
       children,
       displaySearchFilters,
-      additionalFixedContent: AdditionalFixedContent
+      additionalFixedContent: AdditionalFixedContent,
+      isPreview
     } = this.props;
 
     const {
@@ -165,6 +167,8 @@ class FrontsCAPISearchInput extends React.Component<
     const searchTermsExist = !!tags.length || !!sections.length || !!q;
 
     const allTags = tags.concat(sections);
+
+    const dateParams = isPreview ? { 'order-by': 'oldest'} : { 'use-date': 'first-publication' };
 
     if (!displaySearchFilters) {
       return (
@@ -194,11 +198,12 @@ class FrontsCAPISearchInput extends React.Component<
               section: sections.join(','),
               q,
               'page-size': '20',
-              'use-date': 'first-publication',
               'show-elements': 'image',
-              'show-fields': 'internalPageCode,trailText'
+              'show-fields': 'internalPageCode,trailText',
+              ...dateParams
             }}
             poll={30000}
+            isPreview={isPreview}
           >
             {children}
           </SearchQuery>

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -30,6 +30,15 @@ const capiQuery = (
 
     return response.json();
   },
+  scheduled: async (params: any): Promise<CAPISearchQueryReponse> => {
+    const response = await fetch(
+      `${baseURL}content/scheduled${qs({
+        ...params
+      })}`
+    );
+
+    return response.json();
+  },
   tags: async (params: any): Promise<CAPITagQueryReponse> => {
     const response = await fetch(
       `${baseURL}tags${qs({


### PR DESCRIPTION
Turns out the old tool does a slightly different capi query for draft content. I've now fixed it so that in draft we see exactly what we do in the old tool and live shows slightly different results as requested by our users.