### PR TITLE
Enable selection of supporting articles in Front and Clipboard views

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -5,10 +5,11 @@ import * as Guration from 'lib/guration';
 import { Edit } from 'lib/guration';
 import { State } from 'types/State';
 import { urlToArticle } from 'util/collectionUtils';
+import { ArticleFragmentTree } from 'shared/selectors/shared';
 import {
-  ArticleFragmentTree
-} from 'shared/selectors/shared';
-import {   clipboardAsTreeSelector, ClipboardTree } from 'selectors/clipboardSelectors';
+  clipboardAsTreeSelector,
+  ClipboardTree
+} from 'selectors/clipboardSelectors';
 import DropZone from 'components/DropZone';
 import ArticlePolaroid from 'shared/components/ArticlePolaroid';
 import ArticlePolaroidSub from 'shared/components/ArticlePolaroidSub';
@@ -19,7 +20,8 @@ import {
 } from 'actions/ArticleFragments';
 import {
   editorSelectArticleFragment,
-  selectEditorArticleFragment
+  selectEditorArticleFragment,
+  editorClearArticleFragmentSelection
 } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
 import { ArticleFragmentDenormalised } from 'shared/types/Collection';
@@ -28,9 +30,10 @@ interface ClipboardProps {
   addArticleFragment: (id: string, supporting: string[]) => Promise<string>;
   selectedArticleFragmentId: string | void;
   selectArticleFragment: (id: string) => void;
+  clearArticleFragmentSelection: (id: string) => void;
   tree: ClipboardTree; // TODO add typing,
   dispatch: Dispatch;
-};
+}
 
 class Clipboard extends React.Component<ClipboardProps> {
   // TODO: this code is repeated in src/components/FrontsEdit/Front.js
@@ -80,6 +83,12 @@ class Clipboard extends React.Component<ClipboardProps> {
     });
   };
 
+  public clearArticleFragmentSelectionIfNeeded = (articleId: string) => {
+    if (articleId === this.props.selectedArticleFragmentId) {
+      this.props.clearArticleFragmentSelection(clipboardId);
+    }
+  };
+
   public render() {
     const { tree } = this.props;
     return (
@@ -123,6 +132,10 @@ class Clipboard extends React.Component<ClipboardProps> {
             <ArticlePolaroid
               id={articleFragment.uuid}
               onSelect={this.props.selectArticleFragment}
+              isSelected={
+                !this.props.selectedArticleFragmentId ||
+                this.props.selectedArticleFragmentId === articleFragment.uuid
+              }
               {...getArticleNodeProps()}
             >
               <Guration.Level
@@ -143,6 +156,11 @@ class Clipboard extends React.Component<ClipboardProps> {
                   <ArticlePolaroidSub
                     id={supporting.uuid}
                     parentId={articleFragment.uuid}
+                    onSelect={this.props.selectArticleFragment}
+                    isSelected={
+                      !this.props.selectedArticleFragmentId ||
+                      this.props.selectedArticleFragmentId === supporting.uuid
+                    }
                     {...getSupportingNodeProps()}
                   />
                 )}
@@ -165,6 +183,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(addArticleFragment(id, supporting)),
   selectArticleFragment: (frontId: string, articleFragmentId: string) =>
     dispatch(editorSelectArticleFragment(frontId, articleFragmentId)),
+  clearArticleFragmentSelection: (frontId: string) =>
+    dispatch(editorClearArticleFragmentSelection(frontId)),
   dispatch
 });
 

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -136,6 +136,9 @@ class Clipboard extends React.Component<ClipboardProps> {
                 !this.props.selectedArticleFragmentId ||
                 this.props.selectedArticleFragmentId === articleFragment.uuid
               }
+              onDelete={
+                this.clearArticleFragmentSelectionIfNeeded
+              }
               {...getArticleNodeProps()}
             >
               <Guration.Level
@@ -162,6 +165,9 @@ class Clipboard extends React.Component<ClipboardProps> {
                       this.props.selectedArticleFragmentId === supporting.uuid
                     }
                     {...getSupportingNodeProps()}
+                    onDelete={
+                      this.clearArticleFragmentSelectionIfNeeded
+                    }
                   />
                 )}
               </Guration.Level>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.tsx
@@ -35,14 +35,6 @@ const dropZoneStyle = {
   padding: '3px'
 };
 
-const ArticleFragmentContainer = styled('div')`
-  ${({ isSelected }: { isSelected: boolean }) =>
-    !isSelected &&
-    css`
-      opacity: 0.5;
-    `};
-`;
-
 const ArticleFragment = ({
   uuid,
   isSelected,
@@ -52,30 +44,31 @@ const ArticleFragment = ({
   onSelect,
   onDelete
 }: ArticleFragmentProps) => (
-  <ArticleFragmentContainer
-    isSelected={isSelected}
+  <Article
+    id={uuid}
+    {...getNodeProps()}
+    onDelete={onDelete}
     onClick={() => onSelect(uuid)}
+    fade={!isSelected}
   >
-    <Article id={uuid} {...getNodeProps()} onDelete={onDelete}>
-      {supporting && (
-        <Guration.Level
-          arr={supporting}
-          type="articleFragment"
-          getKey={({ uuid: key }) => key}
-          renderDrop={(getDropProps, { canDrop, isTarget }) => (
-            <DropZone
-              {...getDropProps()}
-              override={!!canDrop && !!isTarget}
-              style={dropZoneStyle}
-              indicatorStyle={dropIndicatorStyle}
-            />
-          )}
-        >
-          {children}
-        </Guration.Level>
-      )}
-    </Article>
-  </ArticleFragmentContainer>
+    {supporting && (
+      <Guration.Level
+        arr={supporting}
+        type="articleFragment"
+        getKey={({ uuid: key }) => key}
+        renderDrop={(getDropProps, { canDrop, isTarget }) => (
+          <DropZone
+            {...getDropProps()}
+            override={!!canDrop && !!isTarget}
+            style={dropZoneStyle}
+            indicatorStyle={dropIndicatorStyle}
+          />
+        )}
+      >
+        {children}
+      </Guration.Level>
+    )}
+  </Article>
 );
 
 const mapDispatchToProps = (

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleFragment.tsx
@@ -9,13 +9,13 @@ import { removeGroupArticleFragment } from 'actions/ArticleFragments';
 import { ArticleFragmentDenormalised } from 'shared/types/Collection';
 
 interface ContainerProps {
-  isSelected: boolean;
+  isSelected?: boolean;
   uuid: string;
   supporting?: ArticleFragmentDenormalised[];
   children: any;
   getNodeProps: () => object;
   onSelect: (uuid: string) => void;
-  onCancel: (uuid: string) => void;
+  onDelete: (uuid: string) => void;
   parentId: string;
 }
 
@@ -73,10 +73,10 @@ const ArticleFragment = ({
 
 const mapDispatchToProps = (
   dispatch: Dispatch,
-  { parentId, uuid, onCancel }: ContainerProps
+  { parentId, uuid, onDelete }: ContainerProps
 ) => ({
   onDelete: () => {
-    onCancel(uuid);
+    onDelete(uuid);
     dispatch(removeGroupArticleFragment(parentId, uuid));
   }
 });

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.tsx
@@ -8,6 +8,7 @@ interface ContainerProps {
   uuid: string;
   parentId: string;
   getNodeProps: any;
+  isSelected?: boolean;
   onSelect: (uuid: string) => void;
 }
 
@@ -17,7 +18,7 @@ type SupportingProps = ContainerProps & {
 
 class Supporting extends React.PureComponent<SupportingProps> {
   public render() {
-    const { uuid, getNodeProps, onDelete } = this.props;
+    const { uuid, getNodeProps, onDelete, isSelected } = this.props;
     return (
       <div onClick={this.handleSelect}>
         <Article
@@ -25,6 +26,7 @@ class Supporting extends React.PureComponent<SupportingProps> {
           {...getNodeProps()}
           size="small"
           onDelete={onDelete}
+          fade={!isSelected}
         />
       </div>
     );

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import Article from 'shared/components/Article';
 import { removeSupportingArticleFragment } from 'actions/ArticleFragments';
 import { Dispatch } from 'types/Store';
+import noop from 'lodash/noop';
 
 interface ContainerProps {
   uuid: string;
@@ -10,13 +11,10 @@ interface ContainerProps {
   getNodeProps: any;
   isSelected?: boolean;
   onSelect: (uuid: string) => void;
+  onDelete: (uuid: string) => void;
 }
 
-type SupportingProps = ContainerProps & {
-  onDelete: () => void;
-};
-
-class Supporting extends React.PureComponent<SupportingProps> {
+class Supporting extends React.PureComponent<ContainerProps> {
   public render() {
     const { uuid, getNodeProps, onDelete, isSelected } = this.props;
     return (
@@ -42,9 +40,12 @@ class Supporting extends React.PureComponent<SupportingProps> {
 
 const mapDispatchToProps = (
   dispatch: Dispatch,
-  { parentId, uuid }: ContainerProps
+  { parentId, uuid, onDelete = noop }: ContainerProps
 ) => ({
-  onDelete: () => dispatch(removeSupportingArticleFragment(parentId, uuid))
+  onDelete: (id: string) => {
+    onDelete(id);
+    dispatch(removeSupportingArticleFragment(parentId, uuid))
+  }
 });
 
 export default connect(

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Supporting.tsx
@@ -8,15 +8,35 @@ interface ContainerProps {
   uuid: string;
   parentId: string;
   getNodeProps: any;
+  onSelect: (uuid: string) => void;
 }
 
 type SupportingProps = ContainerProps & {
   onDelete: () => void;
 };
 
-const Supporting = ({ uuid, getNodeProps, onDelete }: SupportingProps) => (
-  <Article id={uuid} {...getNodeProps()} size="small" onDelete={onDelete} />
-);
+class Supporting extends React.PureComponent<SupportingProps> {
+  public render() {
+    const { uuid, getNodeProps, onDelete } = this.props;
+    return (
+      <div onClick={this.handleSelect}>
+        <Article
+          id={uuid}
+          {...getNodeProps()}
+          size="small"
+          onDelete={onDelete}
+        />
+      </div>
+    );
+  }
+  private handleSelect = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Supporting articles are usually contained within articles,
+    // so we don't want this event to bubble up and select the
+    // wrong thing.
+    e.stopPropagation();
+    this.props.onSelect(this.props.uuid);
+  }
+}
 
 const mapDispatchToProps = (
   dispatch: Dispatch,

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -211,7 +211,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                             parentId={group.uuid}
                             getNodeProps={afNodeProps}
                             onSelect={this.props.selectArticleFragment}
-                            onCancel={
+                            onDelete={
                               this.clearArticleFragmentSelectionIfNeeded
                             }
                             isSelected={

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -228,6 +228,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                 parentId={articleFragment.uuid}
                                 getNodeProps={sNodeProps}
                                 onSelect={this.props.selectArticleFragment}
+                                isSelected={
+                                  !selectedArticleFragmentId ||
+                                  selectedArticleFragmentId === supporting.uuid
+                                }
                               />
                             )}
                           </ArticleFragment>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -232,6 +232,9 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                   !selectedArticleFragmentId ||
                                   selectedArticleFragmentId === supporting.uuid
                                 }
+                                onDelete={
+                                  this.clearArticleFragmentSelectionIfNeeded
+                                }
                               />
                             )}
                           </ArticleFragment>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -227,6 +227,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                 uuid={supporting.uuid}
                                 parentId={articleFragment.uuid}
                                 getNodeProps={sNodeProps}
+                                onSelect={this.props.selectArticleFragment}
                               />
                             )}
                           </ArticleFragment>

--- a/client-v2/src/shared/components/Article.tsx
+++ b/client-v2/src/shared/components/Article.tsx
@@ -20,10 +20,12 @@ import { DerivedArticle } from '../types/Article';
 interface ContainerProps {
   id: string; // eslint-disable-line react/no-unused-prop-types
   draggable?: boolean;
+  fade?: boolean;
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
   onDragOver?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
   onDelete?: () => void;
+  onClick?: () => void;
   selectSharedState?: (state: any) => State; // eslint-disable-line react/no-unused-prop-types
 }
 
@@ -75,6 +77,7 @@ const ArticleContainer = styled('div')`
 
 const ArticleBodyContainer = styled('div')<{
   transitionTime?: number;
+  fade?: boolean;
 }>`
   display: flex;
   position: relative;
@@ -82,6 +85,7 @@ const ArticleBodyContainer = styled('div')<{
   min-height: 35px;
   cursor: pointer;
   position: relative;
+  opacity: ${({ fade }) => (fade ? 0.5 : 1)};
 
   ${HoverActions} {
     bottom: 0;
@@ -184,11 +188,13 @@ const FirstPublished = styled('div')`
 const ArticleComponent = ({
   article,
   size = 'default',
+  fade = false,
   draggable = false,
   onDragStart = noop,
   onDragOver = noop,
   onDrop = noop,
   onDelete = noop,
+  onClick = noop,
   children
 }: ComponentProps) => {
   if (!article) {
@@ -202,8 +208,10 @@ const ArticleComponent = ({
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onClick={onClick}
     >
       <ArticleBodyContainer
+        fade={fade}
         key={article.headline}
         style={{
           borderTopColor:

--- a/client-v2/src/shared/components/Article.tsx
+++ b/client-v2/src/shared/components/Article.tsx
@@ -17,16 +17,20 @@ import {
 import { State } from '../types/State';
 import { DerivedArticle } from '../types/Article';
 
-interface ContainerProps {
-  id: string; // eslint-disable-line react/no-unused-prop-types
+
+interface ArticleComponentProps {
+  id: string;
   draggable?: boolean;
   fade?: boolean;
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
   onDragOver?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
-  onDelete?: () => void;
+  onDelete?: (uuid: string) => void;
   onClick?: () => void;
-  selectSharedState?: (state: any) => State; // eslint-disable-line react/no-unused-prop-types
+}
+
+interface ContainerProps extends ArticleComponentProps {
+  selectSharedState?: (state: any) => State;
 }
 
 type ComponentProps = {
@@ -282,7 +286,7 @@ const ArticleComponent = ({
               onClick={(e: React.SyntheticEvent) => {
                 // stop the parent from opening the edit panel
                 e.stopPropagation();
-                onDelete();
+                onDelete(article.uuid);
               }}
               title="Delete"
             />
@@ -305,5 +309,7 @@ const createMapStateToProps = () => (
     props.id
   )
 });
+
+export { ArticleComponentProps }
 
 export default connect(createMapStateToProps)(ArticleComponent);

--- a/client-v2/src/shared/components/ArticlePolaroid.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroid.tsx
@@ -18,7 +18,7 @@ import Fadeable from './Fadeable';
 interface ContainerProps extends ArticleComponentProps {
   isSelected?: boolean;
   onSelect?: (uuid: string) => void;
-  selectSharedState?: (state: any) => State; // eslint-disable-line react/no-unused-prop-types
+  selectSharedState?: (state: any) => State;
   children?: React.ReactNode;
 }
 
@@ -52,6 +52,7 @@ const ArticleComponent = ({
   onDragOver = noop,
   onDrop = noop,
   onDelete = noop,
+  onSelect = noop,
   isSelected
 }: ComponentProps) => {
   if (!article) {

--- a/client-v2/src/shared/components/ArticlePolaroid.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroid.tsx
@@ -12,14 +12,12 @@ import { DerivedArticle } from '../types/Article';
 import { Dispatch } from 'types/Store';
 import { removeArticleFragmentFromClipboard } from 'actions/ArticleFragments';
 import Button from './input/ButtonDefault';
+import { ArticleComponentProps } from './Article';
+import Fadeable from './Fadeable';
 
-interface ContainerProps {
-  id: string; // eslint-disable-line react/no-unused-prop-types
-  draggable: boolean;
-  onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
-  onDragOver?: (d: React.DragEvent<HTMLElement>) => void;
-  onDrop?: (d: React.DragEvent<HTMLElement>) => void;
-  onSelect: (id: string) => void;
+interface ContainerProps extends ArticleComponentProps {
+  isSelected?: boolean;
+  onSelect?: (uuid: string) => void;
   selectSharedState?: (state: any) => State; // eslint-disable-line react/no-unused-prop-types
   children?: React.ReactNode;
 }
@@ -54,7 +52,7 @@ const ArticleComponent = ({
   onDragOver = noop,
   onDrop = noop,
   onDelete = noop,
-  onSelect = noop
+  isSelected
 }: ComponentProps) => {
   if (!article) {
     return null;
@@ -66,21 +64,23 @@ const ArticleComponent = ({
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
-      onClick={() => onSelect(id)}
     >
-      <CornerButton
-        onClick={e => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        pill
-        priority="muted"
-        size="s"
-      >
-        Delete
-      </CornerButton>
-      {article.thumbnail && <Thumbnail src={article.thumbnail} alt="" />}
-      {truncate(article.headline, { length: 45 })}
+      <Fadeable onClick={() => onSelect(id)} fade={!isSelected}>
+        <CornerButton
+          onClick={e => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          pill
+          priority="muted"
+          size="s"
+        >
+          Delete
+        </CornerButton>
+        {article.thumbnail && <Thumbnail src={article.thumbnail} alt="" />}
+        {truncate(article.headline, { length: 45 })}
+      </Fadeable>
+      >>>>>>> Add handlers and state to clipboard
       {children}
     </BodyContainer>
   );

--- a/client-v2/src/shared/components/ArticlePolaroid.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroid.tsx
@@ -81,7 +81,6 @@ const ArticleComponent = ({
         {article.thumbnail && <Thumbnail src={article.thumbnail} alt="" />}
         {truncate(article.headline, { length: 45 })}
       </Fadeable>
-      >>>>>>> Add handlers and state to clipboard
       {children}
     </BodyContainer>
   );
@@ -99,8 +98,11 @@ const createMapStateToProps = () => (
   )
 });
 
-const mapDispatchToProps = (dispatch: Dispatch, { id }: ContainerProps) => ({
-  onDelete: () => dispatch(removeArticleFragmentFromClipboard(id))
+const mapDispatchToProps = (dispatch: Dispatch, { id, onDelete = noop }: ContainerProps) => ({
+  onDelete: () => {
+    onDelete(id);
+    dispatch(removeArticleFragmentFromClipboard(id))
+  }
 });
 
 export default connect(

--- a/client-v2/src/shared/components/ArticlePolaroidSub.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroidSub.tsx
@@ -101,10 +101,12 @@ const createMapStateToProps = () => (
 
 const mapDispatchToProps = (
   dispatch: Dispatch,
-  { id, parentId }: ContainerProps
+  { id, parentId, onDelete = noop }: ContainerProps
 ) => ({
-  onDelete: () =>
-    dispatch(removeSupportingArticleFragmentFromClipboard(parentId, id))
+  onDelete: () => {
+    onDelete(id);
+    dispatch(removeSupportingArticleFragmentFromClipboard(parentId, id));
+  }
 });
 
 export default connect(

--- a/client-v2/src/shared/components/ArticlePolaroidSub.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroidSub.tsx
@@ -17,6 +17,7 @@ import { ArticleComponentProps } from './Article';
 import Fadeable from './Fadeable';
 
 interface ContainerProps extends ArticleComponentProps {
+  children?: React.ReactNode;
   parentId: string;
   isSelected?: boolean;
   onSelect?: (uuid: string) => void;

--- a/client-v2/src/shared/components/ArticlePolaroidSub.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroidSub.tsx
@@ -13,15 +13,13 @@ import toneColorMap from '../util/toneColorMap';
 import ButtonDefault from './input/ButtonDefault';
 import { removeSupportingArticleFragmentFromClipboard } from 'actions/ArticleFragments';
 import { Dispatch } from 'types/Store';
+import { ArticleComponentProps } from './Article';
+import Fadeable from './Fadeable';
 
-interface ContainerProps {
-  id: string;
+interface ContainerProps extends ArticleComponentProps {
   parentId: string;
-  children?: React.ReactNode;
-  draggable: boolean;
-  onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
-  onDragOver?: (d: React.DragEvent<HTMLElement>) => void;
-  onDrop?: (d: React.DragEvent<HTMLElement>) => void;
+  isSelected?: boolean;
+  onSelect?: (uuid: string) => void;
   selectSharedState?: (state: any) => State;
 }
 
@@ -49,7 +47,9 @@ const ArticleComponent = ({
   onDragStart = noop,
   onDragOver = noop,
   onDrop = noop,
-  onDelete
+  isSelected,
+  onSelect = noop,
+  onDelete = noop
 }: ComponentProps) => {
   if (!article) {
     return null;
@@ -61,24 +61,27 @@ const ArticleComponent = ({
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onClick={() => onSelect(article.uuid)}
     >
-      <TonedKicker tone={article.tone}>{article.sectionName}</TonedKicker>
-      {` ${truncate(article.headline, {
-        length: 40 - article.sectionName.length
-      })}`}
+      <Fadeable fade={!isSelected}>
+        <ButtonDefault
+          onClick={e => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          inline
+          pill
+          size="s"
+          priority="muted"
+        >
+          Delete
+        </ButtonDefault>
+        <TonedKicker tone={article.tone}>{article.sectionName}</TonedKicker>
+        {` ${truncate(article.headline, {
+          length: 40 - article.sectionName.length
+        })}`}
+      </Fadeable>
       {children}
-      <ButtonDefault
-        onClick={e => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        inline
-        pill
-        size="s"
-        priority="muted"
-      >
-        Delete
-      </ButtonDefault>
     </BodyContainer>
   );
 };

--- a/client-v2/src/shared/components/Fadeable.tsx
+++ b/client-v2/src/shared/components/Fadeable.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export default styled('div')<{
+  fade?: boolean
+}>`
+  opacity: ${({ fade }) => (fade ? 0.5 : 1)};
+`;


### PR DESCRIPTION
Enable selection of supporting articles in Front and Clipboard for the meta edit form, watching for deletions and closing the form if needed.