### PR TITLE
Form reset now works as expected

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -15,7 +15,7 @@ import Button from 'shared/components/input/ButtonDefault';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import {
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   selectSharedState,
   articleKickerOptionsSelector
 } from 'shared/selectors/shared';
@@ -154,19 +154,10 @@ const formComponent: React.StatelessComponent<Props> = ({
     <CollectionHeadingPinline>
       Edit
       <ButtonContainer>
-        <Button
-          priority="primary"
-          onClick={onCancel}
-          type="button"
-          size="l"
-        >
+        <Button priority="primary" onClick={onCancel} type="button" size="l">
           Close
         </Button>
-        <Button
-          onClick={reset}
-          type="button"
-          size="l"
-        >
+        <Button onClick={reset} type="button" size="l">
           Discard
         </Button>
         <Button onClick={handleSubmit} disabled={pristine} size="l">
@@ -412,6 +403,7 @@ const ArticleFragmentForm = reduxForm<
   {}
 >({
   destroyOnUnmount: false,
+  enableReinitialize: true,
   onSubmit: (values: ArticleFragmentFormData, _, props: ComponentProps) => {
     const meta: ArticleFragmentMeta = getArticleFragmentMetaFromFormValues(
       values
@@ -439,25 +431,28 @@ const formContainer: React.SFC<ContainerProps> = props => (
   <ArticleFragmentForm {...props} />
 );
 
-const mapStateToProps = (state: State, props: InterfaceProps) => {
-  const valueSelector = formValueSelector(props.articleFragmentId);
-  const article = articleFromArticleFragmentSelector(
-    selectSharedState(state),
-    props.articleFragmentId
-  );
+const createMapStateToProps = () => {
+  const articleSelector = createArticleFromArticleFragmentSelector();
+  return (state: State, props: InterfaceProps) => {
+    const valueSelector = formValueSelector(props.articleFragmentId);
+    const article = articleSelector(
+      selectSharedState(state),
+      props.articleFragmentId
+    );
 
-  return {
-    initialValues: getInitialValuesForArticleFragmentForm(article),
-    kickerOptions: article
-      ? articleKickerOptionsSelector(
-          selectSharedState(state),
-          props.articleFragmentId
-        )
-      : [],
-    imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
-    imageHide: valueSelector(state, 'imageHide'),
-    imageCutoutReplace: valueSelector(state, 'imageCutoutReplace'),
-    showByline: valueSelector(state, 'showByline')
+    return {
+      initialValues: getInitialValuesForArticleFragmentForm(article),
+      kickerOptions: article
+        ? articleKickerOptionsSelector(
+            selectSharedState(state),
+            props.articleFragmentId
+          )
+        : [],
+      imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
+      imageHide: valueSelector(state, 'imageHide'),
+      imageCutoutReplace: valueSelector(state, 'imageCutoutReplace'),
+      showByline: valueSelector(state, 'showByline')
+    };
   };
 };
 
@@ -465,4 +460,4 @@ export {
   getArticleFragmentMetaFromFormValues,
   getInitialValuesForArticleFragmentForm
 };
-export default connect(mapStateToProps)(formContainer);
+export default connect(createMapStateToProps)(formContainer);

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -157,7 +157,7 @@ const formComponent: React.StatelessComponent<Props> = ({
         <Button priority="primary" onClick={onCancel} type="button" size="l">
           Close
         </Button>
-        <Button onClick={reset} type="button" size="l">
+        <Button onClick={reset} disabled={pristine} type="button" size="l">
           Discard
         </Button>
         <Button onClick={handleSubmit} disabled={pristine} size="l">

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   selectSharedState
 } from 'shared/selectors/shared';
 import { State } from 'types/State';
@@ -36,14 +36,14 @@ const ArticleDrag = ({ article }: ComponentProps) => (
   </>
 );
 
-const createMapStateToProps = () => (
-  state: State,
-  props: ContainerProps
-): { article: DerivedArticle | void } => ({
-  article: articleFromArticleFragmentSelector(
-    selectSharedState(state),
-    props.id
-  )
-});
+const createMapStateToProps = () => {
+  const articleSelector = createArticleFromArticleFragmentSelector();
+  return (
+    state: State,
+    props: ContainerProps
+  ): { article: DerivedArticle | void } => ({
+    article: articleSelector(selectSharedState(state), props.id)
+  });
+};
 
 export default connect(createMapStateToProps)(ArticleDrag);

--- a/client-v2/src/shared/components/Article.tsx
+++ b/client-v2/src/shared/components/Article.tsx
@@ -11,7 +11,7 @@ import ButtonHoverAction from 'shared/components/input/ButtonHoverAction';
 import { getPaths } from '../../util/paths';
 
 import {
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   selectSharedState
 } from '../selectors/shared';
 import { State } from '../types/State';
@@ -286,16 +286,19 @@ const ArticleComponent = ({
   );
 };
 
-const createMapStateToProps = () => (
-  state: State,
-  props: ContainerProps
-): { article: DerivedArticle | void } => ({
-  article: articleFromArticleFragmentSelector(
-    props.selectSharedState
-      ? props.selectSharedState(state)
-      : selectSharedState(state),
-    props.id
-  )
-});
+const createMapStateToProps = () => {
+  const articleSelector = createArticleFromArticleFragmentSelector();
+  return (
+    state: State,
+    props: ContainerProps
+  ): { article: DerivedArticle | void } => ({
+    article: articleSelector(
+      props.selectSharedState
+        ? props.selectSharedState(state)
+        : selectSharedState(state),
+      props.id
+    )
+  });
+};
 
 export default connect(createMapStateToProps)(ArticleComponent);

--- a/client-v2/src/shared/components/ArticlePolaroid.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroid.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import truncate from 'lodash/truncate';
 import {
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   selectSharedState
 } from '../selectors/shared';
 import { State } from '../types/State';
@@ -86,17 +86,20 @@ const ArticleComponent = ({
   );
 };
 
-const createMapStateToProps = () => (
+const createMapStateToProps = () => {
+  const articleSelector = createArticleFromArticleFragmentSelector();
+  return (
   state: State,
   props: ContainerProps
 ): { article: DerivedArticle | void } => ({
-  article: articleFromArticleFragmentSelector(
+  article: articleSelector(
     props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state),
     props.id
   )
 });
+}
 
 const mapDispatchToProps = (dispatch: Dispatch, { id }: ContainerProps) => ({
   onDelete: () => dispatch(removeArticleFragmentFromClipboard(id))

--- a/client-v2/src/shared/components/ArticlePolaroidSub.tsx
+++ b/client-v2/src/shared/components/ArticlePolaroidSub.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import truncate from 'lodash/truncate';
 import {
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   selectSharedState
 } from '../selectors/shared';
 import { State } from '../types/State';
@@ -83,17 +83,20 @@ const ArticleComponent = ({
   );
 };
 
-const createMapStateToProps = () => (
-  state: State,
-  props: ContainerProps
-): { article: DerivedArticle | void } => ({
-  article: articleFromArticleFragmentSelector(
-    props.selectSharedState
-      ? props.selectSharedState(state)
-      : selectSharedState(state),
-    props.id
-  )
-});
+const createMapStateToProps = () => {
+  const articleSelector = createArticleFromArticleFragmentSelector();
+  return (
+    state: State,
+    props: ContainerProps
+  ): { article: DerivedArticle | void } => ({
+    article: articleSelector(
+      props.selectSharedState
+        ? props.selectSharedState(state)
+        : selectSharedState(state),
+      props.id
+    )
+  });
+};
 
 const mapDispatchToProps = (
   dispatch: Dispatch,

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -1,6 +1,6 @@
 import {
   externalArticleFromArticleFragmentSelector,
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   createArticlesInCollectionGroupSelector,
   createArticlesInCollectionSelector,
   createCollectionsAsTreeSelector,
@@ -203,9 +203,10 @@ describe('Shared selectors', () => {
     });
   });
 
-  describe('articleFromArticleFragmentSelector', () => {
+  describe('createArticleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an article (externalArticle + articleFragment) referenced by the given article fragment', () => {
-      expect(articleFromArticleFragmentSelector(state, 'af1')).toEqual({
+      const selector = createArticleFromArticleFragmentSelector();
+      expect(selector(state, 'af1')).toEqual({
         id: 'ea1',
         pillarName: 'external-pillar',
         frontPublicationDate: 1,
@@ -219,7 +220,7 @@ describe('Shared selectors', () => {
         byline: 'external-byline'
       });
       expect(
-        articleFromArticleFragmentSelector(state, 'af1WithOverrides')
+        selector(state, 'af1WithOverrides')
       ).toEqual({
         id: 'ea1',
         customKicker: 'fragment-kicker',
@@ -234,7 +235,7 @@ describe('Shared selectors', () => {
         kicker: 'fragment-kicker',
         byline: 'fragment-byline'
       });
-      expect(articleFromArticleFragmentSelector(state, 'invalid')).toEqual(
+      expect(selector(state, 'invalid')).toEqual(
         undefined
       );
     });

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -48,12 +48,10 @@ const externalArticleFromArticleFragmentSelector = (
   return externalArticles[articleFragment.id];
 };
 
-const articleFromArticleFragmentSelector = (
-  state: State,
-  id: string
-): DerivedArticle | void => {
-  const externalArticle = externalArticleFromArticleFragmentSelector(state, id);
-  const articleFragment = articleFragmentSelector(state, id);
+const createArticleFromArticleFragmentSelector = () => createSelector(
+  externalArticleFromArticleFragmentSelector,
+  articleFragmentSelector,
+  (externalArticle, articleFragment) => {
   if (!externalArticle || !articleFragment) {
     return undefined;
   }
@@ -71,7 +69,7 @@ const articleFromArticleFragmentSelector = (
     tone: externalArticle.frontsMeta.tone,
     thumbnail: getThumbnail(articleFragment, externalArticle)
   };
-};
+});
 
 const articleKickerOptionsSelector = (state: State, id: string): string[] => {
   const externalArticle = externalArticleFromArticleFragmentSelector(state, id);
@@ -272,7 +270,7 @@ const createCollectionsAsTreeSelector = () =>
 
 export {
   externalArticleFromArticleFragmentSelector,
-  articleFromArticleFragmentSelector,
+  createArticleFromArticleFragmentSelector,
   articleFragmentsFromRootStateSelector,
   createArticlesInCollectionGroupSelector,
   createArticlesInCollectionSelector,


### PR DESCRIPTION
The form reset button used to reset the form to the state with which it was initially instantiated. It now reverts to the last submitted state.

To keep the reinitialisation performant, I've memoized the selector for DerivedArticles, which should probably have been happening anyway!