### PR TITLE
Reorder groups, add missing groups and display group names

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -49,7 +49,10 @@ function getCollection(collectionId: string): ThunkResult<Promise<string[]>> {
           collection,
           articleFragments,
           groups
-        } = normaliseCollectionWithNestedArticles(collectionWithDraftArticles);
+        } = normaliseCollectionWithNestedArticles(
+          collectionWithDraftArticles,
+          collectionConfig
+        );
 
         dispatch(
           batchActions([

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -26,7 +26,7 @@ import Collection from './CollectionComponents/Collection';
 import ArticleFragment from './CollectionComponents/ArticleFragment';
 import Supporting from './CollectionComponents/Supporting';
 import ArticleFragmentForm from './ArticleFragmentForm';
-import GroupDisplayComponent from 'shared/components/GroupDisplay';
+import GroupDisplay from 'shared/components/GroupDisplay';
 import SupportingLevel from 'components/clipboard/ArticleFragmentLevel';
 import GroupLevel from 'components/clipboard/GroupLevel';
 import { getFront } from 'selectors/frontsSelectors';
@@ -134,10 +134,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                   browsingStage={this.props.browsingStage}
                 >
                   {group => (
-                    <GroupDisplayComponent
-                      key={group.uuid}
-                      groupName={group.id}
-                    >
+                    <GroupDisplay key={group.uuid} groupName={group.name}>
                       <GroupLevel
                         groupId={group.uuid}
                         onMove={this.handleMove}
@@ -182,7 +179,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                           </ArticleFragment>
                         )}
                       </GroupLevel>
-                    </GroupDisplayComponent>
+                    </GroupDisplay>
                   )}
                 </Collection>
               ))}

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -33,16 +33,18 @@ function fetchFrontsConfig(): Promise<FrontsConfig> {
         }),
         {}
       ),
-      collections: Object.keys(json.collections).reduce(
-        (acc, id) => ({
+      collections: Object.keys(json.collections).reduce((acc, id) => {
+        const collection = json.collections[id];
+        const groups = collection.groups && collection.groups.slice().reverse();
+        return {
           ...acc,
           [id]: {
-            ...json.collections[id],
+            ...collection,
+            groups,
             id
           }
-        }),
-        {}
-      )
+        };
+      }, {})
     }));
 }
 

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -35,7 +35,7 @@ function fetchFrontsConfig(): Promise<FrontsConfig> {
       ),
       collections: Object.keys(json.collections).reduce((acc, id) => {
         const collection = json.collections[id];
-        const groups = collection.groups && collection.groups.slice().reverse();
+        const { groups } = collection;
         return {
           ...acc,
           [id]: {

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -33,18 +33,16 @@ function fetchFrontsConfig(): Promise<FrontsConfig> {
         }),
         {}
       ),
-      collections: Object.keys(json.collections).reduce((acc, id) => {
-        const collection = json.collections[id];
-        const { groups } = collection;
-        return {
+      collections: Object.keys(json.collections).reduce(
+        (acc, id) => ({
           ...acc,
           [id]: {
-            ...collection,
-            groups,
+            ...json.collections[id],
             id
           }
-        };
-      }, {})
+        }),
+        {}
+      )
     }));
 }
 

--- a/client-v2/src/shared/components/GroupDisplay.tsx
+++ b/client-v2/src/shared/components/GroupDisplay.tsx
@@ -3,7 +3,7 @@ import HorizontalRule from 'shared/components/layout/HorizontalRule';
 import styled from 'styled-components';
 
 interface GroupDisplayComponentProps {
-  groupName: string;
+  groupName: string | null;
   children: React.ReactNode;
 }
 

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -364,7 +364,9 @@ const liveArticle = {
   id: 'article/live/0',
   frontPublicationDate: 1,
   publishedBy: 'Computers',
-  meta: {}
+  meta: {
+    group: '1'
+  }
 };
 
 const articleWithSupporting = {
@@ -409,6 +411,13 @@ const collection = {
   displayName: 'Example Collection'
 };
 
+const collectionConfig = {
+  id: 'exampleCollection',
+  displayName: 'Example Collection',
+  type: 'any',
+  groups: ['large', 'medium', 'small']
+};
+
 const collectionWithSupportingArticles = {
   live: [
     {
@@ -442,7 +451,7 @@ const stateWithCollection: any = {
         exampleCollection: {
           id: 'exampleCollection',
           displayName: 'Example Collection',
-          live: ['abc'],
+          live: ['abc', 'def'],
           draft: [],
           previously: undefined
         }
@@ -450,10 +459,16 @@ const stateWithCollection: any = {
     },
     groups: {
       abc: {
-        id: '0',
+        id: '1',
         uuid: 'abc',
         articleFragments: [
-          '95e2bfc0-8999-4e6e-a359-19960967c1e0',
+          '95e2bfc0-8999-4e6e-a359-19960967c1e0'
+        ]
+      },
+      def: {
+        id: null,
+        uuid: 'def',
+        articleFragments: [
           '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
           '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d'
         ]
@@ -553,5 +568,6 @@ export {
   stateWithCollection,
   stateWithCollectionAndSupporting,
   liveArticle,
-  articleWithSupporting
+  articleWithSupporting,
+  collectionConfig
 };

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -184,7 +184,7 @@ describe('Shared selectors', () => {
     it('should select a collection by id, reversing the group ids if they exist', () => {
       const selector = createCollectionSelector();
       expect(selector(state, { collectionId: 'c1' })).toEqual({
-        groups: ['group2', 'group1'],
+        groups: ['group1', 'group2'],
         live: ['g1', 'g2'],
         id: 'c1'
       });

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -181,7 +181,7 @@ const stateWithSupportingArticles: any = {
 
 describe('Shared selectors', () => {
   describe('createCollectionSelector', () => {
-    it('should select a collection by id, reversing the group ids if they exist', () => {
+    it('should select a collection by id', () => {
       const selector = createCollectionSelector();
       expect(selector(state, { collectionId: 'c1' })).toEqual({
         groups: ['group1', 'group2'],

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -100,9 +100,7 @@ const createCollectionSelector = () =>
       collections[id]
         ? {
             ...collections[id],
-            groups:
-              collections[id].groups &&
-              collections[id].groups!.slice().reverse()
+            groups: collections[id].groups
           }
         : undefined
   );

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -2,6 +2,7 @@ import { Diff } from 'utility-types';
 
 interface Group {
   id: string;
+  name: string | null;
   uuid: string;
   articleFragments: string[];
 }

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -17,6 +17,7 @@ interface NestedArticleFragmentRootFields {
 type NestedArticleFragment = NestedArticleFragmentRootFields & {
   meta: {
     supporting?: Array<Diff<NestedArticleFragment, { supporting: unknown }>>;
+    group?: string | null;
   };
 };
 

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -144,5 +144,17 @@ describe('Shared utilities', () => {
         )
       ).toBe(true);
     });
+
+    it('should create a single group with with all article fragments when the collection config has no groups', () => {
+      const result = normaliseCollectionWithNestedArticles(
+        collection,
+        {
+          ...collectionConfig,
+          groups: undefined
+        }
+      );
+      const groupId = result.collection.live[0];
+      expect(result.groups[groupId].articleFragments).toHaveLength(3);
+    })
   });
 });

--- a/client-v2/src/shared/util/schema.ts
+++ b/client-v2/src/shared/util/schema.ts
@@ -43,8 +43,7 @@ const articleFragments = createType('articleFragments', {
   field: createFieldType('groups', {
     key: 'meta.group',
     valueKey: 'id',
-    uuid: v4,
-    defaultValue: '0'
+    uuid: v4
   })
 });
 const supportingArticles = createType('articleFragments', {

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -25,20 +25,16 @@ const addMissingGroupsForStage = (
   entities: { [id: string]: Group },
   collectionConfig: CollectionConfig
 ) => {
-  if (collectionConfig.groups) {
-    const groups = groupIds.map(id => entities[id]);
-    const newGroups = collectionConfig.groups.map(
-      (_, i) => groupByIndex(groups, i) || createGroup(`${i}`)
-    );
+  const groups = groupIds.map(id => entities[id]);
+  const newGroups = collectionConfig.groups
+    ? collectionConfig.groups.map(
+        (_, i) => groupByIndex(groups, i) || createGroup(`${i}`)
+      )
+    : [createGroup('0')];
 
-    return {
-      newGroups: keyBy(newGroups, getUUID),
-      groupIds: newGroups.map(getUUID)
-    };
-  }
   return {
-    newGroups: {},
-    groupIds
+    newGroups: keyBy(newGroups, getUUID),
+    groupIds: newGroups.map(getUUID)
   };
 };
 

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -34,7 +34,7 @@ const addMissingGroupsForStage = (
 
   return {
     newGroups: keyBy(newGroups, getUUID),
-    groupIds: newGroups.map(getUUID)
+    groupIds: newGroups.map(getUUID).slice().reverse()
   };
 };
 

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -27,7 +27,7 @@ const groupByIndex = (groups: Group[], index: number): Group | undefined =>
 
 const getAllArticleFragments = (groups: Group[]) =>
   groups.reduce(
-    (acc, { articleFragments: afs }) => [...acc, ...afs],
+    (acc, { articleFragments }) => [...acc, ...articleFragments],
     [] as string[]
   );
 

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -45,7 +45,7 @@ const addMissingGroupsForStage = (
           ? { ...existingGroup, name }
           : createGroup(`${i}`, name);
       })
-    : [createGroup('0', '', getAllArticleFragments(groups))];
+    : [createGroup('0', null, getAllArticleFragments(groups))];
 
   return {
     newGroups: keyBy(newGroups, getUUID),

--- a/client-v2/src/util/__tests__/storeMiddleware.spec.ts
+++ b/client-v2/src/util/__tests__/storeMiddleware.spec.ts
@@ -53,7 +53,7 @@ describe('Store middleware', () => {
         mockCollectionUpdateAction({
           id: 'exampleCollection',
           displayName: 'Example Collection',
-          live: ['abc'],
+          live: ['abc', 'def'],
           draft: [],
           previously: undefined
         })


### PR DESCRIPTION
This spins groups around the right way and ensures that all groups from a collection config are shown in the tool. It also adds the group name to a `Group` when we normalise so that we can get that much more easily from anywhere in the tool.

Most of the changes were additions / updates to the test but the actual change itself (in https://github.com/guardian/facia-tool/blob/b19233595ac99be99585565fc6d36488ff52d05b/client-v2/src/shared/util/shared.ts) seems a bit verbose so feel free to make any suggestions!