### PR TITLE
Fix dropzone gap

### DIFF
--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -27,19 +27,10 @@ import ArticleFragment from './CollectionComponents/ArticleFragment';
 import Supporting from './CollectionComponents/Supporting';
 import ArticleFragmentForm from './ArticleFragmentForm';
 import GroupDisplay from 'shared/components/GroupDisplay';
-import SupportingLevel from 'components/clipboard/ArticleFragmentLevel';
+import ArticleFragmentLevel from 'components/clipboard/ArticleFragmentLevel';
 import GroupLevel from 'components/clipboard/GroupLevel';
 import { getFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
-
-const dropIndicatorStyle = {
-  marginLeft: '83px'
-};
-
-const dropZoneStyle = {
-  marginTop: '-15px',
-  padding: '3px'
-};
 
 const FrontContainer = styled('div')`
   display: flex;
@@ -154,7 +145,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                               selectedArticleFragmentId === articleFragment.uuid
                             }
                           >
-                            <SupportingLevel
+                            <ArticleFragmentLevel
                               articleFragmentId={articleFragment.uuid}
                               onMove={this.handleMove}
                               onDrop={this.handleInsert}
@@ -175,7 +166,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                   }
                                 />
                               )}
-                            </SupportingLevel>
+                            </ArticleFragmentLevel>
                           </ArticleFragment>
                         )}
                       </GroupLevel>

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -40,6 +40,10 @@ const ArticleFragmentLevel = ({
       <DropZone
         {...props}
         override={isTarget}
+        style={{
+          marginTop: '-15px',
+          padding: '3px'
+        }}
         indicatorStyle={{
           marginLeft: '20px'
         }}


### PR DESCRIPTION
Fixes a bug I introduced where drop zones were producing white gaps below the article.

Difficult to see the difference in these pics but you can spot the issue on CODE at the moment.

__Before__
<img width="593" alt="screenshot 2018-10-24 at 14 16 04" src="https://user-images.githubusercontent.com/1652187/47433055-83702b00-d797-11e8-80f0-05e3e23a10cd.png">

__After__
<img width="592" alt="screenshot 2018-10-24 at 14 16 53" src="https://user-images.githubusercontent.com/1652187/47433054-82d79480-d797-11e8-8ddd-a3c31c501cbd.png">