### PR TITLE
Fix article fetching problems

### DIFF
--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -1,5 +1,6 @@
 import { Dispatch, ThunkResult } from 'types/Store';
-import { saveClipboard, getArticles } from 'services/faciaApi';
+import { saveClipboard } from 'services/faciaApi';
+import { fetchArticles } from 'actions/Collections';
 import { actions as externalArticleActions } from 'shared/bundles/externalArticlesBundle';
 import { batchActions } from 'redux-batched-actions';
 import { articleFragmentsReceived } from 'shared/actions/ArticleFragments';
@@ -40,16 +41,7 @@ function storeClipboardContent(clipboardContent: NestedArticleFragment[]) {
     const fragmentIds = Object.values(articleFragments).map(
       fragment => fragment.id
     );
-    return getArticles(fragmentIds)
-      .catch(error => {
-        dispatch(
-          externalArticleActions.fetchError(error, 'Failed to fetch clipboard')
-        );
-        return [];
-      })
-      .then(articles => {
-        dispatch(externalArticleActions.fetchSuccess(articles));
-      });
+    return dispatch(fetchArticles(fragmentIds));
   };
 }
 

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -168,7 +168,7 @@ function getCollection(
 
 const getCapiUriForArticleIds = (articleIds: string[]) => {
   const joinedArticleIds = articleIds.join(',');
-  return `/api/preview/search?ids=${joinedArticleIds}&show-elements=video,main&show-blocks=main&show-tags=all&show-atoms=media&show-fields=internalPageCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,secureThumbnail,liveBloggingNow,membershipAccess,shortUrl`;
+  return `/api/preview/search?ids=${joinedArticleIds}&page-size=50&show-elements=video,main&show-blocks=main&show-tags=all&show-atoms=media&show-fields=internalPageCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,secureThumbnail,liveBloggingNow,membershipAccess,shortUrl`;
 };
 
 function getArticles(articleIds: string[]): Promise<ExternalArticle[]> {
@@ -187,13 +187,7 @@ function getArticles(articleIds: string[]): Promise<ExternalArticle[]> {
     throw new Error('Error getting articles from CAPI - invalid response');
   };
 
-  const articleIdsWithoutSnaps = articleIds.filter(id => !id.match(/^snap/));
-
-  if (!articleIdsWithoutSnaps.length) {
-    return Promise.resolve([]);
-  }
-
-  const articlePromises = chunk(articleIdsWithoutSnaps, 50).map(
+  const articlePromises = chunk(articleIds, 50).map(
     localArticleIds =>
       pandaFetch(getCapiUriForArticleIds(localArticleIds), {
         method: 'get',

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -1,4 +1,3 @@
-import v4 from 'uuid/v4';
 import uniqBy from 'lodash/uniqBy';
 import keyBy from 'lodash/keyBy';
 import { ArticleFragment, ArticleFragmentMeta } from 'shared/types/Collection';


### PR DESCRIPTION
We currently have three problems when fetching articles - 

- Snaplinks are filtered at the fetch level, not the thunk level, and so we aren't filtering all of our snaplinks out of CAPI requests
- Errors aren't raised when the CAPI results length doesn't match the request length, which could lead to orphaned loading states
- The pagesize is set to 10 when our requests can contain up to fifty article ids 🙃 

This PR should fix these issues, and adds regression tests.