### PR TITLE
add default meta to selector

### DIFF
--- a/client-v2/src/fixtures/articleFragment.js
+++ b/client-v2/src/fixtures/articleFragment.js
@@ -1,38 +1,26 @@
-// @flow
+const articleFragmentWithElementsThumbnailMeta = {};
 
-const articleFragmentWithElementsThumbnail = {
-  id: 'internal-code/page/5158391',
-  frontPublicationDate: 1539180309305,
-  meta: {},
-  uuid: '36a2fa8e-0e77-4f53-98d2-271282b5db70'
-};
-
-const articleFragmentWithSlideshowThumbnail = {
-  id: 'internal-code/page/5158391',
-  frontPublicationDate: 1539180309305,
-  meta: {
-    imageSlideshowReplace: true,
-    slideshow: [
-      {
-        src: 'exampleSrc1',
-        thumb: 'exampleThumbnail1',
-        width: 100,
-        height: 100,
-        origin: 'exampleOrigin1'
-      },
-      {
-        src: 'exampleSrc2',
-        thumb: 'exampleThumbnail2',
-        width: 100,
-        height: 100,
-        origin: 'exampleOrigin2'
-      }
-    ]
-  },
-  uuid: '36a2fa8e-0e77-4f53-98d2-271282b5db70'
+const articleFragmentWithSlideshowThumbnailMeta = {
+  imageSlideshowReplace: true,
+  slideshow: [
+    {
+      src: 'exampleSrc1',
+      thumb: 'exampleThumbnail1',
+      width: 100,
+      height: 100,
+      origin: 'exampleOrigin1'
+    },
+    {
+      src: 'exampleSrc2',
+      thumb: 'exampleThumbnail2',
+      width: 100,
+      height: 100,
+      origin: 'exampleOrigin2'
+    }
+  ]
 };
 
 export {
-  articleFragmentWithElementsThumbnail,
-  articleFragmentWithSlideshowThumbnail
+  articleFragmentWithElementsThumbnailMeta,
+  articleFragmentWithSlideshowThumbnailMeta
 };

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -61,6 +61,9 @@ const state: any = {
       ea1: {
         id: 'ea1',
         pillarName: 'external-pillar',
+        frontsMeta: {
+          defaults: {}
+        },
         fields: {
           headline: 'external-headline',
           trailText: 'external-trailText',
@@ -72,6 +75,9 @@ const state: any = {
       ea2: {
         id: 'ea2',
         pillarName: 'external-pillar',
+        frontsMeta: {
+          defaults: {}
+        },
         fields: {
           headline: 'external-headline',
           trailText: 'external-trailText',
@@ -83,6 +89,36 @@ const state: any = {
       ea3: {
         id: 'ea3',
         pillarName: 'external-pillar',
+        frontsMeta: {
+          defaults: {}
+        },
+        fields: {
+          headline: 'external-headline',
+          trailText: 'external-trailText',
+          byline: 'external-byline',
+        }
+      },
+      ea4: {
+        id: 'ea4',
+        pillarName: 'external-pillar',
+        frontsMeta: {
+          defaults: {
+            imageCutoutReplace: false,
+            imageHide: false,
+            imageReplace: false,
+            imageSlideshowReplace: false,
+            isBoosted: false,
+            isBreaking: false,
+            showBoostedHeadline: false,
+            showByline: false,
+            showKickerCustom: false,
+            showKickerSection: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            showMainVideo: false,
+            showQuotedHeadline: false
+          },
+        },
         fields: {
           headline: 'external-headline',
           trailText: 'external-trailText',
@@ -128,7 +164,8 @@ const state: any = {
     },
     af4: {
       uuid: 'af4',
-      meta: {}
+      meta: {},
+      id: 'ea4'
     },
     af5: {
       uuid: 'af5'
@@ -288,6 +325,35 @@ describe('Shared selectors', () => {
         kicker: 'external-pillar',
         byline: 'external-byline',
         isLive: true,
+      });
+    });
+    it('should populate default metadata correctly', () => {
+      const selector = createArticleFromArticleFragmentSelector();
+      expect(selector(state, 'af4')).toEqual({
+        id: 'ea4',
+        pillarName: 'external-pillar',
+        uuid: 'af4',
+        headline: 'external-headline',
+        thumbnail: undefined,
+        trailText: 'external-trailText',
+        kicker: 'external-pillar',
+        byline: 'external-byline',
+        isLive: true,
+        imageCutoutReplace: false,
+        imageHide: false,
+        imageReplace: false,
+        imageSlideshowReplace: false,
+        isBoosted: false,
+        isBreaking: false,
+        showBoostedHeadline: false,
+        showByline: false,
+        showKickerCustom: false,
+        showKickerSection: false,
+        showKickerTag: false,
+        showLivePlayable: false,
+        showMainVideo: false,
+        showQuotedHeadline: false,
+
       });
     });
   });

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -54,11 +54,13 @@ const createArticleFromArticleFragmentSelector = () =>
         return undefined;
       }
 
+      const articleMeta = {...externalArticle.frontsMeta.defaults, ...articleFragment.meta};
+
       return {
         ...omit(externalArticle, 'fields', 'frontsMeta'),
         ...externalArticle.fields,
         ...omit(articleFragment, 'meta'),
-        ...articleFragment.meta,
+        ...articleMeta,
         headline:
           articleFragment.meta.headline || externalArticle.fields.headline,
         trailText:
@@ -66,7 +68,7 @@ const createArticleFromArticleFragmentSelector = () =>
         byline: articleFragment.meta.byline || externalArticle.fields.byline,
         kicker: articleFragment.meta.customKicker || externalArticle.pillarName,
         pillarId: externalArticle.pillarId,
-        thumbnail: getThumbnail(articleFragment, externalArticle),
+        thumbnail: getThumbnail(externalArticle, articleMeta),
         isLive: externalArticle.fields.isLive ? externalArticle.fields.isLive === 'true' : true,
         firstPublicationDate: externalArticle.fields.firstPublicationDate
       };

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -91,8 +91,23 @@ interface CapiArticle {
   fields: CapiArticleFields;
   tags?: Tag[];
   blocks: Blocks;
-  frontsMeta?: {
-    tone: string;
+  frontsMeta: {
+    defaults: {
+      imageCutoutReplace: boolean
+      imageHide: boolean
+      imageReplace: boolean
+      imageSlideshowReplace: boolean
+      isBoosted: boolean
+      isBreaking: boolean
+      showBoostedHeadline: boolean
+      showByline: boolean
+      showKickerCustom: boolean
+      showKickerSection: boolean
+      showKickerTag: boolean
+      showLivePlayable: boolean
+      showMainVideo: boolean
+      showQuotedHeadline: boolean
+    }
   };
 }
 

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -1,6 +1,7 @@
 import { Element, Tag } from 'types/Capi';
 import { ExternalArticle } from '../shared/types/ExternalArticle';
 import { ArticleFragment } from '../shared/types/Collection';
+import { ArticleFragmentMeta } from '../shared/types/Collection';
 
 const getIdFromURL = (url: string): string | null => {
   const [, id = null] =
@@ -46,10 +47,9 @@ function getContributorImage(externalArticle: ExternalArticle) {
 }
 
 function getThumbnail(
-  articleFragment: ArticleFragment,
-  externalArticle: ExternalArticle
+  externalArticle: ExternalArticle,
+  meta: ArticleFragmentMeta
 ): string | void {
-  const { meta } = articleFragment;
   const { fields } = externalArticle;
   const isReplacingImage = meta.imageReplace;
   const metaImageSrcThumb = isReplacingImage && meta.imageSrcThumb;

--- a/client-v2/src/util/__tests__/CAPIUtils.spec.js
+++ b/client-v2/src/util/__tests__/CAPIUtils.spec.js
@@ -2,8 +2,8 @@
 
 import { capiArticleWithElementsThumbnail } from 'fixtures/capiArticle';
 import {
-  articleFragmentWithElementsThumbnail,
-  articleFragmentWithSlideshowThumbnail
+  articleFragmentWithElementsThumbnailMeta,
+  articleFragmentWithSlideshowThumbnailMeta
 } from 'fixtures/articleFragment';
 import { getContributorImage, getThumbnail } from 'util/CAPIUtils';
 
@@ -19,8 +19,8 @@ describe('CAPIUtils', () => {
     it('should get a thumbnail from article elements', () => {
       expect(
         getThumbnail(
-          articleFragmentWithElementsThumbnail,
-          capiArticleWithElementsThumbnail
+          capiArticleWithElementsThumbnail,
+          articleFragmentWithElementsThumbnailMeta
         )
       ).toEqual(
         'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/500.jpg'
@@ -29,20 +29,17 @@ describe('CAPIUtils', () => {
     it('should get a thumbnail from articleFragmentMeta slideshows if imageSlideshowReplace is true', () => {
       expect(
         getThumbnail(
-          articleFragmentWithSlideshowThumbnail,
-          capiArticleWithElementsThumbnail
+          capiArticleWithElementsThumbnail,
+          articleFragmentWithSlideshowThumbnailMeta
         )
       ).toEqual('exampleSrc1');
       expect(
         getThumbnail(
+          capiArticleWithElementsThumbnail,
           {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageSlideshowReplace: false
-            }
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageSlideshowReplace: false
           },
-          capiArticleWithElementsThumbnail
         )
       ).toEqual(
         'https://media.guim.co.uk/6780f7f6f3dca00e549487d9ca6b7bd1cdbe1556/337_105_1313_788/500.jpg'
@@ -52,30 +49,20 @@ describe('CAPIUtils', () => {
       expect(
         getThumbnail(
           {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageCutoutReplace: true
-            }
-          },
-          {
             ...capiArticleWithElementsThumbnail,
             fields: {
               ...capiArticleWithElementsThumbnail.fields,
               thumbnail: 'fieldSrc'
             }
+          },
+          {
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageCutoutReplace: true
           }
         )
       ).toEqual('fieldSrc');
       expect(
         getThumbnail(
-          {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageCutoutReplace: true
-            }
-          },
           {
             ...capiArticleWithElementsThumbnail,
             fields: {
@@ -83,6 +70,10 @@ describe('CAPIUtils', () => {
               thumbnail: 'fieldSrc',
               secureThumbnail: 'fieldSrcSecure'
             }
+          },
+          {
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageCutoutReplace: true
           }
         )
       ).toEqual('fieldSrcSecure');
@@ -91,13 +82,6 @@ describe('CAPIUtils', () => {
       expect(
         getThumbnail(
           {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageCutoutReplace: true
-            }
-          },
-          {
             ...capiArticleWithElementsThumbnail,
             tags: [
               {
@@ -105,7 +89,11 @@ describe('CAPIUtils', () => {
                 bylineLargeImageUrl: 'contributorSrc'
               }
             ]
-          }
+          },
+          {
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageCutoutReplace: true
+          },
         )
       ).toEqual('contributorSrc');
     });
@@ -113,14 +101,6 @@ describe('CAPIUtils', () => {
       expect(
         getThumbnail(
           {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageCutoutReplace: true,
-              imageCutoutSrc: 'imageCutoutSrc'
-            }
-          },
-          {
             ...capiArticleWithElementsThumbnail,
             tags: [
               {
@@ -133,7 +113,12 @@ describe('CAPIUtils', () => {
               thumbnail: 'fieldSrc',
               secureThumbnail: 'fieldSrcSecure'
             }
-          }
+          },
+          {
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageCutoutReplace: true,
+            imageCutoutSrc: 'imageCutoutSrc'
+          },
         )
       ).toEqual('imageCutoutSrc');
     });
@@ -141,16 +126,6 @@ describe('CAPIUtils', () => {
       expect(
         getThumbnail(
           {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageReplace: true,
-              imageCutoutReplace: true,
-              imageCutoutSrc: 'imageCutoutSrc',
-              imageSrc: 'imageSrc'
-            }
-          },
-          {
             ...capiArticleWithElementsThumbnail,
             tags: [
               {
@@ -163,7 +138,14 @@ describe('CAPIUtils', () => {
               thumbnail: 'fieldSrc',
               secureThumbnail: 'fieldSrcSecure'
             }
-          }
+          },
+          {
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageReplace: true,
+            imageCutoutReplace: true,
+            imageCutoutSrc: 'imageCutoutSrc',
+            imageSrc: 'imageSrc'
+          },
         )
       ).toEqual('imageSrc');
     });
@@ -171,17 +153,6 @@ describe('CAPIUtils', () => {
       expect(
         getThumbnail(
           {
-            ...articleFragmentWithSlideshowThumbnail,
-            meta: {
-              ...articleFragmentWithSlideshowThumbnail.meta,
-              imageReplace: true,
-              imageCutoutReplace: true,
-              imageCutoutSrc: 'imageCutoutSrc',
-              imageSrc: 'imageSrc',
-              imageSrcThumb: 'imageSrcThumb'
-            }
-          },
-          {
             ...capiArticleWithElementsThumbnail,
             tags: [
               {
@@ -194,7 +165,15 @@ describe('CAPIUtils', () => {
               thumbnail: 'fieldSrc',
               secureThumbnail: 'fieldSrcSecure'
             }
-          }
+          },
+          {
+            ...articleFragmentWithSlideshowThumbnailMeta,
+            imageReplace: true,
+            imageCutoutReplace: true,
+            imageCutoutSrc: 'imageCutoutSrc',
+            imageSrc: 'imageSrc',
+            imageSrcThumb: 'imageSrcThumb'
+          },
         )
       ).toEqual('imageSrcThumb');
     });


### PR DESCRIPTION
Use capi metadata on articles. 

Behaviour is slightly different from the old tool: the old tool saves the default metadata on the article when the article is added to the collection, we only save it once we make any other metadata edits to the article. Dotcom knows how to render the defaults even without us saving them in the fronts tool so I don't see how this could be a problem.