### PR TITLE
Remove discard button and rename close button to save and discard

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -157,9 +157,6 @@ const formComponent: React.StatelessComponent<Props> = ({
         <Button priority="primary" onClick={onCancel} type="button" size="l">
           Close
         </Button>
-        <Button onClick={reset} disabled={pristine} type="button" size="l">
-          Discard
-        </Button>
         <Button onClick={handleSubmit} disabled={pristine} size="l">
           Save
         </Button>


### PR DESCRIPTION
The close button is broken - it discards and closes. As a fix I removing the discard button and renaming the close button. 

We can restore the discard button with correct behaviour later, it's not a top priority piece of functionality at the moment and will take at least an afternoon to fix. 
![screen shot 2018-10-30 at 13 36 04](https://user-images.githubusercontent.com/3066534/47721796-cbd09280-dc48-11e8-9aa6-56c897db8d2f.png)
