### PR TITLE
Use capi id for search

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -9,6 +9,7 @@ import CAPITagInput, {
   SearchTypes,
   AsyncState
 } from '../FrontsCAPIInterface/TagInput';
+import { getIdFromURL } from 'util/CAPIUtils';
 
 interface FrontsCAPISearchInputProps {
   children: any;
@@ -93,8 +94,15 @@ class FrontsCAPISearchInput extends React.Component<
   public handleSearchInput = ({
     currentTarget
   }: React.SyntheticEvent<HTMLInputElement>) => {
+
+    const targetValue = currentTarget.value;
+
+    const maybeArticleId = getIdFromURL(targetValue);
+
+    const searchTerm = maybeArticleId ? maybeArticleId : targetValue;
+
     this.setState({
-      q: currentTarget.value
+      q: searchTerm
     });
   };
 


### PR DESCRIPTION
Fixes a bug reported by AU central prod where we weren't able to search for articles by pasting a link to the story in the search bar. Once @vlbee's changes are done, we'll also be able to past viewer links to articles. 

The behaviour here is still slightly different from the old tool - in the old tool when you search by article path we only display that one article, here we display search results with that path as search term. The article searched for should still come up on top and Mariana is fine with this change. 