### PR TITLE
Make clipboard drop zone larger (and hover bug fix)

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -66,7 +66,11 @@ class Clipboard extends React.Component<ClipboardProps> {
 
   public render() {
     return (
-      <Root id="clipboard" data-testid="clipboard">
+      <Root
+        id="clipboard"
+        data-testid="clipboard"
+        style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      >
         <ClipboardLevel onMove={this.handleMove} onDrop={this.handleInsert}>
           {(articleFragment, afProps) => (
             <CollectionItem

--- a/client-v2/src/components/DropZone.tsx
+++ b/client-v2/src/components/DropZone.tsx
@@ -14,7 +14,6 @@ const DropIndicator = styled('div')`
 class DropZone extends React.Component<
   {
     onDrop: (e: React.DragEvent) => void;
-    onDragEnter: (e: React.DragEvent) => void;
     onDragOver: (e: React.DragEvent) => void;
     style: React.CSSProperties;
     indicatorStyle: React.CSSProperties;
@@ -37,7 +36,6 @@ class DropZone extends React.Component<
   }
 
   public handleDragEnter = (e: React.DragEvent) => {
-    this.props.onDragEnter(e);
     this.setState({ isHoveredOver: true });
   };
 

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -35,7 +35,14 @@ const ClipboardLevel = ({
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
     renderDrop={(props, isTarget, index) => (
-      <DropZone {...props} override={isTarget} />
+      <DropZone
+        {...props}
+        override={isTarget}
+        style={{
+          flexBasis: '15px',
+          flexGrow: articleFragments.length === index ? 1 : 0
+        }}
+      />
     )}
   >
     {children}

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -38,7 +38,6 @@ interface Move<T> {
 }
 
 interface DropProps {
-  onDragEnter: (e: React.DragEvent) => void;
   onDragOver: (e: React.DragEvent) => void;
   onDrop: (e: React.DragEvent) => void;
 }
@@ -121,7 +120,7 @@ class Level<T> extends React.Component<Props<T>> {
     return i + (isNode ? getDropIndexOffset(e) : 0);
   }
 
-  private onDragEnter = (i: number, isNode: boolean) => (
+  private onDragOver = (i: number, isNode: boolean) => (
     e: React.DragEvent
   ) => {
     if (!this.props.store) {
@@ -133,8 +132,6 @@ class Level<T> extends React.Component<Props<T>> {
     e.preventDefault();
     this.props.store.update(this.key, this.getDropIndex(e, i, isNode));
   };
-
-  private onDragOver = (e: React.DragEvent) => e.preventDefault();
 
   private onDrop = (i: number, isNode: boolean) => (e: React.DragEvent) => {
     if (e.defaultPrevented) {
@@ -175,8 +172,7 @@ class Level<T> extends React.Component<Props<T>> {
 
   private getDropProps(i: number) {
     return {
-      onDragEnter: this.onDragEnter(i, false),
-      onDragOver: this.onDragOver,
+      onDragOver: this.onDragOver(i, false),
       onDrop: this.onDrop(i, false)
     };
   }
@@ -184,8 +180,7 @@ class Level<T> extends React.Component<Props<T>> {
   private getNodeProps(i: number, props: NodeChildrenProps) {
     return {
       ...props,
-      onDragEnter: this.onDragEnter(i, true),
-      onDragOver: this.onDragOver,
+      onDragOver: this.onDragOver(i, true),
       onDrop: this.onDrop(i, true)
     };
   }

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -25,7 +25,7 @@ export default class Root extends React.Component<Props, State> {
     return (
       <div
         {...divProps}
-        onDragEnter={this.onDragEnter}
+        onDragOver={this.onDragOver}
         onDragLeave={this.onDragLeave}
         onDragEnd={this.reset}
         onDrop={this.reset}
@@ -39,7 +39,7 @@ export default class Root extends React.Component<Props, State> {
     );
   }
 
-  private onDragEnter = (e: React.DragEvent) => {
+  private onDragOver = (e: React.DragEvent) => {
     if (!e.defaultPrevented) {
       this.reset();
     }


### PR DESCRIPTION
Makes the drop zone in the clipboard expand to the size of the remaining space of the clipboard if it's not vertically full.

Also fixes a small bug where the drag and drop above / below a node wasn't changing at 50% vertically.

![drop-zone](https://user-images.githubusercontent.com/1652187/47854073-aecac980-ddd8-11e8-9567-13c0fd843853.gif)
