### PR TITLE
Add hover button - 'Add To Clipboard'

### DIFF
--- a/client-v2/.gitignore
+++ b/client-v2/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-flow-coverage
+coverage
 *.log

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';
-import { handleMove, handleInsert } from 'util/collectionUtils';
+import { handleMove, handleInsertFromEvent } from 'util/collectionUtils';
 import {
   insertClipboardArticleFragment,
   moveClipboardArticleFragment,
@@ -45,7 +45,7 @@ class Clipboard extends React.Component<ClipboardProps> {
   };
 
   public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-    handleInsert(e, insertClipboardArticleFragment, this.props.dispatch, to);
+    handleInsertFromEvent(e, insertClipboardArticleFragment, this.props.dispatch, to);
   };
 
   public removeCollectionItem = (id: string) => {

--- a/client-v2/src/components/FeedItem.tsx
+++ b/client-v2/src/components/FeedItem.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'types/Store';
 import styled from 'styled-components';
 import distanceInWords from 'date-fns/distance_in_words_to_now';
 import startCase from 'lodash/startCase';
@@ -10,8 +12,12 @@ import { HoverActionsAreaOverlay } from 'shared/components/CollectionHoverItems'
 import { HoverActionsButtonWrapper } from 'shared/components/input/HoverActionButtonWrapper';
 import {
   HoverViewButton,
-  HoverOphanButton
+  HoverOphanButton,
+  HoverAddToClipboardButton
 } from 'shared/components/input/HoverActionButtons';
+
+import { handleClipboardInsert } from 'util/collectionUtils';
+import noop from 'lodash/noop';
 
 const LinkContainer = styled('div')`
   background-color: #f6f6f6;
@@ -82,7 +88,7 @@ const Body = styled('div')`
 `;
 
 interface FeedItemProps {
-  id: string,
+  id: string;
   title: string;
   href: string;
   sectionName: string;
@@ -91,6 +97,7 @@ interface FeedItemProps {
   publicationDate?: string;
   firstPublicationDate?: string;
   isLive: boolean;
+  onAddToClipboard: (id: string) => void;
 }
 
 const dragStart = (
@@ -109,7 +116,8 @@ const FeedItem = ({
   publicationDate,
   internalPageCode,
   firstPublicationDate,
-  isLive
+  isLive,
+  onAddToClipboard = noop
 }: FeedItemProps) => (
   <Container
     data-testid="feed-item"
@@ -141,12 +149,14 @@ const FeedItem = ({
     <HoverActionsAreaOverlay justify="flex-end">
       <HoverActionsButtonWrapper
         buttons={[
+          { text: 'Clipboard', component: HoverAddToClipboardButton },
           { text: 'View', component: HoverViewButton },
           { text: 'Ophan', component: HoverOphanButton }
         ]}
         buttonProps={{
           isLive,
-          urlPath: id
+          urlPath: id,
+          onAddToClipboard: () => onAddToClipboard(id)
         }}
         toolTipPosition={'top'}
         toolTipAlign={'right'}
@@ -155,4 +165,13 @@ const FeedItem = ({
   </Container>
 );
 
-export default FeedItem;
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return {
+    onAddToClipboard: (id: string) => dispatch(handleClipboardInsert(id))
+  };
+};
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(FeedItem);

--- a/client-v2/src/components/FeedItem.tsx
+++ b/client-v2/src/components/FeedItem.tsx
@@ -18,7 +18,6 @@ import {
 
 import { insertClipboardArticleFragment } from 'actions/ArticleFragments';
 import { handleInsert } from 'util/collectionUtils';
-import { handleClipboardInsert } from 'util/collectionUtils';
 import noop from 'lodash/noop';
 
 const LinkContainer = styled('div')`
@@ -169,7 +168,8 @@ const FeedItem = ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    onAddToClipboard: (id: string) => dispatch(handleClipboardInsert(id))
+    onAddToClipboard: (id: string) =>
+      dispatch(handleInsert(id, insertClipboardArticleFragment, true))
   };
 };
 

--- a/client-v2/src/components/FeedItem.tsx
+++ b/client-v2/src/components/FeedItem.tsx
@@ -16,7 +16,8 @@ import {
   HoverAddToClipboardButton
 } from 'shared/components/input/HoverActionButtons';
 
-import { handleClipboardInsert } from 'util/collectionUtils';
+import { insertClipboardArticleFragment } from 'actions/ArticleFragments';
+import { handleInsert } from 'util/collectionUtils';
 import noop from 'lodash/noop';
 
 const LinkContainer = styled('div')`
@@ -167,7 +168,8 @@ const FeedItem = ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    onAddToClipboard: (id: string) => dispatch(handleClipboardInsert(id))
+    onAddToClipboard: (id: string) =>
+      dispatch(handleInsert(id, insertClipboardArticleFragment, true))
   };
 };
 

--- a/client-v2/src/components/FeedItem.tsx
+++ b/client-v2/src/components/FeedItem.tsx
@@ -18,6 +18,7 @@ import {
 
 import { insertClipboardArticleFragment } from 'actions/ArticleFragments';
 import { handleInsert } from 'util/collectionUtils';
+import { handleClipboardInsert } from 'util/collectionUtils';
 import noop from 'lodash/noop';
 
 const LinkContainer = styled('div')`
@@ -168,8 +169,7 @@ const FeedItem = ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    onAddToClipboard: (id: string) =>
-      dispatch(handleInsert(id, insertClipboardArticleFragment, true))
+    onAddToClipboard: (id: string) => dispatch(handleClipboardInsert(id))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -12,7 +12,7 @@ import {
 } from 'shared/types/Collection';
 import SnapLink from 'shared/components/snapLink/SnapLink';
 
-import { handleClipboardInsert } from 'util/collectionUtils'; //
+import { handleClipboardInsert } from 'util/collectionUtils';
 import noop from 'lodash/noop';
 
 interface ContainerProps {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -1,3 +1,4 @@
+import { Dispatch } from 'types/Store';
 import React from 'react';
 import { connect } from 'react-redux';
 import Article from 'shared/components/article/Article';
@@ -5,8 +6,14 @@ import { State } from 'types/State';
 import { createCollectionItemTypeSelector } from 'shared/selectors/collectionItem';
 import { selectSharedState } from 'shared/selectors/shared';
 import collectionItemTypes from 'shared/constants/collectionItemTypes';
-import { CollectionItemTypes, CollectionItemDisplayTypes } from 'shared/types/Collection';
+import {
+  CollectionItemTypes,
+  CollectionItemDisplayTypes
+} from 'shared/types/Collection';
 import SnapLink from 'shared/components/snapLink/SnapLink';
+
+import { handleClipboardInsert } from 'util/collectionUtils'; //
+import noop from 'lodash/noop';
 
 interface ContainerProps {
   isSelected?: boolean;
@@ -21,17 +28,18 @@ interface ContainerProps {
 }
 
 type ArticleContainerProps = ContainerProps & {
-  onDelete: (uuid: string) => void;
+  onAddToClipboard: (uuid: string) => void;
   type: CollectionItemTypes;
 };
 
-const CollectionItemContainer = ({
+const CollectionItem = ({
   uuid,
   isSelected,
   children,
   getNodeProps,
   onSelect,
   onDelete,
+  onAddToClipboard = noop,
   displayType,
   type,
   size
@@ -43,6 +51,7 @@ const CollectionItemContainer = ({
           id={uuid}
           {...getNodeProps()}
           onDelete={onDelete}
+          onAddToClipboard={() => onAddToClipboard(uuid)}
           onClick={() => onSelect(uuid)}
           fade={!isSelected}
           size={size}
@@ -81,6 +90,13 @@ const createMapStateToProps = () => {
   });
 };
 
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return {
+    onAddToClipboard: (id: string) => dispatch(handleClipboardInsert(id))
+  };
+};
+
 export default connect(
-  createMapStateToProps
-)(CollectionItemContainer);
+  createMapStateToProps,
+  mapDispatchToProps
+)(CollectionItem);

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -12,7 +12,8 @@ import {
 } from 'shared/types/Collection';
 import SnapLink from 'shared/components/snapLink/SnapLink';
 
-import { handleClipboardInsert } from 'util/collectionUtils';
+import { insertArticleFragment } from 'actions/ArticleFragments';
+import { handleInsert } from 'util/collectionUtils';
 import noop from 'lodash/noop';
 
 interface ContainerProps {
@@ -92,7 +93,8 @@ const createMapStateToProps = () => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    onAddToClipboard: (id: string) => dispatch(handleClipboardInsert(id))
+    onAddToClipboard: (id: string) =>
+      dispatch(handleInsert(id, insertArticleFragment))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -12,7 +12,7 @@ import {
   removeSupportingArticleFragment,
   removeGroupArticleFragment
 } from 'actions/ArticleFragments';
-import { handleMove, handleInsert } from 'util/collectionUtils';
+import { handleMove, handleInsertFromEvent } from 'util/collectionUtils';
 import { AlsoOnDetail } from 'types/Collection';
 import {
   editorSelectArticleFragment,
@@ -91,7 +91,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 
   public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-    handleInsert(e, insertArticleFragment, this.props.dispatch, to);
+    handleInsertFromEvent(e, insertArticleFragment, this.props.dispatch, to);
   };
 
   public removeCollectionItem(parentId: string, id: string) {

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -16,7 +16,10 @@ import CollectionItemContainer from '../collectionItem/CollectionItemContainer';
 import CollectionItemMetaHeading from '../collectionItem/CollectionItemMetaHeading';
 import ArticleBodyPolaroid from './ArticleBodyPolaroid';
 import ArticleBodyDefault, { ArticleBodyProps } from './ArticleBodyDefault';
-import { CollectionItemDisplayTypes, CollectionItemSizes } from 'shared/types/Collection';
+import {
+  CollectionItemDisplayTypes,
+  CollectionItemSizes
+} from 'shared/types/Collection';
 import { getPillarColor } from 'shared/util/getPillarColor';
 
 const ArticleBodyContainer = styled(CollectionItemBody)`
@@ -37,6 +40,7 @@ interface ArticleComponentProps {
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
   onDelete?: (uuid: string) => void;
   onClick?: () => void;
+  onAddToClipboard?: (id: string) => void;
 }
 
 interface ContainerProps extends ArticleComponentProps {
@@ -51,7 +55,9 @@ type ComponentProps = {
   children: React.ReactNode;
 } & ContainerProps;
 
-const articleBodyComponentMap: { [id: string]: React.ComponentType<ArticleBodyProps> } = {
+const articleBodyComponentMap: {
+  [id: string]: React.ComponentType<ArticleBodyProps>;
+} = {
   default: ArticleBodyDefault,
   polaroid: ArticleBodyPolaroid
 };
@@ -70,6 +76,7 @@ const ArticleComponent = ({
   onDrop = noop,
   onDelete = noop,
   onClick = noop,
+  onAddToClipboard = noop,
   children
 }: ComponentProps) => {
   const ArticleBody = articleBodyComponentMap[displayType];
@@ -101,7 +108,12 @@ const ArticleComponent = ({
         }}
       >
         {article && (
-          <ArticleBody {...article} size={size} onDelete={onDelete} />
+          <ArticleBody
+            {...article}
+            size={size}
+            onDelete={onDelete}
+            onAddToClipboard={onAddToClipboard}
+          />
         )}
         {!article &&
           isLoading && (
@@ -109,6 +121,7 @@ const ArticleComponent = ({
               uuid={id}
               displayPlaceholders={true}
               onDelete={onDelete}
+              onAddToClipboard={onAddToClipboard}
               size={size}
             />
           )}
@@ -118,6 +131,7 @@ const ArticleComponent = ({
               headline="Content not found"
               uuid={id}
               onDelete={onDelete}
+              onAddToClipboard={onAddToClipboard}
               size={size}
             />
           )}

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -16,7 +16,8 @@ import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
 import {
   HoverViewButton,
   HoverOphanButton,
-  HoverDeleteButton
+  HoverDeleteButton,
+  HoverAddToClipboardButton
 } from '../input/HoverActionButtons';
 import {
   HoverActionsAreaOverlay,
@@ -80,6 +81,7 @@ interface ArticleBodyProps {
   displayPlaceholders?: boolean;
   uuid: string;
   onDelete: (id: string) => void;
+  onAddToClipboard: (id: string) => void;
 }
 
 const articleBodyDefault = ({
@@ -95,7 +97,8 @@ const articleBodyDefault = ({
   isLive,
   urlPath,
   displayPlaceholders,
-  onDelete
+  onDelete,
+  onAddToClipboard
 }: ArticleBodyProps) => {
   const ArticleHeadingContainer =
     size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
@@ -184,11 +187,15 @@ const articleBodyDefault = ({
           toolTipAlign={'left'}
         />
         <HoverActionsButtonWrapper
-          buttons={[{ text: 'Delete', component: HoverDeleteButton }]}
+          buttons={[
+            { text: 'Clipboard', component: HoverAddToClipboardButton },
+            { text: 'Delete', component: HoverDeleteButton }
+          ]}
           buttonProps={{
             isLive,
             urlPath,
-            onDelete
+            onDelete,
+            onAddToClipboard
           }}
           size={size}
           toolTipPosition={'top'}

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -50,6 +50,7 @@ interface ButtonPropsFromArticle {
   isLive?: boolean;
   urlPath?: string;
   onDelete?: () => void;
+  onAddToClipboard?: () => void;
 }
 
 type ButtonProps = ButtonPropsFromArticle & ButtonPropsFromWrapper;
@@ -69,6 +70,23 @@ const HoverDeleteButton = ({
     }}
   >
     <Icon src={hoverActionIcons.delete} alt="Delete" />
+  </ActionButton>
+);
+
+const HoverAddToClipboardButton = ({
+  showToolTip,
+  hideToolTip,
+  onAddToClipboard // TODO change to CopyToClipboard
+}: ButtonProps) => (
+  <ActionButton
+    onMouseEnter={showToolTip}
+    onMouseLeave={hideToolTip}
+    onClick={e => {
+      e.stopPropagation();
+      return onAddToClipboard && onAddToClipboard(); // TODO change to CopyToClipboard
+    }}
+  >
+    <Icon src={hoverActionIcons.clipboard} alt="Add to clipboard" />
   </ActionButton>
 );
 
@@ -102,4 +120,9 @@ const HoverOphanButton = ({
     </Link>
   ) : null;
 
-export { HoverDeleteButton, HoverViewButton, HoverOphanButton };
+export {
+  HoverDeleteButton,
+  HoverViewButton,
+  HoverOphanButton,
+  HoverAddToClipboardButton
+};

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -76,14 +76,14 @@ const HoverDeleteButton = ({
 const HoverAddToClipboardButton = ({
   showToolTip,
   hideToolTip,
-  onAddToClipboard // TODO change to CopyToClipboard
+  onAddToClipboard
 }: ButtonProps) => (
   <ActionButton
     onMouseEnter={showToolTip}
     onMouseLeave={hideToolTip}
     onClick={e => {
       e.stopPropagation();
-      return onAddToClipboard && onAddToClipboard(); // TODO change to CopyToClipboard
+      return onAddToClipboard && onAddToClipboard();
     }}
   >
     <Icon src={hoverActionIcons.clipboard} alt="Add to clipboard" />

--- a/client-v2/src/util/collectionUtils.ts
+++ b/client-v2/src/util/collectionUtils.ts
@@ -125,11 +125,38 @@ const handleInsertFromEvent = (
   to: PosSpec
 ) => {
   const id = dropToArticle(e);
-  console.log('drag', id);
   if (!id) {
     return;
   }
   dispatch(handleInsert(id, insertActionCreator, true, to));
 };
 
-export { handleMove, handleInsert, handleInsertFromEvent, InsertActionCreator };
+// @todo can this be refactored into handleInsert?
+const handleClipboardInsert = (id: string): ThunkResult<void> => {
+  return (dispatch: Dispatch, getState) =>
+    // @todo could feed articles live in state/shared?
+    // addArticleFragment pulls externalArticle frag data for feedItem
+    // and adds to state/shared prior to inserting into clipboard collection
+    dispatch(addArticleFragment(id))
+      .then(fragment => {
+        let uuid;
+        if (fragment) {
+          uuid = fragment.uuid;
+        } else {
+          uuid = id;
+        }
+        dispatch(
+          insertClipboardArticleFragment(
+            'clipboard', // type: collection or clipboard
+            'clipboard', // collection id
+            articleFragmentSelector(selectSharedState(getState()), uuid),
+            0 // index
+          )
+        );
+      })
+      .catch(() => {
+        // @todo: implement once error handling is done
+      });
+};
+
+export { handleMove, handleInsert, handleClipboardInsert, InsertActionCreator };

--- a/client-v2/src/util/collectionUtils.ts
+++ b/client-v2/src/util/collectionUtils.ts
@@ -79,7 +79,6 @@ const handleInsert = (
   to: PosSpec
 ) => {
   const id = dropToArticle(e);
-  console.log('drag', id);
   if (!id) {
     return;
   }
@@ -97,24 +96,32 @@ const handleInsert = (
   );
 };
 
-function handleClipboardInsert(id: string): ThunkResult<void> {
+// @todo can this be refactored into handleInsert?
+const handleClipboardInsert = (id: string): ThunkResult<void> => {
   return (dispatch: Dispatch, getState) =>
-    // @todo is capi fetch needed here
+    // @todo could feed articles live in state/shared?
+    // addArticleFragment pulls externalArticle frag data for feedItem
+    // and adds to state/shared prior to inserting into clipboard collection
     dispatch(addArticleFragment(id))
-      // will need to check for frag in feed version
-      .then(fragment =>
+      .then(fragment => {
+        let uuid;
+        if (fragment) {
+          uuid = fragment.uuid;
+        } else {
+          uuid = id;
+        }
         dispatch(
           insertClipboardArticleFragment(
-            'clipboard', // the name of the level above
-            'clipboard',
-            articleFragmentSelector(selectSharedState(getState()), id),
-            0
+            'clipboard', // type: collection or clipboard
+            'clipboard', // collection id
+            articleFragmentSelector(selectSharedState(getState()), uuid),
+            0 // index
           )
-        )
-      )
+        );
+      })
       .catch(() => {
         // @todo: implement once error handling is done
       });
-}
+};
 
 export { handleMove, handleInsert, handleClipboardInsert, InsertActionCreator };

--- a/client-v2/src/util/collectionUtils.ts
+++ b/client-v2/src/util/collectionUtils.ts
@@ -5,7 +5,7 @@ import { Dispatch } from 'types/Store';
 import { Move, PosSpec } from 'lib/dnd';
 import { ArticleFragment } from 'shared/types/Collection';
 import { addArticleFragment } from 'shared/actions/ArticleFragments';
-
+import { insertClipboardArticleFragment } from 'actions/ArticleFragments';
 import {
   articleFragmentSelector,
   selectSharedState
@@ -125,6 +125,7 @@ const handleInsertFromEvent = (
   to: PosSpec
 ) => {
   const id = dropToArticle(e);
+  console.log('drag', id);
   if (!id) {
     return;
   }

--- a/client-v2/src/util/collectionUtils.ts
+++ b/client-v2/src/util/collectionUtils.ts
@@ -5,6 +5,11 @@ import { Dispatch } from 'types/Store';
 import { Move, PosSpec } from 'lib/dnd';
 import { ArticleFragment } from 'shared/types/Collection';
 import { addArticleFragment } from 'shared/actions/ArticleFragments';
+import { insertClipboardArticleFragment } from 'actions/ArticleFragments';
+import {
+  articleFragmentSelector,
+  selectSharedState
+} from 'shared/selectors/shared';
 
 const dropToArticle = (e: React.DragEvent): string | null => {
   const map = {
@@ -74,6 +79,7 @@ const handleInsert = (
   to: PosSpec
 ) => {
   const id = dropToArticle(e);
+  console.log('drag', id);
   if (!id) {
     return;
   }
@@ -91,4 +97,24 @@ const handleInsert = (
   );
 };
 
-export { handleMove, handleInsert, InsertActionCreator };
+function handleClipboardInsert(id: string): ThunkResult<void> {
+  return (dispatch: Dispatch, getState) =>
+    // @todo is capi fetch needed here
+    dispatch(addArticleFragment(id))
+      // will need to check for frag in feed version
+      .then(fragment =>
+        dispatch(
+          insertClipboardArticleFragment(
+            'clipboard', // the name of the level above
+            'clipboard',
+            articleFragmentSelector(selectSharedState(getState()), id),
+            0
+          )
+        )
+      )
+      .catch(() => {
+        // @todo: implement once error handling is done
+      });
+}
+
+export { handleMove, handleInsert, handleClipboardInsert, InsertActionCreator };

--- a/client-v2/src/util/collectionUtils.ts
+++ b/client-v2/src/util/collectionUtils.ts
@@ -5,7 +5,7 @@ import { Dispatch } from 'types/Store';
 import { Move, PosSpec } from 'lib/dnd';
 import { ArticleFragment } from 'shared/types/Collection';
 import { addArticleFragment } from 'shared/actions/ArticleFragments';
-import { insertClipboardArticleFragment } from 'actions/ArticleFragments';
+
 import {
   articleFragmentSelector,
   selectSharedState
@@ -131,32 +131,4 @@ const handleInsertFromEvent = (
   dispatch(handleInsert(id, insertActionCreator, true, to));
 };
 
-// @todo can this be refactored into handleInsert?
-const handleClipboardInsert = (id: string): ThunkResult<void> => {
-  return (dispatch: Dispatch, getState) =>
-    // @todo could feed articles live in state/shared?
-    // addArticleFragment pulls externalArticle frag data for feedItem
-    // and adds to state/shared prior to inserting into clipboard collection
-    dispatch(addArticleFragment(id))
-      .then(fragment => {
-        let uuid;
-        if (fragment) {
-          uuid = fragment.uuid;
-        } else {
-          uuid = id;
-        }
-        dispatch(
-          insertClipboardArticleFragment(
-            'clipboard', // type: collection or clipboard
-            'clipboard', // collection id
-            articleFragmentSelector(selectSharedState(getState()), uuid),
-            0 // index
-          )
-        );
-      })
-      .catch(() => {
-        // @todo: implement once error handling is done
-      });
-};
-
-export { handleMove, handleInsert, handleClipboardInsert, InsertActionCreator };
+export { handleMove, handleInsert, handleInsertFromEvent, InsertActionCreator };


### PR DESCRIPTION
Adds "Copy to Clipboard" hover action button functionality to both CollectionItem and FeedItem, via `handleClipboardInsert` in `collectionUtils.ts`

I tried to repurpose existing code that does the same thing for drag events, but wondering if there is a way to refactor into single `handleInsert` function  in `collectionUtils.ts`? 

Also not sure best way to handle CAPI fetch when copying from Feed vs copying from Collection.
@RichieAHB  - your thoughts would be much appreciated on this one :) 
