### PR TITLE
Duplicate platform specific containers are now cleaned up when added ...

### DIFF
--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -224,8 +224,8 @@ export default class ConfigFront extends BaseClass {
         }
         const duplicates = this.getDuplicatePlatformSpecificCollections();
         if (duplicates.length) {
-            alert('Cannot share platform-specific collections with other fronts - removing collection(s) from front \''  + this.props.webTitle() + '\' before saving');
-            duplicateCollections.forEach(c => this._depopulateCollection(c))
+            alert('Cannot share platform-specific collections with other fronts - removing collection(s) from front \'' + this.props.webTitle() + '\' before saving');
+            duplicates.forEach(c => this._depopulateCollection(c));
             // depopulateCollection takes care of persistence, so we return early here.
             return;
         }

--- a/public/src/js/models/config/front.js
+++ b/public/src/js/models/config/front.js
@@ -222,15 +222,18 @@ export default class ConfigFront extends BaseClass {
             alert('You must choose a group');
             return;
         }
-        if (this.hasDuplicatePlatformSpecificCollection()) {
-            alert('Cannot share platform-specific collections with other fronts');
+        const duplicates = this.getDuplicatePlatformSpecificCollections();
+        if (duplicates.length) {
+            alert('Cannot share platform-specific collections with other fronts - removing collection(s) from front \''  + this.props.webTitle() + '\' before saving');
+            duplicateCollections.forEach(c => this._depopulateCollection(c))
+            // depopulateCollection takes care of persistence, so we return early here.
             return;
         }
         return persistence.front.update(this);
     }
 
-    hasDuplicatePlatformSpecificCollection() {
-        return undefined !== _.find(
+     getDuplicatePlatformSpecificCollections() {
+        return _.filter(
             this.collections.items(),
             c => isPlatformSpecificCollection(c.meta.platform()) && c.parents().length > 1
         );

--- a/public/src/js/modules/grid.js
+++ b/public/src/js/modules/grid.js
@@ -4,7 +4,7 @@ import {CONST} from 'modules/vars';
 export function recordUsage(mediaId, frontId) {
     const usageData = {
         mediaId: mediaId,
-        front: frontId,
+        front: frontId
     };
 
     return request({


### PR DESCRIPTION
... as beforehand, they remained in the front and there were ways around validation, allowing fronts to be persisted in invalid states.

![fronts-probs](https://user-images.githubusercontent.com/7767575/48211570-abec4d80-e371-11e8-95d9-d7ec77fb8ce8.gif)

Tested on CODE. There aren't any tests for this yet but I'd be happy to pair with somebody to cover this case - I couldn't find any that covered similar cases.