### PR TITLE
Fix reordering not working

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -213,6 +213,10 @@ const createMoveArticleFragment = (persistTo: 'collection' | 'clipboard') => (
   }
 
   const replace = addPersistMetaToAction(replaceAction, {
+    // this serves as a reference article fragment id which the persistence can
+    // derive the collection from, otherwise it will use`id` on the action,
+    // which is a group id *not* an article fragment id
+    id,
     persistTo
   });
 


### PR DESCRIPTION
Re-ordering was not persisting due to a problem with the persist action we were using to save those updates. We run a variety of actions when deduplicating but the last action (which replaces the children of a certain level to clean up duplication) is the one that has the persist meta added to it. However this action doesn't have an `articleFragmentId` on it, so to give the persist middleware the clue it needs to find out which collection to update, we directly pass the id of the article fragment we were moving to the middleware.