### PR TITLE
Fix integration tests

### DIFF
--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -20,7 +20,7 @@ module.exports = async () =>
       res.sendFile(path.join(__dirname, './index.html'))
     );
 
-    // send all api requests to here
+    // Endpoint for api search requests here
     app.get(/\/api\/(preview|live)\/search/, (req, res) => {
       const ids = (req.query.ids || '').split(',').filter(Boolean);
       switch (ids.length) {
@@ -54,6 +54,7 @@ module.exports = async () =>
       }
     });
 
+    // Endpoint for api requests for single pieces of content
     const handler = (req, res) => {
       const match = req.params[0];
       if (!match) {

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -78,7 +78,7 @@ module.exports = async () =>
     };
     // Attempts at a capture group:
     // /api/(preview|live)/*
-    // /api/(?!preview|live)/*
+    // /api/(?:preview|live)/*
     app.get('/api/live/*', handler);
     app.get('/api/preview/*', handler);
 

--- a/client-v2/src/shared/util/url.ts
+++ b/client-v2/src/shared/util/url.ts
@@ -24,7 +24,7 @@ function getHostname(url: string) {
 }
 
 function isValidURL(url: string) {
-  return getHostname(url) !== window.location.host;
+  return getHostname(url) !== window.location.hostname;
 }
 
 function isGuardianUrl(url: string) {


### PR DESCRIPTION
... because my previous PR broke them! For two reasons:

- window.location.(hostname|name) are not the same thing, and the integration tests caught this subtle distinction 🎉 
- the CAPI response the integration tests are modelling changes when we request individual pieces of content.