### PR TITLE
Rv kicker confusions

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -36,6 +36,7 @@ const NotLiveContainer = styled(CollectionItemMetaHeading)`
 
 const KickerHeading = styled(CollectionItemHeading)`
   font-family: GHGuardianHeadline-Bold;
+  padding-right: 3px;
 `;
 
 const ArticleHeadingSmall = CollectionItemHeading.extend`
@@ -145,10 +146,11 @@ const articleBodyDefault = ({
               {size === 'default' && <TextPlaceholder width={25} />}
             </>
           )}
-          <KickerHeading style={{ color: getPillarColor(pillarId, true) }}>
-            {kicker}
-          </KickerHeading>
-          &nbsp;
+          { kicker && (
+            <KickerHeading style={{ color: getPillarColor(pillarId, true) }}>
+              {kicker}
+            </KickerHeading>
+          )}
           {size === 'default' ? (
             <CollectionItemHeading data-testid="headline">
               {headline}

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -34,11 +34,11 @@ const ArticlePolaroidComponent = ({
   displayPlaceholders,
   pillarId,
   thumbnail,
-  sectionName,
+  kicker,
   isLive
 }: ArticleBodyProps) => {
   const articleLabel =
-    getArticleLabel(firstPublicationDate, sectionName, isLive) || '';
+    getArticleLabel(firstPublicationDate, kicker, isLive) || '';
   return (
     <>
       {size === 'default' &&

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -272,7 +272,6 @@ describe('Shared selectors', () => {
         headline: 'external-headline',
         thumbnail: undefined,
         trailText: 'external-trailText',
-        kicker: 'external-pillar',
         byline: 'external-byline',
         isLive: true,
         firstPublicationDate: '2018-10-19T10:30:39Z'
@@ -308,7 +307,6 @@ describe('Shared selectors', () => {
         headline: 'external-headline',
         thumbnail: undefined,
         trailText: 'external-trailText',
-        kicker: 'external-pillar',
         byline: 'external-byline',
         isLive: false,
       });
@@ -322,7 +320,6 @@ describe('Shared selectors', () => {
         headline: 'external-headline',
         thumbnail: undefined,
         trailText: 'external-trailText',
-        kicker: 'external-pillar',
         byline: 'external-byline',
         isLive: true,
       });
@@ -336,7 +333,6 @@ describe('Shared selectors', () => {
         headline: 'external-headline',
         thumbnail: undefined,
         trailText: 'external-trailText',
-        kicker: 'external-pillar',
         byline: 'external-byline',
         isLive: true,
         imageCutoutReplace: false,

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -66,7 +66,7 @@ const createArticleFromArticleFragmentSelector = () =>
         trailText:
           articleFragment.meta.trailText || externalArticle.fields.trailText,
         byline: articleFragment.meta.byline || externalArticle.fields.byline,
-        kicker: articleFragment.meta.customKicker || externalArticle.pillarName,
+        kicker: articleFragment.meta.customKicker,
         pillarId: externalArticle.pillarId,
         thumbnail: getThumbnail(externalArticle, articleMeta),
         isLive: externalArticle.fields.isLive ? externalArticle.fields.isLive === 'true' : true,


### PR DESCRIPTION
Previously if we had no kicker on the article we'd display the pillar name in place of the kicker. On the clipboard we'd never display the kicker here, we'd only ever display the section name or draft or taken down label if the article wasn't live. Jessie pointed out that this is confusing as it was hard to tell which articles had kickers and which did not. Now we are only displaying kickers expect when an article is draft on the clipboard in which case we display the draft label. So we still have a problem on displaying kickers on the clipboard for articles which are not live. Any ideas for what to do about this?
![screen shot 2018-11-15 at 15 35 21](https://user-images.githubusercontent.com/3066534/48563394-27a74680-e8ec-11e8-9cbe-c96fe79863e2.png)
