### PR TITLE
fetch last press indicators

### DIFF
--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -75,10 +75,13 @@ function publishCollection(
           .then(([collection, lastPressed]) => {
             const lastPressedInMilliseconds = new Date(lastPressed).getTime();
             dispatch(
-              recordStaleFronts(
-                frontId,
-                isFrontStale(collection.lastUpdated, lastPressedInMilliseconds)
-              )
+              batchActions([
+                recordStaleFronts(
+                  frontId,
+                  isFrontStale(collection.lastUpdated, lastPressedInMilliseconds)
+                ),
+                fetchLastPressedSuccess(frontId, lastPressed)
+              ])
             );
           });
       })

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -46,6 +46,7 @@ const FrontsHeaderText = styled('span')`
 
 const LastPressedContainer = styled('span')`
   margin-right: 6px;
+  font-size: 10px;
 `;
 
 interface FrontsContainerProps {
@@ -80,12 +81,12 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
         this.props.selectedFront.collections
       );
     }
+    if (!this.props.lastPressed) {
+      this.props.frontsActions.fetchLastPressed(this.props.frontId);
+    }
   }
 
   public componentWillReceiveProps(nextProps: FrontsComponentProps) {
-    if (this.props.frontId !== nextProps.frontId || !this.props.lastPressed) {
-      this.props.frontsActions.fetchLastPressed(nextProps.frontId);
-    }
     // If we mounted without a front configuration,
     // fetch it when it's eventually available.
     if (!this.props.selectedFront && nextProps.selectedFront) {


### PR DESCRIPTION
The little text indicating when a front was last pressed had gone missing - this restores the text. The 'refresh it' button which exists in v1 is still not there and I think this whole thing requires UX/design work - will add a card to trello to add these. 
![screen shot 2018-11-16 at 09 40 22](https://user-images.githubusercontent.com/3066534/48613460-ac916f00-e983-11e8-89e6-6f1d7e7b7a50.png)

