### PR TITLE
Add DropDisabler component

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled, { injectGlobal, ThemeProvider } from 'styled-components';
 import { Switch, Route } from 'react-router-dom';
+import DropDisabler from './util/DropDisabler';
 
 import theme from 'shared/constants/theme';
 import { priorities } from 'constants/priorities';
@@ -84,20 +85,22 @@ const BackgroundHeader = styled('div')`
 
 const App = () => (
   <ThemeProvider theme={theme}>
-    <AppContainer>
-      <BackgroundHeader>
-        <SectionHeaderWithLogo />
-      </BackgroundHeader>
-      <Switch>
-        <Route
-          exact
-          path={`/:priority(${Object.keys(priorities).join('|')})/:frontId?`}
-          component={FrontsEdit}
-        />
-        <Route exact path="/" component={Home} />
-        <Route component={NotFound} />
-      </Switch>
-    </AppContainer>
+    <DropDisabler>
+      <AppContainer>
+        <BackgroundHeader>
+          <SectionHeaderWithLogo />
+        </BackgroundHeader>
+        <Switch>
+          <Route
+            exact
+            path={`/:priority(${Object.keys(priorities).join('|')})/:frontId?`}
+            component={FrontsEdit}
+          />
+          <Route exact path="/" component={Home} />
+          <Route component={NotFound} />
+        </Switch>
+      </AppContainer>
+    </DropDisabler>
   </ThemeProvider>
 );
 

--- a/client-v2/src/components/util/DropDisabler.tsx
+++ b/client-v2/src/components/util/DropDisabler.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface DropDisablerChildren {
+  children: React.ReactNode;
+}
+
+// This component prevents the default behaviour for drop events on this node,
+// or its child nodes. When dropping links (perhaps when missing a drop
+// zone), the default behaviour is navigating to the linked document
+const DropDisabler = ({ children }: DropDisablerChildren) => (
+  <div onDragOver={e => e.preventDefault()} onDrop={e => e.preventDefault()}>
+    {children}
+  </div>
+);
+
+export default DropDisabler;


### PR DESCRIPTION
This just means that link drops that miss their target now don't navigate to that link!

Could be worth an integration test?