### PR TITLE
Do not allow sending breaking news alerts if we are in an invalid state

### DIFF
--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -181,12 +181,16 @@ export default class Collection extends BaseClass {
 
     }
 
+    getDraftArticles() {
+        return _.chain(this.groups)
+            .map(group => group.items())
+            .flatten();
+    }
+
     addedInDraft() {
         const live = (this.raw || {}).live || [];
 
-        return _.chain(this.groups)
-            .map(group => group.items())
-            .flatten()
+        return this.getDraftArticles()
             .filter(draftArticle =>
                 !_.find(live, liveArticle => liveArticle.id === draftArticle.id())
             )
@@ -222,6 +226,10 @@ export default class Collection extends BaseClass {
 
     discardDraft() {
         this.processDraft(false);
+    }
+
+    containsEmptyAlerts() {
+        return this.front.confirmSendingAlert() && !this.addedInDraft().length;
     }
 
     processDraft(goLive, opts = {}) {

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -1,4 +1,8 @@
 <div class="collection" data-bind="ownerClass: $data">
+    <div class="collectionEditWarning" data-bind="visible: containsEmptyAlerts() && getDraftArticles().value().length > 0">
+        This story must be removed from the container before another
+        alert can be sent containing it.
+    </div>
     <div class="list-header" data-bind="
         css: {collapsed: state.collapsed() || configMeta.uneditable()}
     ">
@@ -10,9 +14,10 @@
                 <span class="tool draft-warning">Show unlaunched changes</a>
 
             <span data-bind="
-                visible: front.mode() !== 'live',
+                visible: front.mode() !== 'live' && !containsEmptyAlerts(),
                 css: {'pending': isPending()}
             ">
+
                 <a class="tool draft-publish" data-bind="
                     click: publishDraft,
                     text: getPublishText()"></a


### PR DESCRIPTION
We do not allow sending a breaking news alert twice on the same story without re-adding that story to the collection first. But currently, the UI allows the user to hit publish and send an invalid breaking news alert which will fail to be sent. This pr hides all publish buttons and displays an error message to the user if they are attempting to send the same alert twice. Will clear this with central prod and the network front editors before merging.

![screen shot 2018-11-20 at 14 51 24](https://user-images.githubusercontent.com/3066534/48781547-1edfb780-ecd4-11e8-9cd8-636749432c5f.png)
