### PR TITLE
Add snap link drag n drop integration tests

### DIFF
--- a/client-v2/integration/fixtures/snap-tag-page.js
+++ b/client-v2/integration/fixtures/snap-tag-page.js
@@ -1,0 +1,49 @@
+export default `
+<!DOCTYPE html>
+<html id="js-context" class="js-off is-not-modern id--signed-out" lang="en" data-page-path="/tone/recipes">
+<head>
+<title>Recipes | The Guardian</title>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+<meta name="format-detection" content="telephone=no"/>
+<meta name="HandheldFriendly" content="True"/>
+<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+<link rel="dns-prefetch" href="https://assets.guim.co.uk/"/>
+<link rel="dns-prefetch" href="https://i.guim.co.uk"/>
+<link rel="dns-prefetch" href="https://api.nextgen.guardianapps.co.uk"/>
+<link rel="dns-prefetch" href="https://hits-secure.theguardian.com"/>
+<link rel="dns-prefetch" href="//j.ophan.co.uk"/>
+<link rel="dns-prefetch" href="//ophan.theguardian.com"/>
+<link rel="dns-prefetch" href="//phar.gu-web.net"/>
+<link rel="dns-prefetch" href="//www.google-analytics.com"/>
+<link rel="dns-prefetch" href="//sb.scorecardresearch.com"/>
+<link rel="apple-touch-icon" sizes="152x152" href="https://assets.guim.co.uk/images/favicons/fee5e2d638d1c35f6d501fa397e53329/152x152.png"/>
+<link rel="apple-touch-icon" sizes="144x144" href="https://assets.guim.co.uk/images/favicons/1fe70b29879674433702d5266abcb0d4/144x144.png"/>
+<link rel="apple-touch-icon" sizes="120x120" href="https://assets.guim.co.uk/images/favicons/c58143bd2a5b5426b6256cd90ba6eb47/120x120.png"/>
+<link rel="apple-touch-icon" sizes="114x114" href="https://assets.guim.co.uk/images/favicons/68cbd5cf267598abd6a026f229ef6b45/114x114.png"/>
+<link rel="apple-touch-icon" sizes="72x72" href="https://assets.guim.co.uk/images/favicons/873381bf11d58e20f551905d51575117/72x72.png"/>
+<link rel="apple-touch-icon-precomposed" href="https://assets.guim.co.uk/images/favicons/6a2aa0ea5b4b6183e92d0eac49e2f58b/57x57.png"/>
+<link rel="manifest" href="/2015-06-24-manifest.json" crossorigin="use-credentials">
+<link rel="shortcut icon" type="image/png" href="https://assets.guim.co.uk/images/favicons/46bd2faa1ab438684a6d4528a655a8bd/32x32.ico"/>
+<link rel="canonical" href="https://www.theguardian.com/tone/recipes"/>
+<meta name="apple-mobile-web-app-title" content="Guardian"/>
+<meta name="application-name" content="The Guardian"/>
+<meta name="msapplication-TileColor" content="#052962"/>
+<meta name="theme-color" content="#052962">
+<meta name="msapplication-TileImage" content="https://assets.guim.co.uk/images/favicons/023dafadbf5ef53e0865e4baaaa32b3b/windows_tile_144_b.png"/>
+<meta name="apple-itunes-app" content="app-id=409128287, app-argument=https://www.theguardian.com/tone/recipes, affiliate-data=ct=newsmartappbanner&pt=304191">
+<link rel="publisher" href="https://plus.google.com/113000071431138202574"/>
+<meta name="description" content="Recipes from the Guardian"/>
+<meta property="og:url" content="http://www.theguardian.com/tone/recipes"/>
+<meta property="og:description" content="Recipes from the Guardian"/>
+<meta property="og:image" content="https://assets.guim.co.uk/images/eada8aa27c12fe2d5afa3a89d3fbae0d/fallback-logo.png"/>
+<meta property="al:ios:url" content="gnmguardian://tone/recipes?contenttype=front&amp;source=applinks"/>
+<meta property="og:type" content="website"/>
+<meta property="al:ios:app_store_id" content="409128287"/>
+<meta property="fb:app_id" content="180444840287"/>
+<meta property="al:ios:app_name" content="The Guardian"/>
+<meta property="og:site_name" content="the Guardian"/>
+<meta name="twitter:app:id:iphone" content="409128287"/>
+</head>
+<body></body>
+</html>`;

--- a/client-v2/integration/fixtures/snap-tag.js
+++ b/client-v2/integration/fixtures/snap-tag.js
@@ -1,0 +1,3394 @@
+module.exports = {
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 9105,
+    "startIndex": 1,
+    "pageSize": 2,
+    "currentPage": 1,
+    "pages": 4553,
+    "orderBy": "newest",
+    "tag": {
+      "id": "tone/recipes",
+      "type": "tone",
+      "webTitle": "Recipes",
+      "webUrl": "https://www.theguardian.com/tone/recipes",
+      "apiUrl": "https://preview.content.guardianapis.com/tone/recipes"
+    },
+    "results": [
+      {
+        "id": "food/2018/nov/24/pear-recipes-cheesecake-choc-chip-cookie-ginger-cake-yotam-ottolenghi",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2018-11-20T13:40:01Z",
+        "webTitle": "Yotam Ottolenghiâ€™s pear recipes",
+        "webUrl": "https://www.theguardian.com/food/2018/nov/24/pear-recipes-cheesecake-choc-chip-cookie-ginger-cake-yotam-ottolenghi",
+        "apiUrl": "https://preview.content.guardianapis.com/food/2018/nov/24/pear-recipes-cheesecake-choc-chip-cookie-ginger-cake-yotam-ottolenghi",
+        "fields": {
+          "headline": "Yotam Ottolenghiâ€™s pear recipes",
+          "trailText": "Pears make the perfect autumn dessert by themselves, but are stellar in a cheesecake, a gooey cookie and a moist ginger cake",
+          "byline": "Yotam Ottolenghi",
+          "internalPageCode": "5345934",
+          "scheduledPublicationDate": "2018-11-24T09:30:00Z",
+          "shortUrl": "https://gu.com/p/axg6f",
+          "thumbnail": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_380_4241_2544/500.jpg",
+          "isLive": "false"
+        },
+        "tags": [
+          {
+            "id": "food/series/yotam-ottolenghi-recipes",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Yotam Ottolenghi recipes",
+            "webUrl": "https://www.theguardian.com/food/series/yotam-ottolenghi-recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/yotam-ottolenghi-recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/fruit",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Fruit",
+            "webUrl": "https://www.theguardian.com/food/fruit",
+            "apiUrl": "https://preview.content.guardianapis.com/food/fruit",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/yotamottolenghi",
+            "type": "contributor",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Yotam Ottolenghi",
+            "webUrl": "https://www.theguardian.com/profile/yotamottolenghi",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/yotamottolenghi",
+            "references": [
+              
+            ],
+            "bio": "<p>Yotam Ottolenghi&nbsp;is\n chef-patron of the Ottolenghi delis and NOPI restaurant. He has \npublished six bestselling cookbooks: Plenty and Plenty More; Ottolenghi:\n The Cookbook and Jerusalem, co-authored with Sami Tamimi; The NOPI \nCookbook, co-authored with Ramael Scully, and his latest book, <a href=\"https://www.guardianbookshop.com/sweet-513805.html\">Sweet</a>, \nco-written with Helen Goh</p>",
+            "bylineImageUrl": "https://uploads.guim.co.uk/2017/09/27/Yotam-Ottolenghi.jpg",
+            "firstName": "ottolenghi",
+            "lastName": "",
+            "twitterHandle": "ottolenghi",
+            "r2ContributorId": "25460"
+          },
+          {
+            "id": "publication/theguardian",
+            "type": "publication",
+            "sectionId": "theguardian",
+            "sectionName": "From the Guardian",
+            "webTitle": "The Guardian",
+            "webUrl": "https://www.theguardian.com/theguardian/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theguardian",
+            "references": [
+              
+            ],
+            "description": "All the latest from the world's leading liberal voice."
+          },
+          {
+            "id": "theguardian/feast",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Feast",
+            "webUrl": "https://www.theguardian.com/theguardian/feast",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/feast",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theguardian/feast/feast",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Feast",
+            "webUrl": "https://www.theguardian.com/theguardian/feast/feast",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/feast/feast",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tracking/commissioningdesk/feast",
+            "type": "tracking",
+            "webTitle": "UK Feast",
+            "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/feast",
+            "apiUrl": "https://preview.content.guardianapis.com/tracking/commissioningdesk/feast",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "5bf3f616e4b07e5fcd49e579",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"28fe956489ad6432aedcd3cf99da239ba6084ce7\"> <img src=\"https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/1000.jpg\" alt=\"Yotam Ottolenghiâ€™s white chocolate and pear cookies with lime and cardamom.\" width=\"1000\" height=\"851\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Yotam Ottolenghiâ€™s white chocolate and pear cookies with lime and cardamom. Photographs by Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay.</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2018-11-20T11:55:02Z",
+            "lastModifiedDate": "2018-11-20T11:56:26Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "dave.hall@guardian.co.uk",
+              "firstName": "Dave",
+              "lastName": "Hall"
+            },
+            "lastModifiedBy": {
+              "email": "dave.hall@guardian.co.uk",
+              "firstName": "Dave",
+              "lastName": "Hall"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/2000.jpg",
+                    "typeData": {
+                      "width": 2000,
+                      "height": 1702
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/1000.jpg",
+                    "typeData": {
+                      "width": 1000,
+                      "height": 851
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/500.jpg",
+                    "typeData": {
+                      "width": 500,
+                      "height": 425
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/140.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 119
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/4241.jpg",
+                    "typeData": {
+                      "width": 4241,
+                      "height": 3609
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/28fe956489ad6432aedcd3cf99da239ba6084ce7/0_0_4241_3609/master/4241.jpg",
+                    "typeData": {
+                      "width": 4241,
+                      "height": 3609,
+                      "isMaster": true
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Yotam Ottolenghiâ€™s white chocolate and pear cookies with lime and cardamom. Photographs by Louise Hagger for the Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay.",
+                  "copyright": "Louise Hagger",
+                  "displayCredit": false,
+                  "credit": "Photograph: Louise Hagger/The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay.",
+                  "source": "The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay.",
+                  "photographer": "Louise Hagger",
+                  "alt": "Yotam Ottolenghiâ€™s white chocolate and pear cookies with lime and cardamom.",
+                  "mediaId": "28fe956489ad6432aedcd3cf99da239ba6084ce7",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/28fe956489ad6432aedcd3cf99da239ba6084ce7",
+                  "suppliersReference": "White chocolate and pear cookies with cardamom & lime",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "food/2018/nov/20/sri-lankan-curry-chicken-sweet-potato-peas",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2018-11-20T13:14:03Z",
+        "webTitle": "Sri Lankan inspired chicken curry, with sweet potato and peas",
+        "webUrl": "https://www.theguardian.com/food/2018/nov/20/sri-lankan-curry-chicken-sweet-potato-peas",
+        "apiUrl": "https://preview.content.guardianapis.com/food/2018/nov/20/sri-lankan-curry-chicken-sweet-potato-peas",
+        "fields": {
+          "headline": "Sri Lankan inspired chicken curry, with sweet potato and peas",
+          "trailText": "This curry is full of flavour and makes the most of whatever vegetables you have in the fridge",
+          "byline": "Yohini Nandakumar",
+          "internalPageCode": "5346075",
+          "shortUrl": "https://gu.com/p/axgby",
+          "thumbnail": "https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/49_0_982_589/500.jpg",
+          "isLive": "false"
+        },
+        "tags": [
+          {
+            "id": "food/series/fast-food",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Fast food",
+            "webUrl": "https://www.theguardian.com/food/series/fast-food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/fast-food",
+            "references": [
+              
+            ],
+            "description": "<p>Top chefs choose their favourite quick'n'easy meals</p>"
+          },
+          {
+            "id": "food/fast-food",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Fast food",
+            "webUrl": "https://www.theguardian.com/food/fast-food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/fast-food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "publication/theguardian",
+            "type": "publication",
+            "sectionId": "theguardian",
+            "sectionName": "From the Guardian",
+            "webTitle": "The Guardian",
+            "webUrl": "https://www.theguardian.com/theguardian/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theguardian",
+            "references": [
+              
+            ],
+            "description": "All the latest from the world's leading liberal voice."
+          },
+          {
+            "id": "theguardian/g2",
+            "type": "newspaper-book",
+            "sectionId": "theguardian",
+            "sectionName": "From the Guardian",
+            "webTitle": "G2",
+            "webUrl": "https://www.theguardian.com/theguardian/g2",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/g2",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theguardian/g2/features",
+            "type": "newspaper-book-section",
+            "sectionId": "theguardian",
+            "sectionName": "From the Guardian",
+            "webTitle": "Comment & features",
+            "webUrl": "https://www.theguardian.com/theguardian/g2/features",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/g2/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tracking/commissioningdesk/uk-g2-features",
+            "type": "tracking",
+            "webTitle": "UK G2 Features",
+            "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-g2-features",
+            "apiUrl": "https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-g2-features",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "5bf4003de4b07e5fcd49e620",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"62686ecf0755985b923912924666bf060f8e8dac\"> <img src=\"https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/0_0_1050_589/1000.jpg\" alt=\"Yohini Nandakumarâ€™s Sri Lankan inspired chicken curry, with sweet potato and pea.\" width=\"1000\" height=\"561\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Yohini Nandakumarâ€™s Sri Lankan inspired chicken curry, with sweet potato and peas.</span> <span class=\"element-image__credit\">Photograph: PR</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2018-11-20T12:38:21Z",
+            "lastModifiedDate": "2018-11-20T12:53:56Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "edward.henderson@guardian.co.uk",
+              "firstName": "Edward",
+              "lastName": "Henderson"
+            },
+            "lastModifiedBy": {
+              "email": "edward.henderson@guardian.co.uk",
+              "firstName": "Edward",
+              "lastName": "Henderson"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/0_0_1050_589/1000.jpg",
+                    "typeData": {
+                      "width": 1000,
+                      "height": 561
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/0_0_1050_589/500.jpg",
+                    "typeData": {
+                      "width": 500,
+                      "height": 280
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/0_0_1050_589/140.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 79
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/0_0_1050_589/1050.jpg",
+                    "typeData": {
+                      "width": 1050,
+                      "height": 589
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/62686ecf0755985b923912924666bf060f8e8dac/0_0_1050_589/master/1050.jpg",
+                    "typeData": {
+                      "width": 1050,
+                      "height": 589,
+                      "isMaster": true
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Yohini Nandakumarâ€™s Sri Lankan inspired chicken curry, with sweet potato and peas.",
+                  "displayCredit": true,
+                  "credit": "Photograph: PR",
+                  "source": "PR",
+                  "alt": "Yohini Nandakumarâ€™s Sri Lankan inspired chicken curry, with sweet potato and pea.",
+                  "mediaId": "62686ecf0755985b923912924666bf060f8e8dac",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/62686ecf0755985b923912924666bf060f8e8dac",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      }
+    ],
+    "leadContent": [
+      {
+        "id": "global/2018/aug/12/liam-charles-recipe-knickerbocker-glory-cheesecake",
+        "type": "article",
+        "sectionId": "global",
+        "sectionName": "Global",
+        "webPublicationDate": "2018-08-12T05:00:55Z",
+        "webTitle": "Liam Charlesâ€™s recipe for knickerbocker glory cheesecake",
+        "webUrl": "https://www.theguardian.com/global/2018/aug/12/liam-charles-recipe-knickerbocker-glory-cheesecake",
+        "apiUrl": "https://preview.content.guardianapis.com/global/2018/aug/12/liam-charles-recipe-knickerbocker-glory-cheesecake",
+        "fields": {
+          "headline": "Liam Charlesâ€™s recipe for knickerbocker glory cheesecake",
+          "trailText": "<strong>The sweet spot</strong> This mashup of a bake has evolved from ice-cream van to dessert showstopper â€“ and still has the sprinkles ",
+          "byline": "Liam Charles",
+          "firstPublicationDate": "2018-08-12T05:00:55Z",
+          "internalPageCode": "4895495",
+          "shortUrl": "https://gu.com/p/95j9h",
+          "thumbnail": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_739_3685_2210/500.jpg",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/baking",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Baking",
+            "webUrl": "https://www.theguardian.com/food/baking",
+            "apiUrl": "https://preview.content.guardianapis.com/food/baking",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/dessert",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Dessert",
+            "webUrl": "https://www.theguardian.com/food/dessert",
+            "apiUrl": "https://preview.content.guardianapis.com/food/dessert",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/series/the-sweet-spot",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "The sweet spot",
+            "webUrl": "https://www.theguardian.com/food/series/the-sweet-spot",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/the-sweet-spot",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/liam-charles",
+            "type": "contributor",
+            "webTitle": "Liam Charles",
+            "webUrl": "https://www.theguardian.com/profile/liam-charles",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/liam-charles",
+            "references": [
+              
+            ],
+            "bio": "<p>Liam Charles presents Bake Off: The Professionals on Channel 4. He was also a contestant in the 2017 series of The Great British Bake Off.&nbsp;</p>",
+            "bylineImageUrl": "https://uploads.guim.co.uk/2018/07/11/LIAM_CHARLES.jpg",
+            "firstName": "Liam",
+            "lastName": "Charles",
+            "twitterHandle": "LiamcBakes",
+            "r2ContributorId": "82866"
+          },
+          {
+            "id": "publication/theguardian",
+            "type": "publication",
+            "sectionId": "theguardian",
+            "sectionName": "From the Guardian",
+            "webTitle": "The Guardian",
+            "webUrl": "https://www.theguardian.com/theguardian/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theguardian",
+            "references": [
+              
+            ],
+            "description": "All the latest from the world's leading liberal voice."
+          },
+          {
+            "id": "theguardian/feast",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Feast",
+            "webUrl": "https://www.theguardian.com/theguardian/feast",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/feast",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theguardian/feast/feast",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Feast",
+            "webUrl": "https://www.theguardian.com/theguardian/feast/feast",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/feast/feast",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tracking/commissioningdesk/feast",
+            "type": "tracking",
+            "webTitle": "UK Feast",
+            "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/feast",
+            "apiUrl": "https://preview.content.guardianapis.com/tracking/commissioningdesk/feast",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "5b69ba05e4b07edd55384670",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"3b3eecfeded2d76cc331b67111a6b277dfbfd11a\"> <img src=\"https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/1000.jpg\" alt=\"Liam Charlesâ€™s knickerbocker glory cheesecake.\" width=\"1000\" height=\"792\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Liam Charlesâ€™s knickerbocker glory cheesecake.</span> <span class=\"element-image__credit\">Photograph: Louise Hagger/The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay. Food Assistant: Katy Gilhooly</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2018-08-07T15:25:57Z",
+            "lastModifiedDate": "2018-08-07T15:26:36Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "lola.oduba-vine@guardian.co.uk",
+              "firstName": "Lola",
+              "lastName": "Oduba"
+            },
+            "lastModifiedBy": {
+              "email": "lola.oduba-vine@guardian.co.uk",
+              "firstName": "Lola",
+              "lastName": "Oduba"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/2000.jpg",
+                    "typeData": {
+                      "width": 2000,
+                      "height": 1585
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/1000.jpg",
+                    "typeData": {
+                      "width": 1000,
+                      "height": 792
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/500.jpg",
+                    "typeData": {
+                      "width": 500,
+                      "height": 396
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/140.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 111
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/3685.jpg",
+                    "typeData": {
+                      "width": 3685,
+                      "height": 2920
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://media.guim.co.uk/3b3eecfeded2d76cc331b67111a6b277dfbfd11a/0_628_3685_2920/master/3685.jpg",
+                    "typeData": {
+                      "width": 3685,
+                      "height": 2920,
+                      "isMaster": true
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Liam Charlesâ€™s knickerbocker glory cheesecake.",
+                  "copyright": "Louise Hagger",
+                  "displayCredit": true,
+                  "credit": "Photograph: Louise Hagger/The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay. Food Assistant: Katy Gilhooly",
+                  "source": "The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay. Food Assistant: Katy Gilhooly",
+                  "photographer": "Louise Hagger",
+                  "alt": "Liam Charlesâ€™s knickerbocker glory cheesecake.",
+                  "mediaId": "3b3eecfeded2d76cc331b67111a6b277dfbfd11a",
+                  "mediaApiUri": "https://api.media.gutools.co.uk/images/3b3eecfeded2d76cc331b67111a6b277dfbfd11a",
+                  "suppliersReference": "Knickerbocker glory Cheesecake",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/feb/20/squash-soup-recipe-mexican-tuscan-or-thai-back-to-basics-henry-dimbleby-jane-baxter",
+        "type": "article",
+        "sectionId": "global",
+        "sectionName": "Global",
+        "webPublicationDate": "2015-02-20T12:15:00Z",
+        "webTitle": "Soup up your squash and give it some added kick",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/feb/20/squash-soup-recipe-mexican-tuscan-or-thai-back-to-basics-henry-dimbleby-jane-baxter",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/feb/20/squash-soup-recipe-mexican-tuscan-or-thai-back-to-basics-henry-dimbleby-jane-baxter",
+        "fields": {
+          "headline": "Soup up your squash and give it some added kick",
+          "trailText": "<strong>Back to Basics: </strong>Soup is the most adaptable dish, in which a tiny tweak can produce any number of variations. Take the humble squash for instance...",
+          "byline": "Henry Dimbleby and Jane Baxter",
+          "firstPublicationDate": "2015-02-20T12:15:00Z",
+          "internalPageCode": "2244468",
+          "shortUrl": "https://gu.com/p/46vmc",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/series/back-to-basics",
+            "type": "series",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Back to basics",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/series/back-to-basics",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/series/back-to-basics",
+            "references": [
+              
+            ],
+            "description": "Aimed at helping kids, students and anyone else who's a bit nervous in the kitchen to get a few basic tools in their belt"
+          },
+          {
+            "id": "food/soup",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Soup",
+            "webUrl": "https://www.theguardian.com/food/soup",
+            "apiUrl": "https://preview.content.guardianapis.com/food/soup",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/henry-dimbleby",
+            "type": "contributor",
+            "webTitle": "Henry Dimbleby",
+            "webUrl": "https://www.theguardian.com/profile/henry-dimbleby",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/henry-dimbleby",
+            "references": [
+              
+            ],
+            "bio": "<p>Henry Dimbleby is a regular columnist for Cook and co-founder of the natural fast-food restaurant chain Leon.</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/2/10/1392050666963/HenryDimbleby.png",
+            "firstName": "dimbleby",
+            "lastName": "henry",
+            "twitterHandle": "HenryDimbleby",
+            "r2ContributorId": "35217"
+          },
+          {
+            "id": "profile/jane-baxter",
+            "type": "contributor",
+            "webTitle": "Jane Baxter",
+            "webUrl": "https://www.theguardian.com/profile/jane-baxter",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/jane-baxter",
+            "references": [
+              
+            ],
+            "bio": "<p>Chef and food writer Jane Baxter is a regular columnist for Cook. She trained at the Carved Angel under Joyce Molyneux before moving to the River CafÃ©, and in 2005 she set up the acclaimed <a href=\"http://www.theguardian.com/lifeandstyle/2007/sep/01/foodanddrink.restaurants\">Riverford Field Kitchen</a>. She currently runs food and event company <a href=\"http://www.wildartichokes.co.uk\">Wild Artichokes</a>, based in Devon, and her latest book, co-written with Henry Dimbleby, is <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781840916102\">Leon: Fast Vegetarian</a>.</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/12/1294851249814/Chef-Jane-Baxter-003.jpg",
+            "firstName": "baxter",
+            "lastName": "jane",
+            "twitterHandle": "baxcooka",
+            "r2ContributorId": "38982"
+          },
+          {
+            "id": "publication/theguardian",
+            "type": "publication",
+            "sectionId": "theguardian",
+            "sectionName": "From the Guardian",
+            "webTitle": "The Guardian",
+            "webUrl": "https://www.theguardian.com/theguardian/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theguardian",
+            "references": [
+              
+            ],
+            "description": "All the latest from the world's leading liberal voice."
+          },
+          {
+            "id": "theguardian/cook",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Cook",
+            "webUrl": "https://www.theguardian.com/theguardian/cook",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/cook",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theguardian/cook/cook",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Cook",
+            "webUrl": "https://www.theguardian.com/theguardian/cook/cook",
+            "apiUrl": "https://preview.content.guardianapis.com/theguardian/cook/cook",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "54e5bfdce4b079e91c6d631c",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"99c61b730930025f78de50287525cf5cc6da6b3d\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343001237/dc34da06-e0ab-4c1e-9e10-633a640c0697-460x276.jpeg\" alt=\"Squash soup\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Take a basic squash soup â€¦ and tart it up with some orange and cardomom.</span> <span class=\"element-image__credit\">Photograph: Jill Mead for the Guardian</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-02-19T10:50:04Z",
+            "lastModifiedDate": "2015-02-19T10:50:04Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "pas.paschali.casual@guardian.co.uk",
+              "firstName": "Pas",
+              "lastName": "Paschali (Casual)"
+            },
+            "lastModifiedBy": {
+              "email": "pas.paschali.casual@guardian.co.uk",
+              "firstName": "Pas",
+              "lastName": "Paschali (Casual)"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343000974/4f8b17af-45be-42ea-a758-1f99cb85c5bb-220x132.jpeg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132,
+                      "name": "220x132"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343001237/dc34da06-e0ab-4c1e-9e10-633a640c0697-460x276.jpeg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276,
+                      "name": "460x276"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343001440/b00bc02e-46f3-4f2b-8982-51e8f7053d58-540x324.jpeg",
+                    "typeData": {
+                      "width": 540,
+                      "height": 324,
+                      "name": "540x324"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343001638/9be7726c-b092-40b8-94a7-6c1abc3f2cf1-140x84.jpeg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84,
+                      "name": "140x84"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343001897/f947738d-16d6-44ae-9f57-4fa34e57ff40-1020x612.jpeg",
+                    "typeData": {
+                      "width": 1020,
+                      "height": 612,
+                      "name": "1020x612"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343002196/f6e44ac2-c328-4ce4-baae-b0adc233c2cb-300x180.jpeg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180,
+                      "name": "300x180"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343002340/07db7c60-f00d-48a6-a2c7-96eca47b6f3c-380x228.jpeg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228,
+                      "name": "380x228"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343002517/4ca4ea40-7b68-44df-a416-97585f4087b1-620x372.jpeg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372,
+                      "name": "620x372"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/19/1424343003210/e86b324d-711e-4989-a741-30b8026adf49-2060x1236.jpeg",
+                    "typeData": {
+                      "width": 2060,
+                      "height": 1236,
+                      "name": "2060x1236"
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Take a basic squash soup â€¦ and tart it up with some orange and cardomom.",
+                  "displayCredit": true,
+                  "credit": "Photograph: Jill Mead for the Guardian",
+                  "source": "The Guardian",
+                  "photographer": "Jill Mead",
+                  "alt": "Squash soup",
+                  "mediaId": "99c61b730930025f78de50287525cf5cc6da6b3d",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/feb/10/nigel-slater-hasselback-potatoes-baked-cheese-ham-recipe",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-02-10T12:00:07Z",
+        "webTitle": "Nigel Slaterâ€™s hasselback potatoes, baked cheese and ham recipe",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/feb/10/nigel-slater-hasselback-potatoes-baked-cheese-ham-recipe",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/feb/10/nigel-slater-hasselback-potatoes-baked-cheese-ham-recipe",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s hasselback potatoes, baked cheese and ham recipe",
+          "trailText": "A hot and crispy, salty and satisfying easy meal from<strong> Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-02-10T12:00:07Z",
+          "internalPageCode": "2235132",
+          "shortUrl": "https://gu.com/p/45fvt",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slaters-midweek-dinner",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater's midweek dinner",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slaters-midweek-dinner",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slaters-midweek-dinner",
+            "references": [
+              
+            ],
+            "description": "<p>Nigel Slater reveals how to make a special yet simple midweek dinner</p>"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/potatoes",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Potatoes",
+            "webUrl": "https://www.theguardian.com/food/potatoes",
+            "apiUrl": "https://preview.content.guardianapis.com/food/potatoes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "66e67697-b862-43ce-919a-995e9c3b8d9b",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"285a7337ff9c7e4abbcd985f5419e998a2ef5e0e\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242637575/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-460x276.jpeg\" alt=\"Sliced hasselback potatoes with ham and cheese on a board\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Easy does it: Nigel Slaterâ€™s hasselback potatoes recipe.</span> <span class=\"element-image__credit\">Photograph: Jonathan Lovekin/Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-02-03T16:02:05Z",
+            "lastModifiedDate": "2015-02-06T17:10:40Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "lastModifiedBy": {
+              "email": "chris.pearson@guardian.co.uk",
+              "firstName": "Chris",
+              "lastName": "Pearson"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242637385/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-220x132.jpeg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132,
+                      "name": "220x132"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242637575/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-460x276.jpeg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276,
+                      "name": "460x276"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242637742/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-540x324.jpeg",
+                    "typeData": {
+                      "width": 540,
+                      "height": 324,
+                      "name": "540x324"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242637891/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-140x84.jpeg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84,
+                      "name": "140x84"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242638188/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-1020x612.jpeg",
+                    "typeData": {
+                      "width": 1020,
+                      "height": 612,
+                      "name": "1020x612"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242638479/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-300x180.jpeg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180,
+                      "name": "300x180"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242638637/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-380x228.jpeg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228,
+                      "name": "380x228"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242638871/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-620x372.jpeg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372,
+                      "name": "620x372"
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/6/1423242639408/b634a73a-d8cf-42d2-aefe-6ee0685fcb50-2060x1236.jpeg",
+                    "typeData": {
+                      "width": 2060,
+                      "height": 1236,
+                      "name": "2060x1236"
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Easy does it: Nigel Slaterâ€™s hasselback potatoes recipe.",
+                  "displayCredit": true,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Sliced hasselback potatoes with ham and cheese on a board",
+                  "mediaId": "285a7337ff9c7e4abbcd985f5419e998a2ef5e0e",
+                  "picdarUrn": "GD*49835047",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/feb/08/nigel-slater-valentines-day-cake-recipes",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-02-08T13:00:03Z",
+        "webTitle": "Nigel Slaterâ€™s Valentineâ€™s Day cake recipes",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/feb/08/nigel-slater-valentines-day-cake-recipes",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/feb/08/nigel-slater-valentines-day-cake-recipes",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s Valentineâ€™s Day cake recipes",
+          "trailText": "With St Valentineâ€™s Day around the corner, you now have the perfect excuse  (as if one were needed) to make these irresistible little cakes for someone special, says <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-02-08T13:00:03Z",
+          "internalPageCode": "2235086",
+          "shortUrl": "https://gu.com/p/45epq",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slater-recipes",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater recipes",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slater-recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slater-recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/cake",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Cake",
+            "webUrl": "https://www.theguardian.com/food/cake",
+            "apiUrl": "https://preview.content.guardianapis.com/food/cake",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/valentines-day",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Valentine's Day",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/valentines-day",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/valentines-day",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "e0becc48-3630-4db8-a498-563cf773b998",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"dc1dcd854a95f690fc811793a7ec48c039c2c639\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976656747/Nigel-Slaters-orange-and--005.jpg\" alt=\"Nigel Slater's orange and lemon apricot cake with icing\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">A little of what you fancy: orange and lemon apricot cake. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-02-03T15:17:48Z",
+            "lastModifiedDate": "2015-02-03T15:17:48Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "lastModifiedBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976656747/Nigel-Slaters-orange-and--005.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976652295/Nigel-Slaters-orange-and--001.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976659058/Nigel-Slaters-orange-and--007.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976653332/Nigel-Slaters-orange-and--002.jpg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976654374/Nigel-Slaters-orange-and--003.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976655607/Nigel-Slaters-orange-and--004.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976657860/Nigel-Slaters-orange-and--006.jpg",
+                    "typeData": {
+                      "width": 540,
+                      "height": 324
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976660954/Nigel-Slaters-orange-and--008.jpg",
+                    "typeData": {
+                      "width": 1020,
+                      "height": 612
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/2/3/1422976663051/Nigel-Slaters-orange-and--009.jpg",
+                    "typeData": {
+                      "width": 2060,
+                      "height": 1236
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "A little of what you fancy: orange and lemon apricot cake. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Nigel Slater's orange and lemon apricot cake with icing",
+                  "mediaId": "dc1dcd854a95f690fc811793a7ec48c039c2c639",
+                  "picdarUrn": "GD*49835090",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/feb/03/nigel-slater-roots-and-rice-recipe",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-02-03T12:00:01Z",
+        "webTitle": "Nigel Slaterâ€™s roots and rice recipe",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/feb/03/nigel-slater-roots-and-rice-recipe",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/feb/03/nigel-slater-roots-and-rice-recipe",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s roots and rice recipe",
+          "trailText": "A simple but tasty vegetarian dish, by <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-02-03T12:00:01Z",
+          "internalPageCode": "2231406",
+          "shortUrl": "https://gu.com/p/459zt",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slaters-midweek-dinner",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater's midweek dinner",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slaters-midweek-dinner",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slaters-midweek-dinner",
+            "references": [
+              
+            ],
+            "description": "<p>Nigel Slater reveals how to make a special yet simple midweek dinner</p>"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/vegetarian",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Vegetarian food and drink",
+            "webUrl": "https://www.theguardian.com/food/vegetarian",
+            "apiUrl": "https://preview.content.guardianapis.com/food/vegetarian",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "f259e422-2cd8-451e-a67a-c24a296c1e44",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"45521f2f18f212808c32da63a6c7170343b1c631\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422449623163/Roots-and-rice-recipe-004.jpg\" alt=\"Roots and rice recipe\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">â€˜I always wash rice three times. It never sticksâ€™: Nigel Slaterâ€™s roots and rice recipe. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-01-28T12:53:54Z",
+            "lastModifiedDate": "2015-01-29T17:36:27Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "kate.edgley@guardian.co.uk",
+              "firstName": "Kate",
+              "lastName": "Edgley"
+            },
+            "lastModifiedBy": {
+              "email": "kate.edgley@guardian.co.uk",
+              "firstName": "Kate",
+              "lastName": "Edgley"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422449623163/Roots-and-rice-recipe-004.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422449624926/Roots-and-rice-recipe-005.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422449620102/Roots-and-rice-recipe-002.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422449621853/Roots-and-rice-recipe-003.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "â€˜I always wash rice three times. It never sticksâ€™: Nigel Slaterâ€™s roots and rice recipe. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Roots and rice recipe",
+                  "mediaId": "45521f2f18f212808c32da63a6c7170343b1c631",
+                  "picdarUrn": "GD*49688848",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/feb/01/nigel-slater-scotch-egg-recipes",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-02-01T13:00:02Z",
+        "webTitle": "Nigel Slaterâ€™s â€˜Scotch eggâ€™ recipes",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/feb/01/nigel-slater-scotch-egg-recipes",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/feb/01/nigel-slater-scotch-egg-recipes",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s â€˜Scotch eggâ€™ recipes",
+          "trailText": "Like a Scotch egg, these golden nuggets â€“ a delicious combination of complementary flavours â€“ are almost as fun to make as they are to eat, says <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-02-01T13:00:02Z",
+          "internalPageCode": "2231289",
+          "shortUrl": "https://gu.com/p/459k9",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slater-recipes",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater recipes",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slater-recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slater-recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "63935777-bee8-421a-bd1f-3cd638e1f046",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"e7cb5c0ec4413de9340d172fc40f5c8840c846e0\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444645834/chicken-croquettes-stuffe-011.jpg\" alt=\"chicken croquettes stuffed with comte\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Melting point: chicken croquettes stuffed with\rcomtÃ©. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-01-28T11:30:56Z",
+            "lastModifiedDate": "2015-01-28T11:30:56Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "kate.edgley@guardian.co.uk",
+              "firstName": "Kate",
+              "lastName": "Edgley"
+            },
+            "lastModifiedBy": {
+              "email": "kate.edgley@guardian.co.uk",
+              "firstName": "Kate",
+              "lastName": "Edgley"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444645834/chicken-croquettes-stuffe-011.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444640297/chicken-croquettes-stuffe-006.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444647089/chicken-croquettes-stuffe-012.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444641426/chicken-croquettes-stuffe-007.jpg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444643662/chicken-croquettes-stuffe-009.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/28/1422444644744/chicken-croquettes-stuffe-010.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Melting point: chicken croquettes stuffed with\rcomtÃ©. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "chicken croquettes stuffed with comte",
+                  "mediaId": "e7cb5c0ec4413de9340d172fc40f5c8840c846e0",
+                  "picdarUrn": "GD*49688843",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/jan/27/nigel-slater-chicken-caolo-nero-squash-soup",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-01-27T12:00:05Z",
+        "webTitle": "Nigel Slaterâ€™s chicken, cavolo nero and squash soup",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/jan/27/nigel-slater-chicken-caolo-nero-squash-soup",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/jan/27/nigel-slater-chicken-caolo-nero-squash-soup",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s chicken, cavolo nero and squash soup",
+          "trailText": "A seasonal chicken soup to warm your way through winter from <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-01-27T12:00:05Z",
+          "internalPageCode": "2226506",
+          "shortUrl": "https://gu.com/p/45355",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slaters-midweek-dinner",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater's midweek dinner",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slaters-midweek-dinner",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slaters-midweek-dinner",
+            "references": [
+              
+            ],
+            "description": "<p>Nigel Slater reveals how to make a special yet simple midweek dinner</p>"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/soup",
+            "type": "keyword",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Soup",
+            "webUrl": "https://www.theguardian.com/food/soup",
+            "apiUrl": "https://preview.content.guardianapis.com/food/soup",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "28a97c3b-daee-4fab-89f0-f99a37ca9e68",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"18fc1c708ec300e9ebb4abf01e5effa4c8463620\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764178209/Nigel-Slaters-chicken-cav-011.jpg\" alt=\"Nigel Slater's chicken, cavolo nero and squash soup in a deep bowl\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Nigel Slaterâ€™s chicken, cavolo nero and squash soup. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-01-20T14:29:48Z",
+            "lastModifiedDate": "2015-01-22T11:50:11Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "lastModifiedBy": {
+              "email": "katie.forster@guardian.co.uk",
+              "firstName": "Katie",
+              "lastName": "Forster"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764178209/Nigel-Slaters-chicken-cav-011.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764171986/Nigel-Slaters-chicken-cav-006.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764179376/Nigel-Slaters-chicken-cav-012.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764173001/Nigel-Slaters-chicken-cav-007.jpg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764175835/Nigel-Slaters-chicken-cav-009.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421764176956/Nigel-Slaters-chicken-cav-010.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Nigel Slaterâ€™s chicken, cavolo nero and squash soup. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Nigel Slater's chicken, cavolo nero and squash soup in a deep bowl",
+                  "mediaId": "18fc1c708ec300e9ebb4abf01e5effa4c8463620",
+                  "picdarUrn": "GD*49475454",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/jan/25/nigel-slater-sloe-gin-recipes",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-01-25T06:00:00Z",
+        "webTitle": "Nigel Slaterâ€™s sloe gin recipes",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/jan/25/nigel-slater-sloe-gin-recipes",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/jan/25/nigel-slater-sloe-gin-recipes",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s sloe gin recipes",
+          "trailText": "Whether you make your own or not, sloe gin works as well as a perfect tipple on  a frosty night, or as a marinade for roast pheasant, apples or rhubarb, says <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-01-25T06:00:00Z",
+          "internalPageCode": "2226557",
+          "shortUrl": "https://gu.com/p/45372",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slater-recipes",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater recipes",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slater-recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slater-recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "8ac18a86-e9f9-46a7-80b0-ba9e20de0078",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"0973e4104b365acc3e563034f0b01a76a4e1d5cb\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766918674/Nigel-Slaters-pheasant-wi-011.jpg\" alt=\"Nigel Slater's pheasant with sloe gin and peas on a wooden platter\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Nice and sloe: Nigel Slaterâ€™s pheasant with sloe gin and pears recipe. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2015-01-20T15:15:30Z",
+            "lastModifiedDate": "2015-01-20T15:17:00Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "lastModifiedBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766918674/Nigel-Slaters-pheasant-wi-011.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766912854/Nigel-Slaters-pheasant-wi-006.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766919925/Nigel-Slaters-pheasant-wi-012.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766913896/Nigel-Slaters-pheasant-wi-007.jpg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766916097/Nigel-Slaters-pheasant-wi-009.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/20/1421766917214/Nigel-Slaters-pheasant-wi-010.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Nice and sloe: Nigel Slaterâ€™s pheasant with sloe gin and pears recipe. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Nigel Slater's pheasant with sloe gin and peas on a wooden platter",
+                  "mediaId": "0973e4104b365acc3e563034f0b01a76a4e1d5cb",
+                  "picdarUrn": "GD*49475475",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/jan/06/nigel-slaters-orzo-with-brussels-sprouts-and-sausage-recipe",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-01-06T12:00:11Z",
+        "webTitle": "Nigel Slaterâ€™s orzo with brussels sprouts and sausage recipe",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/jan/06/nigel-slaters-orzo-with-brussels-sprouts-and-sausage-recipe",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/jan/06/nigel-slaters-orzo-with-brussels-sprouts-and-sausage-recipe",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s orzo with brussels sprouts and sausage recipe",
+          "trailText": "A filling dish with a still seasonally appropriate vegetable from <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-01-06T12:00:11Z",
+          "internalPageCode": "2214501",
+          "shortUrl": "https://gu.com/p/44djf",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slaters-midweek-dinner",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater's midweek dinner",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slaters-midweek-dinner",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slaters-midweek-dinner",
+            "references": [
+              
+            ],
+            "description": "<p>Nigel Slater reveals how to make a special yet simple midweek dinner</p>"
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "444839d9-e477-4ae4-b279-25198e3da454",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"b0b752e128b1c71548a09eb4f9a02c87cac92c27\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333575664/Bowl-of-orzo-with-brussel-011.jpg\" alt=\"Bowl of orzo with brussels sprouts and sausage\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Sprouting up: Nigel Slaterâ€™s orzo with brussels sprouts and sausage recipe. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2014-12-23T11:19:46Z",
+            "lastModifiedDate": "2014-12-23T11:37:25Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "lastModifiedBy": {
+              "email": "leah.jewett@guardian.co.uk",
+              "firstName": "Leah",
+              "lastName": "Jewett"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333575664/Bowl-of-orzo-with-brussel-011.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333570127/Bowl-of-orzo-with-brussel-006.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333577092/Bowl-of-orzo-with-brussel-012.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333571207/Bowl-of-orzo-with-brussel-007.jpg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333573316/Bowl-of-orzo-with-brussel-009.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/23/1419333574561/Bowl-of-orzo-with-brussel-010.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Sprouting up: Nigel Slaterâ€™s orzo with brussels sprouts and sausage recipe. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Bowl of orzo with brussels sprouts and sausage",
+                  "mediaId": "b0b752e128b1c71548a09eb4f9a02c87cac92c27",
+                  "picdarUrn": "GD*48940641",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      },
+      {
+        "id": "lifeandstyle/2015/jan/04/nigel-slater-hazelnut-recipes",
+        "type": "article",
+        "sectionId": "food",
+        "sectionName": "Food",
+        "webPublicationDate": "2015-01-04T06:00:13Z",
+        "webTitle": "Nigel Slaterâ€™s hazelnut recipes | Nigel Slater",
+        "webUrl": "https://www.theguardian.com/lifeandstyle/2015/jan/04/nigel-slater-hazelnut-recipes",
+        "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/2015/jan/04/nigel-slater-hazelnut-recipes",
+        "fields": {
+          "headline": "Nigel Slaterâ€™s hazelnut recipes",
+          "trailText": "Whether theyâ€™re soft shavings in a salad, baked into dark chocolate or teamed with maple syrup in a biscuit, hazelnuts are in their element in winter, writes <strong>Nigel Slater</strong>",
+          "byline": "Nigel Slater",
+          "firstPublicationDate": "2015-01-04T06:00:13Z",
+          "internalPageCode": "2215888",
+          "shortUrl": "https://gu.com/p/44fgp",
+          "isLive": "true"
+        },
+        "tags": [
+          {
+            "id": "food/series/nigel-slater-recipes",
+            "type": "series",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webTitle": "Nigel Slater recipes",
+            "webUrl": "https://www.theguardian.com/food/series/nigel-slater-recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/food/series/nigel-slater-recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "food/food",
+            "type": "keyword",
+            "webTitle": "Food",
+            "webUrl": "https://www.theguardian.com/food/food",
+            "apiUrl": "https://preview.content.guardianapis.com/food/food",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "lifeandstyle/lifeandstyle",
+            "type": "keyword",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life and style",
+            "webUrl": "https://www.theguardian.com/lifeandstyle/lifeandstyle",
+            "apiUrl": "https://preview.content.guardianapis.com/lifeandstyle/lifeandstyle",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/recipes",
+            "type": "tone",
+            "webTitle": "Recipes",
+            "webUrl": "https://www.theguardian.com/tone/recipes",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/recipes",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "tone/features",
+            "type": "tone",
+            "webTitle": "Features",
+            "webUrl": "https://www.theguardian.com/tone/features",
+            "apiUrl": "https://preview.content.guardianapis.com/tone/features",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "type/article",
+            "type": "type",
+            "webTitle": "Article",
+            "webUrl": "https://www.theguardian.com/articles",
+            "apiUrl": "https://preview.content.guardianapis.com/type/article",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "profile/nigelslater",
+            "type": "contributor",
+            "webTitle": "Nigel Slater",
+            "webUrl": "https://www.theguardian.com/profile/nigelslater",
+            "apiUrl": "https://preview.content.guardianapis.com/profile/nigelslater",
+            "references": [
+              
+            ],
+            "bio": "<p>Nigel Slater has been the Observer's food writer for 20 years. His cookery books, which include Appetite, Eat and the Kitchen Diaries have won a host of awards, while his autobiography Toast â€“ The Story of a Boy's Hunger was adapted by BBC Films, starring Helena Bonham Carter and Freddie Highmore</p>",
+            "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/4/17/1397749337461/NigelSlaterLv2.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2017/10/09/Nigel_Slater,-L.png",
+            "firstName": "slater",
+            "lastName": "",
+            "rcsId": "GNL209262",
+            "r2ContributorId": "16196"
+          },
+          {
+            "id": "publication/theobserver",
+            "type": "publication",
+            "sectionId": "theobserver",
+            "sectionName": "From the Observer",
+            "webTitle": "The Observer",
+            "webUrl": "https://www.theguardian.com/theobserver/all",
+            "apiUrl": "https://preview.content.guardianapis.com/publication/theobserver",
+            "references": [
+              
+            ],
+            "description": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
+          },
+          {
+            "id": "theobserver/magazine",
+            "type": "newspaper-book",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Observer Magazine",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine",
+            "references": [
+              
+            ]
+          },
+          {
+            "id": "theobserver/magazine/life-and-style",
+            "type": "newspaper-book-section",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Life & style",
+            "webUrl": "https://www.theguardian.com/theobserver/magazine/life-and-style",
+            "apiUrl": "https://preview.content.guardianapis.com/theobserver/magazine/life-and-style",
+            "references": [
+              
+            ]
+          }
+        ],
+        "elements": [
+          
+        ],
+        "references": [
+          
+        ],
+        "blocks": {
+          "main": {
+            "id": "a7f84d1e-f7d4-49ab-9d4f-26ce9be75ef5",
+            "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"0e098fcc3317a5887bf8a08eda0ebd9c3ea70453\"> <img src=\"https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867123110/Nigels-chocolate-fruit-an-011.jpg\" alt=\"Nigel's chocolate fruit and nut crisp\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Nuts, oh, hazelnuts: chocolate fruit and nut crisp. Photograph: Jonathan Lovekin for the Observer</span> </figcaption> </figure>",
+            "bodyTextSummary": "",
+            "attributes": {
+              
+            },
+            "published": false,
+            "createdDate": "2014-12-29T15:32:15Z",
+            "lastModifiedDate": "2014-12-29T15:32:15Z",
+            "contributors": [
+              
+            ],
+            "createdBy": {
+              "email": "kate.edgley@guardian.co.uk",
+              "firstName": "Kate",
+              "lastName": "Edgley"
+            },
+            "lastModifiedBy": {
+              "email": "kate.edgley@guardian.co.uk",
+              "firstName": "Kate",
+              "lastName": "Edgley"
+            },
+            "elements": [
+              {
+                "type": "image",
+                "assets": [
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867123110/Nigels-chocolate-fruit-an-011.jpg",
+                    "typeData": {
+                      "width": 460,
+                      "height": 276
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867117645/Nigels-chocolate-fruit-an-006.jpg",
+                    "typeData": {
+                      "width": 140,
+                      "height": 84
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867124640/Nigels-chocolate-fruit-an-012.jpg",
+                    "typeData": {
+                      "width": 620,
+                      "height": 372
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867118663/Nigels-chocolate-fruit-an-007.jpg",
+                    "typeData": {
+                      "width": 220,
+                      "height": 132
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867120865/Nigels-chocolate-fruit-an-009.jpg",
+                    "typeData": {
+                      "width": 300,
+                      "height": 180
+                    }
+                  },
+                  {
+                    "type": "image",
+                    "mimeType": "image/jpeg",
+                    "file": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/29/1419867121960/Nigels-chocolate-fruit-an-010.jpg",
+                    "typeData": {
+                      "width": 380,
+                      "height": 228
+                    }
+                  }
+                ],
+                "imageTypeData": {
+                  "caption": "Nuts, oh, hazelnuts: chocolate fruit and nut crisp. Photograph: Jonathan Lovekin for the Observer",
+                  "displayCredit": false,
+                  "credit": "Photograph: Jonathan Lovekin/Observer",
+                  "source": "Observer",
+                  "photographer": "Jonathan Lovekin",
+                  "alt": "Nigel's chocolate fruit and nut crisp",
+                  "mediaId": "0e098fcc3317a5887bf8a08eda0ebd9c3ea70453",
+                  "picdarUrn": "GD*48940568",
+                  "imageType": "Photograph"
+                }
+              }
+            ]
+          }
+        },
+        "isGone": false,
+        "isHosted": false,
+        "pillarId": "pillar/lifestyle",
+        "pillarName": "Lifestyle",
+        "frontsMeta": {
+          "defaults": {
+            "isBreaking": false,
+            "isBoosted": false,
+            "showMainVideo": false,
+            "imageHide": false,
+            "showKickerCustom": false,
+            "showByline": false,
+            "showQuotedHeadline": false,
+            "imageSlideshowReplace": false,
+            "showKickerTag": false,
+            "showLivePlayable": false,
+            "imageReplace": false,
+            "imageCutoutReplace": false,
+            "showKickerSection": false,
+            "showBoostedHeadline": false
+          },
+          "tone": "feature"
+        }
+      }
+    ]
+  }
+}

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -8,6 +8,7 @@ const HEADLINE_SELECTOR = 'headline';
 const DROP_ZONE_SELECTOR = 'drop-zone';
 const HOVER_OVERLAY_SELECTOR = 'hover-overlay';
 const ADD_TO_CLIPBOARD_BUTTON = 'add-to-clipboard-hover-button';
+const SNAP_SELECTOR = 'snap';
 
 const maybeGetNth = selector => (n = null) =>
   n === null ? selector : selector.nth(n);
@@ -47,4 +48,18 @@ export const frontItemAddToClipboardHoverButton = maybeGetNth(
 );
 export const collectionItemHoverZone = maybeGetNth(
   select(COLLECTION_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
+);
+
+// Mocks //
+const GUARDIAN_TAG_ANCHOR = 'external-tag';
+const GUARDIAN_SECTION_ANCHOR = 'external-section';
+const EXTERNAL_LINK_ANCHOR = 'external-link';
+
+export const guardianTagSnapLink = maybeGetNth(select(GUARDIAN_TAG_ANCHOR));
+export const guardianSectionSnapLink = maybeGetNth(
+  select(GUARDIAN_SECTION_ANCHOR)
+);
+export const externalSnapLink = maybeGetNth(select(EXTERNAL_LINK_ANCHOR));
+export const frontSnapLink = maybeGetNth(
+  select(FRONT_SELECTOR, SNAP_SELECTOR)
 );

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -9,6 +9,9 @@ const DROP_ZONE_SELECTOR = 'drop-zone';
 const HOVER_OVERLAY_SELECTOR = 'hover-overlay';
 const ADD_TO_CLIPBOARD_BUTTON = 'add-to-clipboard-hover-button';
 const SNAP_SELECTOR = 'snap';
+// Html Mocks //
+const GUARDIAN_TAG_ANCHOR = 'guardian-tag';
+const EXTERNAL_LINK_ANCHOR = 'external-link';
 
 const maybeGetNth = selector => (n = null) =>
   n === null ? selector : selector.nth(n);
@@ -50,16 +53,7 @@ export const collectionItemHoverZone = maybeGetNth(
   select(COLLECTION_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
 );
 
-// Mocks //
-const GUARDIAN_TAG_ANCHOR = 'external-tag';
-const GUARDIAN_SECTION_ANCHOR = 'external-section';
-const EXTERNAL_LINK_ANCHOR = 'external-link';
-
-export const guardianTagSnapLink = maybeGetNth(select(GUARDIAN_TAG_ANCHOR));
-export const guardianSectionSnapLink = maybeGetNth(
-  select(GUARDIAN_SECTION_ANCHOR)
-);
+// Snaps //
+export const guardianSnapLink = maybeGetNth(select(GUARDIAN_TAG_ANCHOR));
 export const externalSnapLink = maybeGetNth(select(EXTERNAL_LINK_ANCHOR));
-export const frontSnapLink = maybeGetNth(
-  select(FRONT_SELECTOR, SNAP_SELECTOR)
-);
+export const frontSnapLink = maybeGetNth(select(SNAP_SELECTOR));

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -2,20 +2,49 @@ import { select } from '../helpers';
 
 const FRONT_SELECTOR = 'test/front';
 const FEED_ITEM_SELECTOR = 'feed-item';
+const COLLECTION_ITEM_SELECTOR = 'article-body';
+const CLIPBOARD_SELECTOR = 'clipboard';
 const HEADLINE_SELECTOR = 'headline';
 const DROP_ZONE_SELECTOR = 'drop-zone';
+const HOVER_OVERLAY_SELECTOR = 'hover-overlay';
+const ADD_TO_CLIPBOARD_BUTTON = 'add-to-clipboard-hover-button';
 
 const maybeGetNth = selector => (n = null) =>
   n === null ? selector : selector.nth(n);
 
+// Feed //
 export const feedItem = maybeGetNth(select(FEED_ITEM_SELECTOR));
-
-export const frontHeadline = maybeGetNth(
-  select(FRONT_SELECTOR, HEADLINE_SELECTOR)
-);
 export const feedItemHeadline = maybeGetNth(
   select(FEED_ITEM_SELECTOR, HEADLINE_SELECTOR)
 );
+export const feedItemHoverZone = maybeGetNth(
+  select(FEED_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
+);
+
+// Clipboard //
+export const clipboardDropZone = maybeGetNth(
+  select(CLIPBOARD_SELECTOR, DROP_ZONE_SELECTOR)
+);
+export const clipboardItem = maybeGetNth(
+  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR)
+);
+export const clipboardItemTruncatedHeadline = maybeGetNth(
+  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, HEADLINE_SELECTOR)
+);
+export const feedItemAddToClipboardHoverButton = maybeGetNth(
+  select(FEED_ITEM_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
+);
+
+// Fronts //
+export const frontHeadline = maybeGetNth(
+  select(FRONT_SELECTOR, HEADLINE_SELECTOR)
+);
 export const frontDropZone = maybeGetNth(
   select(FRONT_SELECTOR, DROP_ZONE_SELECTOR)
+);
+export const frontItemAddToClipboardHoverButton = maybeGetNth(
+  select(FRONT_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
+);
+export const collectionItemHoverZone = maybeGetNth(
+  select(COLLECTION_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
 );

--- a/client-v2/integration/server/index.html
+++ b/client-v2/integration/server/index.html
@@ -27,7 +27,7 @@
     <div class="wrap" id="react-mount"></div>
     <div id="mocks">
       <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /><a
-        data-testid="external-tag"
+        data-testid="guardian-tag"
         class="subnav-link"
         href="https://www.theguardian.com/tone/recipes"
         data-link-name="nav2 : subnav : Recipes"
@@ -36,20 +36,11 @@
       </a>
 
       <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /><a
-        data-testid="external-section"
-        class="subnav-link"
-        href="https://www.theguardian.com/food"
-        data-link-name="nav2 : subnav : Food"
-      >
-        Food
-      </a>
-
-      <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /><a
         data-testid="external-link"
-        href="https://www.nytimes.com/2018/11/14/technology/facebook-data-russia-election-racism.html?action=click&amp;module=Top%20Stories&amp;pgtype=Homepage"
+        href="https://www.bbc.co.uk/news/business"
         data-link-name="in body link"
         class="u-underline"
-        >New York Times</a
+        >Business - BBC News</a
       >
     </div>
     <script type="application/json" id="config">

--- a/client-v2/integration/server/index.html
+++ b/client-v2/integration/server/index.html
@@ -1,88 +1,113 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Document</title>
-  <style>
-    *,
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
+    <style>
+      *,
       *:before,
       *:after {
-          box-sizing: border-box;
+        box-sizing: border-box;
       }
 
       html,
       body,
       .wrap {
-          height: 100%;
-          margin: 0;
-          padding: 0;
-          width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        width: 100%;
       }
-  </style>
-</head>
+    </style>
+  </head>
 
-<body>
-  <div class="wrap" id="react-mount"></div>
-  <script type="application/json" id="config">
-    {
-      "dev": true,
-      "env": "code",
-      "editions": ["uk", "us", "au"],
-      "email": "richard.beddington@guardian.co.uk",
-      "avatarUrl": "https://lh3.googleusercontent.com/-ZbWEH5tBZWU/AAAAAAAAAAI/AAAAAAAAAAA/ABtNlbDL_UpljZgqBjPvw4n0SmYiLD0amw/mo/photo.jpg",
-      "firstName": "Richard",
-      "lastName": "Beddington",
-      "sentryPublicDSN": "https://4527e03d554a4962ae99a7481e9278ff@app.getsentry.com/35467",
-      "mediaBaseUrl": "https://media.gutools.co.uk",
-      "apiBaseUrl": "https://api.media.test.dev-gutools.co.uk",
-      "switches": {
-        "facia-tool-allow-breaking-news-for-all": false,
-        "facia-tool-permissions-access": true,
-        "facia-tool-allow-edit-editorial-fronts-for-all": false,
-        "facia-tool-allow-config-for-all": false,
-        "facia-tool-allow-launch-editorial-fronts-for-all": false,
-        "facia-tool-allow-launch-commercial-fronts-for-all": false,
-        "facia-tool-sparklines": true,
-        "facia-tool-draft-content": true,
-        "facia-tool-disable": false
-      },
-      "acl": {
-        "fronts": { "breaking-news": false },
-        "permissions": { "configure-config": true }
-      },
-      "collectionCap": 20,
-      "navListCap": 40,
-      "navListType": "nav/list",
-      "collectionMetadata": [
-        { "type": "Canonical" },
-        { "type": "Special" },
-        { "type": "Breaking" },
-        { "type": "Branded" }
-      ],
-      "clipboardArticles": [
-        {
-          "id": "internal-code/page/5224281",
-          "frontPublicationDate": 1540381197498,
-          "meta": {
-            "supporting": [
-              {
-                "id": "internal-code/page/2309422",
-                "frontPublicationDate": 1540379258808,
-                "meta": {}
-              }
-            ]
+  <body>
+    <div class="wrap" id="react-mount"></div>
+    <div id="mocks">
+      <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /><a
+        data-testid="external-tag"
+        class="subnav-link"
+        href="https://www.theguardian.com/tone/recipes"
+        data-link-name="nav2 : subnav : Recipes"
+      >
+        Recipes
+      </a>
+
+      <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /><a
+        data-testid="external-section"
+        class="subnav-link"
+        href="https://www.theguardian.com/food"
+        data-link-name="nav2 : subnav : Food"
+      >
+        Food
+      </a>
+
+      <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" /><a
+        data-testid="external-link"
+        href="https://www.nytimes.com/2018/11/14/technology/facebook-data-russia-election-racism.html?action=click&amp;module=Top%20Stories&amp;pgtype=Homepage"
+        data-link-name="in body link"
+        class="u-underline"
+        >New York Times</a
+      >
+    </div>
+    <script type="application/json" id="config">
+      {
+        "dev": true,
+        "env": "code",
+        "editions": ["uk", "us", "au"],
+        "email": "richard.beddington@guardian.co.uk",
+        "avatarUrl": "https://lh3.googleusercontent.com/-ZbWEH5tBZWU/AAAAAAAAAAI/AAAAAAAAAAA/ABtNlbDL_UpljZgqBjPvw4n0SmYiLD0amw/mo/photo.jpg",
+        "firstName": "Richard",
+        "lastName": "Beddington",
+        "sentryPublicDSN": "https://4527e03d554a4962ae99a7481e9278ff@app.getsentry.com/35467",
+        "mediaBaseUrl": "https://media.gutools.co.uk",
+        "apiBaseUrl": "https://api.media.test.dev-gutools.co.uk",
+        "switches": {
+          "facia-tool-allow-breaking-news-for-all": false,
+          "facia-tool-permissions-access": true,
+          "facia-tool-allow-edit-editorial-fronts-for-all": false,
+          "facia-tool-allow-config-for-all": false,
+          "facia-tool-allow-launch-editorial-fronts-for-all": false,
+          "facia-tool-allow-launch-commercial-fronts-for-all": false,
+          "facia-tool-sparklines": true,
+          "facia-tool-draft-content": true,
+          "facia-tool-disable": false
+        },
+        "acl": {
+          "fronts": { "breaking-news": false },
+          "permissions": { "configure-config": true }
+        },
+        "collectionCap": 20,
+        "navListCap": 40,
+        "navListType": "nav/list",
+        "collectionMetadata": [
+          { "type": "Canonical" },
+          { "type": "Special" },
+          { "type": "Breaking" },
+          { "type": "Branded" }
+        ],
+        "clipboardArticles": [
+          {
+            "id": "internal-code/page/5224281",
+            "frontPublicationDate": 1540381197498,
+            "meta": {
+              "supporting": [
+                {
+                  "id": "internal-code/page/2309422",
+                  "frontPublicationDate": 1540379258808,
+                  "meta": {}
+                }
+              ]
+            }
           }
-        }
-      ],
-      "frontIds": ["test/front"],
-      "capiLiveUrl": "/api/live/",
-      "capiPreviewUrl": "/api/preview/"
-    }
-  </script>
-  <script src="/dist/app.bundle.js"></script>
-</body>
-
+        ],
+        "frontIds": ["test/front"],
+        "capiLiveUrl": "/api/live/",
+        "capiPreviewUrl": "/api/preview/"
+      }
+    </script>
+    <script src="/dist/app.bundle.js"></script>
+  </body>
 </html>

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -6,6 +6,7 @@ const config = require('../fixtures/config');
 const collection = require('../fixtures/collection');
 const capiCollection = require('../fixtures/capi-collection');
 const capiSearch = require('../fixtures/capi-search');
+const snapTag = require('../fixtures/snap-tag');
 
 const findArticleWithIDFromResponse = id =>
   console.log('query', id) ||
@@ -17,13 +18,14 @@ const findArticleWithIDFromResponse = id =>
 module.exports = async () =>
   new Promise((res, rej) => {
     const app = express();
+
     app.get('/v2/*', (_, res) =>
       res.sendFile(path.join(__dirname, './index.html'))
     );
 
     // Endpoint for api search requests here
     app.get(/\/api\/(preview|live)\/search/, (req, res) => {
-      console.log('search');
+      console.log('search', req.params);
       const ids = (req.query.ids || '').split(',').filter(Boolean);
       switch (ids.length) {
         case 0: {
@@ -57,9 +59,8 @@ module.exports = async () =>
     });
 
     // Endpoint for api requests for single pieces of content
-    // Endpoint for api requests for single pieces of content
     const handler = (req, res) => {
-      console.log('handle', req.params);
+      console.log('handle', req.params, req.url);
 
       const match = req.params[0];
       if (!match) {
@@ -101,8 +102,12 @@ module.exports = async () =>
     // Attempts at a capture group:
     // /api/(preview|live)/*
     // /api/(?:preview|live)/*
+    app.get('/api/preview/tone/*', (req, res) => {
+      console.log('api', req.params) || res.json(snapTag);
+    });
     app.get('/api/live/*', handler);
     app.get('/api/preview/*', handler);
+    
 
     app.get('/config', (_, res) => console.log('config') || res.json(config));
     app.get(
@@ -110,18 +115,12 @@ module.exports = async () =>
       (_, res) => console.log('col id') || res.json(collection)
     );
     // send the assets from dist
-    app.get(
-      '*/:file',
-      (req, res) =>
-        console.log('file') ||
-        res.sendFile(
-          path.join(
-            __dirname,
-            '../../../public/client-v2/dist',
-            req.params.file
-          )
-        )
+    app.get('*/:file', (req, res) =>
+      res.sendFile(
+        path.join(__dirname, '../../../public/client-v2/dist', req.params.file)
+      )
     );
+
     // this catches update requests and pretends they went through ok
     app.post('*', (_, res) => res.json({ ok: true }));
     const server = app.listen(port, err => {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -3,11 +3,15 @@ import teardown from '../server/teardown';
 import {
   frontDropZone,
   frontHeadline,
+  frontSnapLink,
   frontItemAddToClipboardHoverButton,
   feedItem,
   feedItemHeadline,
   feedItemAddToClipboardHoverButton,
-  clipboardItemTruncatedHeadline
+  clipboardItemTruncatedHeadline,
+  guardianSectionSnapLink,
+  guardianTagSnapLink,
+  externalSnapLink
 } from '../selectors';
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
@@ -38,18 +42,50 @@ test('Drag and drop', async t => {
     .eql(topFrontHeadline);
 });
 
+test('Snap Links - Guardian Tag', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  const tagSnap = await guardianTagSnapLink();
+  await t
+    .setNativeDialogHandler(() => false)
+    .dragToElement(tagSnap, frontDropZone(1))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 1)
+    .expect(frontSnapLink(0).textContent)
+    .contains('Recipes')
+    .expect(frontSnapLink(0).textContent)
+    .notContains('Latest');
+});
+
+test('Snap Links - Guardian Tag Latest', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  const tagSnap = await guardianTagSnapLink();
+
+  await t
+    .setNativeDialogHandler(() => true)
+    .dragToElement(tagSnap, frontDropZone(1))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 1)
+    .expect(frontSnapLink(0).textContent)
+    .contains(' {Recipes }')
+    .expect(frontSnapLink(0).textContent)
+    .contains('Latest');
+});
+
 // TODO TestCafe .hover method does not work. Buttons remain hidden, click fails on visibility check.
-test.skip('Add to Clipboard hover button', async t => {
+test.skip('Add to Clipboard from Feed hover button works', async t => {
   const feedHeadline = await feedItemHeadline(5).textContent;
   const feedHeadlineTruncated = feedHeadline.slice(0, 35);
-  const topFrontHeadline = await frontHeadline(0).textContent;
-  const topFrontHeadlineTruncated = topFrontHeadline.slice(0, 35);
   await t
     // check feed to clipboard //
     // TODO .hover()
     .click(feedItemAddToClipboardHoverButton(5), { visibilityCheck: false })
     .expect(clipboardItemTruncatedHeadline(0).textContent)
-    .contains(feedHeadlineTruncated)
+    .contains(feedHeadlineTruncated);
+});
+test.skip('Add to Clipboard from Front hover button works', async t => {
+  const topFrontHeadline = await frontHeadline(0).textContent;
+  const topFrontHeadlineTruncated = topFrontHeadline.slice(0, 35);
+  await t
     // check front to clipboard //
     // TODO .hover()
     .click(frontItemAddToClipboardHoverButton(0), { visibilityCheck: false })

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -1,10 +1,13 @@
 import setup from '../server/setup';
 import teardown from '../server/teardown';
 import {
-  frontHeadline,
-  feedItemHeadline,
   frontDropZone,
-  feedItem
+  frontHeadline,
+  frontItemAddToClipboardHoverButton,
+  feedItem,
+  feedItemHeadline,
+  feedItemAddToClipboardHoverButton,
+  clipboardItemTruncatedHeadline
 } from '../selectors';
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
@@ -33,4 +36,23 @@ test('Drag and drop', async t => {
     .notEql(topFeedHeadline)
     .expect(frontHeadline().textContent)
     .eql(topFrontHeadline);
+});
+
+// TODO TestCafe .hover method does not work. Buttons remain hidden, click fails on visibility check.
+test.skip('Add to Clipboard hover button', async t => {
+  const feedHeadline = await feedItemHeadline(5).textContent;
+  const feedHeadlineTruncated = feedHeadline.slice(0, 35);
+  const topFrontHeadline = await frontHeadline(0).textContent;
+  const topFrontHeadlineTruncated = topFrontHeadline.slice(0, 35);
+  await t
+    // check feed to clipboard //
+    // TODO .hover()
+    .click(feedItemAddToClipboardHoverButton(5), { visibilityCheck: false })
+    .expect(clipboardItemTruncatedHeadline(0).textContent)
+    .contains(feedHeadlineTruncated)
+    // check front to clipboard //
+    // TODO .hover()
+    .click(frontItemAddToClipboardHoverButton(0), { visibilityCheck: false })
+    .expect(clipboardItemTruncatedHeadline(0).textContent)
+    .contains(topFrontHeadlineTruncated);
 });

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -4,13 +4,9 @@ import {
   frontDropZone,
   frontHeadline,
   frontSnapLink,
-  frontItemAddToClipboardHoverButton,
   feedItem,
   feedItemHeadline,
-  feedItemAddToClipboardHoverButton,
-  clipboardItemTruncatedHeadline,
-  guardianSectionSnapLink,
-  guardianTagSnapLink,
+  guardianSnapLink,
   externalSnapLink
 } from '../selectors';
 
@@ -42,53 +38,45 @@ test('Drag and drop', async t => {
     .eql(topFrontHeadline);
 });
 
-test('Snap Links - Guardian Tag', async t => {
+test('Snap Links - Guardian', async t => {
   const frontDropsCount = await frontDropZone().count;
-  const tagSnap = await guardianTagSnapLink();
+  const tagSnap = await guardianSnapLink();
   await t
+    .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => false)
     .dragToElement(tagSnap, frontDropZone(1))
     .expect(frontDropZone().count)
     .eql(frontDropsCount + 1)
     .expect(frontSnapLink(0).textContent)
-    .contains('Recipes')
+    .contains('Recipes | The Guardian')
     .expect(frontSnapLink(0).textContent)
     .notContains('Latest');
 });
 
-test('Snap Links - Guardian Tag Latest', async t => {
+test('Snap Links - Guardian Latest', async t => {
   const frontDropsCount = await frontDropZone().count;
-  const tagSnap = await guardianTagSnapLink();
-
+  const tagSnap = await guardianSnapLink();
   await t
+    .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => true)
     .dragToElement(tagSnap, frontDropZone(1))
     .expect(frontDropZone().count)
     .eql(frontDropsCount + 1)
     .expect(frontSnapLink(0).textContent)
-    .contains(' {Recipes }')
+    .contains('{ Recipes }')
     .expect(frontSnapLink(0).textContent)
     .contains('Latest');
 });
 
-// TODO TestCafe .hover method does not work. Buttons remain hidden, click fails on visibility check.
-test.skip('Add to Clipboard from Feed hover button works', async t => {
-  const feedHeadline = await feedItemHeadline(5).textContent;
-  const feedHeadlineTruncated = feedHeadline.slice(0, 35);
+test('Snap Links - External', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  const externalSnap = await externalSnapLink();
   await t
-    // check feed to clipboard //
-    // TODO .hover()
-    .click(feedItemAddToClipboardHoverButton(5), { visibilityCheck: false })
-    .expect(clipboardItemTruncatedHeadline(0).textContent)
-    .contains(feedHeadlineTruncated);
-});
-test.skip('Add to Clipboard from Front hover button works', async t => {
-  const topFrontHeadline = await frontHeadline(0).textContent;
-  const topFrontHeadlineTruncated = topFrontHeadline.slice(0, 35);
-  await t
-    // check front to clipboard //
-    // TODO .hover()
-    .click(frontItemAddToClipboardHoverButton(0), { visibilityCheck: false })
-    .expect(clipboardItemTruncatedHeadline(0).textContent)
-    .contains(topFrontHeadlineTruncated);
+    .maximizeWindow() // needed to find DOM elements in headless mode
+    .setNativeDialogHandler(() => false)
+    .dragToElement(externalSnap, frontDropZone(1))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 1)
+    .expect(frontSnapLink(0).textContent)
+    .contains('Business - BBC News');
 });

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -56,7 +56,7 @@
     "react-testing-library": "^5.2.1",
     "redux-mock-store": "^1.5.3",
     "style-loader": "^0.23.1",
-    "testcafe": "0.23.1-alpha.2",
+    "testcafe": "^0.23.2",
     "ts-jest": "^23.10.4",
     "ts-loader": "^5.2.2",
     "tsconfig-paths-webpack-plugin": "^3.2.0",

--- a/client-v2/scripts/fronts-find.sh
+++ b/client-v2/scripts/fronts-find.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-git grep $1 ':!*bbcSectionPage.ts' ':!*guardianTagPage.ts'
+git grep $1 ':!*bbcSectionPage.ts' ':!*guardianTagPage.ts' ':!*snap-tag-page.js'

--- a/client-v2/src/components/FeedItem.tsx
+++ b/client-v2/src/components/FeedItem.tsx
@@ -146,7 +146,7 @@ const FeedItem = ({
     <Body>
       <Title data-testid="headline">{title}</Title>
     </Body>
-    <HoverActionsAreaOverlay justify="flex-end">
+    <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
       <HoverActionsButtonWrapper
         buttons={[
           { text: 'Clipboard', component: HoverAddToClipboardButton },

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -50,7 +50,7 @@ const ArticlePolaroidComponent = ({
             }}
           />
         ))}
-      <CollectionItemContent displayType="polaroid">
+      <CollectionItemContent displayType="polaroid" data-testid="headline">
         {displayPlaceholders ? (
           <>
             <TextPlaceholder />

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -62,6 +62,7 @@ const HoverDeleteButton = ({
 }: ButtonProps) => (
   <ActionButton
     danger
+    data-testid={'delete-hover-button'}
     onMouseEnter={showToolTip}
     onMouseLeave={hideToolTip}
     onClick={e => {
@@ -79,6 +80,7 @@ const HoverAddToClipboardButton = ({
   onAddToClipboard
 }: ButtonProps) => (
   <ActionButton
+    data-testid={'add-to-clipboard-hover-button'}
     onMouseEnter={showToolTip}
     onMouseLeave={hideToolTip}
     onClick={e => {

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -65,6 +65,7 @@ const SnapLink = ({
   return (
     <CollectionItemContainer {...rest}>
       <CollectionItemBody
+        data-testid="snap"
         size={size}
         fade={fade}
         displayType={displayType}

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -3890,6 +3890,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emittery@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.4.1.tgz#abe9d3297389ba424ac87e53d1c701962ce7433d"
+  integrity sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -5392,6 +5397,11 @@ ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
+import-lazy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
+  integrity sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -9139,10 +9149,10 @@ replace-ext@^1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
-replicator@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/replicator/-/replicator-1.0.2.tgz#f21812f28f3b853a34795a7d52814581df652fe1"
-  integrity sha512-y2yeUd+NDfSk6SHELNJfMwglmjDYxw65VKgDYMEYGLdJVnqz/sER0mFJbHrawqKfQoVRJ5vN3pSouL9ZLUVd8w==
+replicator@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/replicator/-/replicator-1.0.3.tgz#c0b3ea31e749015bae5d52273f2ae35d541b87ef"
+  integrity sha512-WsKsraaM0x0QHy5CtzdgFXUxyowoBhyNkmPqmZShW6h+rOWnyT6Od3zRdTX9r616rAA6kDC9MKQGnSM/CJKfVQ==
 
 request-promise-core@1.1.1:
   version "1.1.1"
@@ -10158,10 +10168,10 @@ testcafe-browser-tools@1.6.5:
     read-file-relative "^1.2.0"
     which-promise "^1.0.0"
 
-testcafe-hammerhead@14.4.0:
-  version "14.4.0"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.4.0.tgz#443cfdb6c4e125bc48676ab02e4c0b53201f5b35"
-  integrity sha512-RTFmgE0XvjcJd6PmZucwPWYoH3qxeq6Cd4T/I8ZodYkAcbBMK9849Kj3wOp6EpgTR45owCHAvqyc4S23LTzh9w==
+testcafe-hammerhead@14.4.7:
+  version "14.4.7"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.4.7.tgz#9b2794864199b40a3445859c1f987191d3b9650f"
+  integrity sha512-9Su+yt0dSsc9y/LHZaRuZApN8yAc5zL6t5nx3CPXRhdgxi6OJ3hw+xAG32NRufaZrS8H/VXwknmfe+Pqw7d8KA==
   dependencies:
     bowser "1.6.0"
     brotli "^1.3.1"
@@ -10187,10 +10197,10 @@ testcafe-hammerhead@14.4.0:
     tunnel-agent "0.6.0"
     webauth "^1.1.0"
 
-testcafe-legacy-api@3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-3.1.8.tgz#1ddf66ba1a4cf4cf36d2dd49b9c3af63bcda698f"
-  integrity sha512-Hv4jZwAE1s9oWvzhk8SMG3mBhTr77TsQJNfYxC5qZ3YpjqNmwJjaQKNxbGameef+27dWbTWkvGkE6cq284bowg==
+testcafe-legacy-api@3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-3.1.9.tgz#9f1a730aeae56c72484f3b4e65cd58bdeac6bd0e"
+  integrity sha512-oV6Ej2+YWiirLjJEHs+GbgmPnwf2KuoegDoFg//0rZ6uIK0O3zPtTNTV+pZERwQReaNY7M3e9Jz8t0ZjDweZyA==
   dependencies:
     async "0.2.6"
     babel-runtime "^5.8.34"
@@ -10230,10 +10240,10 @@ testcafe-reporter-xunit@^2.1.0:
   resolved "https://registry.yarnpkg.com/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz#e6d66c572ce15af266706af0fd610b2a841dd443"
   integrity sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=
 
-testcafe@0.23.1-alpha.2:
-  version "0.23.1-alpha.2"
-  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-0.23.1-alpha.2.tgz#b7362caa3c27adcf79c4f0f5f1b0063963fee051"
-  integrity sha512-X2HpcUGd6ebnWlKgRZBcBda/PnWAWwZuWjkDkSaiM71Jz4uU+kRs5gMlrfCsM92HUuIoXvgTJndKUT+Mv3Pfzw==
+testcafe@^0.23.2:
+  version "0.23.3"
+  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-0.23.3.tgz#8f9c6511b43ac99593d532bb08ae06c55ff72b5c"
+  integrity sha512-/ykDZ/Pvbb9oCK5kI/47DNm9nKYr8d7eY6U4nm7or5ETREkL9yEQwEzzyb2pC3Nt7iYzK+ZyPAcPWN4QFGiOXA==
   dependencies:
     async-exit-hook "^1.1.2"
     babel-core "^6.22.1"
@@ -10257,14 +10267,17 @@ testcafe@0.23.1-alpha.2:
     dedent "^0.4.0"
     del "^3.0.0"
     elegant-spinner "^1.0.1"
+    emittery "^0.4.1"
     endpoint-utils "^1.0.2"
     error-stack-parser "^1.3.6"
     globby "^3.0.1"
     graceful-fs "^4.1.11"
     gulp-data "^1.3.1"
+    import-lazy "^3.1.0"
     indent-string "^1.2.2"
     is-ci "^1.0.10"
     is-glob "^2.0.1"
+    is-stream "^1.1.0"
     lodash "^4.17.10"
     log-update-async-hook "^2.0.2"
     make-dir "^1.3.0"
@@ -10283,15 +10296,15 @@ testcafe@0.23.1-alpha.2:
     ps-node "^0.1.6"
     qrcode-terminal "^0.10.0"
     read-file-relative "^1.2.0"
-    replicator "^1.0.0"
+    replicator "^1.0.3"
     resolve-cwd "^1.0.0"
     resolve-from "^4.0.0"
     sanitize-filename "^1.6.0"
     source-map-support "^0.5.5"
     strip-bom "^2.0.0"
     testcafe-browser-tools "1.6.5"
-    testcafe-hammerhead "14.4.0"
-    testcafe-legacy-api "3.1.8"
+    testcafe-hammerhead "14.4.7"
+    testcafe-legacy-api "3.1.9"
     testcafe-reporter-json "^2.1.0"
     testcafe-reporter-list "^2.1.0"
     testcafe-reporter-minimal "^2.1.0"


### PR DESCRIPTION
**Adds 3 tests**  

1. Drag and Drop renders a Guardian Snap Link correctly
2. Drag and Drop renders a Latest Guardian Snap Link correctly
3. Drag and Drop renders an external page Snap Link correctly

**Notes** 

- for dnd, I had to mock html anchor tags in index.html
- TestCafe bug - sometimes headless tests don't pass b/c it can't find DOM nodes unless you `t.maximizeWindow()` 
- Express server endpoints are specific to the fixtures used. 

The last Express `.get` endpoint is throwing an error _I think_ because at some point it's interpreting the front id `test/front` as an endpoint and trying to serve this static file: 
`Error: ENOENT: no such file or directory, stat '/client-v2/dist/front'`

This does not seem to be affecting test behavior, and I think it's due to the implementation of the Express server endpoints. Any thoughts if needs fixing and how? 