### PR TITLE
App collection warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ TwirlKeys.templateImports ++= Seq(
 )
 
 val awsVersion = "1.11.293"
-val capiModelsVersion = "12.0"
+val capiModelsVersion = "12.10"
 val json4sVersion = "3.6.0-M2"
 
 resolvers ++= Seq(
@@ -90,7 +90,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "2.6.2",
+    "com.gu" %% "fapi-client-play26" % "2.6.2-SNAPSHOT",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-client" % "1.2",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.1",

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "2.6.2-SNAPSHOT",
+    "com.gu" %% "fapi-client-play26" % "2.6.5",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-client" % "1.2",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.1",

--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 import { AlsoOnDetail } from 'types/Collection';
 import Button from 'shared/components/input/ButtonDefault';
 
-interface AlsoOnNotificationProps {
-  alsoOn: AlsoOnDetail
+interface CollectionNotificationProps {
+  alsoOn: AlsoOnDetail,
+  displayEditWarning: boolean
 }
 
 interface ComponentState {
@@ -17,8 +18,8 @@ const WarningText = styled('span')`
   color: #e05e00;
 `;
 
-class AlsoOnNotification extends React.Component<
-  AlsoOnNotificationProps,
+class CollectionNotification extends React.Component<
+  CollectionNotificationProps,
   ComponentState
 > {
   public state = {
@@ -26,7 +27,13 @@ class AlsoOnNotification extends React.Component<
   };
 
   public render() {
-    const { alsoOn } = this.props;
+    const { alsoOn, displayEditWarning } = this.props;
+    if (displayEditWarning) {
+      return (
+        <div><WarningText>Warning: do not change or delete this container. Please speak to Central Production.</WarningText></div>
+      );
+    }
+
     if (alsoOn.fronts.length > 0) {
       return (
         <div>
@@ -71,4 +78,4 @@ class AlsoOnNotification extends React.Component<
   }
 }
 
-export default AlsoOnNotification;
+export default CollectionNotification;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -2,7 +2,7 @@ import { Dispatch } from 'types/Store';
 import React from 'react';
 import { connect } from 'react-redux';
 import CollectionDisplay from 'shared/components/Collection';
-import AlsoOnNotification from 'components/AlsoOnNotification';
+import CollectionNotification from 'components/CollectionNotification';
 import Button from 'shared/components/input/ButtonDefault';
 import { AlsoOnDetail } from 'types/Collection';
 import { publishCollection } from 'actions/Fronts';
@@ -11,6 +11,7 @@ import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
 import {
   createCollectionStageGroupsSelector,
+  createCollectionEditWarningSelector,
   selectSharedState
 } from 'shared/selectors/shared';
 
@@ -27,6 +28,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   hasUnpublishedChanges: boolean;
   canPublish: boolean;
   groups: Group[];
+  displayEditWarning: boolean;
 };
 
 const Collection = ({
@@ -38,7 +40,8 @@ const Collection = ({
   hasUnpublishedChanges,
   canPublish = true,
   publishCollection: publish,
-  frontId
+  frontId,
+  displayEditWarning
 }: CollectionProps) => (
   <CollectionDisplay
     id={id}
@@ -52,8 +55,8 @@ const Collection = ({
       )
     }
     metaContent={
-      alsoOn[id].fronts.length ? (
-        <AlsoOnNotification alsoOn={alsoOn[id]} />
+      (alsoOn[id].fronts.length || displayEditWarning) ? (
+        <CollectionNotification displayEditWarning={displayEditWarning} alsoOn={alsoOn[id]} />
       ) : null
     }
   >
@@ -63,12 +66,16 @@ const Collection = ({
 
 const createMapStateToProps = () => {
   const collectionStageGroupsSelector = createCollectionStageGroupsSelector();
+  const editWarningSelector = createCollectionEditWarningSelector();
   return (state: State, { browsingStage, id }: CollectionPropsBeforeState) => ({
     hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
       collectionId: id
     }),
     groups: collectionStageGroupsSelector(selectSharedState(state), {
       collectionSet: browsingStage,
+      collectionId: id
+    }),
+    displayEditWarning: editWarningSelector(selectSharedState(state), {
       collectionId: id
     })
   });

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -129,6 +129,16 @@ const createCollectionStageGroupsSelector = () => {
   );
 };
 
+const createCollectionEditWarningSelector = () => {
+  const collectionSelector = createCollectionSelector();
+  return createSelector(
+    collectionSelector,
+    (
+      collection: Collection | void
+    ): boolean => !!(collection && collection.frontsToolSettings && collection.frontsToolSettings.displayEditWarning)
+  );
+};
+
 const groupNameSelector = (
   _: unknown,
   { groupName }: { groupName: string; collectionSet: CollectionItemSets; collectionId: string }
@@ -222,5 +232,6 @@ export {
   createDemornalisedArticleFragment,
   selectSharedState,
   articleFragmentSelector,
-  articleKickerOptionsSelector
+  articleKickerOptionsSelector,
+  createCollectionEditWarningSelector
 };

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -1,4 +1,5 @@
 import { Diff } from 'utility-types';
+import { FrontsToolSettings } from 'types/FaciaApi';
 
 interface Group {
   id: string;
@@ -117,6 +118,7 @@ interface Collection {
   displayName: string;
   groups?: string[];
   type: string
+  frontsToolSettings?: FrontsToolSettings;
 }
 
 export {

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -20,6 +20,10 @@ interface FrontConfigResponse {
 
 type Platform = 'Web' | 'Platform';
 
+interface FrontsToolSettings {
+  displayEditWarning?: boolean;
+}
+
 interface CollectionConfigResponse {
   displayName: string,
   type: string,
@@ -37,7 +41,8 @@ interface CollectionConfigResponse {
   showLatestUpdate?: boolean,
   excludeFromRss?: boolean,
   hideShowMore?: boolean,
-  platform?: Platform
+  platform?: Platform,
+  frontsToolSettings?: FrontsToolSettings;
 }
 
 interface FrontsConfigResponse {
@@ -91,5 +96,6 @@ export {
   FrontsConfigResponse,
   FrontConfigMap,
   ArticleDetails,
-  VisibleArticlesResponse
+  VisibleArticlesResponse,
+  FrontsToolSettings
 };

--- a/client-v2/src/util/frontsUtils.ts
+++ b/client-v2/src/util/frontsUtils.ts
@@ -34,7 +34,8 @@ const combineCollectionWithConfig = (
     id: collection.id,
     displayName: collectionConfig.displayName,
     groups: collectionConfig.groups,
-    type: collectionConfig.type
+    type: collectionConfig.type,
+    frontsToolSettings: collectionConfig.frontsToolSettings
   });
 
 const populateDraftArticles = (collection: CollectionWithNestedArticles) =>

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -26,7 +26,7 @@ export default class Collection extends BaseClass {
         this.id = opts.id;
 
         this.front = opts.front;
-
+        const podcastCollectionId = '75ef80cd-2f3d-40d6-abf6-2021f88ece8e';
         this.raw = undefined;
 
         this.groups = this.createGroups(opts.groups);
@@ -105,6 +105,10 @@ export default class Collection extends BaseClass {
         this.state.visibleCount({});
 
         this.lastAlertSentHuman = ko.observable(this.getLastAlertHuman());
+
+        this.isPodcastCollection = this.id === podcastCollectionId ||
+            (this.configMeta.frontsToolSettings()  && this.configMeta.frontsToolSettings().displayEditWarning);
+
     }
 
     getLastAlertHuman() {

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -23,9 +23,7 @@ export default class Collection extends BaseClass {
         super();
         if (!opts.id) { return; }
 
-        const podcastCollectionId = '75ef80cd-2f3d-40d6-abf6-2021f88ece8e';
         this.id = opts.id;
-        this.isPodcastCollection = this.id === podcastCollectionId;
 
         this.front = opts.front;
 
@@ -61,7 +59,8 @@ export default class Collection extends BaseClass {
             'href',
             'uneditable',
             'metadata',
-            'platform'
+            'platform',
+            'frontsToolSettings'
         ]);
         populateObservables(this.configMeta, opts);
 

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -38,12 +38,18 @@ export default class ConfigCollection extends DropTarget {
                 'backfill',
                 'description',
                 'metadata',
-                'platform'
+                'platform',
+                'frontsToolSettings'
             ]),
             {
                 displayHints: asObservableProps([
                     'maxItemsToDisplay'
                 ], observableNumeric)
+            },
+            {
+                frontsToolSettings: asObservableProps([
+                    'displayEditWarning'
+                ])
             }
         );
 

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -37,7 +37,7 @@
             (<span class="non-zero">updating...</span>)
         </span>
 
-        <span class="also" data-bind="if: alsoOn && alsoOn.length && (!configMeta.frontsToolSettings() || !configMeta.frontsToolSettings().displayEditWarning)">
+        <span class="also" data-bind="if: alsoOn && alsoOn.length && !isPodcastCollection">
             <a class="alsoOnToggle" data-bind="click: alsoOnToggle">
                 <span data-bind="if: !alsoOnHasDifferentPriority">Also on&hellip;</span>
                 <span data-bind="if: alsoOnHasDifferentPriority">
@@ -54,7 +54,7 @@
                 </span>
             </a>
         </span>
-        <span class="collectionEditWarning" data-bind="if: configMeta.frontsToolSettings() && configMeta.frontsToolSettings().displayEditWarning">
+        <span class="collectionEditWarning" data-bind="if: isPodcastCollection">
             Warning: do not change or delete the <span data-bind="text: collectionMeta.displayName()"></span> container. Please speak to Central Production.
         </span>
 

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -37,7 +37,7 @@
             (<span class="non-zero">updating...</span>)
         </span>
 
-        <span class="also" data-bind="if: alsoOn && alsoOn.length && !isPodcastCollection">
+        <span class="also" data-bind="if: alsoOn && alsoOn.length && (!configMeta.frontsToolSettings() || !configMeta.frontsToolSettings().displayEditWarning)">
             <a class="alsoOnToggle" data-bind="click: alsoOnToggle">
                 <span data-bind="if: !alsoOnHasDifferentPriority">Also on&hellip;</span>
                 <span data-bind="if: alsoOnHasDifferentPriority">
@@ -54,9 +54,9 @@
                 </span>
             </a>
         </span>
-        <div class="collectionEditWarning" data-bind="if: isPodcastCollection">
-            Warning: do not change or delete the Podcast container. Please speak to Central Production.
-        </div>
+        <span class="collectionEditWarning" data-bind="if: configMeta.frontsToolSettings() && configMeta.frontsToolSettings().displayEditWarning">
+            Warning: do not change or delete the <span data-bind="text: collectionMeta.displayName()"></span> container. Please speak to Central Production.
+        </span>
 
         <span class="list-header__timings" data-bind="
             css: {'has-concurrent-user': state.hasConcurrentEdits}">

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -264,6 +264,9 @@
             <input type="checkbox" data-bind="
                 checked: meta.uneditable" />
 
+            <label for="frontsToolSettings.displayEditWarning">Display edit warning</label>
+            <input id="hideShowMore" type="checkbox" data-bind="checked: meta.frontsToolSettings.displayEditWarning" />
+
             <div class="platform-edit">
                 <span>Platform: </span><span data-bind="text: getPlatform()"></span>
                 <!-- ko if: !thisIsPlatformSpecificCollection && parents().length <= 1 -->

--- a/test/config/TransformationsSpec.scala
+++ b/test/config/TransformationsSpec.scala
@@ -53,6 +53,7 @@ import updates.CreateFront
     None,
     None,
     None,
+    None,
     None
   )
 


### PR DESCRIPTION
Instead of audio collection warning being hardcoded in the code, collections warnings are now configurable properties. Will remove the hardcoded podcast id once this change has gone in so that we don't lose the warnings during merge.