### PR TITLE
Show Collection Config "platform" setting on Front Collection

### DIFF
--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -46,15 +46,21 @@ const prioritySelector = (state: State, { priority }: { priority: string }) =>
 const frontIdSelector = (state: State, { frontId }: { frontId: string }) =>
   frontId;
 
-const collectionSetSelector = (state: State, { collectionSet }: { collectionSet: CollectionItemSets }) =>
-  collectionSet;
+const collectionSetSelector = (
+  state: State,
+  { collectionSet }: { collectionSet: CollectionItemSets }
+) => collectionSet;
 
-const collectionIdAndStageSelector = (state: State, { stage, collectionId }: { stage: Stages, collectionId: string }) => ({
+const collectionIdAndStageSelector = (
+  state: State,
+  { stage, collectionId }: { stage: Stages; collectionId: string }
+) => ({
   stage,
   collectionId
-})
+});
 
-const collectionVisibilitiesSelector = (state: State) => state.fronts.collectionVisibility;
+const collectionVisibilitiesSelector = (state: State) =>
+  state.fronts.collectionVisibility;
 
 const collectionIdSelector = (
   state: State,
@@ -83,6 +89,7 @@ const getFrontsWithPriority = (state: State, priority: string): FrontConfig[] =>
 
 const getCollections = (state: State): CollectionConfigMap =>
   frontsConfigSelectors.selectAll(state).collections || {};
+
 const getCollectionConfig = (state: State, id: string): CollectionConfig =>
   getCollections(state)[id] || null;
 
@@ -223,7 +230,11 @@ const alsoOnFrontSelector = (
             )
           };
         },
-        { priorities: [] as string[], fronts: [] as Array<{ id: string; priority: string }>, meritsWarning: false }
+        {
+          priorities: [] as string[],
+          fronts: [] as Array<{ id: string; priority: string }>,
+          meritsWarning: false
+        }
       );
 
       return {
@@ -246,8 +257,9 @@ const clipboardSelector = (state: State) => state.clipboard;
 const visibleArticlesSelector = createSelector(
   [collectionVisibilitiesSelector, collectionIdAndStageSelector],
   (collectionVisibilities, { collectionId, stage }) => {
-  return collectionVisibilities[stage][collectionId];
-});
+    return collectionVisibilities[stage][collectionId];
+  }
+);
 
 const visibleFrontArticlesSelector = createSelector(
   [collectionVisibilitiesSelector, collectionSetSelector],
@@ -257,8 +269,7 @@ const visibleFrontArticlesSelector = createSelector(
     }
     return collectionVisibilities[collectionSet];
   }
-)
-
+);
 
 export {
   getFront,

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -119,7 +119,9 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
           </CollectionHeadingText>
           {/* extra info containter */}
           <ConfigContentContainer>
-            {collection.platform ? `${collection.platform} only` : null}
+            {collection.platform && collection.platform !== 'Any'
+              ? `${collection.platform} only`
+              : null}
           </ConfigContentContainer>
           {headlineContent && (
             <HeadlineContentContainer>

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -8,23 +8,27 @@ import ShortVerticalPinline from './layout/ShortVerticalPinline';
 import ContainerHeadingPinline from './typography/ContainerHeadingPinline';
 import { Collection, CollectionItemSets } from '../types/Collection';
 import ButtonCircularCaret from './input/ButtonCircularCaret';
-import { State } from '../types/State';
+import { State as SharedState } from '../types/State';
+import { State as RootState } from '../../types/State';
+import { CollectionConfig } from '../../types/FaciaApi';
 import {
   selectSharedState,
   createArticlesInCollectionSelector
 } from '../selectors/shared';
+import { getCollectionConfig } from '../../selectors/frontsSelectors';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
 import ContentContainer from './layout/ContentContainer';
 
 interface ContainerProps {
   id: string;
-  selectSharedState?: (state: any) => State;
+  selectSharedState?: (state: any) => SharedState;
   browsingStage: CollectionItemSets;
 }
 
 type Props = ContainerProps & {
   collection: Collection;
+  config: CollectionConfig;
   articleIds?: string[];
   headlineContent: React.ReactNode;
   metaContent: React.ReactNode;
@@ -97,6 +101,7 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
       articleIds,
       headlineContent,
       metaContent,
+      config,
       children
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
@@ -106,6 +111,7 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
           <CollectionHeadingText>
             {collection.displayName}
           </CollectionHeadingText>
+          <span>{config.platform ? config.platform : null}</span>
           {headlineContent && (
             <HeadlineContentContainer>
               {headlineContent}
@@ -151,12 +157,13 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
 
 const createMapStateToProps = () => {
   const selectArticlesInCollection = createArticlesInCollectionSelector();
-  return (state: State, props: ContainerProps) => {
+  return (state: RootState, props: ContainerProps) => {
     const sharedState = props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state);
     return {
       collection: collectionSelectors.selectById(sharedState, props.id),
+      config: getCollectionConfig(state, props.id),
       articleIds: selectArticlesInCollection(sharedState, {
         collectionId: props.id,
         collectionSet: props.browsingStage

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -47,6 +47,15 @@ const HeadlineContentContainer = styled('span')`
   line-height: 0px;
 `;
 
+const ConfigContentContainer = styled('span')`
+  position: relative;
+  font-family: TS3TextSans;
+  font-size: 14px;
+  font-weight: bold;
+  margin: 0 0;
+  padding: 0 25px;
+`;
+
 const CollectionMetaContainer = styled('div')`
   display: flex;
   position: relative;
@@ -111,7 +120,9 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
           <CollectionHeadingText>
             {collection.displayName}
           </CollectionHeadingText>
-          <span>{config.platform ? config.platform : null}</span>
+          <ConfigContentContainer>
+            {config.platform ? `${config.platform} only` : null}
+          </ConfigContentContainer>
           {headlineContent && (
             <HeadlineContentContainer>
               {headlineContent}

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -9,13 +9,12 @@ import ContainerHeadingPinline from './typography/ContainerHeadingPinline';
 import { Collection, CollectionItemSets } from '../types/Collection';
 import ButtonCircularCaret from './input/ButtonCircularCaret';
 import { State as SharedState } from '../types/State';
-import { State as RootState } from '../../types/State';
+import { State } from '../../types/State';
 import { CollectionConfig } from '../../types/FaciaApi';
 import {
   selectSharedState,
   createArticlesInCollectionSelector
 } from '../selectors/shared';
-import { getCollectionConfig } from '../../selectors/frontsSelectors';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
 import ContentContainer from './layout/ContentContainer';
@@ -28,7 +27,6 @@ interface ContainerProps {
 
 type Props = ContainerProps & {
   collection: Collection;
-  config: CollectionConfig;
   articleIds?: string[];
   headlineContent: React.ReactNode;
   metaContent: React.ReactNode;
@@ -110,7 +108,6 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
       articleIds,
       headlineContent,
       metaContent,
-      config,
       children
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
@@ -120,8 +117,9 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
           <CollectionHeadingText>
             {collection.displayName}
           </CollectionHeadingText>
+          {/* extra info containter */}
           <ConfigContentContainer>
-            {config.platform ? `${config.platform} only` : null}
+            {collection.platform ? `${collection.platform} only` : null}
           </ConfigContentContainer>
           {headlineContent && (
             <HeadlineContentContainer>
@@ -168,13 +166,12 @@ class CollectionDetail extends React.Component<Props, { isOpen: boolean }> {
 
 const createMapStateToProps = () => {
   const selectArticlesInCollection = createArticlesInCollectionSelector();
-  return (state: RootState, props: ContainerProps) => {
+  return (state: State, props: ContainerProps) => {
     const sharedState = props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state);
     return {
       collection: collectionSelectors.selectById(sharedState, props.id),
-      config: getCollectionConfig(state, props.id),
       articleIds: selectArticlesInCollection(sharedState, {
         collectionId: props.id,
         collectionSet: props.browsingStage

--- a/client-v2/src/util/frontsUtils.ts
+++ b/client-v2/src/util/frontsUtils.ts
@@ -1,19 +1,22 @@
 import { FrontConfig, CollectionConfig } from 'types/FaciaApi';
-import { CollectionWithNestedArticles, ArticleFragment } from 'shared/types/Collection';
+import {
+  CollectionWithNestedArticles,
+  ArticleFragment
+} from 'shared/types/Collection';
 import { detectPressFailureMs } from 'constants/fronts';
 import { ArticleDetails } from 'types/FaciaApi';
 import { Stages, Collection } from 'shared/types/Collection';
 import { frontStages } from 'constants/fronts';
 
 const getFrontCollections = (
-  frontId: string|void,
+  frontId: string | void,
   fronts: FrontConfig[],
   collections: { [id: string]: CollectionConfig }
 ): CollectionConfig[] => {
   if (!frontId) {
     return [];
   }
-  const selectedFront: FrontConfig|void = fronts.find(
+  const selectedFront: FrontConfig | void = fronts.find(
     (front: FrontConfig) => front.id === frontId
   );
 
@@ -35,7 +38,8 @@ const combineCollectionWithConfig = (
     displayName: collectionConfig.displayName,
     groups: collectionConfig.groups,
     type: collectionConfig.type,
-    frontsToolSettings: collectionConfig.frontsToolSettings
+    frontsToolSettings: collectionConfig.frontsToolSettings,
+    platform: collectionConfig.platform
   });
 
 const populateDraftArticles = (collection: CollectionWithNestedArticles) =>
@@ -48,20 +52,25 @@ const isFrontStale = (lastUpdated?: number, lastPressed?: number) => {
   return false;
 };
 
-const getVisibilityArticleDetails = (groupsWithArticles: ArticleFragment[][]) => groupsWithArticles.reduce((articles, articlesInGroup, index) => {
-  const numberOfGroups = groupsWithArticles.length;
-   const groupArticles = articlesInGroup.map(story => ({ group: numberOfGroups - index - 1, isBoosted: !!story.meta.isBoosted }));
-    return articles.concat(groupArticles);
-
-  }, [] as ArticleDetails[]);
+const getVisibilityArticleDetails = (groupsWithArticles: ArticleFragment[][]) =>
+  groupsWithArticles.reduce(
+    (articles, articlesInGroup, index) => {
+      const numberOfGroups = groupsWithArticles.length;
+      const groupArticles = articlesInGroup.map(story => ({
+        group: numberOfGroups - index - 1,
+        isBoosted: !!story.meta.isBoosted
+      }));
+      return articles.concat(groupArticles);
+    },
+    [] as ArticleDetails[]
+  );
 
 const getGroupsByStage = (collection: Collection, stage: Stages) => {
   if (stage === frontStages.draft) {
     return (collection.draft ? collection.draft : collection.live) || [];
   }
   return collection.live ? collection.live : [];
-}
-
+};
 
 export {
   getFrontCollections,


### PR DESCRIPTION
A Front Collection headline area will now display whether a collection has been marked for 'App only' or 'Web only' dependant on the collection's config settings. 

Note: UI is tbc

I've reused the  `getCollectionConfig` from `../../selectors/frontsSelectors` which makes all of a collection's config values readily available (including uneditable, metaData, etc).   


![image](https://user-images.githubusercontent.com/32312712/48917852-cf8aba00-ee80-11e8-8ccf-0378c03aeed7.png)


