### PR TITLE
remove hardcoded podcast id

### DIFF
--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -26,7 +26,6 @@ export default class Collection extends BaseClass {
         this.id = opts.id;
 
         this.front = opts.front;
-        const podcastCollectionId = '75ef80cd-2f3d-40d6-abf6-2021f88ece8e';
         this.raw = undefined;
 
         this.groups = this.createGroups(opts.groups);
@@ -106,8 +105,7 @@ export default class Collection extends BaseClass {
 
         this.lastAlertSentHuman = ko.observable(this.getLastAlertHuman());
 
-        this.isPodcastCollection = this.id === podcastCollectionId ||
-            (this.configMeta.frontsToolSettings()  && this.configMeta.frontsToolSettings().displayEditWarning);
+        this.displayEditWarning = this.configMeta.frontsToolSettings()  && this.configMeta.frontsToolSettings().displayEditWarning;
 
     }
 

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -37,7 +37,7 @@
             (<span class="non-zero">updating...</span>)
         </span>
 
-        <span class="also" data-bind="if: alsoOn && alsoOn.length && !isPodcastCollection">
+        <span class="also" data-bind="if: alsoOn && alsoOn.length && !displayEditWarning">
             <a class="alsoOnToggle" data-bind="click: alsoOnToggle">
                 <span data-bind="if: !alsoOnHasDifferentPriority">Also on&hellip;</span>
                 <span data-bind="if: alsoOnHasDifferentPriority">
@@ -54,7 +54,7 @@
                 </span>
             </a>
         </span>
-        <span class="collectionEditWarning" data-bind="if: isPodcastCollection">
+        <span class="collectionEditWarning" data-bind="if: displayEditWarning">
             Warning: do not change or delete the <span data-bind="text: collectionMeta.displayName()"></span> container. Please speak to Central Production.
         </span>
 


### PR DESCRIPTION
Mariana is going to turn the configurable edit warning on for the podcast collection, once that is done we can remove the hardcoded podcast id.