### PR TITLE
Collection cap tests

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -206,7 +206,8 @@ const updateClipboardArticleFragmentMetaWithPersist = addPersistMetaToAction(
 const insertArticleFragmentWithCreate = (
   to: PosSpec,
   id: string,
-  persistTo: 'collection' | 'clipboard'
+  persistTo: 'collection' | 'clipboard',
+  articleFragmentFactory = createArticleFragment
 ): ThunkResult<void> => {
   return (dispatch: Dispatch) => {
     const insertActionCreator = getInsertionActionCreatorFromType(
@@ -216,7 +217,7 @@ const insertArticleFragmentWithCreate = (
     if (!insertActionCreator) {
       return;
     }
-    dispatch(createArticleFragment(id))
+    return dispatch(articleFragmentFactory(id))
       .then(fragment => {
         if (fragment) {
           dispatch(insertActionCreator(to.id, to.index, fragment.uuid, null));

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -207,6 +207,7 @@ const insertArticleFragmentWithCreate = (
   to: PosSpec,
   id: string,
   persistTo: 'collection' | 'clipboard',
+  // allow the factory to be injected for testing
   articleFragmentFactory = createArticleFragment
 ): ThunkResult<void> => {
   return (dispatch: Dispatch) => {

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -1,15 +1,13 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import {
-  insertGroupArticleFragment,
-  insertSupportingArticleFragment
-} from '../../shared/actions/ArticleFragments';
 import clipboardReducer from '../../reducers/clipboardReducer';
 import groupsReducer from '../../shared/reducers/groupsReducer';
 import articleFragmentsReducer from '../../shared/reducers/articleFragmentsReducer';
 import {
   createGroupArticlesSelector,
-  createSupportingArticlesSelector
+  createSupportingArticlesSelector,
+  articleFragmentSelector,
+  selectSharedState
 } from '../../shared/selectors/shared';
 import { clipboardSelector as innerClipboardSelector } from '../../selectors/frontsSelectors';
 import {
@@ -17,13 +15,14 @@ import {
   ArticleFragmentSpec,
   specToFragment
 } from './utils';
-import { moveArticleFragment } from 'actions/ArticleFragments';
+import {
+  moveArticleFragment,
+  insertArticleFragment
+} from 'actions/ArticleFragments';
 import {
   reducer as collectionsReducer,
   initialState as collectionsState
 } from 'shared/bundles/collectionsBundle';
-import { insertClipboardArticleFragment } from 'actions/Clipboard';
-import { Action } from 'types/Action';
 
 const root = (state: any = {}, action: any) => ({
   clipboard: clipboardReducer(state.clipboard, action, state.shared),
@@ -77,25 +76,22 @@ const buildStore = (added: ArticleFragmentSpec) => {
   return createStore(root, state as any, applyMiddleware(thunk));
 };
 
-const insert = (
+const insert = async (
   [uuid, id]: [string, string],
   index: number,
   parentType: string,
   parentId: string
 ) => {
-  const insertActionMap: {
-    [key: string]: (
-      id: string,
-      index: number,
-      articleFragmentId: string
-    ) => Action;
-  } = {
-    clipboard: insertClipboardArticleFragment,
-    articleFragment: insertSupportingArticleFragment,
-    group: insertGroupArticleFragment
-  };
   const { dispatch, getState } = buildStore([uuid, id, undefined]);
-  dispatch(insertActionMap[parentType](parentId, index, uuid) as any);
+  await dispatch(insertArticleFragment(
+    { type: parentType, id: parentId, index },
+    parentId,
+    'collection',
+    afId => () =>
+      Promise.resolve(
+        articleFragmentSelector(selectSharedState(getState()), uuid)
+      )
+  ) as any);
   return getState();
 };
 
@@ -139,58 +135,58 @@ const supportingArticlesSelector = (state: any, articleFragmentId: string) =>
 
 describe('ArticleFragments actions', () => {
   describe('insert', () => {
-    it('adds article fragments that exist in the state', () => {
+    it('adds article fragments that exist in the state', async () => {
       expect(
-        clipboardSelector(insert(['h', '8'], 2, 'clipboard', 'clipboard'))
+        clipboardSelector(await insert(['h', '8'], 2, 'clipboard', 'clipboard'))
       ).toEqual(['d', 'e', 'h', 'f']);
 
       expect(
-        groupArticlesSelector(insert(['h', '8'], 2, 'group', 'a'), 'a')
+        groupArticlesSelector(await insert(['h', '8'], 2, 'group', 'a'), 'a')
       ).toEqual(['a', 'b', 'h', 'c']);
 
       expect(
         supportingArticlesSelector(
-          insert(['h', '8'], 2, 'articleFragment', 'a'),
+          await insert(['h', '8'], 2, 'articleFragment', 'a'),
           'a'
         )
       ).toEqual(['g', 'h']);
     });
 
-    it('moves existing articles when duplicates are added', () => {
+    it('moves existing articles when duplicates are added', async () => {
       expect(
-        clipboardSelector(insert(['h', '6'], 0, 'clipboard', 'clipboard'))
+        clipboardSelector(await insert(['h', '6'], 0, 'clipboard', 'clipboard'))
       ).toEqual(['h', 'd', 'e']);
 
       expect(
-        groupArticlesSelector(insert(['h', '3'], 0, 'group', 'a'), 'a')
+        groupArticlesSelector(await insert(['h', '3'], 0, 'group', 'a'), 'a')
       ).toEqual(['h', 'a', 'b']);
 
       expect(
         supportingArticlesSelector(
-          insert(['h', '7'], 0, 'articleFragment', 'a'),
+          await insert(['h', '7'], 0, 'articleFragment', 'a'),
           'a'
         )
       ).toEqual(['h']);
     });
 
-    it('dedupe across groups in the same collection', () => {
-      const state = insert(['h', '3'], 0, 'group', 'b');
+    it('dedupe across groups in the same collection', async () => {
+      const state = await insert(['h', '3'], 0, 'group', 'b');
       expect(groupArticlesSelector(state, 'a')).toEqual(['a', 'b']);
       expect(groupArticlesSelector(state, 'b')).toEqual(['h', 'i', 'j', 'k']);
     });
 
-    it('adds to the end when the index is too high', () => {
+    it('adds to the end when the index is too high', async () => {
       expect(
-        clipboardSelector(insert(['h', '8'], 100, 'clipboard', 'clipboard'))
+        clipboardSelector(await insert(['h', '8'], 100, 'clipboard', 'clipboard'))
       ).toEqual(['d', 'e', 'f', 'h']);
 
       expect(
-        groupArticlesSelector(insert(['h', '8'], 100, 'group', 'a'), 'a')
+        groupArticlesSelector(await insert(['h', '8'], 100, 'group', 'a'), 'a')
       ).toEqual(['a', 'b', 'c', 'h']);
 
       expect(
         supportingArticlesSelector(
-          insert(['h', '8'], 100, 'articleFragment', 'a'),
+          await insert(['h', '8'], 100, 'articleFragment', 'a'),
           'a'
         )
       ).toEqual(['g', 'h']);

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -90,9 +90,11 @@ const insert = async (
   index: number,
   parentType: string,
   parentId: string,
+  // sets the collection cap and allows a way to accept, reject, ignore the
+  // modal immediately
   collectionCapInfo?: {
     cap: number;
-    accept: boolean;
+    accept: boolean | null;
   }
 ) => {
   const { dispatch, getState } = buildStore(
@@ -109,7 +111,7 @@ const insert = async (
       )
   ) as any);
 
-  if (collectionCapInfo) {
+  if (collectionCapInfo && collectionCapInfo.accept !== null) {
     dispatch(endConfirmModal(collectionCapInfo.accept));
   }
 
@@ -123,6 +125,8 @@ const move = (
   toId: string,
   fromType: string,
   fromId: string,
+  // sets the collection cap and allows a way to accept, reject, ignore the
+  // modal immediately
   collectionCapInfo?: {
     cap: number;
     accept: boolean | null;

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -86,7 +86,7 @@ const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
 };
 
 const insert = async (
-  [uuid, id]: [string, string],
+  insertedArticleFragmentSpec: [string, string],
   index: number,
   parentType: string,
   parentId: string,
@@ -97,6 +97,7 @@ const insert = async (
     accept: boolean | null;
   }
 ) => {
+  const [uuid, id] = insertedArticleFragmentSpec;
   const { dispatch, getState } = buildStore(
     [uuid, id, undefined],
     collectionCapInfo ? collectionCapInfo.cap : Infinity
@@ -119,7 +120,7 @@ const insert = async (
 };
 
 const move = (
-  [uuid, id]: [string, string],
+  movedArticleFragmentSpec: [string, string],
   index: number,
   toType: string,
   toId: string,
@@ -132,6 +133,7 @@ const move = (
     accept: boolean | null;
   }
 ) => {
+  const [uuid, id] = movedArticleFragmentSpec;
   const { dispatch, getState } = buildStore(
     [uuid, id, undefined],
     collectionCapInfo ? collectionCapInfo.cap : Infinity


### PR DESCRIPTION
Somehow these tests didn't make it through on the original PR. These do the actual testing of the group collection caps (and use the _actual_ insert action creator used at the application level). Much safe 🚑 ...

Also, because who _doesn't_ want to see a large passing test suite:

![kapture 2018-12-06 at 15 19 15](https://user-images.githubusercontent.com/1652187/49592958-56a05d80-f96a-11e8-8451-a5906dfd8aea.gif)
