### PR TITLE
Optimization for loading massive fronts config

### DIFF
--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -95,6 +95,7 @@ export {
   FrontsConfig,
   FrontsConfigResponse,
   FrontConfigMap,
+  CollectionConfigMap,
   ArticleDetails,
   VisibleArticlesResponse,
   FrontsToolSettings


### PR DESCRIPTION
We were creating a new object on each iteration of a fronts config key which was taking ~2s to load all of them! 😨 