### PR TITLE
Snap link creation should handle guardian link with no CAPI results

### DIFF
--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -158,6 +158,13 @@ function createArticleFragment(
         return persistAndReturnFragment(dispatch, createFragment(article.id));
       }
     } catch (e) {
+      if (isURL) {
+        // If there was an error getting content for CAPI, assume the link is valid
+        // and create a link snap as a fallback. This catches cases like non-tag or
+        // section guardian.co.uk URLs, which aren't in CAPI and are sometimes linked.
+        const fragment = await createLinkSnap(resourceId);
+        return persistAndReturnFragment(dispatch, fragment)
+      }
       dispatch(externalArticleActions.fetchError(e.message, [id]));
     }
   };

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -68,39 +68,78 @@ describe('articleFragments actions', () => {
         })
       );
     });
-    it('should fetch tag articles and create a corresponding collection item representing a snap of type \'latest\' given user input', async () => {
+    it("should fetch tag articles and create a corresponding collection item representing a snap of type 'latest' given user input", async () => {
       fetchMock.once('begin:/api/preview', {
         response: {
           results: [capiArticle, capiArticle],
           tag: { webTitle: 'Example title' }
         }
       });
-      fetchMock.once('/http/proxy/https://www.theguardian.com/example/tag/page?view=mobile', guardianTagPage);
+      fetchMock.once(
+        '/http/proxy/https://www.theguardian.com/example/tag/page?view=mobile',
+        guardianTagPage
+      );
       (window as any).confirm = jest.fn(() => true);
       const store = mockStore({});
-      await store.dispatch(createArticleFragment('https://www.theguardian.com/example/tag/page') as any);
+      await store.dispatch(createArticleFragment(
+        'https://www.theguardian.com/example/tag/page'
+      ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createLatestSnap('https://www.theguardian.com/example/tag/page', 'Example title')
+          uuid: await createLatestSnap(
+            'https://www.theguardian.com/example/tag/page',
+            'Example title'
+          )
         })
       );
     });
-    it('should fetch tag articles and create a corresponding collection item representing a snap of type \'link\' given user input', async () => {
+    it("should fetch tag articles and create a corresponding collection item representing a snap of type 'link' given user input", async () => {
       fetchMock.once('begin:/api/preview', {
         response: {
           results: [capiArticle, capiArticle],
           tag: { webTitle: 'Example title' }
         }
       });
-      fetchMock.mock('/http/proxy/https://www.theguardian.com/example/tag/page?view=mobile', guardianTagPage);
+      fetchMock.mock(
+        '/http/proxy/https://www.theguardian.com/example/tag/page?view=mobile',
+        guardianTagPage
+      );
       (window as any).confirm = jest.fn(() => false);
       const store = mockStore({});
-      await store.dispatch(createArticleFragment('https://www.theguardian.com/example/tag/page') as any);
+      await store.dispatch(createArticleFragment(
+        'https://www.theguardian.com/example/tag/page'
+      ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createLinkSnap('https://www.theguardian.com/example/tag/page')
+          uuid: await createLinkSnap(
+            'https://www.theguardian.com/example/tag/page'
+          )
+        })
+      );
+    });
+    it('should create a snap link if a Guardian URL is provided and no content is returned from CAPI', async () => {
+      fetchMock.once('begin:/api/preview', {
+        response: {
+          status: 'error',
+          message: 'The requested resource could not be found.'
+        }
+      });
+      fetchMock.mock(
+        '/http/proxy/https://www.theguardian.com/example/non/tag/page?view=mobile',
+        guardianTagPage
+      );
+      const store = mockStore({});
+      await store.dispatch(createArticleFragment(
+        'https://www.theguardian.com/example/non/tag/page'
+      ) as any);
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(
+        articleFragmentsReceived({
+          uuid: await createLinkSnap(
+            'https://www.theguardian.com/example/non/tag/page'
+          )
         })
       );
     });


### PR DESCRIPTION
A PR to handle URLs like https://www.theguardian.com/business/all, which are valid but don't represent a slug that CAPI can parse.