### PR TITLE
Search for fronts by name

### DIFF
--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -3,10 +3,12 @@ import styled, { css } from 'styled-components';
 
 import ButtonCircular from 'shared/components/input/ButtonCircular';
 import MoreImage from 'shared/images/icons/more.svg';
+import TextHighlighter from './util/TextHighlighter';
 
 interface Props {
-  fronts: Array<{ id: string, isOpen: boolean }>,
-  onSelect: (frontId: string) => void
+  fronts: Array<{ id: string; isOpen: boolean }>;
+  onSelect: (frontId: string) => void;
+  searchString: string;
 }
 
 const ListItem = styled('li')`
@@ -41,12 +43,23 @@ const ButtonAdd = ButtonCircular.extend`
   padding: 3px;
 `;
 
-const FrontList = ({ fronts, onSelect }: Props) =>
-  fronts ? (
+const FrontList = ({ fronts, onSelect, searchString }: Props) => {
+  if (!fronts) {
+    return null;
+  }
+  const frontsToRender = searchString
+    ? fronts.filter(_ => _.id.includes(searchString))
+    : fronts;
+  return (
     <ListContainer>
-      {fronts.map(front => (
+      {frontsToRender.map(front => (
         <ListItem key={front.id}>
-          <ListLabel isActive={front.isOpen}>{front.id}</ListLabel>
+          <ListLabel isActive={front.isOpen}>
+            <TextHighlighter
+              originalString={front.id}
+              searchString={searchString}
+            />
+          </ListLabel>
           {front.isOpen && (
             <ButtonAdd onClick={() => onSelect(front.id)}>
               <img src={MoreImage} alt="" width="100%" height="100%" />
@@ -55,6 +68,7 @@ const FrontList = ({ fronts, onSelect }: Props) =>
         </ListItem>
       ))}
     </ListContainer>
-  ) : null;
+  );
+};
 
 export default FrontList;

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -10,6 +10,7 @@ import Overlay from '../layout/Overlay';
 import FrontsList from '../../containers/FrontsList';
 import Row from 'components/Row';
 import Col from 'components/Col';
+import searchImage from 'shared/images/icons/search.svg';
 
 const FrontsMenuContent = styled('div')`
   flex: 1;
@@ -27,11 +28,11 @@ const FrontsMenuHeading = LargeSectionHeader.extend`
 `;
 
 const FrontsMenuSubHeading = styled('div')`
+  position: relative;
   padding: 10px 0;
   font-size: 16px;
-  line-height: 28px;
+  line-height: 30px;
   font-weight: bold;
-  line-height: 20px;
   border-bottom: solid 1px #5e5e5e;
   max-height: 100%;
 `;
@@ -55,16 +56,29 @@ const FrontsMenuContainer = styled('div')<{ isOpen?: boolean }>`
     isOpen ? 'translate3d(0px, 0, 0)' : 'translate3d(390px, 0, 0)'};
 `;
 
-const FrontsMenuInput = styled('input')`
+const FrontsMenuSearchInputContainer = Col.extend`
+  position: relative;
+`;
+
+const FrontsMenuSearchInput = styled('input')`
   background-color: rgba(0, 0, 0, 0.2);
+  height: 30px;
   width: 100%;
-  padding: 2px;
+  padding: 5px;
+  padding-right: 20px;
   border: 0;
   color: white;
   font-size: 16px;
-  :active, :focus {
+  :active,
+  :focus {
     outline: none;
   }
+`;
+
+const FrontsMenuSearchImage = styled('img')`
+  position: absolute;
+  right: 5px;
+  top: 0;
 `;
 
 interface Props {
@@ -81,6 +95,10 @@ class FrontsMenu extends React.Component<Props, State> {
     isOpen: false,
     searchString: ''
   };
+  public inputRef = React.createRef<HTMLInputElement>();
+  public constructor(props: Props) {
+    super(props);
+  }
 
   public onSelectFront = (frontId: string) => {
     this.toggleFrontsMenu();
@@ -97,6 +115,9 @@ class FrontsMenu extends React.Component<Props, State> {
   };
 
   public toggleFrontsMenu = () => {
+    if (!this.state.isOpen && this.inputRef.current) {
+      this.inputRef.current.focus();
+    }
     this.setState({
       isOpen: !this.state.isOpen
     });
@@ -126,13 +147,17 @@ class FrontsMenu extends React.Component<Props, State> {
               <FrontsMenuSubHeading>
                 <Row>
                   <Col>All</Col>
-                  <Col>
-                    <FrontsMenuInput
+                  <FrontsMenuSearchInputContainer>
+                    <FrontsMenuSearchInput
                       value={this.state.searchString}
                       onChange={this.onInput}
-                      autoFocus
+                      innerRef={this.inputRef}
                     />
-                  </Col>
+                    <FrontsMenuSearchImage
+                      src={searchImage}
+                      alt="Search fronts"
+                    />
+                  </FrontsMenuSearchInputContainer>
                 </Row>
               </FrontsMenuSubHeading>
               <FrontsMenuItems>

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -8,6 +8,8 @@ import ButtonOverlay from '../inputs/ButtonOverlay';
 import ScrollContainer from '../ScrollContainer';
 import Overlay from '../layout/Overlay';
 import FrontsList from '../../containers/FrontsList';
+import Row from 'components/Row';
+import Col from 'components/Col';
 
 const FrontsMenuContent = styled('div')`
   flex: 1;
@@ -27,6 +29,7 @@ const FrontsMenuHeading = LargeSectionHeader.extend`
 const FrontsMenuSubHeading = styled('div')`
   padding: 10px 0;
   font-size: 16px;
+  line-height: 28px;
   font-weight: bold;
   line-height: 20px;
   border-bottom: solid 1px #5e5e5e;
@@ -39,7 +42,7 @@ const ButtonOverlayContainer = styled('div')`
   bottom: 30px;
 `;
 
-const FrontsMenuContainer = styled('div')<{ isOpen?: boolean}>`
+const FrontsMenuContainer = styled('div')<{ isOpen?: boolean }>`
   background-color: #333;
   position: fixed;
   height: 100%;
@@ -52,22 +55,45 @@ const FrontsMenuContainer = styled('div')<{ isOpen?: boolean}>`
     isOpen ? 'translate3d(0px, 0, 0)' : 'translate3d(390px, 0, 0)'};
 `;
 
+const FrontsMenuInput = styled('input')`
+  background-color: rgba(0, 0, 0, 0.2);
+  width: 100%;
+  padding: 2px;
+  border: 0;
+  color: white;
+  font-size: 16px;
+  :active, :focus {
+    outline: none;
+  }
+`;
+
 interface Props {
-  onSelectFront: (frontId: string) => void
+  onSelectFront: (frontId: string) => void;
 }
 
 interface State {
-  isOpen: boolean
+  isOpen: boolean;
+  searchString: string;
 }
 
 class FrontsMenu extends React.Component<Props, State> {
   public state = {
-    isOpen: false
+    isOpen: false,
+    searchString: ''
   };
 
   public onSelectFront = (frontId: string) => {
     this.toggleFrontsMenu();
     this.props.onSelectFront(frontId);
+  };
+
+  public onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!event.target || !(event.target instanceof HTMLInputElement)) {
+      return;
+    }
+    this.setState({
+      searchString: event.target.value
+    });
   };
 
   public toggleFrontsMenu = () => {
@@ -97,9 +123,23 @@ class FrontsMenu extends React.Component<Props, State> {
             fixed={<FrontsMenuHeading>Add Front</FrontsMenuHeading>}
           >
             <FrontsMenuContent>
-              <FrontsMenuSubHeading>All</FrontsMenuSubHeading>
+              <FrontsMenuSubHeading>
+                <Row>
+                  <Col>All</Col>
+                  <Col>
+                    <FrontsMenuInput
+                      value={this.state.searchString}
+                      onChange={this.onInput}
+                      autoFocus
+                    />
+                  </Col>
+                </Row>
+              </FrontsMenuSubHeading>
               <FrontsMenuItems>
-                <FrontsList onSelect={this.onSelectFront} />
+                <FrontsList
+                  onSelect={this.onSelectFront}
+                  searchString={this.state.searchString}
+                />
               </FrontsMenuItems>
             </FrontsMenuContent>
           </ScrollContainer>

--- a/client-v2/src/components/util/TextHighlighter.tsx
+++ b/client-v2/src/components/util/TextHighlighter.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+const  Muted = styled('span')`
+  opacity: 0.5;
+`;
+
+interface IProps {
+  originalString: string;
+  searchString: string;
+}
+
+/**
+ * Generates the text with a highlighted search string.
+ */
+const textHighlighter: React.StatelessComponent<IProps> = ({
+  originalString,
+  searchString
+}) => {
+  if (!searchString) {
+    return <span>{originalString}</span>
+  }
+  const splitStr = originalString.split(searchString);
+  if (splitStr.length === 1) {
+    return <Muted>{originalString}</Muted>;
+  }
+  const results = splitStr
+    .reduce(
+      (acc, strPart, index) =>
+        index !== splitStr.length - 1
+          ? acc.concat([strPart, searchString])
+          : acc.concat(strPart),
+      [] as string[]
+    )
+    .filter(_ => !!_);
+
+  return (
+    <span>
+      {results.map(
+        (result, index) =>
+          result === searchString ? (
+            <span key={`${result}-${index}`}>{result}</span>
+          ) : (
+            <Muted key={`${result}-${index}`}>{result}</Muted>
+          )
+      )}
+    </span>
+  );
+};
+
+export default textHighlighter;

--- a/client-v2/src/components/util/__tests__/TextHighlighter.spec.tsx
+++ b/client-v2/src/components/util/__tests__/TextHighlighter.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, prettyDOM, cleanup } from 'react-testing-library';
+import TextHighlighter from 'components/util/TextHighlighter';
+import { ThemeProvider } from 'styled-components';
+import theme from 'shared/constants/theme';
+
+describe('TextHighlighter', () => {
+  afterEach(cleanup);
+  it('should render text with the parts that match the search string highlighted', () => {
+    const { getAllByText } = render(
+      <ThemeProvider theme={theme}>
+        <TextHighlighter
+          originalString="An example string"
+          searchString="example"
+        />
+      </ThemeProvider>
+    );
+    expect(getAllByText('example').length).toBe(1);
+  });
+  it('should find all instances of the search string', () => {
+    const { getAllByText, container } = render(
+      <ThemeProvider theme={theme}>
+        <TextHighlighter
+          originalString="An example string with two examples"
+          searchString="example"
+        />
+      </ThemeProvider>
+    );
+    expect(getAllByText('example').length).toBe(2);
+  });
+});

--- a/client-v2/src/containers/FrontsList.ts
+++ b/client-v2/src/containers/FrontsList.ts
@@ -7,7 +7,8 @@ import FrontList from '../components/FrontList';
 import { getFrontsWithPriority } from '../selectors/frontsSelectors';
 
 type Props = {
-  match: match<{ priority: string }>
+  match: match<{ priority: string }>,
+  searchString: string;
 } & RouteComponentProps<any>;
 
 const mapStateToProps = (state: State, props: Props) => {


### PR DESCRIPTION
Adds the ability to search for fronts by name. Autofocuses when the fronts menu opens.

![front-search](https://user-images.githubusercontent.com/7767575/50018208-63562e80-ffc6-11e8-91fb-b1804c23789f.gif)

... if there's a better way to get both the matched and unmatched parts of a stringß (a regex while loop was very verbose) feedback is very welcome!