### PR TITLE
Fix arrow key navigation on Tag/Section Search dropdowns

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.tsx
@@ -23,14 +23,14 @@ const TagDropdown = styled('div')`
 `;
 
 const DropdownItem = styled('div')`
-  background-color: ${({ selected }: { selected: boolean }) =>
-    selected ? '#dcdcdc' : 'white'};
+  background-color: ${({ highlighted }: { highlighted: boolean }) =>
+    highlighted ? '#dcdcdc' : 'white'};
   :hover {
-    background-color: #dcdcdc
+    background-color: #dcdcdc;
   }
   font-size: 14px;
-  front-weight: bold;
-  padding: 7px; 15px; 7px; 15px;
+  font-weight: bold;
+  padding: 7px 15px 7px 15px;
   border-left: 1px solid #c4c4c4;
   color: #121212;
 `;


### PR DESCRIPTION
Key board navigation in the Feed search wasn't working properly. This fixes it.
 
![kapture 2018-12-18 at 17 07 01](https://user-images.githubusercontent.com/32312712/50170282-77ac6b00-02e7-11e9-8a84-260f55077811.gif)
