### PR TITLE
Improve fronts search

### DIFF
--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -11,13 +11,21 @@ interface Props {
   searchString: string;
 }
 
-const ListItem = styled('li')`
+const ListItem = styled('li')<{ isActive?: boolean }>`
   position: relative;
-  padding: 10px 0;
+  padding: 10px 5px;
   font-family: TS3TextSans;
   font-size: 16px;
   line-height: 20px;
   border-bottom: solid 1px #5e5e5e;
+  ${({ isActive }) =>
+    isActive &&
+    css`
+      cursor: pointer;
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.05);
+      }
+    `};
 `;
 
 const ListContainer = styled('ul')`
@@ -39,7 +47,7 @@ const ButtonAdd = ButtonCircular.extend`
   background-color: #4d4d4d;
   position: absolute;
   top: 8px;
-  right: 0;
+  right: 5px;
   padding: 3px;
 `;
 
@@ -53,15 +61,19 @@ const FrontList = ({ fronts, onSelect, searchString }: Props) => {
   return (
     <ListContainer>
       {frontsToRender.map(front => (
-        <ListItem key={front.id}>
-          <ListLabel isActive={front.isOpen}>
+        <ListItem
+          isActive={!front.isOpen}
+          key={front.id}
+          onClick={!front.isOpen ? () => onSelect(front.id) : undefined}
+        >
+          <ListLabel isActive={!front.isOpen}>
             <TextHighlighter
               originalString={front.id}
               searchString={searchString}
             />
           </ListLabel>
-          {front.isOpen && (
-            <ButtonAdd onClick={() => onSelect(front.id)}>
+          {!front.isOpen && (
+            <ButtonAdd>
               <img src={MoreImage} alt="" width="100%" height="100%" />
             </ButtonAdd>
           )}

--- a/client-v2/src/components/util/TextHighlighter.tsx
+++ b/client-v2/src/components/util/TextHighlighter.tsx
@@ -17,7 +17,7 @@ const textHighlighter: React.StatelessComponent<IProps> = ({
   originalString,
   searchString
 }) => {
-  if (!searchString) {
+  if (!searchString || searchString.length < 2) {
     return <span>{originalString}</span>
   }
   const splitStr = originalString.split(searchString);

--- a/client-v2/src/components/util/__tests__/TextHighlighter.spec.tsx
+++ b/client-v2/src/components/util/__tests__/TextHighlighter.spec.tsx
@@ -22,4 +22,20 @@ describe('TextHighlighter', () => {
     );
     expect(getAllByText('example').length).toBe(2);
   });
+  it('should only search for two characters or more', () => {
+    let element = render(
+      <TextHighlighter
+        originalString="An example string with two examples"
+        searchString="e"
+      />
+    );
+    expect(element.getAllByText('An example string with two examples').length).toBe(1);
+    element = render(
+      <TextHighlighter
+        originalString="An example string with two examples"
+        searchString="ex"
+      />
+    );
+    expect(element.getAllByText('ex').length).toBe(2);
+  });
 });

--- a/client-v2/src/containers/FrontsList.ts
+++ b/client-v2/src/containers/FrontsList.ts
@@ -16,7 +16,7 @@ const mapStateToProps = (state: State, props: Props) => {
     fronts: getFrontsWithPriority(state, props.match.params.priority || '').map(
       ({ id }) => ({
         id,
-        isOpen: openFrontIds.indexOf(id) === -1
+        isOpen: openFrontIds.indexOf(id) !== -1
       })
     )
   };


### PR DESCRIPTION
Two quick wins to improve the fronts search - 

- the text highlighting only searches for matches of two characters or more, which removes a little input lag
- the entire list item is now selectable, not just the button, which is a very small target - often I've seen users try to click the list item, and only navigate to the button once that fails to work.

![front-search-improvement](https://user-images.githubusercontent.com/7767575/50590227-f7a70900-0e81-11e9-800e-626e46d55761.gif)


