### PR TITLE
Expand form textareas

### DIFF
--- a/client-v2/src/shared/components/input/InputTextArea.ts
+++ b/client-v2/src/shared/components/input/InputTextArea.ts
@@ -1,9 +1,14 @@
 import InputBase from './InputBase';
 import createInput from './CreateInput';
 
-const InputTextAreaBase = InputBase.withComponent('textarea').extend`
+const InputTextAreaBase = InputBase.withComponent('textarea').extend<{
+  minHeight?: number;
+  maxHeight?: number;
+}>`
   height: auto;
-  resize: none;
+  resize: vertical;
+  min-height: ${({ minHeight = 40 }) => minHeight}px;
+  max-height: ${({ maxHeight = 120 }) => maxHeight}px;
 `;
 
 export default createInput(InputTextAreaBase);


### PR DESCRIPTION
Re: Francisco's feedback, add the ability to expand the form textareas a reasonable amount to make room for larger standfirsts/headlines.

![front-textarea](https://user-images.githubusercontent.com/7767575/50591884-aef34e00-0e89-11e9-963e-98f82dcea23a.gif)
