### PR TITLE
Handle Guardian URLs in search

### DIFF
--- a/client-v2/src/components/CAPI/SearchQuery.tsx
+++ b/client-v2/src/components/CAPI/SearchQuery.tsx
@@ -7,12 +7,12 @@ type CAPISearch = ReturnType<typeof capiQuery>['search'];
 type SearchReturn = ReturnType<CAPISearch>;
 type ChildrenParams = AsyncState<SearchReturn>;
 
-interface CAPISearchQueryProps<SearchOptions = {}> {
+interface CAPISearchQueryProps {
   baseURL?: string;
   fetch?: Fetch;
   children: AsyncChild<SearchReturn>;
   params: object;
-  options?: SearchOptions;
+  options?: { isResource: boolean };
   poll?: number;
   isPreview: boolean;
 }
@@ -23,8 +23,8 @@ interface CAPISearchQueryState {
   fetch?: Fetch;
 }
 
-class SearchQuery<SearchOptions = {}> extends React.Component<
-  CAPISearchQueryProps<SearchOptions>,
+class SearchQuery extends React.Component<
+  CAPISearchQueryProps,
   CAPISearchQueryState
 > {
   public static defaultProps = {

--- a/client-v2/src/components/CAPI/SearchQuery.tsx
+++ b/client-v2/src/components/CAPI/SearchQuery.tsx
@@ -7,11 +7,12 @@ type CAPISearch = ReturnType<typeof capiQuery>['search'];
 type SearchReturn = ReturnType<CAPISearch>;
 type ChildrenParams = AsyncState<SearchReturn>;
 
-interface CAPISearchQueryProps {
+interface CAPISearchQueryProps<SearchOptions = {}> {
   baseURL?: string;
   fetch?: Fetch;
   children: AsyncChild<SearchReturn>;
   params: object;
+  options?: SearchOptions;
   poll?: number;
   isPreview: boolean;
 }
@@ -22,8 +23,8 @@ interface CAPISearchQueryState {
   fetch?: Fetch;
 }
 
-class SearchQuery extends React.Component<
-  CAPISearchQueryProps,
+class SearchQuery<SearchOptions = {}> extends React.Component<
+  CAPISearchQueryProps<SearchOptions>,
   CAPISearchQueryState
 > {
   public static defaultProps = {
@@ -85,7 +86,7 @@ class SearchQuery extends React.Component<
   };
 
   public render() {
-    const { params, children, fetch, baseURL, ...props } = this.props;
+    const { params, children, fetch, baseURL, options, ...props } = this.props;
     return (
       <Async<any[], SearchReturn>
         ref={(node: Async<any[], SearchReturn> | null) => {
@@ -93,7 +94,7 @@ class SearchQuery extends React.Component<
         }}
         {...props}
         fn={this.state.capi}
-        args={[params]}
+        args={[params, options]}
       >
         {children}
       </Async>

--- a/client-v2/src/components/Feed.tsx
+++ b/client-v2/src/components/Feed.tsx
@@ -12,6 +12,7 @@ import Loader from './Loader';
 import { capiFeedSpecsSelector } from '../selectors/configSelectors';
 import { RadioButton, RadioGroup } from './inputs/RadioButtons';
 import { State } from 'types/State';
+import { CapiArticle } from 'types/Capi';
 
 interface ErrorDisplayProps {
   error: Error | string | void;
@@ -133,14 +134,23 @@ class Feed extends React.Component<FeedProps, FeedState> {
                 pending,
                 error,
                 value
-              }: AsyncState<CAPISearchQueryReponse>) => (
-                <React.Fragment>
-                  <ErrorDisplay error={error}>
-                    <LoaderDisplay loading={!value && pending}>
-                      <div>
-                        {value &&
-                          value.response.results &&
-                          value.response.results
+              }: AsyncState<CAPISearchQueryReponse>) => {
+                let results: CapiArticle[];
+                if (!value) {
+                  results = [];
+                } else {
+                  results =
+                    value.response.results ||
+                    (value.response.content && [value.response.content]) ||
+                    [];
+                }
+
+                return (
+                  <React.Fragment>
+                    <ErrorDisplay error={error}>
+                      <LoaderDisplay loading={!value && pending}>
+                        <div>
+                          {results
                             .filter(result => result.webTitle)
                             .map(
                               ({
@@ -172,16 +182,17 @@ class Feed extends React.Component<FeedProps, FeedState> {
                                 />
                               )
                             )}
-                        {value &&
-                          value.response.results &&
-                          value.response.results.length === 0 && (
-                            <NoResults>No results found</NoResults>
-                          )}
-                      </div>
-                    </LoaderDisplay>
-                  </ErrorDisplay>
-                </React.Fragment>
-              )}
+                          {value &&
+                            value.response.results &&
+                            value.response.results.length === 0 && (
+                              <NoResults>No results found</NoResults>
+                            )}
+                        </div>
+                      </LoaderDisplay>
+                    </ErrorDisplay>
+                  </React.Fragment>
+                );
+              }}
             </SearchInput>
           </CAPIParamsContext.Provider>
         )}

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -32,6 +32,8 @@ type SelectedTags = SearchTypeMap<string[]>;
 
 interface FrontsCAPISearchInputState {
   q: string | void;
+  // Was the current search string derived from a URL?
+  isResource: boolean;
   searchTerms: SearchTerms;
   selected: SelectedTags;
   fromDate: moment.Moment | null;
@@ -63,10 +65,11 @@ const emptySearchTerms = {
   ratings: '',
   fromDate: null,
   toDate: null
-}
+};
 
 const emptyState = {
   q: undefined,
+  isResource: false,
   searchTerms: emptySearchTerms,
   selected: {
     tags: [] as string[],
@@ -76,7 +79,7 @@ const emptyState = {
   },
   fromDate: null,
   toDate: null
-} as FrontsCAPISearchInputState
+} as FrontsCAPISearchInputState;
 
 class FrontsCAPISearchInput extends React.Component<
   FrontsCAPISearchInputProps,
@@ -84,8 +87,11 @@ class FrontsCAPISearchInput extends React.Component<
 > {
   public state = emptyState;
 
-  public onDateChange = (fromDate: moment.Moment | null, toDate: moment.Moment | null) => {
-    this.setState({fromDate, toDate});
+  public onDateChange = (
+    fromDate: moment.Moment | null,
+    toDate: moment.Moment | null
+  ) => {
+    this.setState({ fromDate, toDate });
   };
 
   public clearInput = () => {
@@ -128,7 +134,8 @@ class FrontsCAPISearchInput extends React.Component<
     const searchTerm = maybeArticleId ? maybeArticleId : targetValue;
 
     this.setState({
-      q: searchTerm
+      q: searchTerm,
+      isResource: !!maybeArticleId
     });
   };
 
@@ -190,29 +197,27 @@ class FrontsCAPISearchInput extends React.Component<
           onClick={() => this.clearIndividualSearchTerm(searchTerm)}
           title="Clear search"
         >
-          <ClearButtonIcon
-            src={moreImage}
-            alt=""
-            height="22px"
-            width="22px"
-          />
+          <ClearButtonIcon src={moreImage} alt="" height="22px" width="22px" />
         </SmallRoundButton>
       </SearchTermItem>
     ));
 
-  public renderSelectedDates = (fromDate: moment.Moment | null, toDate: moment.Moment | null) => {
+  public renderSelectedDates = (
+    fromDate: moment.Moment | null,
+    toDate: moment.Moment | null
+  ) => {
     const renderDateAsString = (date: moment.Moment | null) => {
       if (!date) {
         return 'Not selected';
       }
       return date.format('DD/MM/YYYY');
-    }
+    };
 
     if (fromDate || toDate) {
       return (
         <SearchTermItem>
-          <span>From: { renderDateAsString(fromDate) } </span>
-          <span>To: { renderDateAsString(toDate) } </span>
+          <span>From: {renderDateAsString(fromDate)} </span>
+          <span>To: {renderDateAsString(toDate)} </span>
           <SmallRoundButton
             onClick={() => this.clearSelectedDates()}
             title="Clear search"
@@ -228,7 +233,7 @@ class FrontsCAPISearchInput extends React.Component<
       );
     }
     return null;
-  }
+  };
 
   public render() {
     const {
@@ -240,6 +245,7 @@ class FrontsCAPISearchInput extends React.Component<
 
     const {
       q,
+      isResource,
       selected: { tags, sections, desks, ratings },
       fromDate,
       toDate
@@ -252,7 +258,7 @@ class FrontsCAPISearchInput extends React.Component<
       !!ratings.length ||
       !!q ||
       !!fromDate ||
-      !!toDate
+      !!toDate;
 
     const allSearchTerms = tags.concat(sections, desks, ratings);
 
@@ -291,6 +297,7 @@ class FrontsCAPISearchInput extends React.Component<
           }
         >
           <SearchQuery
+            options={{ isResource }}
             params={{
               tag: searchTags,
               section: sections.join(','),

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -128,9 +128,7 @@ class FrontsCAPISearchInput extends React.Component<
     currentTarget
   }: React.SyntheticEvent<HTMLInputElement>) => {
     const targetValue = currentTarget.value;
-
     const maybeArticleId = getIdFromURL(targetValue);
-
     const searchTerm = maybeArticleId ? maybeArticleId : targetValue;
 
     this.setState({

--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -42,6 +42,36 @@ describe('CAPI', () => {
     });
   });
 
+  describe('scheduled', () => {
+    it('makes a network request on a query', () => {
+      const apiKey = 'my-api-key';
+      const capi = capiQuery();
+      capi.scheduled({
+        'api-key': apiKey
+      });
+      expect((global as any).fetch).toBeCalled();
+      const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
+      expect(fetchEndpoint).toEqual('https://content.guardianapis.com/content/scheduled?api-key=my-api-key')
+    });
+    it('changes URL appropriately if the isResource option is passed', () => {
+      const apiKey = 'my-api-key';
+      const capi = capiQuery();
+      const q = 'an/example/url';
+      capi.scheduled(
+        {
+          'api-key': apiKey,
+          q
+        },
+        {
+          isResource: true
+        }
+      );
+      expect((global as any).fetch).toBeCalled();
+      const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
+      expect(fetchEndpoint).toBe('https://content.guardianapis.com/an%2Fexample%2Furl?api-key=my-api-key');
+    });
+  });
+
   describe('tags', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';

--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -15,9 +15,30 @@ describe('CAPI', () => {
         'api-key': apiKey
       });
       expect((global as any).fetch).toBeCalled();
-      expect((global as any).fetch.mock.calls[0][0].includes(apiKey)).toBe(true);
+      expect((global as any).fetch.mock.calls[0][0].includes(apiKey)).toBe(
+        true
+      );
       // bad heuristic to check it's going to the right endpoint
-      expect((global as any).fetch.mock.calls[0][0].includes('search')).toBe(true);
+      expect((global as any).fetch.mock.calls[0][0].includes('search')).toBe(
+        true
+      );
+    });
+    it('changes URL appropriately if the isResource option is passed', () => {
+      const apiKey = 'my-api-key';
+      const capi = capiQuery();
+      const q = 'an/example/url';
+      capi.search(
+        {
+          'api-key': apiKey,
+          q
+        },
+        {
+          isResource: true
+        }
+      );
+      expect((global as any).fetch).toBeCalled();
+      const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
+      expect(fetchEndpoint).toBe('https://content.guardianapis.com/an%2Fexample%2Furl?api-key=my-api-key');
     });
   });
 
@@ -29,9 +50,13 @@ describe('CAPI', () => {
         'api-key': apiKey
       });
       expect((global as any).fetch).toBeCalled();
-      expect((global as any).fetch.mock.calls[0][0].includes(apiKey)).toBe(true);
+      expect((global as any).fetch.mock.calls[0][0].includes(apiKey)).toBe(
+        true
+      );
       // bad heuristic to check it's going to the right endpoint
-      expect((global as any).fetch.mock.calls[0][0].includes('tags')).toBe(true);
+      expect((global as any).fetch.mock.calls[0][0].includes('tags')).toBe(
+        true
+      );
     });
   });
 });

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -34,63 +34,72 @@ interface CAPITagQueryReponse {
   };
 }
 
-const capiQuery = (
-  baseURL: string = API_BASE,
-  fetch: Fetch = window.fetch
-) => ({
-  search: async (
+
+const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
+  const getCAPISearchString = (
+    path: string,
     params: any,
     options?: CAPIOptions
-  ): Promise<CAPISearchQueryReponse> => {
+  ) => {
     const { q, ...rest } = params;
-    const response = await fetch(
-      options && options.isResource
-        ? `${baseURL}${encodeURIComponent(q)}${qs({ ...rest })}`
-        : `${baseURL}search${qs({
-            ...params
-          })}`
-    );
+    return options && options.isResource
+      ? `${baseURL}${encodeURIComponent(q)}${qs({ ...rest })}`
+      : `${baseURL}${path}${qs({
+          ...params
+        })}`;
+  };
 
-    return response.json();
-  },
-  scheduled: async (params: any): Promise<CAPISearchQueryReponse> => {
-    const response = await fetch(
-      `${baseURL}content/scheduled${qs({
-        ...params
-      })}`
-    );
+  return {
+    search: async (
+      params: any,
+      options?: CAPIOptions
+    ): Promise<CAPISearchQueryReponse> => {
+      const response = await fetch(
+        getCAPISearchString(`search`, params, options)
+      );
 
-    return response.json();
-  },
-  tags: async (params: any): Promise<CAPITagQueryReponse> => {
-    const response = await fetch(
-      `${baseURL}tags${qs({
-        ...params
-      })}`
-    );
+      return response.json();
+    },
+    scheduled: async (
+      params: any,
+      options?: CAPIOptions
+    ): Promise<CAPISearchQueryReponse> => {
+      const response = await fetch(
+        getCAPISearchString(`content/scheduled`, params, options)
+      );
 
-    return response.json();
-  },
-  sections: async (params: any): Promise<CAPITagQueryReponse> => {
-    const response = await fetch(
-      `${baseURL}sections${qs({
-        ...params
-      })}`
-    );
+      return response.json();
+    },
+    tags: async (params: any): Promise<CAPITagQueryReponse> => {
+      const response = await fetch(
+        `${baseURL}tags${qs({
+          ...params
+        })}`
+      );
 
-    return response.json();
-  },
-  desks: async (params: any): Promise<CAPITagQueryReponse> => {
-    const response = await fetch(
-      `${baseURL}tags${qs({
-        type: 'tracking',
-        ...params
-      })}`
-    );
+      return response.json();
+    },
+    sections: async (params: any): Promise<CAPITagQueryReponse> => {
+      const response = await fetch(
+        `${baseURL}sections${qs({
+          ...params
+        })}`
+      );
 
-    return response.json();
-  }
-});
+      return response.json();
+    },
+    desks: async (params: any): Promise<CAPITagQueryReponse> => {
+      const response = await fetch(
+        `${baseURL}tags${qs({
+          type: 'tracking',
+          ...params
+        })}`
+      );
+
+      return response.json();
+    }
+  };
+};
 
 export { Fetch, CapiArticle, CAPISearchQueryReponse, CAPITagQueryReponse };
 export default capiQuery;

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -21,8 +21,10 @@ interface CAPISearchQueryReponse {
 }
 
 interface CAPIOptions {
-  // Does the query represent a single resource, e.g. an article
-  // or a tag/section page?
+  // Does the query represent a single resource, e.g. an article or a
+  // tag/section page? If so, we need to make a slightly different query.
+  // We can't derive it from the query string becuase it has already been
+  // trimmed of everything but its path and parameters.
   isResource: boolean;
 }
 

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -20,6 +20,12 @@ interface CAPISearchQueryReponse {
   };
 }
 
+interface CAPIOptions {
+  // Does the query represent a single resource, e.g. an article
+  // or a tag/section page?
+  isResource: boolean;
+}
+
 interface CAPITagQueryReponse {
   response: {
     results: Tag[];
@@ -30,11 +36,17 @@ const capiQuery = (
   baseURL: string = API_BASE,
   fetch: Fetch = window.fetch
 ) => ({
-  search: async (params: any): Promise<CAPISearchQueryReponse> => {
+  search: async (
+    params: any,
+    options?: CAPIOptions
+  ): Promise<CAPISearchQueryReponse> => {
+    const { q, ...rest } = params;
     const response = await fetch(
-      `${baseURL}search${qs({
-        ...params
-      })}`
+      options && options.isResource
+        ? `${baseURL}${encodeURIComponent(q)}${qs({ ...rest })}`
+        : `${baseURL}search${qs({
+            ...params
+          })}`
     );
 
     return response.json();


### PR DESCRIPTION
Dropping Guardian URLs into the search box in v1 runs the path through CAPI, allowing you to quickly search for a single article, tag etc.

This PR brings adds that behaviour to v2, tested for the site and viewer.gutools for live and preview. (It was stripping the path in the input, but not making the appropriate queries.)