### PR TITLE
Do not URI-encode queries for CAPI resources

### DIFF
--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -38,7 +38,7 @@ describe('CAPI', () => {
       );
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
-      expect(fetchEndpoint).toBe('https://content.guardianapis.com/an%2Fexample%2Furl?api-key=my-api-key');
+      expect(fetchEndpoint).toBe('https://content.guardianapis.com/an/example/url?api-key=my-api-key');
     });
   });
 
@@ -68,7 +68,7 @@ describe('CAPI', () => {
       );
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
-      expect(fetchEndpoint).toBe('https://content.guardianapis.com/an%2Fexample%2Furl?api-key=my-api-key');
+      expect(fetchEndpoint).toBe('https://content.guardianapis.com/an/example/url?api-key=my-api-key');
     });
   });
 

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -34,7 +34,6 @@ interface CAPITagQueryReponse {
   };
 }
 
-
 const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
   const getCAPISearchString = (
     path: string,
@@ -43,7 +42,7 @@ const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
   ) => {
     const { q, ...rest } = params;
     return options && options.isResource
-      ? `${baseURL}${encodeURIComponent(q)}${qs({ ...rest })}`
+      ? `${baseURL}${q}${qs({ ...rest })}`
       : `${baseURL}${path}${qs({
           ...params
         })}`;


### PR DESCRIPTION
... because it breaks in CODE and PROD for reasons (as yet) unknown. (Arguably we shouldn't have been doing it in the first place)

Edit: the difference between environments was caused by #516.