### PR TITLE
Remove trailing slash in nginx proxy config

### DIFF
--- a/nginx/nginx-mapping.yml
+++ b/nginx/nginx-mapping.yml
@@ -2,4 +2,4 @@ name: fronts
 mappings:
   - prefix: fronts
     port: 9000
-    path: /
+    path:


### PR DESCRIPTION
... which stops nginx from decoding URI-encoded chars. This lead to odd inconsistencies between local and CODE/PROD when proxying HTTP requests.