### PR TITLE
Collection caps now only care about live articles

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -11,7 +11,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import {
   selectSharedState,
   articleFragmentsSelector,
-  groupSiblingsArticleCountSelector
+  groupSiblingsLiveArticleCountSelector
 } from 'shared/selectors/shared';
 import { ThunkResult, Dispatch } from 'types/Store';
 import { addPersistMetaToAction } from 'util/storeMiddleware';
@@ -96,7 +96,7 @@ const maybeInsertGroupArticleFragment = (
     const state = getState();
 
     const collectionCap = collectionCapSelector(getState());
-    const collectionArticleCount = groupSiblingsArticleCountSelector(
+    const collectionArticleCount = groupSiblingsLiveArticleCountSelector(
       selectSharedState(state),
       id
     );

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -13,7 +13,8 @@ import { clipboardSelector as innerClipboardSelector } from '../../selectors/fro
 import {
   createArticleFragmentStateFromSpec,
   ArticleFragmentSpec,
-  specToFragment
+  specToFragment,
+  creatExternalArticleStateFromSpec
 } from './utils';
 import {
   moveArticleFragment,
@@ -23,6 +24,7 @@ import {
   reducer as collectionsReducer,
   initialState as collectionsState
 } from 'shared/bundles/collectionsBundle';
+import { reducer as externalArticlesReducer } from 'shared/bundles/externalArticlesBundle';
 import confirmModal from 'reducers/confirmModalReducer';
 import { endConfirmModal } from 'actions/ConfirmModal';
 import config from 'reducers/configReducer';
@@ -37,7 +39,8 @@ const root = (state: any = {}, action: any) => ({
       state.shared
     ),
     collections: collectionsReducer(state.shared.collections, action),
-    groups: groupsReducer(state.shared.groups, action, state.shared)
+    groups: groupsReducer(state.shared.groups, action, state.shared),
+    externalArticles: externalArticlesReducer(state.shared.externalArticles, action)
   },
   config: config(state.config, action)
 });
@@ -75,6 +78,7 @@ const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
         }
       },
       articleFragments: createArticleFragmentStateFromSpec(all),
+      externalArticles: { data: creatExternalArticleStateFromSpec(all) },
       groups: {
         a: { articleFragments: groupA.map(([uuid]) => uuid), uuid: 'a' },
         b: { articleFragments: groupB.map(([uuid]) => uuid), uuid: 'b' }

--- a/client-v2/src/actions/__tests__/utils.ts
+++ b/client-v2/src/actions/__tests__/utils.ts
@@ -21,6 +21,13 @@ export const specToFragment = ([uuid, id, supporting]: ArticleFragmentSpec) => (
   }
 });
 
+export const specToExternalArticle = (id: string) => ({
+  id,
+  fields: {
+    isLive: 'true'
+  }
+});
+
 export const createArticleFragmentStateFromSpec = (
   specs: ArticleFragmentSpec[]
 ) =>
@@ -44,3 +51,23 @@ export const createArticleFragmentStateFromSpec = (
     }),
     {} as ArticleFragmentMap
   );
+
+  export const creatExternalArticleStateFromSpec = (
+    specs: ArticleFragmentSpec[]
+  ) =>
+    specs.reduce(
+      (acc, [_, id, supporting]) => ({
+        ...acc,
+        [id]: specToExternalArticle(id),
+        ...(supporting
+          ? supporting.reduce(
+              (sacc, [__, sid]) => ({
+                ...sacc,
+                [sid]: specToExternalArticle(sid)
+              }),
+              {}
+            )
+          : {})
+      }),
+      {}
+    );

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -4,7 +4,8 @@ import {
   createArticlesInCollectionGroupSelector,
   createArticlesInCollectionSelector,
   createCollectionSelector,
-  groupSiblingsSelector
+  groupSiblingsSelector,
+  groupSiblingsLiveArticleCountSelector
 } from '../shared';
 
 const state: any = {
@@ -97,6 +98,7 @@ const state: any = {
           headline: 'external-headline',
           trailText: 'external-trailText',
           byline: 'external-byline',
+          isLive: 'true'
         }
       },
       ea4: {
@@ -124,6 +126,7 @@ const state: any = {
           headline: 'external-headline',
           trailText: 'external-trailText',
           byline: 'external-byline',
+          isLive: 'true'
         }
       },
       ea5: {
@@ -137,6 +140,7 @@ const state: any = {
           headline: 'external-headline',
           trailText: 'external-trailText',
           byline: 'external-byline',
+          isLive: 'true'
         }
       }
     }
@@ -494,6 +498,14 @@ describe('Shared selectors', () => {
     it('selects the sibling groups of a given group id', () => {
       expect(groupSiblingsSelector(state, 'g1').map(({ uuid }) => uuid)).toEqual(
         ['g1', 'g2']
+      );
+    });
+  });
+
+  describe('groupSiblingsArticleCountSelector', () => {
+    it('selects the number of articles in a given group and its siblings', () => {
+      expect(groupSiblingsLiveArticleCountSelector(state, 'g1')).toEqual(
+       1
       );
     });
   });

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -332,9 +332,17 @@ const groupSiblingsSelector = (state: State, groupId: string) => {
   );
 };
 
-const groupSiblingsArticleCountSelector = (state: State, groupId: string) =>
+/**
+ * Given a group id, give the total number of live articles contained in the
+ * group's parent collection.
+ */
+const groupSiblingsLiveArticleCountSelector = (state: State, groupId: string) =>
   groupSiblingsSelector(state, groupId).reduce(
-    (acc, group) => acc + group.articleFragments.length,
+    (acc, group) => acc + group.articleFragments.filter(id => {
+      const maybeArticleFragment = articleFragmentSelector(state, id);
+      const maybeExternalArticle = maybeArticleFragment && externalArticleSelectors.selectById(state, maybeArticleFragment.id)
+      return maybeExternalArticle && maybeExternalArticle.fields.isLive === 'true'
+    }).length,
     0
   );
 
@@ -355,6 +363,6 @@ export {
   articleFragmentsSelector,
   groupCollectionSelector,
   groupSiblingsSelector,
-  groupSiblingsArticleCountSelector,
+  groupSiblingsLiveArticleCountSelector,
   articleTagSelector
 };


### PR DESCRIPTION
... because that's the way the old tool works; collection caps don't apply to draft content.

Don't merge -- the auto-removal doesn't take into account the draft article exemption yet!