### PR TITLE
update redux dev tools initialisation

### DIFF
--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -31,7 +31,7 @@ export default function configureStore() {
         persistClipboardOnEdit(),
         persistOpenFrontsOnEdit()
       ),
-      window.devToolsExtension ? window.devToolsExtension() : (f: unknown) => f
+      (window as any).__REDUX_DEVTOOLS_EXTENSION__ && (window as any).__REDUX_DEVTOOLS_EXTENSION__()
     )
   );
 


### PR DESCRIPTION
This removes a deprecation warning. TS foo brought to you by https://github.com/jaysoo/todomvc-redux-react-typescript/issues/8#issuecomment-406702349.