### PR TITLE
Revert "update redux dev tools initialisation"

### DIFF
--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -31,7 +31,7 @@ export default function configureStore() {
         persistClipboardOnEdit(),
         persistOpenFrontsOnEdit()
       ),
-      (window as any).__REDUX_DEVTOOLS_EXTENSION__ && (window as any).__REDUX_DEVTOOLS_EXTENSION__()
+      window.devToolsExtension ? window.devToolsExtension() : (f: unknown) => f
     )
   );
 


### PR DESCRIPTION
Reverts guardian/facia-tool#524 -- this throws on app launch when the redux devtools hook isn't present on window.