### PR TITLE
Make a single request for multiple collections

### DIFF
--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import _root_.util.Acl
-import com.gu.facia.api.models.TrainingPriority
+import com.gu.facia.client.models.{CollectionJson}
 import com.gu.facia.api.models.faciapress.{Draft, FrontPath, Live, PressJob}
 import com.gu.facia.client.models.Metadata
 import com.gu.pandomainauth.action.UserRequest
@@ -40,39 +40,44 @@ class FaciaToolController(
       NoCache {
         Ok(Json.toJson(configJson)).as("application/json")}}}
 
-  def getCollection(collectionId: String) = AccessAPIAuthAction.async { implicit request =>
+  def getCollection(collectionId: String): Action[AnyContent] = AccessAPIAuthAction.async { implicit request =>
     val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
-      val collections = fetchCollections(List(collectionId))
+      val collectionsFuture = fetchCollections(List(collectionId))
 
-      collections.head.map(c => NoCache {
-        Ok(Json.toJson(c)).as("application/json")
-      })
+      collectionsFuture.map { collections =>
+        collections.headOption.map { collection =>
+           NoCache {
+            Ok(Json.toJson(collection)).as("application/json")
+          }
+        }.getOrElse(Results.NotFound)
+      }
     }
   }
 
-  def getCollections(collectionIdsString: String) = AccessAPIAuthAction.async { implicit request =>
-    val collectionIds = collectionIdsString.split(",").toList
+  def getCollections(): Action[AnyContent] = AccessAPIAuthAction.async { implicit request =>
+    val collectionIds = request.queryString.getOrElse("ids", Seq()).toList
     val collectionPriorities = collectionIds.flatMap(configAgent.getFrontsPermissionsPriorityByCollectionId(_)).toSet
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
       val collections = fetchCollections(collectionIds)
 
-      Future.sequence(collections).map(c => NoCache {
+      collections.map(c => NoCache {
         Ok(Json.toJson(c)).as("application/json")
       })
     }
   }
 
-  def fetchCollections(collectionIds: List[String]) = {
+  def fetchCollections(collectionIds: List[String]): Future[List[Option[CollectionJson]]] = {
     FaciaToolMetrics.ApiUsageCount.increment()
-    collectionIds.map(collectionId => frontsApi.amazonClient.collection(collectionId).flatMap { collectionJson =>
+    val futures = collectionIds.map(collectionId => frontsApi.amazonClient.collection(collectionId).flatMap { collectionJson =>
       collectionJson.map(json => mediaServiceClient.addThumbnailsToCollection(json, collectionId)) match {
-        case Some(f) => f.map(Some(_))
+        case Some(collectionFuture) => collectionFuture.map(Some(_))
         case None => Future.successful(None)
       }
     })
+    Future.sequence(futures)
   }
 
 

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -45,9 +45,9 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
   }
 
   def withModifyGroupPermissionForCollections[A](priorities: Set[PermissionsPriority], secondaryPriorities: Set[PermissionsPriority],
-                                                 isLaunch: Boolean = false)(block: => Future[Result])
-                                                (implicit request: UserRequest[A],
-                                                 executionContext: ExecutionContext): Future[Result] = {
+    isLaunch: Boolean = false)(block: => Future[Result])
+  (implicit request: UserRequest[A],
+  executionContext: ExecutionContext): Future[Result] = {
 
     (testAccess(request.user.email, priorities, isLaunch), testAccess(request.user.email, secondaryPriorities, isLaunch)) match {
       case (AccessGranted, AccessGranted) => block

--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -5,12 +5,13 @@ import {
   fetchFrontsConfig,
   fetchLastPressed as fetchLastPressedApi,
   publishCollection as publishCollectionApi,
+  getCollections as getCollectionsApi,
   getCollection as getCollectionApi
 } from 'services/faciaApi';
 import { actions as frontsConfigActions } from 'bundles/frontsConfigBundle';
 import { recordUnpublishedChanges } from 'actions/UnpublishedChanges';
 import { isFrontStale } from 'util/frontsUtils';
-import { getCollection } from 'actions/Collections';
+import { getCollections } from 'actions/Collections';
 import { VisibleArticlesResponse } from 'types/FaciaApi';
 import { visibleArticlesSelector } from 'selectors/frontsSelectors';
 import { Stages } from 'shared/types/Collection';
@@ -87,7 +88,7 @@ function publishCollection(
           ])
         );
 
-        dispatch(getCollection(collectionId));
+        dispatch(getCollections([collectionId]));
 
         return new Promise(resolve => setTimeout(resolve, 10000))
           .then(() =>

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -58,7 +58,7 @@ type FrontsComponentProps = FrontsContainerProps & {
   alsoOn: { [id: string]: AlsoOnDetail };
   lastPressed: string | null;
   frontsActions: {
-    getCollectionsAndArticles: (collectionIds: string[]) => Promise<void[]>;
+    getCollectionsAndArticles: (collectionIds: string[]) => Promise<void>;
     fetchLastPressed: (frontId: string) => void;
     editorCloseFront: (frontId: string) => void;
   };

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -10,7 +10,7 @@ import {
 } from 'types/FaciaApi';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import {
-  CollectionResponse,
+  CollectionsResponse,
   CollectionWithNestedArticles,
   NestedArticleFragment
 } from 'shared/types/Collection';
@@ -185,18 +185,32 @@ async function saveOpenFrontIds(frontIds?: string[]): Promise<void> {
   }
 }
 
-function getCollection(
+async function getCollection(
   collectionId: string
 ): Promise<CollectionWithNestedArticles> {
-  return pandaFetch(`/collection/${collectionId}`, {
+  const response = await pandaFetch(`/collection/${collectionId}`, {
     method: 'get',
     credentials: 'same-origin'
   })
-    .then(response => response.json())
-    .then((json: CollectionResponse) => ({
-      ...json,
-      id: collectionId
-    }));
+  const collection: CollectionsResponse = await response.json();
+  return {
+    ...collection,
+    id: collectionId
+  };
+}
+
+async function getCollections(
+  collectionIds: string[]
+): Promise<CollectionWithNestedArticles[]> {
+  const response = await pandaFetch(`/collections/${collectionIds.join(',')}`, {
+    method: 'get',
+    credentials: 'same-origin'
+  })
+  const collections: CollectionsResponse[] = await response.json();
+  return collections.map((collection, index) => ({
+    ...collection,
+    id: collectionIds[index]
+  }));
 }
 
 /**
@@ -292,6 +306,7 @@ async function getArticlesBatched(
 export {
   fetchFrontsConfig,
   getCollection,
+  getCollections,
   getContent,
   getTagOrSectionTitle,
   getArticlesBatched,

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -10,7 +10,7 @@ import {
 } from 'types/FaciaApi';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import {
-  CollectionsResponse,
+  CollectionResponse,
   CollectionWithNestedArticles,
   NestedArticleFragment
 } from 'shared/types/Collection';
@@ -185,28 +185,30 @@ async function saveOpenFrontIds(frontIds?: string[]): Promise<void> {
   }
 }
 
-async function getCollection(
+function getCollection(
   collectionId: string
 ): Promise<CollectionWithNestedArticles> {
-  const response = await pandaFetch(`/collection/${collectionId}`, {
+  return pandaFetch(`/collection/${collectionId}`, {
     method: 'get',
     credentials: 'same-origin'
   })
-  const collection: CollectionsResponse = await response.json();
-  return {
-    ...collection,
-    id: collectionId
-  };
+    .then(response => response.json())
+    .then((json: CollectionResponse) => ({
+      ...json,
+      id: collectionId
+    }));
 }
 
 async function getCollections(
   collectionIds: string[]
 ): Promise<CollectionWithNestedArticles[]> {
-  const response = await pandaFetch(`/collections/${collectionIds.join(',')}`, {
+  const params = new URLSearchParams();
+  collectionIds.map(_ => params.append('ids', _))
+  const response = await pandaFetch(`/collections?${params.toString()}`, {
     method: 'get',
     credentials: 'same-origin'
   })
-  const collections: CollectionsResponse[] = await response.json();
+  const collections: CollectionResponse[] = await response.json();
   return collections.map((collection, index) => ({
     ...collection,
     id: collectionIds[index]
@@ -305,8 +307,8 @@ async function getArticlesBatched(
 
 export {
   fetchFrontsConfig,
-  getCollection,
   getCollections,
+  getCollection,
   getContent,
   getTagOrSectionTitle,
   getArticlesBatched,

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -90,7 +90,7 @@ interface ArticleFragmentDenormalised extends ArticleFragmentRootFields {
   meta: ArticleFragmentMetaDenormalised;
 }
 
-interface CollectionsResponse {
+interface CollectionResponse {
   live: NestedArticleFragment[];
   draft?: NestedArticleFragment[];
   previously?: NestedArticleFragment[];
@@ -102,7 +102,7 @@ interface CollectionsResponse {
   groups?: string[];
 }
 
-type CollectionWithNestedArticles = CollectionsResponse & {
+type CollectionWithNestedArticles = CollectionResponse & {
   id: string;
 };
 
@@ -134,7 +134,7 @@ export {
   ArticleFragmentRootFields,
   ArticleFragmentMeta,
   CollectionWithNestedArticles,
-  CollectionsResponse,
+  CollectionResponse,
   Collection,
   CollectionItemTypes,
   CollectionItemDisplayTypes,

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -90,7 +90,7 @@ interface ArticleFragmentDenormalised extends ArticleFragmentRootFields {
   meta: ArticleFragmentMetaDenormalised;
 }
 
-interface CollectionResponse {
+interface CollectionsResponse {
   live: NestedArticleFragment[];
   draft?: NestedArticleFragment[];
   previously?: NestedArticleFragment[];
@@ -102,7 +102,7 @@ interface CollectionResponse {
   groups?: string[];
 }
 
-type CollectionWithNestedArticles = CollectionResponse & {
+type CollectionWithNestedArticles = CollectionsResponse & {
   id: string;
 };
 
@@ -134,7 +134,7 @@ export {
   ArticleFragmentRootFields,
   ArticleFragmentMeta,
   CollectionWithNestedArticles,
-  CollectionResponse,
+  CollectionsResponse,
   Collection,
   CollectionItemTypes,
   CollectionItemDisplayTypes,

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -39,8 +39,8 @@ describe('Shared utilities', () => {
         collection,
         collectionConfig
       );
-      expect(result.collection.live).toHaveLength(3);
-      const [gId1, gId2, gId3] = result.collection.live;
+      expect(result.normalisedCollection.live).toHaveLength(3);
+      const [gId1, gId2, gId3] = result.normalisedCollection.live!;
       const g1Articles = result.groups[gId1].articleFragments;
       const g2Articles = result.groups[gId2].articleFragments;
       const g3Articles = result.groups[gId3].articleFragments;
@@ -81,28 +81,28 @@ describe('Shared utilities', () => {
         },
         collectionConfig
       );
-      expect(result.collection.live.length).toEqual(3);
-      expect(result.collection.draft.length).toEqual(3);
-      expect(result.collection.previously.length).toEqual(3);
+      expect(result.normalisedCollection.live!.length).toEqual(3);
+      expect(result.normalisedCollection.draft!.length).toEqual(3);
+      expect(result.normalisedCollection.previously!.length).toEqual(3);
       expect(
-        result.collection.live.every(
+        result.normalisedCollection.live!.every(
           (articleId: string) => typeof articleId === 'string'
         )
       ).toBe(true);
       expect(
-        result.collection.draft.every(
+        result.normalisedCollection.draft!.every(
           (articleId: string) => typeof articleId === 'string'
         )
       ).toBe(true);
       expect(
-        result.collection.previously.every(
+        result.normalisedCollection.previously!.every(
           (articleId: string) => typeof articleId === 'string'
         )
       ).toBe(true);
       expect(Object.keys(result.articleFragments).length).toEqual(5);
-      const liveGroup2 = result.groups[result.collection.live[1]];
-      const draftGroup3 = result.groups[result.collection.draft[2]];
-      const prevGroup3= result.groups[result.collection.previously[2]];
+      const liveGroup2 = result.groups[result.normalisedCollection.live![1]];
+      const draftGroup3 = result.groups[result.normalisedCollection.draft![2]];
+      const prevGroup3= result.groups[result.normalisedCollection.previously![2]];
       expect(result.articleFragments[liveGroup2.articleFragments[0]].id).toBe(
         'article/live/0'
       );
@@ -122,9 +122,9 @@ describe('Shared utilities', () => {
         },
         collectionConfigWithoutGroups
       );
-      expect(result.collection.live).toHaveLength(1);
-      expect(result.collection.draft).toHaveLength(1);
-      expect(result.collection.previously).toHaveLength(1);
+      expect(result.normalisedCollection.live).toHaveLength(1);
+      expect(result.normalisedCollection.draft).toHaveLength(1);
+      expect(result.normalisedCollection.previously).toHaveLength(1);
       expect(Object.keys(result.articleFragments)).toHaveLength(0);
     });
     it('should normalise supporting article fragments', () => {
@@ -132,13 +132,13 @@ describe('Shared utilities', () => {
         collectionWithSupportingArticles,
         collectionConfig
       );
-      expect(result.collection.live.length).toEqual(3);
+      expect(result.normalisedCollection.live!.length).toEqual(3);
       expect(Object.keys(result.articleFragments).length).toEqual(4);
       expect(
         Object.keys(result.articleFragments).every(
           articleId =>
-            !result.articleFragments[articleId].supporting ||
-            result.articleFragments[articleId].supporting.map(
+            !result.articleFragments[articleId].meta.supporting ||
+            result.articleFragments[articleId].meta.supporting!.every(
               (id: string) => typeof id === 'string'
             )
         )
@@ -153,7 +153,7 @@ describe('Shared utilities', () => {
           groups: undefined
         }
       );
-      const groupId = result.collection.live[0];
+      const groupId = result.normalisedCollection.live![0];
       expect(result.groups[groupId].articleFragments).toHaveLength(3);
     })
   });

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -1,4 +1,4 @@
-import { CollectionWithNestedArticles, Group } from 'shared/types/Collection';
+import { CollectionWithNestedArticles, Group, Collection, ArticleFragment } from 'shared/types/Collection';
 import { selectors as collectionSelectors } from 'shared/bundles/collectionsBundle';
 import { selectSharedState } from 'shared/selectors/shared';
 import { State } from 'types/State';
@@ -92,7 +92,11 @@ const addEmptyGroupsFromCollectionConfig = (
 const normaliseCollectionWithNestedArticles = (
   collection: CollectionWithNestedArticles,
   collectionConfig: CollectionConfig
-) => {
+): {
+  normalisedCollection: Collection,
+  groups: {[key: string]: Group},
+  articleFragments: {[key: string]: ArticleFragment}
+} => {
   const normalisedCollection = normalize(collection);
   const {
     addedGroups,
@@ -104,7 +108,7 @@ const normaliseCollectionWithNestedArticles = (
     collectionConfig
   );
   return {
-    collection: {
+    normalisedCollection: {
       ...normalisedCollection.result,
       live,
       draft,

--- a/conf/routes
+++ b/conf/routes
@@ -43,6 +43,7 @@ GET         /front/lastmodified/*path                controllers.PressController
 GET         /front/lastmodifiedstatus/:stage/*path   controllers.PressController.getLastModifiedStatus(stage, path)
 
 GET         /collection/*collectionId                controllers.FaciaToolController.getCollection(collectionId)
+GET         /collections/*collectionIds              controllers.FaciaToolController.getCollections(collectionIds)
 POST        /edits                                   controllers.FaciaToolController.collectionEdits
 POST        /v2Edits                                 controllers.FaciaToolV2Controller.collectionEdits
 GET         /config                                  controllers.FaciaToolController.getConfig

--- a/conf/routes
+++ b/conf/routes
@@ -43,7 +43,7 @@ GET         /front/lastmodified/*path                controllers.PressController
 GET         /front/lastmodifiedstatus/:stage/*path   controllers.PressController.getLastModifiedStatus(stage, path)
 
 GET         /collection/*collectionId                controllers.FaciaToolController.getCollection(collectionId)
-GET         /collections/*collectionIds              controllers.FaciaToolController.getCollections(collectionIds)
+GET         /collections                             controllers.FaciaToolController.getCollections
 POST        /edits                                   controllers.FaciaToolController.collectionEdits
 POST        /v2Edits                                 controllers.FaciaToolV2Controller.collectionEdits
 GET         /config                                  controllers.FaciaToolController.getConfig


### PR DESCRIPTION
... which makes fetching large fronts slightly quicker -- in our (very thorough and scientific) tests, opening the tool with CODE/UK loaded saw an 8% speed boost from page load to idle.

It also makes the behaviour slightly more predictable for the user -- there's a longer wait for the initial collections, but less jank in between as the view isn't constantly thrashing as new collections arrive.