### PR TITLE
Open top <n> collections on front open

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -2,7 +2,9 @@ import reducer, {
   editorOpenFront,
   editorCloseFront,
   editorClearOpenFronts,
-  editorSetOpenFronts
+  editorSetOpenFronts,
+  editorOpenCollections,
+  editorCloseCollections
 } from '../frontsUIBundle';
 
 describe('frontsUIBundle', () => {
@@ -31,6 +33,29 @@ describe('frontsUIBundle', () => {
         editorSetOpenFronts(['front1', 'front3'])
       );
       expect(state.frontIds).toEqual(['front1', 'front3']);
+    });
+    it('should add a collection to the open editor collections', () => {
+      const state = reducer(undefined, editorOpenCollections(
+        'exampleCollection'
+      ) as any);
+      expect(state.collectionIds).toEqual(['exampleCollection']);
+    });
+    it('should add multiple collections to the open editor collections', () => {
+      const state = reducer(undefined, editorOpenCollections([
+        'exampleCollection',
+        'exampleCollection2'
+      ]) as any);
+      expect(state.collectionIds).toEqual([
+        'exampleCollection',
+        'exampleCollection2'
+      ]);
+    });
+    it('should remove multiple collections from the open editor collections', () => {
+      const state = reducer(
+        { collectionIds: ['collection1', 'collection2'] } as any,
+        editorCloseCollections(['collection1', 'collection2'])
+      );
+      expect(state.collectionIds).toEqual([]);
     });
   });
 });

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -17,6 +17,11 @@ import {
   createCollectionEditWarningSelector,
   selectSharedState
 } from 'shared/selectors/shared';
+import {
+  selectIsCollectionOpen,
+  editorOpenCollections,
+  editorCloseCollections
+} from 'bundles/frontsUIBundle';
 
 interface CollectionPropsBeforeState {
   id: string;
@@ -33,6 +38,8 @@ type CollectionProps = CollectionPropsBeforeState & {
   groups: Group[];
   displayEditWarning: boolean;
   isUneditable: boolean;
+  isOpen: boolean;
+  onChangeOpenState: (id: string, isOpen: boolean) => void;
 };
 
 const Collection = ({
@@ -46,12 +53,16 @@ const Collection = ({
   publishCollection: publish,
   frontId,
   displayEditWarning,
-  isUneditable
+  isUneditable,
+  isOpen,
+  onChangeOpenState
 }: CollectionProps) => (
   <CollectionDisplay
     id={id}
     browsingStage={browsingStage}
     isUneditable={isUneditable}
+    isOpen={isOpen}
+    onChangeOpenState={() => onChangeOpenState(id, !isOpen)}
     headlineContent={
       hasUnpublishedChanges &&
       canPublish && (
@@ -87,16 +98,17 @@ const createMapStateToProps = () => {
     }),
     displayEditWarning: editWarningSelector(selectSharedState(state), {
       collectionId: id
-    })
+    }),
+    isOpen: selectIsCollectionOpen(state, id)
   });
 };
 
-const mapDispatchToProps = (dispatch: Dispatch) => {
-  return {
-    publishCollection: (id: string, frontId: string) =>
-      dispatch(publishCollection(id, frontId))
-  };
-};
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  publishCollection: (id: string, frontId: string) =>
+    dispatch(publishCollection(id, frontId)),
+  onChangeOpenState: (id: string, isOpen: boolean) =>
+    dispatch(isOpen ? editorOpenCollections(id) : editorCloseCollections(id))
+});
 
 export default connect(
   createMapStateToProps,

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -9,6 +9,8 @@ import {
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { createCollectionId } from 'shared/components/Collection';
+import { editorOpenCollections } from 'bundles/frontsUIBundle';
+import { Dispatch } from 'types/Store';
 
 interface FrontCollectionOverviewContainerProps {
   collectionId: string;
@@ -18,6 +20,7 @@ interface FrontCollectionOverviewContainerProps {
 type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
   collection: Collection | undefined;
   articleCount: number;
+  openCollection: (id: string) => void;
 };
 
 const Container = styled.button`
@@ -68,7 +71,8 @@ const Name = styled.span`
 
 const CollectionOverview = ({
   collection,
-  articleCount
+  articleCount,
+  openCollection
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
@@ -82,6 +86,7 @@ const CollectionOverview = ({
             block: 'start'
           });
         }
+        openCollection(collection.id)
       }}
     >
       <TextLeft>
@@ -105,4 +110,8 @@ const mapStateToProps = () => {
   });
 };
 
-export default connect(mapStateToProps)(CollectionOverview);
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  openCollection: (id: string) => dispatch(editorOpenCollections(id))
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(CollectionOverview);

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -14,7 +14,8 @@ import { AlsoOnDetail } from 'types/Collection';
 import {
   editorSelectArticleFragment,
   selectEditorArticleFragment,
-  editorClearArticleFragmentSelection
+  editorClearArticleFragmentSelection,
+  editorOpenCollections
 } from 'bundles/frontsUIBundle';
 import {
   ArticleFragmentMeta,
@@ -32,6 +33,7 @@ import { getFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
 import { visibleFrontArticlesSelector } from 'selectors/frontsSelectors';
 import { VisibleArticlesResponse } from 'types/FaciaApi';
+import { noOfOpenCollectionsOnFirstLoad } from 'constants/fronts';
 
 const FrontContainer = styled('div')`
   display: flex;
@@ -58,6 +60,7 @@ type FrontProps = FrontPropsBeforeState & {
   clearArticleFragmentSelection: () => void;
   removeCollectionItem: (parentId: string, id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
+  editorOpenCollections: (ids: string[]) => void;
   front: FrontConfig;
   articlesVisible: { [id: string]: VisibleArticlesResponse };
 };
@@ -72,6 +75,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
     this.state = {
       error: undefined
     };
+  }
+
+  public componentWillMount() {
+    this.props.editorOpenCollections(this.props.front.collections.slice(0, noOfOpenCollectionsOnFirstLoad))
   }
 
   public handleError = (error: string) => {
@@ -296,7 +303,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       dispatch(
         removeArticleFragment('articleFragment', parentId, uuid, 'collection')
       );
-    }
+    },
+    editorOpenCollections: (ids: string[]) => dispatch(editorOpenCollections(ids))
   };
 };
 

--- a/client-v2/src/constants/fronts.ts
+++ b/client-v2/src/constants/fronts.ts
@@ -20,3 +20,5 @@ export const notLiveLabels: { [key: string]: string } = {
 };
 
 export const detectPressFailureMs = 10000;
+
+export const noOfOpenCollectionsOnFirstLoad = 3;

--- a/client-v2/src/lib/createAsyncResourceBundle/index.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/index.ts
@@ -143,10 +143,6 @@ type RootState = any;
  *
  * Consumers can add add their own actions and selectors, and extend
  * the given reducer, to provide additional functionality.
- *
- * @todo The any type here is a massive cop-out to cope with the fact
- * that the shape of the resource might be keyed by ID, or just a blob
- * of state that we don't index. Solutions welcome!
  */
 function createAsyncResourceBundle<Resource>(
   // The name of the entity for which this reducer is responsible
@@ -160,11 +156,10 @@ function createAsyncResourceBundle<Resource>(
     // Provides a namespace for the created actions, separated by a slash,
     // e.g.the resource 'books' namespaced with 'shared' becomes SHARED/BOOKS
     namespace?: string;
-    // The initial state of the reducer data. Defaults to null.
-    initialData?: any;
+    // The initial state of the reducer data. Defaults to an empty object.
+    initialData?: Resource;
   } = {
-    indexById: false,
-    initialData: {}
+    indexById: false
   }
 ) {
   const { indexById } = options;

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -35,6 +35,8 @@ type Props = ContainerProps & {
   metaContent: React.ReactNode;
   children: React.ReactNode;
   isUneditable?: boolean;
+  isOpen?: boolean;
+  onChangeOpenState?: (isOpen: boolean) => void;
 };
 
 const CollectionContainer = ContentContainer.extend`
@@ -136,16 +138,16 @@ const CollectionShortVerticalPinline = ShortVerticalPinline.extend`
   left: 0;
 `;
 
-class CollectionDisplay extends React.Component<Props, { isOpen: boolean }> {
+class CollectionDisplay extends React.Component<Props> {
   public static defaultProps = {
-    isUneditable: false
-  };
-  public state = {
-    isOpen: !this.props.isUneditable
+    isUneditable: false,
+    isOpen: true
   };
 
   public toggleVisibility = () => {
-    this.setState({ isOpen: !this.state.isOpen });
+    if (this.props.onChangeOpenState) {
+      this.props.onChangeOpenState(!this.props.isOpen);
+    }
   };
 
   public render() {
@@ -160,7 +162,6 @@ class CollectionDisplay extends React.Component<Props, { isOpen: boolean }> {
     const itemCount = articleIds ? articleIds.length : 0;
     return !!collection ? (
       <CollectionContainer id={createCollectionId(collection)}>
-
         <ContainerHeadingPinline>
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText>
@@ -215,12 +216,12 @@ class CollectionDisplay extends React.Component<Props, { isOpen: boolean }> {
           )}
           <CollectionToggleContainer>
             <ButtonCircularCaret
-              active={this.state.isOpen}
+              active={this.props.isOpen!}
               onClick={this.toggleVisibility}
             />
           </CollectionToggleContainer>
         </CollectionMetaContainer>
-        {this.state.isOpen && <FadeIn>{children}</FadeIn>}
+        {this.props.isOpen && <FadeIn>{children}</FadeIn>}
         {isUneditable ? (
           <CollectionDisabledTheme className="DisabledTheme" />
         ) : null}

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -28,6 +28,15 @@ interface EditorCloseFront {
   payload: { frontId: string };
   meta: PersistMeta;
 }
+interface EditorOpenCollection {
+  type: 'EDITOR_OPEN_COLLECTION';
+  payload: { collectionIds: string|string[] };
+}
+
+interface EditorCloseCollection {
+  type: 'EDITOR_CLOSE_COLLECTION';
+  payload: { collectionIds: string|string[] };
+}
 
 interface EditorClearOpenFronts {
   type: 'EDITOR_CLEAR_OPEN_FRONTS';
@@ -201,7 +210,9 @@ type Action =
   | BatchAction
   | FetchVisibleArticlesSuccess
   | StartConfirm
-  | EndConfirm;
+  | EndConfirm
+  | EditorOpenCollection
+  | EditorCloseCollection
 
 export {
   ActionError,
@@ -229,6 +240,8 @@ export {
   EditorClearOpenFronts,
   EditorSetOpenFronts,
   EditorCloseFront,
+  EditorOpenCollection,
+  EditorCloseCollection,
   EditorSelectArticleFragment,
   EditorClearArticleFragmentSelection,
   RecordStaleFronts,


### PR DESCRIPTION
For performance reasons, only open the top <n> collections when a front is opened.

Clicking a collection in the right-hand overview also opens a collection, so navigation along the happy path (via overview) remains snappy.

Even without conditionally loading content (the total number of requests to the server remains the same), this makes a serious difference to the performance of startup for fronts with large numbers of collections, e.g. the UK front -- it loads on average almost three times faster on CODE, from ~15 seconds to ~6secs from hard refresh.