### PR TITLE
Add error logging to live capi endpoint

### DIFF
--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -71,6 +71,10 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
     val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
     wsClient.url(url).get().map { response =>
+
+      if (response.status != OK) {
+        logger.error(s"Request to live capi with url $url failed with response $response, ${response.body}")
+      }
       Cached(60) {
         Ok(rewriteBody(response.body)).as("application/javascript")
       }


### PR DESCRIPTION
David Constable experienced errors from the live capi endpoint but we can't figure out which queries caused these errors because we don't log them. Ideally we would not be responding with OK if things are not OK but changing this would also require making changes to the error handling in the old tool which I think is more trouble than it's worth. We probably should make different capi endpoints for v2 which return better responses.