### PR TITLE
use thumbnail for...thumbnail

### DIFF
--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -164,7 +164,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
           {...this.props}
           style={{
             backgroundImage:
-              this.props.input.value && `url(${this.props.input.value.src}`
+              this.props.input.value && `url(${this.props.input.value.thumb}`
           }}
         >
           <ButtonDelete type="button" priority="primary">


### PR DESCRIPTION
Originally part of https://github.com/guardian/facia-tool/compare/aa-use-smaller-image?expand=1 however I think there is value in doing this separately.

Previously, we were using the master which is / can be huge! The API response is providing a 140px wide image for the thumb which doesn't look great in the 178px wide element, however I'll address this in another PR.

This should make the Tool that much faster as the client isn't downloading a 7MB+ image where there is an override in place.