### PR TITLE
Fix reauthenticating

### DIFF
--- a/client-v2/src/services/frontsCapi.ts
+++ b/client-v2/src/services/frontsCapi.ts
@@ -1,5 +1,6 @@
-import capiQuery from "./capiQuery";
-import urls from "constants/urls";
+import capiQuery from './capiQuery';
+import urls from 'constants/urls';
+import pandaFetch from './pandaFetch';
 
-export const liveCapi = capiQuery(urls.capiLiveUrl);
-export const previewCapi = capiQuery(urls.capiPreviewUrl);
+export const liveCapi = capiQuery(urls.capiLiveUrl, pandaFetch);
+export const previewCapi = capiQuery(urls.capiPreviewUrl, pandaFetch);


### PR DESCRIPTION
This PR changes the fetch implementation for `capiQuery` to `pandaFetch` (which handles 419 requests by trying to reauthenticate and then fire the original request again) instead of `window.fetch`.

I'm fairly sure this is why the CAPI feed failed to work with David Constable. The requests weren't wrapped in `pandaFetch`. This would go unnoticed if any other request was being made in this time as these requests would do the reauthenticating for you. It doesn't totally explain David seeing it even after a page refresh but it'd be interesting to see if it goes away after this, as this was definitely a regression and his problems did seem to start on Friday.

Have tested this locally but not waited for the Facia creds to time out to see if it actually fixes the issue. Will do that tomorrow am.