### PR TITLE
Add v2 analytics

### DIFF
--- a/app/views/V2App/app.scala.html
+++ b/app/views/V2App/app.scala.html
@@ -35,6 +35,8 @@ String) <!DOCTYPE html>
                 width: 100%;
             }
         </style>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78290349-2"></script>
     </head>
 
     <body>

--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -17,6 +17,7 @@ import { Stages, CollectionItemSets } from 'shared/types/Collection';
 import { frontStages, noOfOpenCollectionsOnFirstLoad } from 'constants/fronts';
 import { State } from 'types/State';
 import { editorOpenCollections } from 'bundles/frontsUIBundle';
+import { events } from 'services/GA';
 
 function fetchLastPressedSuccess(frontId: string, datePressed: string): Action {
   return {
@@ -77,6 +78,9 @@ function publishCollection(
   collectionId: string,
   frontId: string
 ): ThunkResult<Promise<void>> {
+
+  events.collectionPublished(frontId, collectionId);
+
   return (dispatch: Dispatch, getState: () => State) => {
     const draftVisibleArticles = visibleArticlesSelector(getState(), {
       collectionId,

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -1,6 +1,6 @@
 import reducer, {
-  editorOpenFrontPure as editorOpenFront,
-  editorCloseFrontPure as editorCloseFront,
+  editorOpenFront,
+  editorCloseFront,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -1,6 +1,6 @@
 import reducer, {
-  editorOpenFront,
-  editorCloseFront,
+  editorOpenFrontPure as editorOpenFront,
+  editorCloseFrontPure as editorCloseFront,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -38,30 +38,33 @@ const editorCloseCollections = (
   payload: { collectionIds }
 });
 
-const editorOpenFrontPure = (frontId: string): EditorAddFront => ({
-  type: EDITOR_OPEN_FRONT,
-  payload: { frontId },
-  meta: {
-    persistTo: 'openFrontIds'
-  }
-});
+/**
+ * !SIDE EFFECTS IN ACTION CREATOR
+ * we could change these to thunks but the analytics calls are essentially
+ * transparent and adding thunks makese the tests for these actions more
+ * involved. On balance we're going for it ...
+ */
 
-const editorOpenFront = (frontId: string): ThunkResult<void> => dispatch => {
+const editorOpenFront = (frontId: string): EditorAddFront => {
   events.addFront(frontId);
-  dispatch(editorOpenFrontPure(frontId));
+  return {
+    type: EDITOR_OPEN_FRONT,
+    payload: { frontId },
+    meta: {
+      persistTo: 'openFrontIds'
+    }
+  };
 };
 
-const editorCloseFrontPure = (frontId: string): EditorCloseFront => ({
-  type: EDITOR_CLOSE_FRONT,
-  payload: { frontId },
-  meta: {
-    persistTo: 'openFrontIds'
-  }
-});
-
-const editorCloseFront = (frontId: string): ThunkResult<void> => dispatch => {
+const editorCloseFront = (frontId: string): EditorCloseFront => {
   events.removeFront(frontId);
-  dispatch(editorCloseFrontPure(frontId));
+  return {
+    type: EDITOR_CLOSE_FRONT,
+    payload: { frontId },
+    meta: {
+      persistTo: 'openFrontIds'
+    }
+  };
 };
 
 const editorClearOpenFronts = (): EditorClearOpenFronts => ({

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -11,6 +11,8 @@ import {
   EditorCloseCollection
 } from 'types/Action';
 import { State as GlobalState } from 'types/State';
+import { ThunkResult } from 'types/Store';
+import { events } from 'services/GA';
 
 const EDITOR_OPEN_FRONT = 'EDITOR_OPEN_FRONT';
 const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
@@ -36,7 +38,7 @@ const editorCloseCollections = (
   payload: { collectionIds }
 });
 
-const editorOpenFront = (frontId: string): EditorAddFront => ({
+const editorOpenFrontPure = (frontId: string): EditorAddFront => ({
   type: EDITOR_OPEN_FRONT,
   payload: { frontId },
   meta: {
@@ -44,13 +46,23 @@ const editorOpenFront = (frontId: string): EditorAddFront => ({
   }
 });
 
-const editorCloseFront = (frontId: string): EditorCloseFront => ({
+const editorOpenFront = (frontId: string): ThunkResult<void> => dispatch => {
+  events.addFront(frontId);
+  dispatch(editorOpenFrontPure(frontId));
+};
+
+const editorCloseFrontPure = (frontId: string): EditorCloseFront => ({
   type: EDITOR_CLOSE_FRONT,
   payload: { frontId },
   meta: {
     persistTo: 'openFrontIds'
   }
 });
+
+const editorCloseFront = (frontId: string): ThunkResult<void> => dispatch => {
+  events.removeFront(frontId);
+  dispatch(editorCloseFrontPure(frontId));
+};
 
 const editorClearOpenFronts = (): EditorClearOpenFronts => ({
   type: EDITOR_CLEAR_OPEN_FRONTS,
@@ -196,7 +208,10 @@ export {
   selectEditorFronts,
   selectEditorFrontsByPriority,
   selectEditorArticleFragment,
-  selectIsCollectionOpen
+  selectIsCollectionOpen,
+  // testing
+  editorOpenFrontPure,
+  editorCloseFrontPure
 };
 
 export default reducer;

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -211,10 +211,7 @@ export {
   selectEditorFronts,
   selectEditorFrontsByPriority,
   selectEditorArticleFragment,
-  selectIsCollectionOpen,
-  // testing
-  editorOpenFrontPure,
-  editorCloseFrontPure
+  selectIsCollectionOpen
 };
 
 export default reducer;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -45,6 +45,7 @@ type CollectionProps = CollectionPropsBeforeState & {
 
 const Collection = ({
   id,
+  frontId,
   children,
   alsoOn,
   groups,
@@ -52,13 +53,13 @@ const Collection = ({
   hasUnpublishedChanges,
   canPublish = true,
   publishCollection: publish,
-  frontId,
   displayEditWarning,
   isUneditable,
   isOpen,
   onChangeOpenState
 }: CollectionProps) => (
   <CollectionDisplay
+    frontId={frontId}
     id={id}
     browsingStage={browsingStage}
     isUneditable={isUneditable}

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -9,11 +9,12 @@ import {
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { createCollectionId } from 'shared/components/Collection';
-import { editorOpenCollections } from 'bundles/frontsUIBundle';
 import { Dispatch } from 'types/Store';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
+import { events } from 'services/GA';
 
 interface FrontCollectionOverviewContainerProps {
+  frontId: string;
   collectionId: string;
   browsingStage: CollectionItemSets;
 }
@@ -73,12 +74,14 @@ const Name = styled.span`
 const CollectionOverview = ({
   collection,
   articleCount,
-  openCollection
+  openCollection,
+  frontId
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
       onClick={e => {
         e.preventDefault();
+        events.overviewItemClicked(frontId)
         const el = document.getElementById(createCollectionId(collection));
         if (el) {
           el.scrollIntoView({

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -34,6 +34,7 @@ import { FrontConfig } from 'types/FaciaApi';
 import { visibleFrontArticlesSelector } from 'selectors/frontsSelectors';
 import { VisibleArticlesResponse } from 'types/FaciaApi';
 import { initialiseFront } from 'actions/Fronts';
+import { events } from 'services/GA';
 
 const FrontContainer = styled('div')`
   display: flex;
@@ -70,6 +71,9 @@ interface FrontState {
   error: string | void;
 }
 
+const isDropFromCAPIFeed = (e: React.DragEvent) =>
+  e.dataTransfer.types.includes('capi');
+
 class FrontComponent extends React.Component<FrontProps, FrontState> {
   constructor(props: FrontProps) {
     super(props);
@@ -95,12 +99,17 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 
   public handleMove = (move: Move<TArticleFragment>) => {
+    events.dropArticle(this.props.front.id, 'collection');
     this.props.dispatch(
       moveArticleFragment(move.to, move.data, move.from || null, 'collection')
     );
   };
 
   public handleInsert = (e: React.DragEvent, to: PosSpec) => {
+    events.dropArticle(
+      this.props.front.id,
+      isDropFromCAPIFeed(e) ? 'feed' : 'url'
+    );
     this.props.dispatch(
       insertArticleFragmentFromDropEvent(e, to, 'collection')
     );

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -27,15 +27,15 @@ const Container = styled(ContentContainer)`
 `;
 
 const FrontCollectionsOverview = ({
+  id,
   front,
   browsingStage
 }: FrontCollectionOverviewProps) => (
   <Container setBack>
-    <ContainerHeadingPinline>
-      Overview
-    </ContainerHeadingPinline>
+    <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
     {front.collections.map(collectionId => (
       <CollectionOverview
+        frontId={id}
         key={collectionId}
         collectionId={collectionId}
         browsingStage={browsingStage}

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -12,7 +12,8 @@
 const DIMENSION_MAP = {
   dimension1: 'front_id',
   dimension2: 'drag_source',
-  dimension3: 'collection_id'
+  dimension3: 'collection_id',
+  dimension4: 'version'
 };
 
 const w: any = window;
@@ -27,7 +28,8 @@ const init = () => {
   // script provided from GA
   gtag('js', new Date());
   gtag('config', 'UA-78290349-2', {
-    custom_map: DIMENSION_MAP
+    custom_map: DIMENSION_MAP,
+    version: '2'
   });
 };
 

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -11,7 +11,8 @@
  */
 const DIMENSION_MAP = {
   dimension1: 'front_id',
-  dimension2: 'drag_source'
+  dimension2: 'drag_source',
+  dimension3: 'collection_id'
 };
 
 const w: any = window;

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -23,6 +23,8 @@ function gtag(...args: any[]) {
 }
 
 const init = () => {
+  // these calls have been extracted (and modified) from the original tracking
+  // script provided from GA
   gtag('js', new Date());
   gtag('config', 'UA-78290349-2', {
     custom_map: DIMENSION_MAP

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -1,0 +1,60 @@
+/**
+ * For this to work as expected this script tag needs to exist in the <head></head> tag:
+ *
+ * <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78290349-2"></script>
+ */
+
+/**
+ * Custom dimensions need to be added here such that we can send events like
+ *
+ * `gtag('event', 'drop_article', { front_id: 'my_id_134' })`
+ */
+const DIMENSION_MAP = {
+  dimension1: 'front_id',
+  dimension2: 'drag_source'
+};
+
+const w: any = window;
+w.dataLayer = w.dataLayer || [];
+
+function gtag(...args: any[]) {
+  w.dataLayer.push(...args);
+}
+
+const init = () => {
+  gtag('js', new Date());
+  gtag('config', 'UA-78290349-2', {
+    custom_map: DIMENSION_MAP
+  });
+};
+
+const events = {
+  addFront: (frontId: string) =>
+    gtag('event', 'add_front', {
+      front_id: frontId // either front id or 'clipboard'
+    }),
+  removeFront: (frontId: string) =>
+    gtag('event', 'remove_front', {
+      front_id: frontId
+    }),
+  dropArticle: (frontId: string, source?: string) =>
+    gtag('event', 'drop_article', {
+      front_id: frontId,
+      drag_source: source // 'feed', 'url', 'collection' etc.
+    }),
+  overviewItemClicked: (frontId: string) =>
+    gtag('event', 'overview_item_clicked', {
+      front_id: frontId
+    }),
+  collectionToggleClicked: (frontId: string) =>
+    gtag('event', 'collection_toggle_clicked', {
+      front_id: frontId
+    }),
+  collectionPublished: (frontId: string, collectionId: string) =>
+    gtag('event', 'collection_published', {
+      collection_id: collectionId,
+      front_id: frontId
+    })
+};
+
+export { init, events };

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -20,6 +20,7 @@ import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
 import ContentContainer from './layout/ContentContainer';
 import { css } from 'styled-components';
+import { events } from 'services/GA';
 
 export const createCollectionId = ({ id }: Collection) => `collection-${id}`;
 
@@ -27,6 +28,7 @@ interface ContainerProps {
   id: string;
   selectSharedState?: (state: any) => SharedState;
   browsingStage: CollectionItemSets;
+  frontId: string;
 }
 
 type Props = ContainerProps & {
@@ -93,7 +95,6 @@ const ItemCountMeta = CollectionMetaBase.extend`
   flex: 0;
 `;
 
-
 const CollectionHeadlineWithConfigContainer = styled('div')`
   flex-grow: 1;
   max-width: calc(100% - 95px);
@@ -152,6 +153,7 @@ class CollectionDisplay extends React.Component<Props> {
   };
 
   public toggleVisibility = () => {
+    events.collectionToggleClicked(this.props.frontId);
     if (this.props.onChangeOpenState) {
       this.props.onChangeOpenState(!this.props.isOpen);
     }
@@ -171,9 +173,9 @@ class CollectionDisplay extends React.Component<Props> {
       <CollectionContainer id={collection && createCollectionId(collection)}>
         <ContainerHeadingPinline>
           <CollectionHeadlineWithConfigContainer>
-          <CollectionHeadingText isLoading={!collection}>
-            {collection ? collection.displayName : 'Loading'}
-          </CollectionHeadingText>
+            <CollectionHeadingText isLoading={!collection}>
+              {collection ? collection.displayName : 'Loading'}
+            </CollectionHeadingText>
             <CollectionConfigContainer>
               {oc(collection).metadata[0].type() ? (
                 <CollectionConfigText>
@@ -181,7 +183,9 @@ class CollectionDisplay extends React.Component<Props> {
                   {oc(collection).metadata[0].type()}
                 </CollectionConfigText>
               ) : null}
-              {collection && collection.platform && collection.platform !== 'Any' ? (
+              {collection &&
+              collection.platform &&
+              collection.platform !== 'Any' ? (
                 <CollectionConfigText>
                   <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
                   {`${collection.platform} Only`}


### PR DESCRIPTION
This adds some analytics calls for the v2 app. I'm going to add the _do not merge_ tag as it's yet to be tested but I thought I'd throw it up here first to show how I'd structured it. A few points to focus on:

1. Because there is no real interface / types for this I _think_ I have dispatched the events correctly (taken from [here](https://developers.google.com/analytics/devguides/collection/gtagjs/events)) as well as setup [custom dimensions](https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets) properly. Further to this, there aren't - [as yet](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23718) - types for `gtag`. This means that (as the second commit here shows!) you can add custom dimensions to an `event` call without defining them in the custom map. Potentially we could do a small subset of the types here for our use case?

2. Are we happy with where I've put the calls. Some events seem to be more around the actions themselves (add / remove fronts) and some more about the actual clicking of a UI element (the overview clicking).

3. ~Instead of confusing the frontsUIBundle with the thunk middleware I've just exported the previous plain action. As a results the thunks aren't tested. Happy to add tests for these and bootstrap the middleware and test the store instead of the reducer. Be interested to see what people thought ...~ After speaking to @jonathonherbert I'm just side effecting in action creators for simplicity.