### PR TITLE
Revert back to default trail, headline and byline when they are erased

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -15,7 +15,8 @@ import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadi
 import {
   createArticleFromArticleFragmentSelector,
   selectSharedState,
-  articleTagSelector
+  articleTagSelector,
+  externalArticleFromArticleFragmentSelector
 } from 'shared/selectors/shared';
 import { createSelectFormFieldsForCollectionItem } from 'selectors/formSelectors';
 import { ArticleFragmentMeta, ArticleTag } from 'shared/types/Collection';
@@ -34,8 +35,10 @@ import ConditionalComponent from 'components/layout/ConditionalComponent';
 import {
   ArticleFragmentFormData,
   getArticleFragmentMetaFromFormValues,
-  getInitialValuesForArticleFragmentForm
+  getInitialValuesForArticleFragmentForm,
+  getCapiValuesForArticleTextFields
 } from 'util/form';
+import { CapiTextFields } from 'util/form';
 
 interface ComponentProps extends ContainerProps {
   articleFragmentId: string;
@@ -122,6 +125,7 @@ const formComponent: React.StatelessComponent<Props> = ({
   imageCutoutReplace,
   onCancel,
   initialValues,
+  articleCapiFieldValues,
   pristine,
   showByline,
   editableFields,
@@ -148,7 +152,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           permittedFields={editableFields}
           name="headline"
           label="Headline"
-          placeholder={initialValues.headline}
+          placeholder={articleCapiFieldValues.headline}
           component={InputTextArea}
           useHeadlineFont
           rows="2"
@@ -271,7 +275,7 @@ const formComponent: React.StatelessComponent<Props> = ({
             name="byline"
             label="Byline"
             component={InputText}
-            placeholder="Replace byline"
+            placeholder={articleCapiFieldValues.byline}
             useHeadlineFont
           />
         )}
@@ -280,7 +284,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="trailText"
           label="Trail text"
           component={InputTextArea}
-          placeholder="Replace trail text"
+          placeholder={articleCapiFieldValues.trailText}
         />
       </InputGroup>
       <RowContainer>
@@ -398,6 +402,7 @@ interface ContainerProps extends InterfaceProps {
   editableFields: string[];
   showKickerTag: boolean;
   showKickerSection: boolean;
+  articleCapiFieldValues: CapiTextFields;
 }
 
 interface InterfaceProps {
@@ -420,11 +425,13 @@ const createMapStateToProps = () => {
     state: State,
     { articleFragmentId, isSupporting = false }: InterfaceProps
   ) => {
+    const externalArticle = externalArticleFromArticleFragmentSelector(selectSharedState(state), articleFragmentId);
     const valueSelector = formValueSelector(articleFragmentId);
     const article = selectArticle(selectSharedState(state), articleFragmentId);
 
     return {
       initialValues: getInitialValuesForArticleFragmentForm(article),
+      articleCapiFieldValues: getCapiValuesForArticleTextFields(externalArticle),
       editableFields: article
         ? selectFormFields(state, article.uuid, isSupporting)
         : [],

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -1,5 +1,6 @@
 import { ArticleFragmentMeta } from 'shared/types/Collection';
 import { DerivedArticle } from 'shared/types/Article';
+import { CapiArticle } from 'types/Capi';
 import omit from 'lodash/omit';
 import compact from 'lodash/compact';
 import clamp from 'lodash/clamp';
@@ -31,8 +32,29 @@ export interface ImageData {
   thumb?: string;
 }
 
+export interface CapiTextFields {
+  headline: string,
+  trailText: string,
+  byline: string
+}
+
 const strToInt = (str: string | void) => (str ? parseInt(str, 10) : undefined);
 const intToStr = (int: number | void) => (int ? int.toString() : undefined);
+
+export const getCapiValuesForArticleTextFields = (article: CapiArticle | void): CapiTextFields => {
+  if (!article) {
+    return {
+      headline: '',
+      trailText: '',
+      byline: ''
+    };
+  }
+  return {
+    headline: article.fields.headline || '',
+    trailText: article.fields.trailText || '',
+    byline: article.fields.byline || ''
+  };
+}
 
 export const getInitialValuesForArticleFragmentForm = (
   article: DerivedArticle | void
@@ -97,9 +119,19 @@ export const getArticleFragmentMetaFromFormValues = (
       height: intToStr(image.height)
     })
   );
+  const getStringField = (field: string) => {
+    if (field.length === 0) {
+      return undefined;
+    }
+    return field;
+  }
+
   return omit(
     {
       ...values,
+      headline: getStringField(values.headline),
+      trailText: getStringField(values.trailText),
+      byline: getStringField(values.byline),
       imageReplace: !!primaryImage.src && !values.imageHide,
       imageSrc: primaryImage.src,
       imageSrcThumb: primaryImage.thumb,


### PR DESCRIPTION
Fixes the problem described here: https://trello.com/c/yT3Ffhup/390-hi-had-a-big-scary-one-today-on-the-old-front-when-youd-backspace-completely-on-a-headline-it-would-autofill-it-back-in-so-today

Also adds in the correct placeholders from capi if the whole field gets removed.