### PR TITLE
Fix broken loading placeholder logic

### DIFF
--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -131,15 +131,14 @@ const ArticleComponent = ({
                 notifications={notifications}
               />
             )}
-          {!article &&
-            isLoading && (
-              <ArticleBody
-                uuid={id}
-                isUneditable={true}
-                displayPlaceholders={true}
-                size={size}
-              />
-            )}
+          {isLoading && (
+            <ArticleBody
+              uuid={id}
+              isUneditable={true}
+              displayPlaceholders={true}
+              size={size}
+            />
+          )}
           {!article &&
             !isLoading && (
               <ArticleBody

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -121,16 +121,15 @@ const ArticleComponent = ({
           pillarId={article.pillarId}
           isLive={article.isLive}
         >
-          {article &&
-            !isLoading && (
-              <ArticleBody
-                {...article}
-                size={size}
-                isUneditable={isUneditable}
-                {...getOverlayEventProps()}
-                notifications={notifications}
-              />
-            )}
+          {article && !isLoading && (
+            <ArticleBody
+              {...article}
+              size={size}
+              isUneditable={isUneditable}
+              {...getOverlayEventProps()}
+              notifications={notifications}
+            />
+          )}
           {isLoading && (
             <ArticleBody
               uuid={id}
@@ -139,15 +138,14 @@ const ArticleComponent = ({
               size={size}
             />
           )}
-          {!article &&
-            !isLoading && (
-              <ArticleBody
-                headline="Content not found"
-                uuid={id}
-                isUneditable={true}
-                size={size}
-              />
-            )}
+          {!article && !isLoading && (
+            <ArticleBody
+              headline="Content not found"
+              uuid={id}
+              isUneditable={true}
+              size={size}
+            />
+          )}
         </ArticleBodyContainer>
       )}
       {children}

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -121,31 +121,34 @@ const ArticleComponent = ({
           pillarId={article.pillarId}
           isLive={article.isLive}
         >
-          {article && (
-            <ArticleBody
-              {...article}
-              size={size}
-              isUneditable={isUneditable}
-              {...getOverlayEventProps()}
-              notifications={notifications}
-            />
-          )}
-          {!article && isLoading && (
-            <ArticleBody
-              uuid={id}
-              isUneditable={true}
-              displayPlaceholders={true}
-              size={size}
-            />
-          )}
-          {!article && !isLoading && (
-            <ArticleBody
-              headline="Content not found"
-              uuid={id}
-              isUneditable={true}
-              size={size}
-            />
-          )}
+          {article &&
+            !isLoading && (
+              <ArticleBody
+                {...article}
+                size={size}
+                isUneditable={isUneditable}
+                {...getOverlayEventProps()}
+                notifications={notifications}
+              />
+            )}
+          {!article &&
+            isLoading && (
+              <ArticleBody
+                uuid={id}
+                isUneditable={true}
+                displayPlaceholders={true}
+                size={size}
+              />
+            )}
+          {!article &&
+            !isLoading && (
+              <ArticleBody
+                headline="Content not found"
+                uuid={id}
+                isUneditable={true}
+                size={size}
+              />
+            )}
         </ArticleBodyContainer>
       )}
       {children}
@@ -164,11 +167,12 @@ const createMapStateToProps = () => {
       : selectSharedState(state);
     const article = articleSelector(sharedState, props.id);
     const articleFragment = articleFragmentSelector(sharedState, props.id);
+    const isLoading =
+      !!articleFragment &&
+      selectors.selectIsLoadingById(sharedState, articleFragment.id);
     return {
       article,
-      isLoading:
-        !!articleFragment &&
-        selectors.selectIsLoadingById(sharedState, articleFragment.id)
+      isLoading
     };
   };
 };

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -100,7 +100,7 @@ const articleBodyDefault = ({
       <CollectionItemMetaContainer>
         {displayPlaceholders && (
           <>
-            <TextPlaceholder />
+            <TextPlaceholder data-testid="loading-placeholder" />
             {size === 'default' && <TextPlaceholder width={25} />}
           </>
         )}

--- a/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
+++ b/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
@@ -61,33 +61,39 @@ describe('Article component ', () => {
 
   it('should render loading placeholders when the isLoading prop is true', () => {
     const { getByTestId } = render(
-      <ArticleComponent
-        children={<React.Fragment />}
-        article={takenDownArticle}
-        id="ea1"
-        isLoading={true}
-      />
+      <ThemeProvider theme={theme}>
+        <ArticleComponent
+          children={<React.Fragment />}
+          article={takenDownArticle}
+          id="ea1"
+          isLoading={true}
+        />
+      </ThemeProvider>
     );
     expect(getByTestId('loading-placeholder')).toBeTruthy();
   });
   it('should not render loading placeholders when the isLoading prop is false or not present', () => {
     let renderResult = render(
-      <ArticleComponent
-        children={<React.Fragment />}
-        article={takenDownArticle}
-        id="ea1"
-        isLoading={false}
-      />
+      <ThemeProvider theme={theme}>
+        <ArticleComponent
+          children={<React.Fragment />}
+          article={takenDownArticle}
+          id="ea1"
+          isLoading={false}
+        />
+      </ThemeProvider>
     );
     expect(
       renderResult.getByTestId.bind(renderResult, 'loading-placeholder')
     ).toThrow();
     renderResult = render(
-      <ArticleComponent
-        children={<React.Fragment />}
-        article={takenDownArticle}
-        id="ea1"
-      />
+      <ThemeProvider theme={theme}>
+        <ArticleComponent
+          children={<React.Fragment />}
+          article={takenDownArticle}
+          id="ea1"
+        />
+      </ThemeProvider>
     );
     expect(
       renderResult.getByTestId.bind(renderResult, 'loading-placeholder')

--- a/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
+++ b/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
@@ -58,4 +58,39 @@ describe('Article component ', () => {
     expect(getByTestId('article-body')).toHaveTextContent('Taken Down');
     expect(getByTestId('article-body')).not.toHaveTextContent('Draft');
   });
+
+  it('should render loading placeholders when the isLoading prop is true', () => {
+    const { getByTestId } = render(
+      <ArticleComponent
+        children={<React.Fragment />}
+        article={takenDownArticle}
+        id="ea1"
+        isLoading={true}
+      />
+    );
+    expect(getByTestId('loading-placeholder')).toBeTruthy();
+  });
+  it('should not render loading placeholders when the isLoading prop is false or not present', () => {
+    let renderResult = render(
+      <ArticleComponent
+        children={<React.Fragment />}
+        article={takenDownArticle}
+        id="ea1"
+        isLoading={false}
+      />
+    );
+    expect(
+      renderResult.getByTestId.bind(renderResult, 'loading-placeholder')
+    ).toThrow();
+    renderResult = render(
+      <ArticleComponent
+        children={<React.Fragment />}
+        article={takenDownArticle}
+        id="ea1"
+      />
+    );
+    expect(
+      renderResult.getByTestId.bind(renderResult, 'loading-placeholder')
+    ).toThrow();
+  });
 });


### PR DESCRIPTION
This PR restores the loading placeholders that disappeared a while ago. The original loading placeholder logic worked somewhat by coincidence, and a change in the way article models were derived broke it.

They're still a bit tardy to appear when collections load, which will be solved when we batch the stories-visible logic.