### PR TITLE
Ensure that we're looking in the right place for resource result

### DIFF
--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -25,6 +25,15 @@ const {
   initialData: []
 });
 
+const fetchResourceOrResults = async (
+  capiService: typeof liveCapi,
+  params: object,
+  isResource: boolean
+) => {
+  const res = await capiService.search(params, { isResource });
+  return isResource ? [res.response.content] : res.response.results;
+}
+
 export const fetchLive = (
   params: object,
   isResource: boolean
@@ -32,7 +41,7 @@ export const fetchLive = (
   dispatch(liveActions.fetchStart('live'));
   let results;
   try {
-    results = (await liveCapi.search(params, { isResource })).response.results;
+    results = await fetchResourceOrResults(liveCapi, params, isResource);
   } catch (e) {
     dispatch(liveActions.fetchError(e.message));
   }
@@ -49,8 +58,7 @@ export const fetchPreview = (
   dispatch(previewActions.fetchStart('preview'));
   let results;
   try {
-    results = (await previewCapi.search(params, { isResource })).response
-      .results;
+    results = await fetchResourceOrResults(previewCapi, params, isResource);
   } catch (e) {
     dispatch(previewActions.fetchError(e.message));
   }


### PR DESCRIPTION
There was a chance to the way we fetch single items from CAPI that I always forget about, which means the shape of a `CAPIResponse` is `{ ..., response: { ..., content?: Article, results?: Article[] }}` because `search` can go to one of two endpoints; one of which returns a `content` key and one that returns a `results` key.

Part of me wants to make the CAPI service less clever and do the forking between the two endpoints outside of the service so that we can have a consistent return type for each service call? I do remember talking to @jonathonherbert about this and can't remember what the reason was that we _didn't_ do this but I remember it being valid!

As for now I've fixed the search issue 😄 