### PR TITLE
Render trail html and sanitize

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -36,6 +36,7 @@
     "@types/react-router-redux": "^5.0.16",
     "@types/redux-form": "^7.4.9",
     "@types/redux-mock-store": "^1.0.0",
+    "@types/sanitize-html": "^1.18.2",
     "@types/styled-components": "^4.0.1",
     "@types/webpack-env": "^1.13.6",
     "babel-core": "^7.0.0-0",
@@ -110,6 +111,7 @@
     "redux-form": "^7.4.2",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1",
+    "sanitize-html": "^1.20.0",
     "styled-components": "^3.2.5",
     "ts-optchain": "^0.1.2",
     "uuid": "^3.2.1"

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -27,7 +27,6 @@ import { CollectionItemSizes } from 'shared/types/Collection';
 import CollectionItemTrail from '../collectionItem/CollectionItemTrail';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
 import CollectionItemNotification from '../collectionItem/CollectionItemNotification';
-import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   width: 130px;
@@ -43,7 +42,7 @@ const KickerHeading = styled(CollectionItemHeading)`
   padding-right: 3px;
 `;
 
-const ArticleHeadingSmall = CollectionItemHeading.extend`
+const ArticleHeadingSmall = styled(CollectionItemHeading)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -142,19 +141,17 @@ const articleBodyDefault = ({
             </KickerHeading>
           )}
           {size === 'default' ? (
-            <CollectionItemHeading data-testid="headline">
+            <CollectionItemHeading html data-testid="headline">
               {headline}
             </CollectionItemHeading>
           ) : (
-            <ArticleHeadingSmall data-testid="headline">
+            <ArticleHeadingSmall html data-testid="headline">
               {headline}
             </ArticleHeadingSmall>
           )}
         </ArticleHeadingContainer>
         {size === 'default' && trailText && (
-          <CollectionItemTrail
-            dangerouslySetInnerHTML={{ __html: sanitizeHTML(trailText) }}
-          />
+          <CollectionItemTrail html>{trailText}</CollectionItemTrail>
         )}
       </CollectionItemContent>
       {size === 'default' &&

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -27,6 +27,7 @@ import { CollectionItemSizes } from 'shared/types/Collection';
 import CollectionItemTrail from '../collectionItem/CollectionItemTrail';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
 import CollectionItemNotification from '../collectionItem/CollectionItemNotification';
+import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   width: 130px;
@@ -151,7 +152,9 @@ const articleBodyDefault = ({
           )}
         </ArticleHeadingContainer>
         {size === 'default' && trailText && (
-          <CollectionItemTrail>{trailText}</CollectionItemTrail>
+          <CollectionItemTrail
+            dangerouslySetInnerHTML={{ __html: sanitizeHTML(trailText) }}
+          />
         )}
       </CollectionItemContent>
       {size === 'default' &&

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -1,7 +1,31 @@
+import React from 'react';
 import { styled } from 'shared/constants/theme';
+import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 
-export default styled('span')`
+const Wrapper = styled('span')`
   font-family: GhGuardianHeadline-Medium;
   padding-top: 2px;
   font-size: 16px;
 `;
+
+type CollectionItemHeading = {
+  children?: string;
+  html?: boolean;
+} & React.HTMLProps<HTMLSpanElement>;
+
+const CollectionItemHeading = ({
+  children = '',
+  html = false,
+  ref, // remove this for TS reasons
+  ...props
+}: CollectionItemHeading) =>
+  html ? (
+    <Wrapper
+      dangerouslySetInnerHTML={{ __html: sanitizeHTML(children) }}
+      {...props}
+    />
+  ) : (
+    <Wrapper {...props}>{children}</Wrapper>
+  );
+
+export default CollectionItemHeading;

--- a/client-v2/src/shared/components/collectionItem/CollectionItemTrail.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemTrail.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { styled } from 'shared/constants/theme';
+import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 
-export default styled('div')`
+const Wrapper = styled('div')`
   width: 100%;
   margin-top: 3px;
   font-size: 14px;
@@ -9,3 +11,25 @@ export default styled('div')`
   text-overflow: ellipsis;
   font-family: TS3TextSans;
 `;
+
+type CollectionItemTrailProps = {
+  children?: string;
+  html?: boolean;
+} & React.HTMLProps<HTMLDivElement>;
+
+const CollectionItemTrail = ({
+  children = '',
+  html = false,
+  ref, // remove this for TS reasons
+  ...props
+}: CollectionItemTrailProps) =>
+  html ? (
+    <Wrapper
+      dangerouslySetInnerHTML={{ __html: sanitizeHTML(children) }}
+      {...props}
+    />
+  ) : (
+    <Wrapper {...props}>{children}</Wrapper>
+  );
+
+export default CollectionItemTrail;

--- a/client-v2/src/shared/components/collectionItem/__tests__/CollectionItemHeading.spec.tsx
+++ b/client-v2/src/shared/components/collectionItem/__tests__/CollectionItemHeading.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, cleanup } from 'react-testing-library';
+import CollectionItemHeading from '../CollectionItemHeading';
+
+afterEach(cleanup);
+
+describe('CollectionItemHeading', () => {
+  it('does not render html by default', () => {
+    const { getByTestId } = render(
+      <CollectionItemHeading children="<strong data-testid='test'>Test</strong>" />
+    );
+    expect(() => getByTestId('test')).toThrow();
+  });
+
+  it('renders sanitized html when asked', () => {
+    const { getByTestId } = render(
+      <CollectionItemHeading
+        html
+        children="<span data-testid='test'><strong>Test</strong><iframe></iframe></span>"
+      />
+    );
+    expect(getByTestId('test').innerHTML).toBe('<strong>Test</strong>');
+  });
+});

--- a/client-v2/src/shared/components/collectionItem/__tests__/CollectionItemTrail.spec.tsx
+++ b/client-v2/src/shared/components/collectionItem/__tests__/CollectionItemTrail.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, cleanup } from 'react-testing-library';
+import CollectionItemTrail from '../CollectionItemTrail';
+
+afterEach(cleanup);
+
+describe('CollectionItemTrail', () => {
+  it('does not render html by default', () => {
+    const { getByTestId } = render(
+      <CollectionItemTrail children="<strong data-testid='test'>Test</strong>" />
+    );
+    expect(() => getByTestId('test')).toThrow();
+  });
+
+  it('renders sanitized html when asked', () => {
+    const { getByTestId } = render(
+      <CollectionItemTrail
+        html
+        children="<span data-testid='test'><strong>Test</strong><iframe></iframe></span>"
+      />
+    );
+    expect(getByTestId('test').innerHTML).toBe('<strong>Test</strong>');
+  });
+});

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -91,7 +91,7 @@ const SnapLink = ({
         )}
         <CollectionItemContent displayType={displayType}>
           {displayType === 'default' ? (
-            <CollectionItemHeading>{headline}</CollectionItemHeading>
+            <CollectionItemHeading html>{headline}</CollectionItemHeading>
           ) : (
             <>
               <strong>Snap link </strong>
@@ -99,7 +99,7 @@ const SnapLink = ({
             </>
           )}
           {size === 'default' && articleFragment.meta.trailText && (
-            <CollectionItemTrail>
+            <CollectionItemTrail html>
               {articleFragment.meta.trailText}
             </CollectionItemTrail>
           )}

--- a/client-v2/src/shared/util/__tests__/sanitizeHTML.spec.ts
+++ b/client-v2/src/shared/util/__tests__/sanitizeHTML.spec.ts
@@ -1,0 +1,13 @@
+import { sanitizeHTML } from '../sanitizeHTML';
+
+describe('sanitizeHTML', () => {
+  it('removes unwanted / unsafe tags', () => {
+    expect(
+      sanitizeHTML('<p>Iframe: <iframe src="http://test.com" /></p>')
+    ).toBe('<p>Iframe: </p>');
+
+    expect(
+      sanitizeHTML('<p>Script</p><script>window.alert("hacked")</script>')
+    ).toBe('<p>Script</p>');
+  });
+});

--- a/client-v2/src/shared/util/sanitizeHTML.ts
+++ b/client-v2/src/shared/util/sanitizeHTML.ts
@@ -1,0 +1,54 @@
+import { default as sanitize } from 'sanitize-html';
+
+// these are the defaults from html-sanitize (although disallowing `iframes`)
+// Thgey've been left quite broad as they allow *rendering* in the fronts tool
+// but we're not trying to keep up to date with what dotcom do / don't allow in
+// the trail
+export const sanitizeHTML = (html: string) =>
+  sanitize(html, {
+    allowedTags: [
+      'blockquote',
+      'p',
+      'a',
+      'ul',
+      'ol',
+      'nl',
+      'li',
+      'b',
+      'i',
+      'strong',
+      'em',
+      'strike',
+      'code',
+      'hr',
+      'br',
+      'div',
+      'table',
+      'thead',
+      'caption',
+      'tbody',
+      'tr',
+      'th',
+      'td',
+      'pre'
+      // 'iframe'
+    ],
+    allowedAttributes: {
+      a: ['href', 'name', 'target'],
+      img: ['src'],
+      selfClosing: [
+        'img',
+        'br',
+        'hr',
+        'area',
+        'base',
+        'basefont',
+        'input',
+        'link',
+        'meta'
+      ]
+    },
+    allowedSchemes: ['http', 'https'],
+    allowedSchemesAppliedToAttributes: ['href', 'src', 'cite'],
+    allowProtocolRelative: false
+  });

--- a/client-v2/src/shared/util/sanitizeHTML.ts
+++ b/client-v2/src/shared/util/sanitizeHTML.ts
@@ -30,10 +30,12 @@ export const sanitizeHTML = (html: string) =>
       'tr',
       'th',
       'td',
-      'pre'
+      'pre',
+      'span'
       // 'iframe'
     ],
     allowedAttributes: {
+      '*': ['data-testid'],
       a: ['href', 'name', 'target'],
       img: ['src'],
       selfClosing: [

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -811,6 +811,13 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.1.tgz#66849a23ceef917b57f0787c885f41ce03480f5c"
   integrity sha512-g7RRtPg2f2OJm3kvYVTAGEr3R+YN53XwZgpP8r4cl3ugJB+95hbPfOU5tjOoAOz4bTLQuiHVUJh8rl4hEDUUjQ==
 
+"@types/htmlparser2@*":
+  version "3.7.31"
+  resolved "https://registry.yarnpkg.com/@types/htmlparser2/-/htmlparser2-3.7.31.tgz#ae89353691ce37fa2463c3b8b4698f20ef67a59b"
+  integrity sha512-6Kjy02k+KfJJE2uUiCytS31SXCYnTjKA+G0ydb83DTlMFzorBlezrV2XiKazRO5HSOEvVW3cpzDFPoP9n/9rSA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/jest@^23.3.5":
   version "23.3.5"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.5.tgz#870a1434208b60603745bfd214fc3fc675142364"
@@ -937,6 +944,13 @@
   integrity sha1-vCtulylhgxr7gqm/TwZybjUflBY=
   dependencies:
     redux-thunk "*"
+
+"@types/sanitize-html@^1.18.2":
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.18.2.tgz#14e9971064d0f29aa4feaa8421122ced9e8346d9"
+  integrity sha512-WSE/HsqOHfHd1c0vPOOWOWNippsscBU72r5tpWT/+pFL3zBiCPJCp0NO7sQT8V0gU0xjSKpMAve3iMEJrRhUWQ==
+  dependencies:
+    "@types/htmlparser2" "*"
 
 "@types/styled-components@^4.0.1":
   version "4.0.1"
@@ -1444,7 +1458,7 @@ array-union@^1.0.1:
   dependencies:
     array-uniq "^1.0.1"
 
-array-uniq@^1.0.1:
+array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
@@ -5459,6 +5473,18 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
+htmlparser2@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
+  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.0.6"
+
 htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
@@ -7044,6 +7070,11 @@ lodash._getnative@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -7053,6 +7084,11 @@ lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
   integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
+
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -7087,6 +7123,11 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
@@ -7100,6 +7141,11 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.mergewith@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -9158,6 +9204,15 @@ read-pkg@^3.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
+  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -9716,6 +9771,22 @@ sanitize-filename@^1.6.0:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+sanitize-html@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.20.0.tgz#9a602beb1c9faf960fb31f9890f61911cc4d9156"
+  integrity sha512-BpxXkBoAG+uKCHjoXFmox6kCSYpnulABoGcZ/R3QyY9ndXbIM5S94eOr1IqnzTG8TnbmXaxWoDDzKC5eJv7fEQ==
+  dependencies:
+    chalk "^2.4.1"
+    htmlparser2 "^3.10.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.1"
+    postcss "^7.0.5"
+    srcset "^1.0.0"
+    xtend "^4.0.1"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -10124,6 +10195,14 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+srcset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
+  integrity sha1-pWad4StC87HV6D7QPHEEb8SPQe8=
+  dependencies:
+    array-uniq "^1.0.2"
+    number-is-nan "^1.0.0"
+
 sshpk@^1.7.0:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
@@ -10265,6 +10344,13 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -11171,7 +11257,7 @@ utf8-byte-length@^1.0.1:
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
   integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -11650,7 +11736,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=


### PR DESCRIPTION
This change allows the rendering of the HTML in the trail (like the `strong` text in the image below). I've used [sanitize-html](https://www.npmjs.com/package/sanitize-html) for this.

As mentioned in the code comments, I've opted to render anything that's safe rather than try and pick a subset that are currently allowed in the frontend (apart from `iframe` which seemed a bit much).

Let me know if there are any other tests to consider!

<img width="613" alt="screenshot 2019-01-16 at 15 17 51" src="https://user-images.githubusercontent.com/1652187/51258442-edb4f800-19a1-11e9-90b3-a354e11cf9a9.png">
