### PR TITLE
Better messaging for CAPI errors

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -70,7 +70,8 @@
     "utility-types": "^2.1.0",
     "webpack": "^4.5.0",
     "webpack-cli": "^2.0.14",
-    "webpack-dev-server": "^3.1.3"
+    "webpack-dev-server": "^3.1.3",
+    "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {
     "@guardian/guration": "^3.0.1",

--- a/client-v2/src/bundles/__tests__/capiFeedBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/capiFeedBundle.spec.ts
@@ -1,0 +1,92 @@
+import configureStore from 'util/configureStore';
+import fetchMock from 'fetch-mock';
+import {
+  fetchLive,
+  fetchPreview,
+  liveSelectors,
+  previewSelectors
+} from '../capiFeedBundle';
+import { capiArticle } from 'shared/fixtures/shared';
+
+const resources = [
+  { fetchAction: fetchLive, selectors: liveSelectors, endpoint: 'live' },
+  {
+    fetchAction: fetchPreview,
+    selectors: previewSelectors,
+    endpoint: 'preview'
+  }
+];
+const createStoreAndFetchMock = (pattern: string, result: object | number) => {
+  fetchMock.get(pattern, result, { overwriteRoutes: true });
+  return configureStore();
+};
+
+describe('capiFeedBundle', () => {
+  beforeEach(() => fetchMock.reset());
+  it('should add CAPI results to the application state', async () => {
+    await Promise.all(
+      resources.map(async resource => {
+        const store = createStoreAndFetchMock(
+          `begin:/api/${resource.endpoint}/search`,
+          {
+            response: {
+              results: [capiArticle]
+            }
+          }
+        );
+        await store.dispatch(resource.fetchAction(
+          {
+            q: 'Something topical'
+          },
+          false
+        ) as any);
+        expect(resource.selectors.selectAll(store.getState())).toEqual([
+          capiArticle
+        ]);
+      })
+    );
+  });
+  it('should add a single CAPI content result to the application state', async () => {
+    await Promise.all(
+      resources.map(async resource => {
+        const store = createStoreAndFetchMock(
+          `begin:/api/${resource.endpoint}/search`,
+          {
+            response: {
+              content: capiArticle
+            }
+          }
+        );
+        await store.dispatch(resource.fetchAction(
+          {
+            q: 'Something topical'
+          },
+          false
+        ) as any);
+        expect(resource.selectors.selectAll(store.getState())).toEqual([
+          capiArticle
+        ]);
+      })
+    );
+  });
+  it('should handle errors', async () => {
+    await Promise.all(
+      resources.map(async resource => {
+        const store = createStoreAndFetchMock(
+          `begin:/api/${resource.endpoint}/search`,
+          400
+        );
+        await store.dispatch(resource.fetchAction(
+          {
+            q: 'Something topical'
+          },
+          false
+        ) as any);
+        expect(resource.selectors.selectAll(store.getState())).toEqual([]);
+        expect(
+          resource.selectors.selectCurrentError(store.getState())
+        ).toContain('400');
+      })
+    );
+  });
+});

--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -43,7 +43,7 @@ export const fetchLive = (
   try {
     results = await fetchResourceOrResults(liveCapi, params, isResource);
   } catch (e) {
-    dispatch(liveActions.fetchError(e.message));
+    return dispatch(liveActions.fetchError(e.message));
   }
 
   if (results) {
@@ -62,7 +62,6 @@ export const fetchPreview = (
   } catch (e) {
     dispatch(previewActions.fetchError(e.message));
   }
-
   if (results) {
     dispatch(previewActions.fetchSuccess(results));
   }

--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -2,19 +2,17 @@ import capiQuery from '../capiQuery';
 
 describe('CAPI', () => {
   beforeEach(() => {
-    (global as any).fetch = jest
-      .fn()
-      .mockImplementation(() =>
-        Promise.resolve({
-          json: () => ({
-            response: {
-              results: []
-            }
-          }),
-          status: 200,
-          ok: true
-        })
-      );
+    (global as any).fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        json: () => ({
+          response: {
+            results: []
+          }
+        }),
+        status: 200,
+        ok: true
+      })
+    );
   });
 
   describe('search', () => {

--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -4,7 +4,17 @@ describe('CAPI', () => {
   beforeEach(() => {
     (global as any).fetch = jest
       .fn()
-      .mockImplementation(() => Promise.resolve({ json: () => {} }));
+      .mockImplementation(() =>
+        Promise.resolve({
+          json: () => ({
+            response: {
+              results: []
+            }
+          }),
+          status: 200,
+          ok: true
+        })
+      );
   });
 
   describe('search', () => {

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -49,7 +49,6 @@ const getErrorMessageFromResponse = (response: Response) =>
 const fetchCAPIResponse = async <
   TCAPIResponse extends CAPISearchQueryReponse | CAPITagQueryReponse
 >(
-  fetch: Fetch = window.fetch,
   request: string
 ) => {
   let response: Response;
@@ -57,6 +56,7 @@ const fetchCAPIResponse = async <
     response = await fetch(request);
   } catch (e) {
     if (e.status && e.statusText) {
+      // pandaFetch can throw a Response or an Error
       throw new Error(getErrorMessageFromResponse(e));
     }
     throw e;
@@ -81,7 +81,7 @@ const fetchCAPIResponse = async <
  *
  * @throws {Error} If fetch throws, CAPI returns an unparsable result, or CAPI returns an error.
  */
-const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
+const capiQuery = (baseURL: string = API_BASE) => {
   const getCAPISearchString = (
     path: string,
     params: any,
@@ -101,7 +101,6 @@ const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
       options?: CAPIOptions
     ): Promise<CAPISearchQueryReponse> => {
       return fetchCAPIResponse<CAPISearchQueryReponse>(
-        fetch,
         getCAPISearchString(`search`, params, options)
       );
     },
@@ -110,13 +109,11 @@ const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
       options?: CAPIOptions
     ): Promise<CAPISearchQueryReponse> => {
       return fetchCAPIResponse<CAPISearchQueryReponse>(
-        fetch,
         getCAPISearchString(`content/scheduled`, params, options)
       );
     },
     tags: async (params: any): Promise<CAPITagQueryReponse> => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
-        fetch,
         `${baseURL}tags${qs({
           ...params
         })}`
@@ -124,7 +121,6 @@ const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
     },
     sections: async (params: any): Promise<CAPITagQueryReponse> => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
-        fetch,
         `${baseURL}sections${qs({
           ...params
         })}`
@@ -132,7 +128,6 @@ const capiQuery = (baseURL: string = API_BASE, fetch: Fetch = window.fetch) => {
     },
     desks: async (params: any): Promise<CAPITagQueryReponse> => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
-        fetch,
         `${baseURL}tags${qs({
           type: 'tracking',
           ...params

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -203,11 +203,11 @@ async function getCollections(
   collectionIds: string[]
 ): Promise<CollectionWithNestedArticles[]> {
   const params = new URLSearchParams();
-  collectionIds.map(_ => params.append('ids', _))
+  collectionIds.map(_ => params.append('ids', _));
   const response = await pandaFetch(`/collections?${params.toString()}`, {
     method: 'get',
     credentials: 'same-origin'
-  })
+  });
   const collections: CollectionResponse[] = await response.json();
   return collections.map((collection, index) => ({
     ...collection,

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -203,11 +203,11 @@ async function getCollections(
   collectionIds: string[]
 ): Promise<CollectionWithNestedArticles[]> {
   const params = new URLSearchParams();
-  collectionIds.map(_ => params.append('ids', _));
+  collectionIds.map(_ => params.append('ids', _))
   const response = await pandaFetch(`/collections?${params.toString()}`, {
     method: 'get',
     credentials: 'same-origin'
-  });
+  })
   const collections: CollectionResponse[] = await response.json();
   return collections.map((collection, index) => ({
     ...collection,
@@ -232,12 +232,6 @@ const getTagOrSectionTitle = (queryResponse: CAPISearchQueryReponse) =>
   (queryResponse.response.tag && queryResponse.response.tag.webTitle) ||
   (queryResponse.response.section && queryResponse.response.section.webTitle);
 
-const getResultsFromCapiResponse = (queryResponse: CAPISearchQueryReponse) =>
-  // We may be dealing with a single result, or an array of results -
-  // CAPI formats each query differently.
-  queryResponse.response.results ||
-  (queryResponse.response.content ? [queryResponse.response.content] : []);
-
 const parseArticleListFromResponses = (
   queryResponse: CAPISearchQueryReponse
 ): ExternalArticle[] => {
@@ -247,14 +241,17 @@ const parseArticleListFromResponses = (
         queryResponse.response.message || 'Unknown error from CAPI'
       );
     }
+    // We may be dealing with a single result, or an array of results -
+    // CAPI formats each query differently.
+    const results: CapiArticle[] =
+      queryResponse.response.results ||
+      (queryResponse.response.content ? [queryResponse.response.content] : []);
 
-    return getResultsFromCapiResponse(queryResponse).map(
-      (externalArticle: CapiArticle) => ({
-        ...externalArticle,
-        urlPath: externalArticle.id,
-        id: `internal-code/page/${externalArticle.fields.internalPageCode}`
-      })
-    );
+    return results.map((externalArticle: CapiArticle) => ({
+      ...externalArticle,
+      urlPath: externalArticle.id,
+      id: `internal-code/page/${externalArticle.fields.internalPageCode}`
+    }));
   } catch (e) {
     throw new Error(
       `Error getting articles from CAPI: cannot parse response - ${e.message}`
@@ -320,7 +317,6 @@ export {
   updateCollection,
   saveClipboard,
   saveOpenFrontIds,
-  getResultsFromCapiResponse,
   getCapiUriForContentIds,
   fetchVisibleArticles
 };

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -232,6 +232,12 @@ const getTagOrSectionTitle = (queryResponse: CAPISearchQueryReponse) =>
   (queryResponse.response.tag && queryResponse.response.tag.webTitle) ||
   (queryResponse.response.section && queryResponse.response.section.webTitle);
 
+const getResultsFromCapiResponse = (queryResponse: CAPISearchQueryReponse) =>
+  // We may be dealing with a single result, or an array of results -
+  // CAPI formats each query differently.
+  queryResponse.response.results ||
+  (queryResponse.response.content ? [queryResponse.response.content] : []);
+
 const parseArticleListFromResponses = (
   queryResponse: CAPISearchQueryReponse
 ): ExternalArticle[] => {
@@ -241,17 +247,14 @@ const parseArticleListFromResponses = (
         queryResponse.response.message || 'Unknown error from CAPI'
       );
     }
-    // We may be dealing with a single result, or an array of results -
-    // CAPI formats each query differently.
-    const results: CapiArticle[] =
-      queryResponse.response.results ||
-      (queryResponse.response.content ? [queryResponse.response.content] : []);
 
-    return results.map((externalArticle: CapiArticle) => ({
-      ...externalArticle,
-      urlPath: externalArticle.id,
-      id: `internal-code/page/${externalArticle.fields.internalPageCode}`
-    }));
+    return getResultsFromCapiResponse(queryResponse).map(
+      (externalArticle: CapiArticle) => ({
+        ...externalArticle,
+        urlPath: externalArticle.id,
+        id: `internal-code/page/${externalArticle.fields.internalPageCode}`
+      })
+    );
   } catch (e) {
     throw new Error(
       `Error getting articles from CAPI: cannot parse response - ${e.message}`
@@ -317,6 +320,7 @@ export {
   updateCollection,
   saveClipboard,
   saveOpenFrontIds,
+  getResultsFromCapiResponse,
   getCapiUriForContentIds,
   fetchVisibleArticles
 };

--- a/client-v2/src/services/frontsCapi.ts
+++ b/client-v2/src/services/frontsCapi.ts
@@ -1,6 +1,5 @@
 import capiQuery from './capiQuery';
 import urls from 'constants/urls';
-import pandaFetch from './pandaFetch';
 
-export const liveCapi = capiQuery(urls.capiLiveUrl, pandaFetch);
-export const previewCapi = capiQuery(urls.capiPreviewUrl, pandaFetch);
+export const liveCapi = capiQuery(urls.capiLiveUrl);
+export const previewCapi = capiQuery(urls.capiPreviewUrl);

--- a/client-v2/src/services/pandaFetch.ts
+++ b/client-v2/src/services/pandaFetch.ts
@@ -1,6 +1,13 @@
 import { reEstablishSession } from 'panda-session';
 
 const reauthUrl = '/login/status';
+
+/**
+ * Make a fetch request with Panda authentication.
+ *
+ * @rejects {Response} If the response status isn't 2XX/3XX.
+ * @rejects {Error} If fetch throws.
+ */
 const pandaFetch = (
   url: string,
   options: RequestInit = {},

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -11522,6 +11522,11 @@ whatwg-fetch@>=0.10.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"


### PR DESCRIPTION
At the moment, there are quite a few different errors that requests to CAPI can produce, and although we catch them, the messaging isn't as clear as it might be.

This PR adds what I hope is clearer messaging for the different scenarios, and some tests to catch regressions.

We now repeat this logic in two places -- once for the feed, and another time for the article fetches via the faciaApi service. For the sake of velocity I haven't made an effort to DRY up this code, but I've added a trello card and we can choose to prioritise this as we'd like it.