### PR TITLE
add sentry to v2

### DIFF
--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -20,8 +20,16 @@ const store = configureStore();
 const config = extractConfigFromPage();
 
 // publish uncaught errors to sentry.io
-if (config.stage === 'PROD' && config.ravenUrl) {
-  Raven.config(config.ravenUrl).install();
+if (config.env.toUpperCase() !== 'DEV' && config.sentryPublicDSN) {
+  const sentryOptions = {
+    tags: {
+      stack: 'cms-fronts',
+      stage: config.env.toUpperCase(),
+      app: 'facia-tool-v2'
+    }
+  };
+
+  Raven.config(config.sentryPublicDSN, sentryOptions).install();
 }
 
 store.dispatch(configReceived(config));

--- a/client-v2/src/types/Config.ts
+++ b/client-v2/src/types/Config.ts
@@ -33,7 +33,6 @@ interface Config {
   collectionMetadata: Metadata[];
   capiLiveUrl: string;
   capiPreviewUrl: string;
-  ravenUrl?: string;
   frontIds: string[];
   clipboardArticles: NestedArticleFragment[];
 }

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -27,8 +27,16 @@ function checkEnabled (res) {
 }
 
 function registerRaven (res) {
-    if (!res.defaults.dev) {
-        Raven.config(res.defaults.sentryPublicDSN).install();
+    if (res.defaults.env.toUpperCase() !== 'DEV' && res.defaults.sentryPublicDSN) {
+        const sentryOptions = {
+            tags: {
+                stack: 'cms-fronts',
+                stage: res.defaults.env.toUpperCase(),
+                app: 'facia-tool'
+            }
+        };
+
+        Raven.config(res.defaults.sentryPublicDSN, sentryOptions).install();
         Raven.setUser({
             email: res.defaults.email || 'anonymous'
         });


### PR DESCRIPTION
Also add SSA tags to sentry config so we can use one sentry property for both apps. This is mainly because I don't have permission to create new properties in Sentry, but it works quite well as the config is simple and we can use saved searches in Sentry to filter by stage.

This relies on local config having `stage` set to `DEV` (run a `./fetch-config.sh` to update your local config).