### PR TITLE
Exclude labs and hosted content

### DIFF
--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -2,6 +2,7 @@ import createAsyncResourceBundle from 'lib/createAsyncResourceBundle';
 import { CapiArticle } from 'types/Capi';
 import { ThunkResult } from 'types/Store';
 import { previewCapi, liveCapi } from 'services/frontsCapi';
+import { State } from 'types/State';
 
 type FeedState = CapiArticle[];
 
@@ -14,6 +15,22 @@ const {
   selectLocalState: state => state.capiLiveFeed,
   initialData: []
 });
+
+const isCommercialArticle = (article: CapiArticle | undefined): boolean => {
+  if (!article) {
+    return false;
+  }
+
+  if (article.isHosted) {
+    return true;
+  }
+
+  if (!article.tags) {
+    return true;
+  }
+
+  return article.tags.every(tag => tag.type !== 'paid-content');
+};
 
 const {
   actions: previewActions,
@@ -47,7 +64,8 @@ export const fetchLive = (
   }
 
   if (results) {
-    dispatch(liveActions.fetchSuccess(results));
+    const nonCommercialResults = results.filter(isCommercialArticle);
+    dispatch(liveActions.fetchSuccess(nonCommercialResults));
   }
 };
 
@@ -64,7 +82,8 @@ export const fetchPreview = (
   }
 
   if (results) {
-    dispatch(previewActions.fetchSuccess(results));
+    const nonCommercialResults = results.filter(isCommercialArticle);
+    dispatch(previewActions.fetchSuccess(nonCommercialResults));
   }
 };
 

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -95,6 +95,7 @@ const getParams = (
   'to-date': to && to.format('YYYY-MM-DD'),
   'page-size': '20',
   'show-elements': 'image',
+  'show-tags': 'all',
   'show-fields': 'internalPageCode,trailText,firstPublicationDate,isLive',
   ...(isPreview
     ? { 'order-by': 'oldest', 'from-date': getTodayDate() }

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -118,6 +118,7 @@ interface CapiArticle {
   tags?: Tag[];
   blocks: Blocks;
   atoms?: Atoms;
+  isHosted?: boolean;
   frontsMeta: {
     defaults: {
       imageCutoutReplace: boolean;


### PR DESCRIPTION
Talked to Harpreet about this and instead of adding a commercial label to commercial content we should just remove it from the capi feed altogether and allow it to be added elsewhere in the tool if someone so wishes for whatever reason. 

The implementation below is not ideal - the best solution would be to filter commercial content out in capi. Such capability does exist but it filters out hosted content, labs content and supported content. We don't want to filter out supported content so we can't use this option. However, I think we can get the filter we want added to capi later so this pr would only be an interim measure.