### PR TITLE
Live and previously are uneditable

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -7,7 +7,7 @@ import Button from 'shared/components/input/ButtonDefault';
 import { AlsoOnDetail } from 'types/Collection';
 import { publishCollection } from 'actions/Fronts';
 import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
-import { isCollectionUneditableSelector } from 'selectors/collectionSelectors';
+import { isCollectionLockedSelector } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
 import {
@@ -37,7 +37,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   canPublish: boolean;
   groups: Group[];
   displayEditWarning: boolean;
-  isCollectionUneditable: boolean;
+  isCollectionLocked: boolean;
   isOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
 };
@@ -53,13 +53,12 @@ const Collection = ({
   canPublish = true,
   publishCollection: publish,
   displayEditWarning,
-  isCollectionUneditable,
+  isCollectionLocked,
   isOpen,
   onChangeOpenState
 }: CollectionProps) => {
-
   const isUneditable =
-    isCollectionUneditable || browsingStage !== collectionItemSets.draft;
+    isCollectionLocked || browsingStage !== collectionItemSets.draft;
 
   return (
     <CollectionDisplay
@@ -67,7 +66,7 @@ const Collection = ({
       id={id}
       browsingStage={browsingStage}
       isUneditable={isUneditable}
-      isLocked={isCollectionUneditable}
+      isLocked={isCollectionLocked}
       isOpen={isOpen}
       onChangeOpenState={() => onChangeOpenState(id, isOpen)}
       headlineContent={
@@ -103,7 +102,7 @@ const createMapStateToProps = () => {
     hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
       collectionId: id
     }),
-    isCollectionUneditable: isCollectionUneditableSelector(state, id),
+    isCollectionLocked: isCollectionLockedSelector(state, id),
     groups: collectionStageGroupsSelector(selectSharedState(state), {
       collectionSet: browsingStage,
       collectionId: id

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -21,6 +21,7 @@ import {
   editorCloseCollections
 } from 'bundles/frontsUIBundle';
 import { getArticlesForCollections } from 'actions/Collections';
+import { collectionItemSets } from 'constants/fronts';
 
 interface CollectionPropsBeforeState {
   id: string;
@@ -36,7 +37,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   canPublish: boolean;
   groups: Group[];
   displayEditWarning: boolean;
-  isUneditable: boolean;
+  isCollectionUneditable: boolean;
   isOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
 };
@@ -52,41 +53,47 @@ const Collection = ({
   canPublish = true,
   publishCollection: publish,
   displayEditWarning,
-  isUneditable,
+  isCollectionUneditable,
   isOpen,
   onChangeOpenState
-}: CollectionProps) => (
-  <CollectionDisplay
-    frontId={frontId}
-    id={id}
-    browsingStage={browsingStage}
-    isUneditable={isUneditable}
-    isOpen={isOpen}
-    onChangeOpenState={() => onChangeOpenState(id, isOpen)}
-    headlineContent={
-      hasUnpublishedChanges &&
-      canPublish && (
-        <Button
-          size="l"
-          priority="primary"
-          onClick={() => publish(id, frontId)}
-        >
-          Launch
-        </Button>
-      )
-    }
-    metaContent={
-      alsoOn[id].fronts.length || displayEditWarning ? (
-        <CollectionNotification
-          displayEditWarning={displayEditWarning}
-          alsoOn={alsoOn[id]}
-        />
-      ) : null
-    }
-  >
-    {groups.map(group => children(group, isUneditable))}
-  </CollectionDisplay>
-);
+}: CollectionProps) => {
+
+  const isUneditable =
+    isCollectionUneditable || browsingStage !== collectionItemSets.draft;
+
+  return (
+    <CollectionDisplay
+      frontId={frontId}
+      id={id}
+      browsingStage={browsingStage}
+      isUneditable={isUneditable}
+      isOpen={isOpen}
+      onChangeOpenState={() => onChangeOpenState(id, isOpen)}
+      headlineContent={
+        hasUnpublishedChanges &&
+        canPublish && (
+          <Button
+            size="l"
+            priority="primary"
+            onClick={() => publish(id, frontId)}
+          >
+            Launch
+          </Button>
+        )
+      }
+      metaContent={
+        alsoOn[id].fronts.length || displayEditWarning ? (
+          <CollectionNotification
+            displayEditWarning={displayEditWarning}
+            alsoOn={alsoOn[id]}
+          />
+        ) : null
+      }
+    >
+      {groups.map(group => children(group, isUneditable))}
+    </CollectionDisplay>
+  );
+};
 
 const createMapStateToProps = () => {
   const collectionStageGroupsSelector = createCollectionStageGroupsSelector();
@@ -95,7 +102,7 @@ const createMapStateToProps = () => {
     hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
       collectionId: id
     }),
-    isUneditable: isCollectionUneditableSelector(state, id),
+    isCollectionUneditable: isCollectionUneditableSelector(state, id),
     groups: collectionStageGroupsSelector(selectSharedState(state), {
       collectionSet: browsingStage,
       collectionId: id

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -67,6 +67,7 @@ const Collection = ({
       id={id}
       browsingStage={browsingStage}
       isUneditable={isUneditable}
+      isLocked={isCollectionUneditable}
       isOpen={isOpen}
       onChangeOpenState={() => onChangeOpenState(id, isOpen)}
       headlineContent={

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -8,7 +8,7 @@ import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
 import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
 import {
-  isCollectionUneditableSelector,
+  isCollectionLockedSelector,
   isCollectionBackfilledSelector,
   createCollectionHasUnsavedArticleEditsWarningSelector
 } from 'selectors/collectionSelectors';
@@ -221,7 +221,7 @@ const mapStateToProps = () => {
     hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
       collectionId: props.collectionId
     }),
-    isUneditable: isCollectionUneditableSelector(state, props.collectionId),
+    isUneditable: isCollectionLockedSelector(state, props.collectionId),
     isBackfilled: isCollectionBackfilledSelector(state, props.collectionId),
     hasUnsavedArticleEdits: hasUnsavedArticleEditsSelector(state, {
       collectionSet: props.browsingStage,

--- a/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
@@ -1,6 +1,6 @@
 import {
   isCollectionBackfilledSelector,
-  isCollectionUneditableSelector,
+  isCollectionLockedSelector,
   createCollectionHasUnsavedArticleEditsWarningSelector
 } from 'selectors/collectionSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
@@ -46,7 +46,7 @@ describe('Checking if Collection Articles on Fronts have dirty form data', () =>
 describe('Validating Front Collection configuration metadata', () => {
   it('validates correctly if Collection is uneditable ', () => {
     expect(
-      isCollectionUneditableSelector(
+      isCollectionLockedSelector(
         {
           fronts: {
             frontsConfig
@@ -56,7 +56,7 @@ describe('Validating Front Collection configuration metadata', () => {
       )
     ).toEqual(true);
     expect(
-      isCollectionUneditableSelector(
+      isCollectionLockedSelector(
         {
           fronts: {
             frontsConfig

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -7,7 +7,7 @@ import {
 import { isDirty } from 'redux-form';
 import { CollectionItemSets } from 'shared/types/Collection';
 
-const isCollectionUneditableSelector = (state: State, id: string): boolean =>
+const isCollectionLockedSelector = (state: State, id: string): boolean =>
   !!getCollectionConfig(state, id).uneditable;
 
 const isCollectionBackfilledSelector = (state: State, id: string): boolean =>
@@ -31,7 +31,7 @@ const collectionHasUnsavedArticleEditsWarningSelector = () => {
 };
 
 export {
-  isCollectionUneditableSelector,
+  isCollectionLockedSelector,
   isCollectionBackfilledSelector,
   collectionHasUnsavedArticleEditsWarningSelector as createCollectionHasUnsavedArticleEditsWarningSelector
 };

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -41,6 +41,7 @@ type Props = ContainerProps & {
   metaContent: React.ReactNode;
   children: React.ReactNode;
   isUneditable?: boolean;
+  isLocked?: boolean;
   isOpen?: boolean;
   onChangeOpenState?: (isOpen: boolean) => void;
 };
@@ -187,6 +188,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       headlineContent,
       metaContent,
       isUneditable,
+      isLocked,
       children
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
@@ -215,7 +217,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               ) : null}
             </CollectionConfigContainer>
           </CollectionHeadlineWithConfigContainer>
-          {isUneditable ? (
+          {isLocked ? (
             <LockedCollectionFlag>Locked</LockedCollectionFlag>
           ) : headlineContent ? (
             <HeadlineContentContainer>


### PR DESCRIPTION
Somehow the code which prevented people from editing live and previously stages of articles got lost somewhere causing some confusion on the opinion desk as we aren't launching live changes. This pr adds the logic back in. The styling here at the moment is the same as it is for collections which are locked - how do people feel about this? Does it make it harder to view what the live content on a collections is.
![screen shot 2019-01-18 at 15 47 02](https://user-images.githubusercontent.com/3066534/51397070-503ffc80-1b38-11e9-88b2-273cf8fe7e54.png)
