### PR TITLE
Add timeout to fix integration tests

### DIFF
--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -30,6 +30,8 @@ test('Drag and drop', async t => {
     .eql(topFeedHeadline)
     // drag top to bottom in front
     .dragToElement(frontHeadline(), frontDropZone(-1))
+    // wait for collection to update
+    .wait(1000)
     .expect(frontDropZone().count)
     .eql(frontDropsCount + 2)
     .expect(frontHeadline().textContent)


### PR DESCRIPTION
Good news: I have enough passing builds with this branch to be reasonably certain this fixes the flakiness in the integration tests with headlines not matching.
Bad news: I may have uncovered a new flaky issue where travis is failing to download chromium. I will take a look at this issue if it reemerges. 