### PR TITLE
Open a closed Collection by dragging and hovering an ArticleFragment over it

### DIFF
--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+type Props = {
+  onIntentConfirm: () => void;
+  onDragIntentStart: () => void;
+  onDragIntentEnd: () => void;
+  active: boolean;
+} & React.HTMLProps<HTMLDivElement>;
+
+class DragIntentContainer extends React.Component<Props> {
+  private dragTimer: number | null = null;
+
+  // Keeps track of dragEvents over the Collection's toggleVisibility button
+  // to determine enter/leave events
+  private dragHoverDepth: number = 0;
+
+  public handleToggleButtonDragEnter = () => {
+    if (this.dragHoverDepth === 0 && this.props.active) {
+      this.registerDragIntent();
+    }
+    this.dragHoverDepth += 1;
+  };
+
+  public handleToggleButtonDragLeave = () => {
+    this.dragHoverDepth -= 1;
+    if (this.dragHoverDepth === 0) {
+      this.deregisterDragIntent();
+    }
+  };
+
+  public handleToggleButtonDrop = () => {
+    this.dragHoverDepth = 0;
+    this.deregisterDragIntent();
+  };
+
+  public registerDragIntent = () => {
+    this.dragTimer = window.setTimeout(() => {
+      if (this.props.active) {
+        this.props.onIntentConfirm();
+        this.deregisterDragIntent();
+      }
+    }, 300);
+    this.props.onDragIntentStart();
+  };
+
+  public deregisterDragIntent = () => {
+    if (this.dragTimer) {
+      window.clearTimeout(this.dragTimer);
+    }
+    this.dragTimer = null;
+    this.props.onDragIntentEnd();
+  };
+
+  public render() {
+    const {
+      children,
+      active, // active prop must be destructured here so it's not passed into div props
+      onIntentConfirm,
+      onDragIntentStart,
+      onDragIntentEnd,
+      ...props
+    }: Props = this.props;
+
+    return (
+      <div
+        {...props}
+        onDragEnter={this.handleToggleButtonDragEnter}
+        onDragLeave={this.handleToggleButtonDragLeave}
+        onDrop={this.handleToggleButtonDrop}
+      >
+        {children}
+      </div>
+    );
+  }
+}
+
+export default DragIntentContainer;

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -34,13 +34,16 @@ class DragIntentContainer extends React.Component<Props> {
   };
 
   public registerDragIntent = () => {
-    this.dragTimer = window.setTimeout(() => {
-      if (this.props.active) {
+    // only register if active
+    // all other events will fire even if not active to allow the parent
+    // to reset its state that was created when drag intent was initialised
+    if (this.props.active) {
+      this.props.onDragIntentStart();
+      this.dragTimer = window.setTimeout(() => {
         this.props.onIntentConfirm();
         this.deregisterDragIntent();
-      }
-    }, 300);
-    this.props.onDragIntentStart();
+      }, 300);
+    }
   };
 
   public deregisterDragIntent = () => {

--- a/client-v2/src/shared/components/__tests__/DragIntentContainer.spec.tsx
+++ b/client-v2/src/shared/components/__tests__/DragIntentContainer.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, cleanup, fireEvent } from 'react-testing-library';
+import DragIntentContainer from '../DragIntentContainer';
+
+afterEach(cleanup);
+jest.useFakeTimers();
+
+describe('DragIntentContainer', () => {
+  it('should fire onIntentConfirm callback 300ms after Drag has entered', async () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const DragIntent = (
+      <DragIntentContainer
+        onIntentConfirm={callback2}
+        onDragIntentStart={callback1}
+        onDragIntentEnd={() => {}}
+        active={true}
+      >
+        <span>
+          <span>Child</span>
+        </span>
+      </DragIntentContainer>
+    );
+    const { getByText } = render(DragIntent);
+    expect(callback1).not.toBeCalled();
+    expect(callback2).not.toBeCalled();
+    fireEvent.dragEnter(getByText('Child'));
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback2).not.toBeCalled();
+    jest.runOnlyPendingTimers();
+    expect(callback2).toHaveBeenCalledTimes(1);
+  });
+  it('should not fire onIntentConfirm callback after 300ms if Drag has left', () => {
+    const callback = jest.fn();
+    const DragIntent = (
+      <DragIntentContainer
+        onIntentConfirm={callback}
+        onDragIntentStart={() => {}}
+        onDragIntentEnd={() => {}}
+        active={true}
+      >
+        <span>
+          <span>Child</span>
+        </span>
+      </DragIntentContainer>
+    );
+    const { getByText } = render(DragIntent);
+    expect(callback).not.toBeCalled();
+    fireEvent.dragEnter(getByText('Child'));
+    fireEvent.dragLeave(getByText('Child'));
+    jest.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+  it('should reset DragIntent on Drop', () => {
+    const callback = jest.fn();
+    const DragIntent = (
+      <DragIntentContainer
+        onIntentConfirm={() => {}}
+        onDragIntentStart={() => {}}
+        onDragIntentEnd={callback}
+        active={true}
+      >
+        <span>
+          <span>Child</span>
+        </span>
+      </DragIntentContainer>
+    );
+    const { getByText } = render(DragIntent);
+    fireEvent.dragEnter(getByText('Child'));
+    expect(callback).not.toBeCalled();
+    fireEvent.drop(getByText('Child'));
+    jest.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+  it('should reset DragIntent when onIntentConfirm callback fired', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const DragIntent = (
+      <DragIntentContainer
+        onIntentConfirm={callback1}
+        onDragIntentStart={() => {}}
+        onDragIntentEnd={callback2}
+        active={true}
+      >
+        <span>
+          <span>Child</span>
+        </span>
+      </DragIntentContainer>
+    );
+    const { getByText } = render(DragIntent);
+    fireEvent.dragEnter(getByText('Child'));
+    expect(callback1).not.toBeCalled();
+    jest.runOnlyPendingTimers();
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledTimes(1);
+  });
+  it('should do nothing on Drag events if Active prop is false', async () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const DragIntent = (
+      <DragIntentContainer
+        onIntentConfirm={callback2}
+        onDragIntentStart={callback1}
+        onDragIntentEnd={() => {}}
+        active={false}
+      >
+        <span>
+          <span>Child</span>
+        </span>
+      </DragIntentContainer>
+    );
+    const { getByText } = render(DragIntent);
+    fireEvent.dragEnter(getByText('Child'));
+    jest.runOnlyPendingTimers();
+    expect(callback1).not.toBeCalled();
+    expect(callback2).not.toBeCalled();
+  });
+});

--- a/client-v2/src/shared/components/__tests__/DragIntentContainer.spec.tsx
+++ b/client-v2/src/shared/components/__tests__/DragIntentContainer.spec.tsx
@@ -7,12 +7,12 @@ jest.useFakeTimers();
 
 describe('DragIntentContainer', () => {
   it('should fire onIntentConfirm callback 300ms after Drag has entered', async () => {
-    const callback1 = jest.fn();
-    const callback2 = jest.fn();
+    const onDragIntentStart = jest.fn();
+    const onIntentConfirm = jest.fn();
     const DragIntent = (
       <DragIntentContainer
-        onIntentConfirm={callback2}
-        onDragIntentStart={callback1}
+        onIntentConfirm={onIntentConfirm}
+        onDragIntentStart={onDragIntentStart}
         onDragIntentEnd={() => {}}
         active={true}
       >
@@ -22,19 +22,19 @@ describe('DragIntentContainer', () => {
       </DragIntentContainer>
     );
     const { getByText } = render(DragIntent);
-    expect(callback1).not.toBeCalled();
-    expect(callback2).not.toBeCalled();
+    expect(onDragIntentStart).not.toBeCalled();
+    expect(onIntentConfirm).not.toBeCalled();
     fireEvent.dragEnter(getByText('Child'));
-    expect(callback1).toHaveBeenCalledTimes(1);
-    expect(callback2).not.toBeCalled();
+    expect(onDragIntentStart).toHaveBeenCalledTimes(1);
+    expect(onIntentConfirm).not.toBeCalled();
     jest.runOnlyPendingTimers();
-    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(onIntentConfirm).toHaveBeenCalledTimes(1);
   });
   it('should not fire onIntentConfirm callback after 300ms if Drag has left', () => {
-    const callback = jest.fn();
+    const onIntentConfirm = jest.fn();
     const DragIntent = (
       <DragIntentContainer
-        onIntentConfirm={callback}
+        onIntentConfirm={onIntentConfirm}
         onDragIntentStart={() => {}}
         onDragIntentEnd={() => {}}
         active={true}
@@ -45,19 +45,19 @@ describe('DragIntentContainer', () => {
       </DragIntentContainer>
     );
     const { getByText } = render(DragIntent);
-    expect(callback).not.toBeCalled();
+    expect(onIntentConfirm).not.toBeCalled();
     fireEvent.dragEnter(getByText('Child'));
     fireEvent.dragLeave(getByText('Child'));
     jest.runOnlyPendingTimers();
-    expect(callback).toHaveBeenCalledTimes(0);
+    expect(onIntentConfirm).toHaveBeenCalledTimes(0);
   });
   it('should reset DragIntent on Drop', () => {
-    const callback = jest.fn();
+    const onDragIntentEnd = jest.fn();
     const DragIntent = (
       <DragIntentContainer
         onIntentConfirm={() => {}}
         onDragIntentStart={() => {}}
-        onDragIntentEnd={callback}
+        onDragIntentEnd={onDragIntentEnd}
         active={true}
       >
         <span>
@@ -67,19 +67,19 @@ describe('DragIntentContainer', () => {
     );
     const { getByText } = render(DragIntent);
     fireEvent.dragEnter(getByText('Child'));
-    expect(callback).not.toBeCalled();
+    expect(onDragIntentEnd).not.toBeCalled();
     fireEvent.drop(getByText('Child'));
     jest.runOnlyPendingTimers();
-    expect(callback).toHaveBeenCalledTimes(1);
+    expect(onDragIntentEnd).toHaveBeenCalledTimes(1);
   });
   it('should reset DragIntent when onIntentConfirm callback fired', () => {
-    const callback1 = jest.fn();
-    const callback2 = jest.fn();
+    const onIntentConfirm = jest.fn();
+    const onDragIntentEnd = jest.fn();
     const DragIntent = (
       <DragIntentContainer
-        onIntentConfirm={callback1}
+        onIntentConfirm={onIntentConfirm}
         onDragIntentStart={() => {}}
-        onDragIntentEnd={callback2}
+        onDragIntentEnd={onDragIntentEnd}
         active={true}
       >
         <span>
@@ -89,18 +89,18 @@ describe('DragIntentContainer', () => {
     );
     const { getByText } = render(DragIntent);
     fireEvent.dragEnter(getByText('Child'));
-    expect(callback1).not.toBeCalled();
+    expect(onIntentConfirm).not.toBeCalled();
     jest.runOnlyPendingTimers();
-    expect(callback1).toHaveBeenCalledTimes(1);
-    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(onIntentConfirm).toHaveBeenCalledTimes(1);
+    expect(onDragIntentEnd).toHaveBeenCalledTimes(1);
   });
   it('should do nothing on Drag events if Active prop is false', async () => {
-    const callback1 = jest.fn();
-    const callback2 = jest.fn();
+    const onDragIntentStart = jest.fn();
+    const onIntentConfirm = jest.fn();
     const DragIntent = (
       <DragIntentContainer
-        onIntentConfirm={callback2}
-        onDragIntentStart={callback1}
+        onIntentConfirm={onIntentConfirm}
+        onDragIntentStart={onDragIntentStart}
         onDragIntentEnd={() => {}}
         active={false}
       >
@@ -112,7 +112,7 @@ describe('DragIntentContainer', () => {
     const { getByText } = render(DragIntent);
     fireEvent.dragEnter(getByText('Child'));
     jest.runOnlyPendingTimers();
-    expect(callback1).not.toBeCalled();
-    expect(callback2).not.toBeCalled();
+    expect(onDragIntentStart).not.toBeCalled();
+    expect(onIntentConfirm).not.toBeCalled();
   });
 });

--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -39,8 +39,8 @@ export default ({
       transform: active
         ? 'rotate(0deg)'
         : preActive
-          ? 'rotate(-45deg)'
-          : undefined
+        ? 'rotate(-45deg)'
+        : undefined
     }}
   >
     <CaretImg src={caretIcon} alt="" />

--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -4,12 +4,19 @@ import { styled } from 'shared/constants/theme';
 import caretIcon from 'shared/images/icons/single-down.svg';
 import ButtonCircular from './ButtonCircular';
 
-const ButtonCircularWithTransition = ButtonCircular.extend`
+const ButtonCircularWithTransition = ButtonCircular.extend<{
+  highlight?: boolean;
+}>`
   transition: transform 0.15s;
   display: inline-block;
   text-align: center;
   padding: 0;
   transform: rotate(-90deg);
+
+  ${({ highlight, theme }) =>
+    highlight
+      ? `background-color: ${theme.button.backgroundColorHighlight}`
+      : ``};
 `;
 
 const CaretImg = styled('img')`
@@ -20,11 +27,21 @@ const CaretImg = styled('img')`
 
 export default ({
   active,
+  preActive,
   ...props
-}: { active: boolean } & React.HTMLAttributes<HTMLButtonElement>) => (
+}: { active: boolean; preActive: boolean } & React.HTMLAttributes<
+  HTMLButtonElement
+>) => (
   <ButtonCircularWithTransition
     {...props}
-    style={{ transform: active ? 'rotate(0deg)' : undefined }}
+    highlight={preActive}
+    style={{
+      transform: active
+        ? 'rotate(0deg)'
+        : preActive
+          ? 'rotate(-45deg)'
+          : undefined
+    }}
   >
     <CaretImg src={caretIcon} alt="" />
   </ButtonCircularWithTransition>


### PR DESCRIPTION
@RichieAHB and I paired on this feature.

### What does this change? 

The user can now drag Article Fragments over closed Collections to open them automatically after a 300ms delay.
![kapture 2019-01-21 at 17 26 23](https://user-images.githubusercontent.com/32312712/51490200-6ea93080-1da2-11e9-9d3e-d939bcfb9000.gif)

A discrete component call `DragIntentContainer` listens for drag events and invokes a function passed in as `onIntentConfirm` prop. It manages drag events fired within nested child nodes to determine the user's intention. 

We use this component to wrap the entire `CollectionMetaContainer` styled component in Collection to give the user a  much larger drag and drop target and create a better UX experience. 

### Tests
Unit tests have been added for the `DragIntentContainer`
