### PR TITLE
Catch errors from panda session

### DIFF
--- a/client-v2/src/services/__tests__/pandaFetch.spec.ts
+++ b/client-v2/src/services/__tests__/pandaFetch.spec.ts
@@ -1,0 +1,45 @@
+import pandaFetchImp from '../pandaFetch';
+import fetchMock from 'fetch-mock';
+
+afterEach(fetchMock.restore);
+
+const getPandaFetchWithSessionMock = (
+  fn: (...args: any[]) => any
+): typeof pandaFetchImp => {
+  jest.resetModules();
+  jest.mock('panda-session', () => ({
+    reEstablishSession: fn
+  }));
+  return require('../pandaFetch').default;
+};
+
+const setReauthedResponse = (res: string | number | object, route: string) => {
+  fetchMock.once(route, 419);
+  fetchMock.once(route, res, { overwriteRoutes: false });
+};
+
+describe('pandaFetch', () => {
+  it('attempts to reauth when auth has timed out', async () => {
+    const pandaFetch = getPandaFetchWithSessionMock(() => Promise.resolve());
+    setReauthedResponse({ ok: true }, '/test');
+    const json = await pandaFetch('/test').then(res => res.json());
+    expect(json.ok).toBe(true);
+  });
+
+  it('rejects with errors from panda-session', async () => {
+    const e = new Error('hai');
+    const pandaFetch = getPandaFetchWithSessionMock(() => {
+      throw e;
+    });
+    setReauthedResponse({ ok: true }, '/test');
+    const thrown = await pandaFetch('/test').catch(er => er);
+    expect(thrown).toBe(e);
+  });
+
+  it('rejects with non 2XX responses', async () => {
+    const pandaFetch = getPandaFetchWithSessionMock(() => Promise.resolve());
+    setReauthedResponse(500, '/test');
+    const res = await pandaFetch('/test').catch(r => r);
+    expect(res.status).toBe(500);
+  });
+});

--- a/client-v2/src/services/pandaFetch.ts
+++ b/client-v2/src/services/pandaFetch.ts
@@ -21,8 +21,8 @@ const pandaFetch = (
       });
 
       if (res.status === 419 && count < 1) {
-        await reEstablishSession(reauthUrl, 5000);
         try {
+          await reEstablishSession(reauthUrl, 5000);
           const res2 = await pandaFetch(url, options, count + 1);
           return resolve(res2);
         } catch (e) {


### PR DESCRIPTION
This solves a problem where timeouts in `panda-session` where not getting caught when making a request. Specifically (seemingly in dev) `panda-session`'s `reEstablishSession` may hit the `5000` timeout and then throw an error.

This moves that call intro the `try {} catch (e) {}` and adds some tests around this and other peculiarities around `pandaFetch`. Notable that it _throws_ non-200 responses!