### PR TITLE
Update colours and spacing for accessibility

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -68,7 +68,11 @@ const Collection = ({
     headlineContent={
       hasUnpublishedChanges &&
       canPublish && (
-        <Button size="l" onClick={() => publish(id, frontId)}>
+        <Button
+          size="l"
+          priority="primary"
+          onClick={() => publish(id, frontId)}
+        >
           Launch
         </Button>
       )

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -54,7 +54,7 @@ const colorMap = {
   },
   deselected: {
     default: theme.colors.white,
-    primary: theme.colors.white,
+    primary: theme.colors.blackDark,
     muted: theme.colors.blackLight
   }
 };
@@ -95,6 +95,12 @@ const backgroundHoverMap = {
   }
 };
 
+const letterSpacingMap = {
+  s: '0px',
+  m: '0px',
+  l: '0.5px'
+};
+
 const getMapKey = ({
   disabled,
   selected
@@ -125,6 +131,7 @@ export default styled(`button`)`
   font-size: ${mapSize(fontSizeMap)};
   font-weight: bold;
   height: ${mapSize(heightMap)};
+  letter-spacing: ${mapSize(letterSpacingMap)};
   line-height: 1;
   margin: 0 ${({ inline }) => (inline ? '5px' : '0')};
   padding: 0 ${mapSize(paddingMap)};


### PR DESCRIPTION
# What does this change?
![screenshot 2019-01-22 at 12 01 03](https://user-images.githubusercontent.com/1652187/51534392-94cfde80-1e3d-11e9-9f72-f36af5420f31.png)

The "Launch" button is now orange 🍊 and all orange buttons now have black text for improved accessibility!

## Before 👎 
![screenshot 2019-01-22 at 12 04 08](https://user-images.githubusercontent.com/1652187/51534525-e2e4e200-1e3d-11e9-91d4-0c54383f7301.png)

## After 👍 
![screenshot 2019-01-22 at 12 04 25](https://user-images.githubusercontent.com/1652187/51534538-ea0bf000-1e3d-11e9-9d6c-a814b79dec92.png)

Shout out to Chrome DevTools for the accessibility contrast ratio info 🎨 

Additionally, large buttons now have a slight letter spacing for improved legibility.