### PR TITLE
Use link tag to help styling visited

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -18,6 +18,7 @@ import {
 
 import { insertArticleFragment } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
+import { getPaths } from 'util/paths';
 
 const LinkContainer = styled('div')`
   background-color: #f6f6f6;
@@ -63,6 +64,13 @@ const Title = styled(`h2`)`
   font-family: GHGuardianHeadline-Medium;
   font-size: 16px;
   font-weight: 500;
+`;
+
+const VisitedWrapper = styled.a`
+  text-decoration: none;
+  :visited ${Title} {
+    color: #888;
+  }
 `;
 
 const MetaContainer = styled('div')`
@@ -119,50 +127,56 @@ const FeedItem = ({
   isLive,
   onAddToClipboard = noop
 }: FeedItemProps) => (
-  <Container
-    data-testid="feed-item"
-    draggable={true}
-    onDragStart={event => dragStart(internalPageCode, event)}
+  <VisitedWrapper
+    href={getPaths(id).live}
+    onClick={e => e.preventDefault()}
+    aria-disabled
   >
-    <MetaContainer>
-      <Tone
-        style={{
-          color: getPillarColor(pillarId, isLive) || '#c9c9c9'
-        }}
-      >
-        {isLive && startCase(sectionName)}
-        {!isLive &&
-          (firstPublicationDate
-            ? notLiveLabels.takendDown
-            : notLiveLabels.draft)}
-      </Tone>
-      {publicationDate && (
-        <FirstPublished>
-          {distanceInWords(new Date(publicationDate))}
-        </FirstPublished>
-      )}
-      <ShortVerticalPinline />
-    </MetaContainer>
-    <Body>
-      <Title data-testid="headline">{title}</Title>
-    </Body>
-    <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
-      <HoverActionsButtonWrapper
-        buttons={[
-          { text: 'Clipboard', component: HoverAddToClipboardButton },
-          { text: 'View', component: HoverViewButton },
-          { text: 'Ophan', component: HoverOphanButton }
-        ]}
-        buttonProps={{
-          isLive,
-          urlPath: id,
-          onAddToClipboard: () => onAddToClipboard(id)
-        }}
-        toolTipPosition={'top'}
-        toolTipAlign={'right'}
-      />
-    </HoverActionsAreaOverlay>
-  </Container>
+    <Container
+      data-testid="feed-item"
+      draggable={true}
+      onDragStart={event => dragStart(internalPageCode, event)}
+    >
+      <MetaContainer>
+        <Tone
+          style={{
+            color: getPillarColor(pillarId, isLive) || '#c9c9c9'
+          }}
+        >
+          {isLive && startCase(sectionName)}
+          {!isLive &&
+            (firstPublicationDate
+              ? notLiveLabels.takendDown
+              : notLiveLabels.draft)}
+        </Tone>
+        {publicationDate && (
+          <FirstPublished>
+            {distanceInWords(new Date(publicationDate))}
+          </FirstPublished>
+        )}
+        <ShortVerticalPinline />
+      </MetaContainer>
+      <Body>
+        <Title data-testid="headline">{title}</Title>
+      </Body>
+      <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
+        <HoverActionsButtonWrapper
+          buttons={[
+            { text: 'Clipboard', component: HoverAddToClipboardButton },
+            { text: 'View', component: HoverViewButton },
+            { text: 'Ophan', component: HoverOphanButton }
+          ]}
+          buttonProps={{
+            isLive,
+            urlPath: id,
+            onAddToClipboard: () => onAddToClipboard(id)
+          }}
+          toolTipPosition={'top'}
+          toolTipAlign={'right'}
+        />
+      </HoverActionsAreaOverlay>
+    </Container>
+  </VisitedWrapper>
 );
 
 const mapDispatchToProps = (dispatch: Dispatch) => {


### PR DESCRIPTION
# What does this change?
This makes visited links appear slightly lighter in the CAPI feed - a behaviour that has been taken from the old tool.

![screenshot 2019-01-22 at 13 46 31](https://user-images.githubusercontent.com/1652187/51539542-32320f00-1e4c-11e9-8963-23b4e4d9efcf.png)

I've (ab)used a link to get this information. The previous implementation used local storage but it seems somewhat unnecessary. Happy to revert back to local storage if people can think of reasons why my link hack is unsound!