### PR TITLE
Stole trash icon from workflow and made button larger

### DIFF
--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { styled } from 'shared/constants/theme';
 import { connect } from 'react-redux';
 import { WrappedFieldProps } from 'redux-form';
-import deleteIcon from '../../images/icons/delete-copy.svg';
+import deleteIcon from '../../images/icons/trash.svg';
+import crossIcon from '../../images/icons/delete-copy.svg';
 import ButtonDefault from './ButtonDefault';
 import InputContainer from './InputContainer';
 import {
@@ -33,10 +34,10 @@ const ImageContainer = styled('div')<{
 const ButtonDelete = styled(ButtonDefault)`
   position: absolute;
   display: block;
-  top: calc(50% - 12px);
-  left: calc(50% - 12px);
-  height: 24px;
-  width: 24px;
+  top: 6px;
+  right: 6px;
+  height: 32px;
+  width: 32px;
   text-align: center;
   padding: 0;
   border-radius: 24px;
@@ -45,10 +46,10 @@ const ButtonDelete = styled(ButtonDefault)`
 const IconDelete = styled('img')`
   display: block;
   position: absolute;
-  height: 10px;
-  width: 10px;
-  top: 7px;
-  left: 7px;
+  height: 14px;
+  width: 14px;
+  top: 9px;
+  left: 9px;
 `;
 
 const IconAdd = IconDelete.extend`
@@ -187,7 +188,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                 }}
               />
             ) : (
-              <IconAdd src={deleteIcon} onClick={this.handleAdd} />
+              <IconAdd src={crossIcon} onClick={this.handleAdd} />
             )}
           </ButtonDelete>
         </ImageContainer>

--- a/client-v2/src/shared/images/icons/trash.svg
+++ b/client-v2/src/shared/images/icons/trash.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30" height="30" viewBox="0 0 128 128">
+  <path fill="#fff" d="M22.2 115.9L34.3 128h59.6l12.1-12.1V31.6H22.2v84.3zM113.9 7.1H89L81.9 0H46.3l-7.1 7.1H14.3v14.2h99.6V7.1z"></path>
+</svg>


### PR DESCRIPTION
# What changed?
See title _Stole trash icon from workflow and made button larger_!

<img width="342" alt="screenshot 2019-01-22 at 15 19 00" src="https://user-images.githubusercontent.com/1652187/51545074-2436bb00-1e59-11e9-94c8-09fbe408c8b3.png">

Stole the trash from here:
<img width="288" alt="screenshot 2019-01-22 at 15 20 11" src="https://user-images.githubusercontent.com/1652187/51545131-3b75a880-1e59-11e9-99b1-2ec1fd11c238.png">

Currently the trash icon is showing when there is not an image 🤔 will add a card for this.