### PR TITLE
Extend button target area for toggling Collection open/close visibility

### DIFF
--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -61,9 +61,12 @@ class CollectionNotification extends React.Component<
           &nbsp;
           <Button
             size="s"
-            onClick={() =>
-              this.setState({ showFrontDetails: !this.state.showFrontDetails })
-            }
+            onClick={e => {
+              e.stopPropagation();
+              return this.setState({
+                showFrontDetails: !this.state.showFrontDetails
+              });
+            }}
           >
             {this.state.showFrontDetails ? 'Hide Details' : 'Show More'}
           </Button>

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -8,8 +8,10 @@ import { oc } from 'ts-optchain';
 import ShortVerticalPinline from './layout/ShortVerticalPinline';
 import ContainerHeadingPinline from './typography/ContainerHeadingPinline';
 import { Collection, CollectionItemSets } from '../types/Collection';
-import ButtonCircularCaret from './input/ButtonCircularCaret';
 import DragIntentContainer from './DragIntentContainer';
+import ButtonCircularCaret, {
+  ButtonCircularWithTransition
+} from './input/ButtonCircularCaret';
 import { State as SharedState } from '../types/State';
 import { State } from '../../types/State';
 
@@ -119,6 +121,21 @@ const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
   text-overflow: ellipsis;
 `;
 
+const CollectionToggleContainer = styled('div')`
+  padding-top: 5px;
+  width: 100%;
+  max-width: 130px;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 2;
+  cursor: pointer;
+  :hover {
+    ${ButtonCircularWithTransition} {
+      background-color: ${({ theme }) => theme.button.backgroundColorFocused};
+    }
+  }
+`;
+
 const CollectionConfigContainer = styled('div')`
   display: inline-block;
   font-family: GHGuardianHeadline-Regular;
@@ -138,12 +155,6 @@ const CollectionConfigText = styled('div')`
 
 const CollectionConfigTextPipe = styled('span')`
   color: ${({ theme }) => theme.base.colors.borderColor};
-`;
-
-const CollectionToggleContainer = styled('div')`
-  padding-top: 5px;
-  margin-left: auto;
-  z-index: 2;
 `;
 
 const CollectionShortVerticalPinline = ShortVerticalPinline.extend`
@@ -221,7 +232,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
           }}
           active={!this.props.isOpen}
         >
-          <CollectionMetaContainer>
+          <CollectionMetaContainer onClick={this.toggleVisibility}>
             <ItemCountMeta>
               {collection && (
                 <>
@@ -254,7 +265,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               <ButtonCircularCaret
                 active={this.props.isOpen!}
                 preActive={this.state.hasDragOpenIntent}
-                onClick={this.toggleVisibility}
               />
             </CollectionToggleContainer>
           </CollectionMetaContainer>

--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -4,7 +4,7 @@ import { styled } from 'shared/constants/theme';
 import caretIcon from 'shared/images/icons/single-down.svg';
 import ButtonCircular from './ButtonCircular';
 
-const ButtonCircularWithTransition = ButtonCircular.extend<{
+export const ButtonCircularWithTransition = ButtonCircular.extend<{
   highlight?: boolean;
 }>`
   transition: transform 0.15s;


### PR DESCRIPTION
📣 Shout out to @laurenemms for her help with this PR. 

### What does this change?

Users now have a much larger target to hit the Collection toggle visibility button. We made the area the width of the article image, so that it did not overlap with any Warning buttons or other, non-clickable text in the meta data header. 

![kapture 2019-01-23 at 14 07 31](https://user-images.githubusercontent.com/32312712/51612263-02047200-1f19-11e9-9011-92ff4d02cf2a.gif)
