### PR TITLE
Add supporting articles to collection articles selectors

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -210,7 +210,8 @@ const mapStateToProps = () => {
     }),
     articleCount: articlesInCollectionSelector(selectSharedState(state), {
       collectionSet: props.browsingStage,
-      collectionId: props.collectionId
+      collectionId: props.collectionId,
+      includeSupportingArticles: false
     }).length,
     hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
       collectionId: props.collectionId

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -27,6 +27,11 @@ const state: any = {
       c4: {
         groups: ['group1'],
         draft: ['g5']
+      },
+      c5: {
+        id: 'c5',
+        groups: ['group6'],
+        live: ['g6']
       }
     }
   },
@@ -55,6 +60,11 @@ const state: any = {
       uuid: 'g5',
       id: 'group1',
       articleFragments: ['af5']
+    },
+    g6: {
+      uuid: 'g6',
+      id: 'group6',
+      articleFragments: ['afWithSupporting']
     }
   },
   externalArticles: {
@@ -208,6 +218,15 @@ const state: any = {
         byline: 'fragment-byline',
         showKickerSection: true
       }
+    },
+    afWithSupporting: {
+      uuid: 'afWithSupporting',
+      id: 'ea5',
+      frontPublicationDate: 1,
+      publishedBy: 'A. N. Author',
+      meta: {
+        supporting: ['afWithSectionKicker']
+      }
     }
   }
 };
@@ -327,7 +346,7 @@ describe('Shared selectors', () => {
     });
   });
 
-  describe('createArticlesInCollectionGroupSelector', () => {
+  describe('createArticlesInCollectionSelector', () => {
     it('should return a list of all the articles in a given collection', () => {
       const selector = createArticlesInCollectionSelector();
       expect(
@@ -336,6 +355,15 @@ describe('Shared selectors', () => {
           collectionSet: 'live'
         })
       ).toEqual(['af2', 'af1']);
+    });
+    it('should return articles in supporting positions', () => {
+      const selector = createArticlesInCollectionSelector();
+      expect(
+        selector(state, {
+          collectionId: 'c5',
+          collectionSet: 'live'
+        })
+      ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
   });
 
@@ -363,6 +391,16 @@ describe('Shared selectors', () => {
           groupName: 'group1'
         })
       ).toEqual(['af3', 'af4']);
+    });
+    it('should return articles in supporting positions', () => {
+      const selector = createArticlesInCollectionGroupSelector();
+      expect(
+        selector(state, {
+          collectionId: 'c5',
+          collectionSet: 'live',
+          groupName: 'group6'
+        })
+      ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
     it('should return an empty array if the collection is not found', () => {
       const selector = createArticlesInCollectionGroupSelector();

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -365,6 +365,16 @@ describe('Shared selectors', () => {
         })
       ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
+    it('should not return articles in supporting positions if includeSupportingArticles is false', () => {
+      const selector = createArticlesInCollectionSelector();
+      expect(
+        selector(state, {
+          collectionId: 'c5',
+          collectionSet: 'live',
+          includeSupportingArticles: false
+        })
+      ).toEqual(['afWithSupporting']);
+    });
   });
 
   describe('createArticlesInCollectionGroupSelector', () => {
@@ -401,6 +411,17 @@ describe('Shared selectors', () => {
           groupName: 'group6'
         })
       ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
+    });
+    it('should not return articles in supporting positions if includeSupportingArticles is false', () => {
+      const selector = createArticlesInCollectionGroupSelector();
+      expect(
+        selector(state, {
+          collectionId: 'c5',
+          collectionSet: 'live',
+          groupName: 'group6',
+          includeSupportingArticles: false
+        })
+      ).toEqual(['afWithSupporting']);
     });
     it('should return an empty array if the collection is not found', () => {
       const selector = createArticlesInCollectionGroupSelector();

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -199,10 +199,23 @@ const groupNameSelector = (
     groupName
   }: {
     groupName?: string;
+    includeSupportingArticles?: boolean;
     collectionSet: CollectionItemSets;
     collectionId: string;
   }
 ) => groupName;
+
+const includeSupportingArticlesSelector = (
+  _: unknown,
+  {
+    includeSupportingArticles
+  }: {
+    groupName?: string;
+    includeSupportingArticles?: boolean;
+    collectionSet: CollectionItemSets;
+    collectionId: string;
+  }
+) => includeSupportingArticles;
 
 const createArticlesInCollectionGroupSelector = () => {
   const collectionStageGroupsSelector = createCollectionStageGroupsSelector();
@@ -210,7 +223,13 @@ const createArticlesInCollectionGroupSelector = () => {
     articleFragmentsSelector,
     collectionStageGroupsSelector,
     groupNameSelector,
-    (articleFragments, collectionGroups, groupName) => {
+    includeSupportingArticlesSelector,
+    (
+      articleFragments,
+      collectionGroups,
+      groupName,
+      includeSupportingArticles = true
+    ) => {
       const groups = groupName
         ? [
             collectionGroups.find(({ id }) => id === groupName) || {
@@ -222,6 +241,9 @@ const createArticlesInCollectionGroupSelector = () => {
         (acc, group) => acc.concat(group.articleFragments || []),
         [] as string[]
       );
+      if (!includeSupportingArticles) {
+        return groupArticleFragmentIds;
+      }
       return groupArticleFragmentIds.reduce(
         (acc, id) => {
           const articleFragment = articleFragments[id];
@@ -247,12 +269,18 @@ const createArticlesInCollectionSelector = () => {
     state: State,
     {
       collectionId,
-      collectionSet
-    }: { collectionId: string; collectionSet: CollectionItemSets }
+      collectionSet,
+      includeSupportingArticles = true
+    }: {
+      collectionId: string;
+      collectionSet: CollectionItemSets;
+      includeSupportingArticles?: boolean;
+    }
   ) =>
     selectArticlesInCollectionGroups(state, {
       collectionId,
-      collectionSet
+      collectionSet,
+      includeSupportingArticles
     });
 };
 


### PR DESCRIPTION
Previously, selectors for articles in collection groups, and entire collections, ignored supporting articles. This meant that CAPI articles for supporting articles were not being picked up when Fronts loaded.

Do not merge -- this change may have consequences for other parts of the app that we haven't thought of yet!