### PR TITLE
Replace first publication with front publication

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -57,6 +57,7 @@ const ArticleHeadingContainerSmall = styled('div')`
 `;
 
 interface ArticleBodyProps {
+  frontPublicationTime?: string;
   firstPublicationDate?: string;
   scheduledPublicationDate?: string;
   pillarId?: string;
@@ -92,7 +93,8 @@ const articleBodyDefault = ({
   onDelete,
   onAddToClipboard,
   notifications,
-  isUneditable
+  isUneditable,
+  frontPublicationTime
 }: ArticleBodyProps) => {
   const ArticleHeadingContainer =
     size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
@@ -117,6 +119,7 @@ const articleBodyDefault = ({
               : notLiveLabels.draft}
           </NotLiveContainer>
         )}
+
         {scheduledPublicationDate && (
           <CollectionItemDraftMetaContent>
             {distanceInWordsStrict(
@@ -125,9 +128,10 @@ const articleBodyDefault = ({
             )}
           </CollectionItemDraftMetaContent>
         )}
-        {(isLive || size === 'default') && firstPublicationDate && (
+
+        {size === 'default' && frontPublicationTime && (
           <CollectionItemMetaContent>
-            {distanceInWordsStrict(Date.now(), new Date(firstPublicationDate))}
+            {distanceInWordsStrict(Date.now(), new Date(frontPublicationTime))}
           </CollectionItemMetaContent>
         )}
       </CollectionItemMetaContainer>

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -268,7 +268,8 @@ describe('Shared selectors', () => {
         trailText: 'external-trailText',
         byline: 'external-byline',
         isLive: true,
-        firstPublicationDate: '2018-10-19T10:30:39Z'
+        firstPublicationDate: '2018-10-19T10:30:39Z',
+        frontPublicationTime: 1
       });
 
       expect(selector(state, 'af1WithOverrides')).toEqual({
@@ -286,7 +287,8 @@ describe('Shared selectors', () => {
         isLive: true,
         firstPublicationDate: '2018-10-19T10:30:39Z',
         pillarId: undefined,
-        showKickerCustom: true
+        showKickerCustom: true,
+        frontPublicationTime: 1
       });
       expect(selector(state, 'invalid')).toEqual(undefined);
     });

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -137,7 +137,8 @@ const createArticleFromArticleFragmentSelector = () =>
             : true,
         firstPublicationDate: externalArticle
           ? externalArticle.fields.firstPublicationDate
-          : undefined
+          : undefined,
+        frontPublicationTime: articleFragment.frontPublicationDate
       };
     }
   );


### PR DESCRIPTION
Instead of showing the last modification date on article in collections, we should show the date the article was added to a collection. Displaying time added is something which has been requested by users and we don't want to be displaying last modified date because we don't keep polling for article updates so it can be misleading. We should to send out comms to everyone using the tool about this change as it is a subtle change! @harpreetpurewal should we just email everyone who is using the tool or go through central prod?