### PR TITLE
Make Hide/Show Details button clickable on locked Collections

### DIFF
--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -18,6 +18,16 @@ const WarningText = styled('span')`
   color: #e05e00;
 `;
 
+const ToggleDetailsButton = Button.extend`
+  position: relative;
+  z-index: 5;
+`;
+
+const AlsoOnLinksWrapper = styled('div')`
+  position: relative;
+  z-index: 5;
+`;
+
 class CollectionNotification extends React.Component<
   CollectionNotificationProps,
   ComponentState
@@ -59,7 +69,7 @@ class CollectionNotification extends React.Component<
           )}
           {!alsoOn.meritsWarning && <span>Also on other fronts.</span>}
           &nbsp;
-          <Button
+          <ToggleDetailsButton
             size="s"
             onClick={e => {
               e.stopPropagation();
@@ -69,15 +79,15 @@ class CollectionNotification extends React.Component<
             }}
           >
             {this.state.showFrontDetails ? 'Hide Details' : 'Show More'}
-          </Button>
+          </ToggleDetailsButton>
           {this.state.showFrontDetails && (
-            <div>
+            <AlsoOnLinksWrapper>
               {alsoOn.fronts.map(front => (
                 <div key={front.id}>
                   <a href={`/v2/${front.priority}/${front.id}`}>{front.id}</a>
                 </div>
               ))}
-            </div>
+            </AlsoOnLinksWrapper>
           )}
         </div>
       );


### PR DESCRIPTION
**Before:** User could not click on **Show More button** on locked collections: 
![screen shot 2019-01-24 at 16 18 35](https://user-images.githubusercontent.com/32312712/51750296-90a7f900-20a9-11e9-8f6d-26980d7ffe00.png)



**Now:** This has been lifted so it's still clickable like the open/close Collection button. 
![kapture 2019-01-25 at 13 54 43](https://user-images.githubusercontent.com/32312712/51750276-82f27380-20a9-11e9-856d-515dc3ed4420.gif)
The Collection itself remains fully locked to any article changes. 