### PR TITLE
Scheduled display

### DIFF
--- a/client-v2/src/bundles/__tests__/capiFeedBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/capiFeedBundle.spec.ts
@@ -10,11 +10,17 @@ import {
 import { capiArticle } from 'shared/fixtures/shared';
 
 const resources = [
-  { fetchAction: fetchLive, selectors: liveSelectors, endpoint: 'live' },
+  {
+    fetchAction: fetchLive,
+    selectors: liveSelectors,
+    endpoint: 'live',
+    searchQuery: '/search'
+  },
   {
     fetchAction: fetchPreview,
     selectors: previewSelectors,
-    endpoint: 'preview'
+    endpoint: 'preview',
+    searchQuery: '/content/scheduled'
   }
 ];
 const createStoreAndFetchMock = (
@@ -32,7 +38,7 @@ describe('capiFeedBundle', () => {
     await Promise.all(
       resources.map(async resource => {
         const store = createStoreAndFetchMock(
-          `begin:/api/${resource.endpoint}/search`,
+          `begin:/api/${resource.endpoint}${resource.searchQuery}`,
           {
             response: {
               results: [capiArticle]
@@ -78,7 +84,7 @@ describe('capiFeedBundle', () => {
     await Promise.all(
       resources.map(async resource => {
         const store = createStoreAndFetchMock(
-          `begin:/api/${resource.endpoint}/search`,
+          `begin:/api/${resource.endpoint}${resource.searchQuery}`,
           400
         );
         await store.dispatch(resource.fetchAction(
@@ -98,7 +104,7 @@ describe('capiFeedBundle', () => {
     await Promise.all(
       resources.map(async resource => {
         const store = createStoreAndFetchMock(
-          `begin:/api/${resource.endpoint}/search`,
+          `begin:/api/${resource.endpoint}${resource.searchQuery}`,
           '{This is not JSON}'
         );
         await store.dispatch(resource.fetchAction(
@@ -118,7 +124,7 @@ describe('capiFeedBundle', () => {
     await Promise.all(
       resources.map(async resource => {
         const store = createStoreAndFetchMock(
-          `begin:/api/${resource.endpoint}/search`,
+          `begin:/api/${resource.endpoint}${resource.searchQuery}`,
           { response: { status: 'error', message: 'CAPI is unwell' } }
         );
         await store.dispatch(resource.fetchAction(

--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -44,9 +44,13 @@ const {
 const fetchResourceOrResults = async (
   capiService: typeof liveCapi,
   params: object,
-  isResource: boolean
+  isResource: boolean,
+  fetchFromPreview: boolean = false
 ) => {
-  const res = await capiService.search(params, { isResource });
+  const capiEndpoint = fetchFromPreview
+    ? capiService.scheduled
+    : capiService.search;
+  const res = await capiEndpoint(params, { isResource });
   return isResource ? [res.response.content] : res.response.results;
 };
 
@@ -75,7 +79,12 @@ export const fetchPreview = (
   dispatch(previewActions.fetchStart('preview'));
   let results;
   try {
-    results = await fetchResourceOrResults(previewCapi, params, isResource);
+    results = await fetchResourceOrResults(
+      previewCapi,
+      params,
+      isResource,
+      true
+    );
   } catch (e) {
     dispatch(previewActions.fetchError(e.message));
   }

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -156,9 +156,12 @@ class FeedsContainer extends React.Component<
     });
 
   public handleFeedClick = (index: number) =>
-    this.setState({
-      capiFeedIndex: index
-    });
+    this.setState(
+      {
+        capiFeedIndex: index
+      },
+      this.runSearch
+    );
 
   public renderFixedContent = () => {
     if (!this.state.displaySearchFilters) {
@@ -228,16 +231,20 @@ class FeedsContainer extends React.Component<
 
   private runSearch() {
     const { inputState } = this.state;
+    const { capiFeedIndex } = this.state;
     const maybeArticleId = getIdFromURL(inputState.query);
     const searchTerm = maybeArticleId ? maybeArticleId : inputState.query;
-    this.props.fetchLive(
-      getParams(searchTerm, inputState, false),
-      !!maybeArticleId
-    );
-    this.props.fetchPreview(
-      getParams(searchTerm, inputState, true),
-      !!maybeArticleId
-    );
+    if (capiFeedIndex === 0) {
+      this.props.fetchLive(
+        getParams(searchTerm, inputState, false),
+        !!maybeArticleId
+      );
+    } else {
+      this.props.fetchPreview(
+        getParams(searchTerm, inputState, true),
+        !!maybeArticleId
+      );
+    }
   }
 
   private runSearchAndRestartPolling() {

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -75,6 +75,17 @@ const ResultsHeadingContainer = styled('div')`
   margin-bottom: 10px;
 `;
 
+const getCapiFieldsToShow = (isPreview: boolean) => {
+  const defaultFieldsToShow =
+    'internalPageCode,trailText,firstPublicationDate,isLive';
+
+  if (!isPreview) {
+    return defaultFieldsToShow;
+  }
+
+  return defaultFieldsToShow + ',scheduledPublicationDate';
+};
+
 const getParams = (
   query: string,
   {
@@ -96,7 +107,7 @@ const getParams = (
   'page-size': '20',
   'show-elements': 'image',
   'show-tags': 'all',
-  'show-fields': 'internalPageCode,trailText,firstPublicationDate,isLive',
+  'show-fields': getCapiFieldsToShow(isPreview),
   ...(isPreview
     ? { 'order-by': 'oldest', 'from-date': getTodayDate() }
     : { 'order-by': 'newest', 'order-date': 'first-publication' })

--- a/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
@@ -59,6 +59,7 @@ const Feed = ({ articles = [], error, loading }: FeedProps) => (
                 internalPageCode={fields && getId(fields.internalPageCode)}
                 firstPublicationDate={fields.firstPublicationDate}
                 isLive={!fields.isLive || fields.isLive === 'true'}
+                scheduledPublicationDate={fields.scheduledPublicationDate}
               />
             )
           )

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -109,6 +109,7 @@ interface FeedItemProps {
   firstPublicationDate?: string;
   isLive: boolean;
   onAddToClipboard: (id: string) => void;
+  scheduledPublicationDate?: string;
 }
 
 const dragStart = (
@@ -128,7 +129,8 @@ const FeedItem = ({
   internalPageCode,
   firstPublicationDate,
   isLive,
-  onAddToClipboard = noop
+  onAddToClipboard = noop,
+  scheduledPublicationDate
 }: FeedItemProps) => (
   <Container
     data-testid="feed-item"
@@ -155,6 +157,11 @@ const FeedItem = ({
         {publicationDate && (
           <FirstPublished>
             {distanceInWords(new Date(publicationDate))}
+          </FirstPublished>
+        )}
+        {scheduledPublicationDate && (
+          <FirstPublished>
+            {distanceInWords(new Date(scheduledPublicationDate))}
           </FirstPublished>
         )}
         <ShortVerticalPinline />

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'types/Store';
 import styled from 'styled-components';
-import distanceInWords from 'date-fns/distance_in_words_to_now';
+import distanceInWordsStrict from 'date-fns/distance_in_words_strict';
 import startCase from 'lodash/startCase';
 
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
-import { getPillarColor } from 'shared/util/getPillarColor';
+import { getPillarColor, notLiveColour } from 'shared/util/getPillarColor';
 import { notLiveLabels } from 'constants/fronts';
 import { HoverActionsAreaOverlay } from 'shared/components/CollectionHoverItems';
 import { HoverActionsButtonWrapper } from 'shared/components/input/HoverActionButtonWrapper';
@@ -87,6 +87,10 @@ const FirstPublished = styled('div')`
   margin: 2px 0;
 `;
 
+const ScheduledPublication = styled(FirstPublished)`
+  color: ${notLiveColour};
+`;
+
 const Tone = styled('div')`
   padding-top: 2px;
   font-size: 12px;
@@ -154,14 +158,17 @@ const FeedItem = ({
               ? notLiveLabels.takendDown
               : notLiveLabels.draft)}
         </Tone>
+        {scheduledPublicationDate && (
+          <ScheduledPublication>
+            {distanceInWordsStrict(
+              new Date(scheduledPublicationDate),
+              Date.now()
+            )}
+          </ScheduledPublication>
+        )}
         {publicationDate && (
           <FirstPublished>
-            {distanceInWords(new Date(publicationDate))}
-          </FirstPublished>
-        )}
-        {scheduledPublicationDate && (
-          <FirstPublished>
-            {distanceInWords(new Date(scheduledPublicationDate))}
+            {distanceInWordsStrict(Date.now(), new Date(publicationDate))}
           </FirstPublished>
         )}
         <ShortVerticalPinline />

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styled } from 'shared/constants/theme';
 import startCase from 'lodash/startCase';
-import distanceInWords from 'date-fns/distance_in_words_to_now';
+import distanceInWordsStrict from 'date-fns/distance_in_words_strict';
 
 import CollectionItemHeading from '../collectionItem/CollectionItemHeading';
 import BasePlaceholder from '../BasePlaceholder';
@@ -26,6 +26,7 @@ import {
 import { CollectionItemSizes } from 'shared/types/Collection';
 import CollectionItemTrail from '../collectionItem/CollectionItemTrail';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
+import CollectionItemDraftMetaContent from '../collectionItem/CollectionItemDraftMetaContent';
 import CollectionItemNotification from '../collectionItem/CollectionItemNotification';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
@@ -109,11 +110,6 @@ const articleBodyDefault = ({
             {startCase(sectionName)}
           </CollectionItemMetaHeading>
         )}
-        {(isLive || size === 'default') && firstPublicationDate && (
-          <CollectionItemMetaContent>
-            {distanceInWords(new Date(firstPublicationDate))}
-          </CollectionItemMetaContent>
-        )}
         {!isLive && !displayPlaceholders && (
           <NotLiveContainer>
             {firstPublicationDate
@@ -122,8 +118,16 @@ const articleBodyDefault = ({
           </NotLiveContainer>
         )}
         {scheduledPublicationDate && (
+          <CollectionItemDraftMetaContent>
+            {distanceInWordsStrict(
+              new Date(scheduledPublicationDate),
+              Date.now()
+            )}
+          </CollectionItemDraftMetaContent>
+        )}
+        {(isLive || size === 'default') && firstPublicationDate && (
           <CollectionItemMetaContent>
-            {distanceInWords(new Date(scheduledPublicationDate))}
+            {distanceInWordsStrict(Date.now(), new Date(firstPublicationDate))}
           </CollectionItemMetaContent>
         )}
       </CollectionItemMetaContainer>

--- a/client-v2/src/shared/components/collectionItem/CollectionItemDraftMetaContent.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemDraftMetaContent.tsx
@@ -1,0 +1,7 @@
+import { styled } from 'shared/constants/theme';
+import CollectionItemMetaContent from './CollectionItemMetaContent';
+import { notLiveColour } from 'shared/util/getPillarColor';
+
+export default styled(CollectionItemMetaContent)`
+  color: ${notLiveColour};
+`;

--- a/client-v2/src/shared/util/getPillarColor.ts
+++ b/client-v2/src/shared/util/getPillarColor.ts
@@ -6,8 +6,9 @@ const pillarColorMap = {
   'pillar/arts': '#a1845c'
 } as { [pillar: string]: string };
 
-const notLiveColour = '#ff7f0f';
 const noPillarColour = '#221133';
+
+export const notLiveColour = '#ff7f0f';
 
 export const getPillarColor = (
   pillar: string | undefined,


### PR DESCRIPTION
This pr fixes the issue where draft capi feed was displaying the wrong results. This was because we were using the wrong query. This pr fixes the issue by using the correct query and displaying the scheduled launch date in the capi feed so the ordering of the article makes sense. I did a few other changes to this as well
- Change the way we display dates, the old way was too long as we now need more dates for draft content
- Only poll for live/draft content if that toggle has been selected
- Nicer colour for scheduled dates in collections

I know @jonathonherbert wanted tests but not sure which tests to add as the problem here was just an incorrect query to capi and bad date displays.

![screen shot 2019-01-25 at 15 31 05](https://user-images.githubusercontent.com/3066534/51755865-8db40500-20b7-11e9-89c1-9ca93f5f88fa.png)
![screen shot 2019-01-25 at 15 30 59](https://user-images.githubusercontent.com/3066534/51755882-9278b900-20b7-11e9-99eb-3895bc285ffa.png)
