### PR TITLE
update mobile-notifications-client

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -137,7 +137,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
 class NotificationHttpProvider(val ws: WSClient) extends HttpProvider with Logging {
   override def post(url: String, apiKey: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse] = {
     ws.url(url)
-      .withHttpHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}", "Authorization" -> s"Bearer: $apiKey")
+      .withHttpHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}", "Authorization" -> s"Bearer $apiKey")
       .post(body)
       .map(extract)
   }

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -135,9 +135,9 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
 }
 
 class NotificationHttpProvider(val ws: WSClient) extends HttpProvider with Logging {
-  override def post(url: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse] = {
+  override def post(url: String, apiKey: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse] = {
     ws.url(url)
-      .withHttpHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}")
+      .withHttpHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}", "Authorization" -> s"Bearer: $apiKey")
       .post(body)
       .map(extract)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ val json4sVersion = "3.6.0-M2"
 
 resolvers ++= Seq(
     Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+    "Guardian Mobile Bintray" at "https://dl.bintray.com/guardian/mobile",
     "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend"
 )
 
@@ -92,7 +93,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.gu" %% "fapi-client-play26" % "2.6.6",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "mobile-notifications-client" % "1.2",
+    "com.gu" %% "mobile-notifications-client" % "1.5",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.1",
 
     "com.gu" %% "scanamo" % "1.0.0-M7",


### PR DESCRIPTION
This updates the mobile-notifications-client and and passes the content api key to the notifications service as a http header rather than a query parameter. The notifications client is now published to bintray ( rather than sonatype ) so I've added this to the resolvers list. 

See: 

https://github.com/guardian/mobile-n10n/pull/320/files
https://github.com/guardian/mobile-n10n/pull/321/files

Tested on CODE 28/1/19