### PR TITLE
Adds a template for PRs

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What's changed?
+
+_Detail the main feature of this PR and optionally a link to the relevant issue / card_
+
+## Implementation notes
+
+_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_
+
+## Checklist
+
+### General
+- [ ] 🤖 Relevant tests added
+- [ ] ✅ CI checks / tests run locally
+- [ ] 🔍 Checked on CODE
+
+### Client
+- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
+- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
+- [ ] 📷 Screenshots / GIFs of relevant UI changes included


### PR DESCRIPTION
I used [this](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) as the reference.

Feel free to suggest _any_ changes to this but it's a good working off point.

Here's what it looks like:

<img width="690" alt="screenshot 2019-01-28 at 17 23 43" src="https://user-images.githubusercontent.com/1652187/51853987-8bed7a00-2321-11e9-812d-de1ac2b9ad98.png">
