### PR TITLE
Fix checkboxes, which are currently broken

### DIFF
--- a/client-v2/src/shared/components/input/CreateInput.tsx
+++ b/client-v2/src/shared/components/input/CreateInput.tsx
@@ -16,7 +16,7 @@ export default (
   type?: string
 ) => ({ label, input, ...rest }: Props) => (
   <InputContainer>
-    {label && <InputLabel for={label}>{label}</InputLabel>}
+    {label && <InputLabel htmlFor={label}>{label}</InputLabel>}
     <Component id={label} {...input} {...rest} type={type} />
   </InputContainer>
 );

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -23,7 +23,7 @@ const Switch = styled('div')`
   -ms-user-select: none;
 `;
 
-const CheckboxLabel = styled('label')<{ for?: string }>`
+const CheckboxLabel = styled('label')`
   display: block;
   overflow: hidden;
   cursor: pointer;
@@ -65,14 +65,24 @@ type Props = {
   label?: string;
 } & WrappedFieldProps;
 
-export default ({ label, input, ...rest }: Props) => (
+export default ({
+  label,
+  input: { onChange, ...inputRest },
+  ...rest
+}: Props) => (
   <>
     <InputContainer>
       <CheckboxContainer>
         <Label size="sm">{label}</Label>
-        <Switch onClick={() => input.onChange(!input.checked)}>
-          <Checkbox type="checkbox" {...input} {...rest} id={label} />
-          <CheckboxLabel for={label} />
+        <Switch>
+          <Checkbox
+            type="checkbox"
+            onClick={() => onChange(!inputRest.checked)}
+            {...inputRest}
+            {...rest}
+            id={label}
+          />
+          <CheckboxLabel htmlFor={label} />
         </Switch>
       </CheckboxContainer>
     </InputContainer>


### PR DESCRIPTION
## What's changed?

Checkboxes are no longer unresponsive to user clicking.

![toggle](https://user-images.githubusercontent.com/7767575/51901401-7d4da400-23af-11e9-85c9-cb673d6cd478.gif)

... yeah.

There aren't any unit tests, but we could conceivably add integration tests for this.

## Implementation notes

This was the odd result of a longstanding mistake (mine!) and a version bump. The label element in the checkbox component had a `for` attribute, and React expects `htmlFor`. #459 introduced a new version of React, which appears to have changed the way React handles `for` -- instead of silently failing, it warns but attaches the attribute. As a result, click events were fired twice on the component, once for the component itself and once bubbled up from the label with the `for` attribute.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
