### PR TITLE
Only add dirtied fields to the article meta on save.

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -41,6 +41,7 @@ import {
   getCapiValuesForArticleTextFields
 } from 'util/form';
 import { CapiTextFields } from 'util/form';
+import { Dispatch } from 'types/Store';
 
 interface ComponentProps extends ContainerProps {
   articleFragmentId: string;
@@ -394,11 +395,22 @@ const ArticleFragmentForm = reduxForm<
 >({
   destroyOnUnmount: false,
   enableReinitialize: true,
-  onSubmit: (values: ArticleFragmentFormData, _, props: ComponentProps) => {
-    const meta: ArticleFragmentMeta = getArticleFragmentMetaFromFormValues(
-      values
-    );
-    props.onSave(meta);
+  onSubmit: (
+    values: ArticleFragmentFormData,
+    dispatch: Dispatch,
+    props: ComponentProps
+  ) => {
+    // By using a thunk, we get access to the application state. We could use
+    // mergeProps, or thread state through the component, to achieve the same
+    // result -- this seemed to be the most concise way.
+    dispatch((_, getState) => {
+      const meta: ArticleFragmentMeta = getArticleFragmentMetaFromFormValues(
+        getState(),
+        props.articleFragmentId,
+        values
+      );
+      props.onSave(meta);
+    });
   }
 })(formComponent);
 

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -1,8 +1,11 @@
+import { reducer, initialize, change } from 'redux-form';
 import {
   getArticleFragmentMetaFromFormValues,
   getInitialValuesForArticleFragmentForm
 } from '../ArticleFragmentForm';
 import derivedArticle from 'fixtures/derivedArticle';
+import initialState from 'fixtures/initialState';
+import { State } from 'types/State';
 
 const formValues = {
   byline: 'Caroline Davies',
@@ -34,6 +37,21 @@ const formValues = {
   showKickerSection: false,
   trailText:
     'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+};
+
+const createStateWithChangedFormFields = (
+  cleanState: State,
+  articleId: string,
+  fieldValueMap: { [field: string]: any }
+) => {
+  const formState = reducer(undefined, initialize(articleId, formValues));
+  return {
+    ...cleanState,
+    form: Object.keys(fieldValueMap).reduce(
+      (acc, key) => reducer(acc, change(articleId, key, fieldValueMap[key])),
+      formState
+    )
+  };
 };
 
 describe('ArticleFragmentForm transform functions', () => {
@@ -129,132 +147,118 @@ describe('ArticleFragmentForm transform functions', () => {
     });
   });
   describe('Derive articleFragment meta from form values', () => {
+    it('should return nothing if no form values were dirtied', () => {
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        {}
+      );
+      expect(
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', formValues)
+      ).toEqual({});
+    });
     it('should derive values, removing the slideshow array if empty', () => {
-      expect(getArticleFragmentMetaFromFormValues(formValues)).toEqual({
-        byline: 'Caroline Davies',
-        customKicker: '',
+      const byline = 'Caroline Davies edited';
+      const headline =
+        "Sister of academic's killer warned police he was mentally ill edited";
+      const trailText =
+        'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him edited';
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        {
+          byline,
+          headline,
+          trailText
+        }
+      );
+      expect(
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', {
+          ...formValues,
+          byline,
+          headline,
+          trailText
+        })
+      ).toEqual({
+        byline: 'Caroline Davies edited',
         headline:
-          "Sister of academic's killer warned police he was mentally ill",
-        imageCutoutReplace: false,
-        imageCutoutSrc: undefined,
-        imageCutoutSrcHeight: undefined,
-        imageCutoutSrcOrigin: undefined,
-        imageCutoutSrcWidth: undefined,
-        imageHide: false,
-        imageReplace: false,
-        imageSlideshowReplace: false,
-        imageSrc: undefined,
-        imageSrcHeight: undefined,
-        imageSrcOrigin: undefined,
-        imageSrcThumb: undefined,
-        imageSrcWidth: undefined,
-        isBoosted: false,
-        isBreaking: false,
-        showBoostedHeadline: false,
-        showByline: false,
-        showKickerTag: false,
-        showKickerSection: false,
-        showQuotedHeadline: false,
-        slideshow: undefined,
+          "Sister of academic's killer warned police he was mentally ill edited",
         trailText:
-          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him edited'
       });
     });
     it('should derive values, setting the imageReplace value if necessary', () => {
+      const values = {
+        primaryImage: {
+          src: 'exampleSrc',
+          width: 100,
+          height: 100,
+          origin: 'exampleOrigin',
+          thumb: 'exampleThumb'
+        }
+      };
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        values
+      );
       expect(
-        getArticleFragmentMetaFromFormValues({
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', {
           ...formValues,
-          primaryImage: {
-            src: 'exampleSrc',
-            width: 100,
-            height: 100,
-            origin: 'exampleOrigin',
-            thumb: 'exampleThumb'
-          }
+          ...values
         })
       ).toEqual({
-        byline: 'Caroline Davies',
-        customKicker: '',
-        headline:
-          "Sister of academic's killer warned police he was mentally ill",
-        imageCutoutReplace: false,
-        imageCutoutSrc: undefined,
-        imageCutoutSrcHeight: undefined,
-        imageCutoutSrcOrigin: undefined,
-        imageCutoutSrcWidth: undefined,
-        imageHide: false,
         imageReplace: true,
-        imageSlideshowReplace: false,
         imageSrc: 'exampleSrc',
         imageSrcHeight: '100',
         imageSrcOrigin: 'exampleOrigin',
         imageSrcThumb: 'exampleThumb',
-        imageSrcWidth: '100',
-        isBoosted: false,
-        isBreaking: false,
-        showBoostedHeadline: false,
-        showByline: false,
-        showKickerSection: false,
-        showKickerTag: false,
-        showQuotedHeadline: false,
-        slideshow: undefined,
-        trailText:
-          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+        imageSrcWidth: '100'
       });
     });
     it('should handle conversion of string values for images', () => {
-      expect(
-        getArticleFragmentMetaFromFormValues({
-          ...formValues,
-          primaryImage: {
+      const values = {
+        primaryImage: {
+          src: 'exampleSrc',
+          width: 100,
+          height: 100,
+          origin: 'exampleOrigin',
+          thumb: 'exampleThumb'
+        },
+        slideshow: [
+          {
             src: 'exampleSrc',
             width: 100,
             height: 100,
             origin: 'exampleOrigin',
             thumb: 'exampleThumb'
           },
-          slideshow: [
-            {
-              src: 'exampleSrc',
-              width: 100,
-              height: 100,
-              origin: 'exampleOrigin',
-              thumb: 'exampleThumb'
-            },
-            {
-              src: 'exampleSrc',
-              width: 100,
-              height: 100,
-              origin: 'exampleOrigin',
-              thumb: 'exampleThumb'
-            }
-          ]
+          {
+            src: 'exampleSrc',
+            width: 100,
+            height: 100,
+            origin: 'exampleOrigin',
+            thumb: 'exampleThumb'
+          }
+        ]
+      };
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        values
+      );
+      expect(
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', {
+          ...formValues,
+          ...values
         })
       ).toEqual({
-        byline: 'Caroline Davies',
-        customKicker: '',
-        headline:
-          "Sister of academic's killer warned police he was mentally ill",
-        imageCutoutReplace: false,
-        imageCutoutSrc: undefined,
-        imageCutoutSrcHeight: undefined,
-        imageCutoutSrcOrigin: undefined,
-        imageCutoutSrcWidth: undefined,
-        imageHide: false,
         imageReplace: true,
-        imageSlideshowReplace: false,
         imageSrc: 'exampleSrc',
         imageSrcHeight: '100',
         imageSrcOrigin: 'exampleOrigin',
         imageSrcThumb: 'exampleThumb',
         imageSrcWidth: '100',
-        isBoosted: false,
-        isBreaking: false,
-        showBoostedHeadline: false,
-        showByline: false,
-        showKickerSection: false,
-        showKickerTag: false,
-        showQuotedHeadline: false,
         slideshow: [
           {
             src: 'exampleSrc',
@@ -270,9 +274,7 @@ describe('ArticleFragmentForm transform functions', () => {
             origin: 'exampleOrigin',
             thumb: 'exampleThumb'
           }
-        ],
-        trailText:
-          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him'
+        ]
       });
     });
   });

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -122,7 +122,8 @@ describe('ArticleFragmentForm transform functions', () => {
           src: 'exampleSrc2',
           width: 200,
           height: 200,
-          origin: 'exampleOrigin'
+          origin: 'exampleOrigin',
+          thumb: 'exampleSrc2'
         },
         slideshow: [
           {

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -105,7 +105,8 @@ export const getInitialValuesForArticleFragmentForm = (
           src: article.imageCutoutSrc,
           width: strToInt(article.imageCutoutSrcWidth),
           height: strToInt(article.imageCutoutSrcHeight),
-          origin: article.imageCutoutSrcOrigin
+          origin: article.imageCutoutSrcOrigin,
+          thumb: article.imageCutoutSrc
         },
         slideshow: slideshow.concat(slideshowBackfill)
       }

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -113,6 +113,10 @@ export const getInitialValuesForArticleFragmentForm = (
     : undefined;
 };
 
+// Because multiple fields in the article meta map to
+// a single field in the form, we need a way to map between
+// the two models to figure out which meta fields should be
+// added to the form output when a form field is dirtied.
 const formToMetaFieldMap: { [fieldName: string]: string } = {
   imageReplace: 'primaryImage',
   imageSrc: 'primaryImage',


### PR DESCRIPTION
## What's changed?

Previously, the form would persist every available field when the user hit 'save'. Now, it just persists what's been dirtied. This makes it less likely that users will stomp on fields concurrently edited by other users, which paves the way for the upcoming collection polling and presence features.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included (N/A)
