### PR TITLE
Keep item count on single line in collection overview

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -100,6 +100,10 @@ const LastUpdated = styled.span`
   font-weight: 400;
 `;
 
+const ItemCount = styled.span`
+  white-space: nowrap;
+`;
+
 const StatusWarning = ButtonDefault.extend`
   outline: transparent;
   :not(:first-child) {
@@ -183,7 +187,8 @@ const CollectionOverview = ({
       }}
     >
       <TextContainerLeft>
-        <Name>{collection.displayName}</Name> {articleCount} items
+        <Name>{collection.displayName}</Name>
+        <ItemCount>{articleCount} items</ItemCount>
       </TextContainerLeft>
       <TextContainerRight>
         {collection && collection.lastUpdated && (


### PR DESCRIPTION
## What's changed?

This --
![screen shot 2019-01-31 at 08 50 54](https://user-images.githubusercontent.com/7767575/52050837-b15ccc80-2549-11e9-8132-4a4980653053.png)
Is now this --
<img width="297" alt="screen shot 2019-01-31 at 10 10 22" src="https://user-images.githubusercontent.com/7767575/52050846-b7eb4400-2549-11e9-8e93-bfe9451fdfd6.png">

(Blurriness aside)

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A)
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
