### PR TITLE
Efficient path for V1 collection fetches

### DIFF
--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -44,12 +44,12 @@ class FaciaToolController(
     val collectionPriorities = configAgent.getFrontsPermissionsPriorityByCollectionId(collectionId)
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
-      val collectionsFuture = collectionService.fetchCollections(List(collectionId))
+      val collectionsFuture = collectionService.fetchCollection(collectionId)
 
-      collectionsFuture.map { collections =>
-        collections.headOption.map { collection =>
+      collectionsFuture.map { collection =>
+        collection.map { collection =>
            NoCache {
-            Ok(Json.toJson(collection.map(_.collection))).as("application/json")
+            Ok(Json.toJson(collection)).as("application/json")
           }
         }.getOrElse(Results.NotFound)
       }

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -30,7 +30,7 @@ class FaciaToolV2Controller(
     val collectionPriorities = collectionIds.flatMap(configAgent.getFrontsPermissionsPriorityByCollectionId(_)).toSet
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
-      val collections = collectionService.fetchCollections(collectionIds)
+      val collections = collectionService.fetchCollectionsAndStoriesVisible(collectionIds)
 
       collections.map(c => NoCache {
         Ok(Json.toJson(c)).as("application/json")


### PR DESCRIPTION
## What's changed?

#563 altered the path for fetching collections for V1 in a costly way - a config fetch each time the service was called. For V2, this is fine, but for V1, this is very costly, because each front calls the collection endpoint for each collection, and polls. As a result, performance in the old tool suffered.

This PR corrects that by restoring the old tools previous path in the new service.

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A)
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included (N/A)
