### PR TITLE
Add styled-components theme to replace all hex colors

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -3,7 +3,7 @@ import { injectGlobal, ThemeProvider } from 'styled-components';
 import { Switch, Route } from 'react-router-dom';
 import DropDisabler from './util/DropDisabler';
 
-import { theme, styled } from 'shared/constants/theme';
+import { theme, styled } from 'constants/theme';
 import { priorities } from 'constants/priorities';
 import SectionHeaderWithLogo from './layout/SectionHeaderWithLogo';
 import GHGuardianHeadlineBoldTtf from '../fonts/headline/GHGuardianHeadline-Bold.ttf';
@@ -87,8 +87,9 @@ injectGlobal`
 `;
 
 const AppContainer = styled('div')`
-  background-color: #fff;
-  color: #333;
+  background-color: ${({ theme }) =>
+    theme.shared.base.colors.backgroundColorLight};
+  color: ${({ theme }) => theme.shared.base.colors.text};
   height: 100%;
   width: 100%;
 `;

--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -3,7 +3,7 @@ import { injectGlobal, ThemeProvider } from 'styled-components';
 import { Switch, Route } from 'react-router-dom';
 import DropDisabler from './util/DropDisabler';
 
-import { theme, styled } from 'constants/theme';
+import { theme as styleTheme, styled } from 'constants/theme';
 import { priorities } from 'constants/priorities';
 import SectionHeaderWithLogo from './layout/SectionHeaderWithLogo';
 import GHGuardianHeadlineBoldTtf from '../fonts/headline/GHGuardianHeadline-Bold.ttf';
@@ -102,7 +102,7 @@ const BackgroundHeader = styled('div')`
 `;
 
 const App = () => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={styleTheme}>
     <DropDisabler>
       <AppContainer>
         <BackgroundHeader>

--- a/client-v2/src/components/Col.tsx
+++ b/client-v2/src/components/Col.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 const Col = styled(`div`)<{
   flex?: number;

--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -15,7 +15,7 @@ interface ComponentState {
 
 const WarningText = styled('span')`
   font-weight: bold;
-  color: #e05e00;
+  color: ${({ theme }) => theme.shared.colors.orangeDark};
 `;
 
 const ToggleDetailsButton = Button.extend`

--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 import { AlsoOnDetail } from 'types/Collection';
 import Button from 'shared/components/input/ButtonDefault';

--- a/client-v2/src/components/ConfirmModal.tsx
+++ b/client-v2/src/components/ConfirmModal.tsx
@@ -21,7 +21,7 @@ const StyledModal = styled(Modal)`
   top: 40px;
   font-size: 14px;
   left: 50%;
-  background: rgb(255, 255, 255);
+  background: ${({ theme }) => theme.shared.base.colors.backgroundColorLight};
   overflow: auto;
   outline: none;
   padding: 20px;
@@ -31,7 +31,8 @@ const StyledModal = styled(Modal)`
 `;
 
 const Actions = styled.div`
-  border-top: 1px solid #ccc;
+  border-top: ${({ theme }) =>
+    `solid 1px ${theme.shared.base.colors.borderColor}`};
   margin-top: 1.5em;
   padding-top: 1.5em;
   text-align: right;

--- a/client-v2/src/components/ConfirmModal.tsx
+++ b/client-v2/src/components/ConfirmModal.tsx
@@ -9,7 +9,7 @@ import {
 import { Dispatch } from 'types/Store';
 import { endConfirmModal } from 'actions/ConfirmModal';
 import { connect } from 'react-redux';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import ButtonDefault from 'shared/components/input/ButtonDefault';
 
 type StyledModalProps = Modal.Props & {

--- a/client-v2/src/components/DropZone.tsx
+++ b/client-v2/src/components/DropZone.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { styled } from 'constants/theme';
+import { theme } from 'constants/theme';
 
 const DropContainer = styled('div')`
   position: relative;
@@ -26,7 +27,7 @@ class DropZone extends React.Component<
   public static defaultProps = {
     style: {},
     indicatorStyle: {},
-    dropColor: 'hsl(0, 0%, 84%)'
+    dropColor: theme.base.colors.dropZone
   };
 
   public state = {

--- a/client-v2/src/components/DropZone.tsx
+++ b/client-v2/src/components/DropZone.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 const DropContainer = styled('div')`
   position: relative;

--- a/client-v2/src/components/ErrorBanner.tsx
+++ b/client-v2/src/components/ErrorBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import { ActionError } from 'types/Action';
 import { error } from '../styleConstants';
 

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -9,14 +9,15 @@ import ClipboardMeta from './ClipboardMeta';
 import Button from 'shared/components/input/ButtonDefault';
 
 const FeedSectionContainer = styled('div')`
-  background-color: #f6f6f6;
+  background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
 `;
 
 const FeedWrapper = styled('div')`
   width: 389px;
   padding-right: 10px;
   margin-right: 10px;
-  border-right: solid 1px #c9c9c9;
+  border-right: ${({ theme }) =>
+    `solid 1px ${theme.shared.base.colors.borderColor}`};
 `;
 
 const ClipboardWrapper = styled('div')`

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 import SectionHeaderWithLogo from './layout/SectionHeaderWithLogo';
 import SectionContent from './layout/SectionContent';

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import SearchInput, {
   SearchInputState,
   initState

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -49,7 +49,7 @@ const RefreshButton = styled.button`
   appearance: none;
   border: none;
   background: transparent;
-  color: #333;
+  color: ${({ theme }) => theme.shared.base.colors.text};
   cursor: pointer;
   font-family: inherit;
   font-size: 13px;
@@ -57,7 +57,7 @@ const RefreshButton = styled.button`
   outline: none;
 
   &:hover {
-    color: #555;
+    color: ${({ theme }) => theme.shared.base.colors.buttonFocused};
   }
 `;
 

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import { css } from 'styled-components';
+import { styled } from 'constants/theme';
 
 import ButtonCircular from 'shared/components/input/ButtonCircular';
 import MoreImage from 'shared/images/icons/more.svg';
@@ -17,7 +18,8 @@ const ListItem = styled('li')<{ isActive?: boolean }>`
   font-family: TS3TextSans;
   font-size: 16px;
   line-height: 20px;
-  border-bottom: solid 1px #5e5e5e;
+  border-bottom: ${({ theme }) =>
+    `solid 1px ${theme.base.colors.frontListBorder}`};
   ${({ isActive }) =>
     isActive &&
     css`
@@ -39,12 +41,12 @@ const ListLabel = styled('span')<{ isActive?: boolean }>`
   ${({ isActive }) =>
     !isActive &&
     css`
-      color: #999;
+      color: ${({ theme }) => theme.base.colors.frontListLabel};
     `};
 `;
 
-const ButtonAdd = ButtonCircular.extend`
-  background-color: #4d4d4d;
+const ButtonAdd = styled(ButtonCircular)`
+  background-color: ${({ theme }) => theme.base.colors.frontListButton};
   position: absolute;
   top: 8px;
   right: 5px;

--- a/client-v2/src/components/FrontsCAPIInterface/DateInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/DateInput.tsx
@@ -33,42 +33,42 @@ const DatePicker = styled('div')`
   .DateInput_input {
     font-size: 16px;
     font-family: TS3TextSans;
-    color: #121212;
+    color: ${({ theme }) => theme.capiInterface.text};
   }
 
   .DateRangePickerInput__withBorder {
-    border: solid 1px #c9c9c9;
+    border: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
   }
 
   .CalendarMonth_caption {
-    color: #121212;
+    color: ${({ theme }) => theme.capiInterface.text};
     font-family: TS3TextSans;
   }
 
   .CalendarDay__selected {
-    background: #ff7f0f;
-    border: 1px double #444444;
-    color: #121212;
+    background: ${({ theme }) => theme.capiInterface.backgroundSelected};
+    border: ${({ theme }) => `1px double ${theme.capiInterface.border}`};
+    color: ${({ theme }) => theme.capiInterface.text};
   }
 
   .CalendarDay__selected_span {
-    background: #dcdcdc;
-    border: 1px double #444444;
-    color: #121212;
+    background: ${({ theme }) => theme.capiInterface.backgroundDark};
+    border: ${({ theme }) => `1px double ${theme.capiInterface.border}`};
+    color: ${({ theme }) => theme.capiInterface.text};
   }
 
   .CalendarDay__hovered_span,
  .CalendarDay__hovered_span: hover {
-    background: #f2f2f2;
-    border: 1px double #444444;
-    color: #121212;
+    background: ${({ theme }) => theme.capiInterface.backgroundLight};
+    border: ${({ theme }) => `1px double ${theme.capiInterface.border}`};
+    color: ${({ theme }) => theme.capiInterface.text};
   }
 
   .CalendarDay__selected: hover,
  .CalendarDay__selected_span: hover {
-    background: #dcdcdc;
-    border: 1px double #444444;
-    color: #121212;
+    background: ${({ theme }) => theme.capiInterface.backgroundDark};
+    border: ${({ theme }) => `1px double ${theme.capiInterface.border}`};
+    color: ${({ theme }) => theme.capiInterface.text};
   }
 `;
 

--- a/client-v2/src/components/FrontsCAPIInterface/DateInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/DateInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import 'react-dates/initialize';
 import 'react-dates/lib/css/_datepicker.css';
 import { DateRangePicker } from 'react-dates';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import moment from 'moment';
 
 interface CAPIDateInputProps {

--- a/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import FeedItem from './FeedItem';
 import { CapiArticle } from 'types/Capi';
 

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -8,6 +8,7 @@ import startCase from 'lodash/startCase';
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
 import { getPillarColor, notLiveColour } from 'shared/util/getPillarColor';
 import { notLiveLabels } from 'constants/fronts';
+import { theme } from 'constants/theme';
 import { HoverActionsAreaOverlay } from 'shared/components/CollectionHoverItems';
 import { HoverActionsButtonWrapper } from 'shared/components/input/HoverActionButtonWrapper';
 import {
@@ -21,7 +22,7 @@ import noop from 'lodash/noop';
 import { getPaths } from 'util/paths';
 
 const LinkContainer = styled('div')`
-  background-color: #f6f6f6;
+  background-color: ${({ theme }) => theme.capiInterface.backgroundLight};
   display: none;
   position: absolute;
   bottom: 20px;
@@ -30,10 +31,11 @@ const LinkContainer = styled('div')`
   padding: 1px 3px;
 `;
 
+//TODO
 const Container = styled('div')`
   display: flex;
   position: relative;
-  border-top: solid 1px #c9c9c9;
+  border-top: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
   color: #221133;
   display: flex;
   font-weight: 400;
@@ -72,7 +74,7 @@ const VisitedWrapper = styled.a`
   color: inherit;
   cursor: auto;
   :visited ${Title} {
-    color: #888;
+    color: ${({ theme }) => theme.capiInterface.textVisited};
   }
 `;
 
@@ -149,7 +151,8 @@ const FeedItem = ({
       <MetaContainer>
         <Tone
           style={{
-            color: getPillarColor(pillarId, isLive) || '#c9c9c9'
+            color:
+              getPillarColor(pillarId, isLive) || theme.capiInterface.textLight
           }}
         >
           {isLive && startCase(sectionName)}

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -31,12 +31,11 @@ const LinkContainer = styled('div')`
   padding: 1px 3px;
 `;
 
-//TODO
 const Container = styled('div')`
   display: flex;
   position: relative;
   border-top: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
-  color: #221133;
+  color: ${({ theme }) => theme.capiInterface.feedItemText};
   display: flex;
   font-weight: 400;
   padding-bottom: 20px;

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'types/Store';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import distanceInWordsStrict from 'date-fns/distance_in_words_strict';
 import startCase from 'lodash/startCase';
 

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'types/Store';
-import { styled } from 'constants/theme';
+import { styled, theme as styleTheme } from 'constants/theme';
 import distanceInWordsStrict from 'date-fns/distance_in_words_strict';
 import startCase from 'lodash/startCase';
 
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
 import { getPillarColor, notLiveColour } from 'shared/util/getPillarColor';
 import { notLiveLabels } from 'constants/fronts';
-import { theme } from 'constants/theme';
 import { HoverActionsAreaOverlay } from 'shared/components/CollectionHoverItems';
 import { HoverActionsButtonWrapper } from 'shared/components/input/HoverActionButtonWrapper';
 import {
@@ -151,7 +150,8 @@ const FeedItem = ({
         <Tone
           style={{
             color:
-              getPillarColor(pillarId, isLive) || theme.capiInterface.textLight
+              getPillarColor(pillarId, isLive) ||
+              styleTheme.capiInterface.textLight
           }}
         >
           {isLive && startCase(sectionName)}

--- a/client-v2/src/components/FrontsCAPIInterface/FieldFilter.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FieldFilter.tsx
@@ -18,23 +18,25 @@ const FilterFieldDropdownMenu = FadeIn.extend`
   display: ${({ isOpen }: { isOpen: boolean }) => (isOpen ? 'auto' : 'none')};
 `;
 
-const DropdownItem = styled('div')`
-  background-color: ${({ hightlighted }: { hightlighted: boolean }) =>
-    hightlighted ? '#dcdcdc' : 'white'};
+const DropdownItem = styled('div')<{ highlighted: boolean }>`
+  background-color: ${({ highlighted, theme }) =>
+    highlighted
+      ? theme.capiInterface.backgroundDark
+      : theme.capiInterface.backgroundLight};
   :hover {
-    background-color: #dcdcdc;
+    background-color: ${({ theme }) => theme.capiInterface.backgroundDark};
   }
   font-size: 14px;
   font-weight: bold;
   padding: 7px 15px 7px 15px;
-  border-left: 1px solid #c4c4c4;
-  color: #121212;
+  border-left: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
+  color: ${({ theme }) => theme.capiInterface.text};
 `;
 
 const FilterTitle = styled('label')`
   font-size: 16px;
   font-weight: bold;
-  color: #121212;
+  color: ${({ theme }) => theme.capiInterface.text};
   width: min-content;
   white-space: nowrap;
   margin-right: 9px;
@@ -43,7 +45,7 @@ const FilterTitle = styled('label')`
 const FilterPlaceHolderText = styled('div')`
   display: inline-block;
   background-color: transparent;
-  color: #808080;
+  color: ${({ theme }) => theme.capiInterface.textPlaceholder};
   cursor: pointer;
   border: none;
   padding: 0;
@@ -52,7 +54,8 @@ const FilterPlaceHolderText = styled('div')`
 `;
 
 const FilterContainer = styled('div')`
-  border-bottom: solid 2px #c4c4c4;
+  border-bottom: ${({ theme }) =>
+    `2px solid ${theme.capiInterface.borderLight}`};
   padding: 2px;
   padding-top: 24px;
   margin-right: 19px;

--- a/client-v2/src/components/FrontsCAPIInterface/FieldFilter.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FieldFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Downshift from 'downshift';
 import startCase from 'lodash/startCase';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import ButtonCircularCaret from '../../shared/components/input/ButtonCircularCaret';
 import FadeIn from 'shared/components/animation/FadeIn';
 

--- a/client-v2/src/components/FrontsCAPIInterface/FieldFilter.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FieldFilter.tsx
@@ -12,7 +12,7 @@ interface CAPIFieldFilterProps<T> {
   filterTitle: string;
 }
 
-const FilterFieldDropdownMenu = FadeIn.extend`
+const FilterFieldDropdownMenu = styled(FadeIn)`
   margin-right: 19px;
   margin-left: 93px;
   display: ${({ isOpen }: { isOpen: boolean }) => (isOpen ? 'auto' : 'none')};

--- a/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
@@ -4,15 +4,15 @@ import moreImage from 'shared/images/icons/more.svg';
 import { SmallRoundButton, ClearButtonIcon } from 'util/sharedStyles/buttons';
 
 const SearchTermItem = styled('div')`
-  color: #121212;
+  color: ${({ theme }) => theme.capiInterface.text};
   font-weight: bold;
-  border: solid 1px #c4c4c4;
+  border: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
   font-size: 14px;
-  background-color: #ffffff;
+  background-color: ${({ theme }) => theme.capiInterface.backgroundWhite};
   padding: 7px 15px 7px 15px;
   margin-bottom: 10px;
   :hover {
-    color: #c4c4c4;
+    color: ${({ theme }) => theme.capiInterface.textLight};
   }
 `;
 

--- a/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import moreImage from 'shared/images/icons/more.svg';
 import { SmallRoundButton, ClearButtonIcon } from 'util/sharedStyles/buttons';
 

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import ScrollContainer from '../ScrollContainer';
 import TextInput from '../TextInput';
 import CAPITagInput from '../FrontsCAPIInterface/TagInput';

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -31,7 +31,7 @@ interface SearchInputProps {
 
 const InputContainer = styled('div')`
   margin-bottom: 20px;
-  background: #ffffff;
+  background: ${({ theme }) => theme.capiInterface.backgroundWhite};
 `;
 
 const renderDateAsString = (date: moment.Moment | null) => {

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.tsx
@@ -18,23 +18,25 @@ const TagDropdown = styled('div')`
   margin-right: 19px;
 `;
 
-const DropdownItem = styled('div')`
-  background-color: ${({ highlighted }: { highlighted: boolean }) =>
-    highlighted ? '#dcdcdc' : 'white'};
+const DropdownItem = styled('div')<{ highlighted: boolean }>`
+  background-color: ${({ highlighted, theme }) =>
+    highlighted
+      ? theme.capiInterface.backgroundDark
+      : theme.capiInterface.backgroundLight};
   :hover {
-    background-color: #dcdcdc;
+    background-color: ${({ theme }) => theme.capiInterface.backgroundDark};
   }
   font-size: 14px;
   font-weight: bold;
   padding: 7px 15px 7px 15px;
-  border-left: 1px solid #c4c4c4;
-  color: #121212;
+  border-left: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
+  color: ${({ theme }) => theme.capiInterface.text};
 `;
 
 const SearchTitle = styled('label')`
   font-size: 16px;
   font-weight: bold;
-  color: #121212;
+  color: ${({ theme }) => theme.capiInterface.text};
   margin-right: 3px;
 `;
 
@@ -54,7 +56,8 @@ const SearchInput = styled('input')`
 `;
 
 const SearchContainer = styled('div')`
-  border-bottom: solid 2px #c4c4c4;
+  border-bottom: ${({ theme }) =>
+    `2px solid ${theme.capiInterface.borderLight}`};
   padding: 2px;
   padding-top: 24px;
   margin-right: 19px;

--- a/client-v2/src/components/FrontsCAPIInterface/TagInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/TagInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Downshift, { GetInputPropsOptions } from 'downshift';
 import capitalize from 'lodash/capitalize';
 import debounce from 'lodash/debounce';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import { Tag } from 'types/Capi';
 import { liveCapi } from 'services/frontsCapi';
 

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -67,7 +67,7 @@ const FormContent = styled('div')`
   overflow-y: scroll;
 `;
 
-const CollectionHeadingPinline = styled(ContainerHeadingPinline)`
+const CollectionHeadingPinline = ContainerHeadingPinline.extend`
   display: flex;
   margin-right: -11px;
   margin-bottom: 10px;

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -8,7 +8,7 @@ import {
   WrappedFieldArrayProps,
   Field
 } from 'redux-form';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -53,7 +53,7 @@ interface ComponentProps extends ContainerProps {
 type Props = ComponentProps &
   InjectedFormProps<ArticleFragmentFormData, ComponentProps, {}>;
 
-const FormContainer = ContentContainer.withComponent('form').extend`
+const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -67,7 +67,7 @@ const FormContent = styled('div')`
   overflow-y: scroll;
 `;
 
-const CollectionHeadingPinline = ContainerHeadingPinline.extend`
+const CollectionHeadingPinline = styled(ContainerHeadingPinline)`
   display: flex;
   margin-right: -11px;
   margin-bottom: 10px;
@@ -82,14 +82,14 @@ const ButtonContainer = styled('div')`
   line-height: 0;
 `;
 
-const SlideshowRow = Row.extend`
+const SlideshowRow = styled(Row)`
   margin-top: 10px;
   margin-bottom: 5px;
 `;
 
 const SlideshowLabel = styled('div')`
   font-size: 12px;
-  color: #767676;
+  color: ${({ theme }) => theme.shared.colors.greyMedium};
 `;
 
 const ImageWrapper = styled('div')`

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
@@ -6,6 +6,7 @@ import {
 } from 'shared/selectors/shared';
 import { State } from 'types/State';
 import { DerivedArticle } from 'shared/types/Article';
+import { theme } from '../../../constants/theme';
 
 interface ContainerProps {
   id: string;
@@ -20,7 +21,7 @@ const ArticleDrag = ({ article }: ComponentProps) => (
     {article && (
       <div
         style={{
-          background: '#eee',
+          background: `${theme.shared.base.colors.backgroundColorFocused}`,
           borderRadius: '4px',
           boxShadow: '-2px -2px 5px 0 rgba(0, 0, 0, 0.5)',
           overflow: 'hidden',

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { styled } from 'shared/constants/theme';
+import { styled } from 'constants/theme';
 import distanceFromNow from 'date-fns/distance_in_words_to_now';
 import { events } from 'services/GA';
 

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -52,8 +52,8 @@ interface CollectionStatusProps {
 const Container = styled.div`
   align-items: center;
   appearance: none;
-  background-color: #f6f6f6;
-  border: 1px solid #c4c4c4;
+  background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
+  border: ${({ theme }) => `solid 1px ${theme.shared.base.colors.borderColor}`};
   border-radius: 1.25em;
   color: inherit;
   cursor: pointer;
@@ -69,7 +69,7 @@ const Container = styled.div`
   transition: background-color 0.3s;
 
   &:hover {
-    background-color: #ddd;
+    background-color: ${({ theme }) => theme.shared.colors.whiteDark};
   }
 
   &:focus {
@@ -90,13 +90,13 @@ const TextContainerRight = styled.div`
 `;
 
 const Name = styled.span`
-  color: #333;
+  color: ${({ theme }) => theme.shared.base.colors.text};
   font-weight: 700;
   padding-right: 0.25em;
 `;
 
 const LastUpdated = styled.span`
-  color: #333;
+  color: ${({ theme }) => theme.shared.base.colors.text};
   font-weight: 400;
 `;
 
@@ -109,7 +109,7 @@ const StatusWarning = ButtonDefault.extend`
   :not(:first-child) {
     margin-left: 5px;
   }
-  color: ${({ theme }) => (theme ? theme.button.color : null)};
+  color: ${({ theme }) => theme.shared.button.color};
   height: 20px;
   width: 20px;
   border-radius: 20px;
@@ -119,7 +119,7 @@ const StatusWarning = ButtonDefault.extend`
   }
 `;
 
-const StatusFlag = StatusWarning.extend`
+const StatusFlag = styled(StatusWarning)`
   &:disabled,
   &:disabled:hover {
     cursor: auto;

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -41,11 +41,11 @@ const SingleFrontContainer = styled('div')`
   min-width: 1011px;
 `;
 
-const FeedContainer = SectionContainer.extend`
+const FeedContainer = styled(SectionContainer)`
   height: 100%;
 `;
 
-const FrontsContainer = SectionContainer.extend`
+const FrontsContainer = styled(SectionContainer)`
   overflow-x: scroll;
 `;
 

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { match } from 'react-router-dom';
-import styled from 'styled-components';
-
+import { styled } from 'constants/theme';
 import getFrontsConfig from 'actions/Fronts';
 import {} from 'bundles/frontsUIBundle';
 import {

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import { connect } from 'react-redux';
 import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { styled } from 'constants/theme';
+import { theme } from 'constants/theme';
 import { connect } from 'react-redux';
 import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';
@@ -140,7 +141,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
       <React.Fragment>
         <div
           style={{
-            background: '#fff',
+            background: theme.shared.base.colors.backgroundColorLight,
             display: this.state.error ? 'block' : 'none',
             padding: '1em',
             position: 'absolute',

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -5,7 +5,7 @@ import { FrontConfig } from 'types/FaciaApi';
 import CollectionOverview from './CollectionOverview';
 import { connect } from 'react-redux';
 import { CollectionItemSets } from 'shared/types/Collection';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -22,7 +22,7 @@ import SectionHeader from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';
 import { CollectionItemSets, Collection } from 'shared/types/Collection';
 
-const FrontHeader = SectionHeader.extend`
+const FrontHeader = styled(SectionHeader)`
   display: flex;
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import distanceInWords from 'date-fns/distance_in_words';
 import startCase from 'lodash/startCase';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import { Dispatch } from 'types/Store';
 import { fetchLastPressed } from 'actions/Fronts';
 import { updateCollection } from 'actions/Collections';

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -16,10 +16,11 @@ const FrontsMenuContent = styled('div')`
   padding: 0 20px;
 `;
 
-const FrontsMenuHeading = LargeSectionHeader.extend`
+const FrontsMenuHeading = styled(LargeSectionHeader)`
   padding: 10px;
   margin: 0 10px 10px;
-  border-bottom: solid 1px #5e5e5e;
+  border-bottom: ${({ theme }) =>
+    `solid 1px ${theme.base.colors.frontListBorder}`};
 `;
 
 const FrontsMenuSubHeading = styled('div')`
@@ -28,7 +29,8 @@ const FrontsMenuSubHeading = styled('div')`
   font-size: 16px;
   line-height: 30px;
   font-weight: bold;
-  border-bottom: solid 1px #5e5e5e;
+  border-bottom: ${({ theme }) =>
+    `solid 1px ${theme.base.colors.frontListBorder}`};
   max-height: 100%;
 `;
 
@@ -40,19 +42,19 @@ const ButtonOverlayContainer = styled('div')`
 
 const FrontsMenuContainer = styled('div')<{ isOpen?: boolean }>`
   z-index: 100;
-  background-color: #333;
+  background-color: ${({ theme }) => theme.shared.colors.blackLight};
   position: fixed;
   height: 100%;
   width: 390px;
   top: 0;
   right: 0;
-  color: #fff;
+  color: ${({ theme }) => theme.shared.base.colors.textLight};
   transition: transform 0.15s;
   transform: ${({ isOpen }) =>
     isOpen ? 'translate3d(0px, 0, 0)' : 'translate3d(390px, 0, 0)'};
 `;
 
-const FrontsMenuSearchInputContainer = Col.extend`
+const FrontsMenuSearchInputContainer = styled(Col)`
   position: relative;
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
-
+import { styled } from 'constants/theme';
 import FadeIn from 'shared/components/animation/FadeIn';
 import MoreImage from 'shared/images/icons/more.svg';
 import LargeSectionHeader from '../layout/LargeSectionHeader';

--- a/client-v2/src/components/GridModal.tsx
+++ b/client-v2/src/components/GridModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Modal from 'react-modal';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import ButtonDefault from 'shared/components/input/ButtonDefault';
 import deleteIcon from 'shared/images/icons/delete-copy.svg';
 
@@ -27,7 +27,7 @@ const ModalButton = styled(ButtonDefault)`
   position: absolute;
   right: 17px;
   top: 15px;
-  border-radius: 50%
+  border-radius: 50%;
   height: 27px;
   width: 27px;
 `;

--- a/client-v2/src/components/Home.tsx
+++ b/client-v2/src/components/Home.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 import { priorities } from 'constants/priorities';
 

--- a/client-v2/src/components/NotFound.tsx
+++ b/client-v2/src/components/NotFound.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { styled } from 'constants/theme';
 
 const NotFoundContainer = styled('div')`
-  background-color: #221133;
-  color: white;
+  background-color: ${({ theme }) => theme.capiInterface.feedItemText};
+  color: ${({ theme }) => theme.shared.base.colors.textLight};
   display: flex;
   font-size: 20px;
   padding: 5px;

--- a/client-v2/src/components/NotFound.tsx
+++ b/client-v2/src/components/NotFound.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 const NotFoundContainer = styled('div')`
   background-color: #221133;

--- a/client-v2/src/components/PressFailAlert.tsx
+++ b/client-v2/src/components/PressFailAlert.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import { error } from '../styleConstants';
 
 interface Props {

--- a/client-v2/src/components/Row.tsx
+++ b/client-v2/src/components/Row.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 const Row = styled('div')`
   display: flex;

--- a/client-v2/src/components/ScrollContainer.tsx
+++ b/client-v2/src/components/ScrollContainer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
-
+import { styled } from 'constants/theme';
 // TODO: get apiKey from context (or speak directly to FrontsAPI)
 
 interface ScrollContainerProps {

--- a/client-v2/src/components/TextInput.tsx
+++ b/client-v2/src/components/TextInput.tsx
@@ -8,12 +8,12 @@ const InputWrapper = styled('div')`
   position: relative;
   width: ${({ width }: { width?: number }) => width || 'auto'};
   display: flex;
-  border: solid 1px #c9c9c9;
-  background: #ffffff;
+  border: ${({ theme }) => `solid 1px ${theme.shared.input.borderColor}`};
+  background: ${({ theme }) => theme.shared.input.backgroundColor};
 `;
 
 const Input = styled(`input`)`
-  background: #fff;
+  background: ${({ theme }) => theme.shared.input.backgroundColor};
   border: none;
   width: 100%;
   height: 50px;
@@ -29,19 +29,22 @@ const Input = styled(`input`)`
   }
 `;
 
-const SmallRoundButtonOrange = SmallRoundButton.extend`
-  background-color: #ff7f0f;
+const SmallRoundButtonOrange = styled(SmallRoundButton)`
+  background-color: ${({ theme }) =>
+    theme.shared.button.backgroundColorHighlight};
   margin-right: 4px;
   padding: 4px;
   :hover {
-    background-color: #ff983f;
+    background-color: ${({ theme }) =>
+      theme.shared.button.backgroundColorHighlightFocused};
   }
 `;
 
-const SmallRoundButtonBlack = SmallRoundButton.extend`
-  background-color: #333333;
+const SmallRoundButtonBlack = styled(SmallRoundButton)`
+  background-color: ${({ theme }) => theme.shared.button.backgroundColor};
   :hover {
-    background-color: #505050;
+    background-color: ${({ theme }) =>
+      theme.shared.button.backgroundColorFocused};
   }
 `;
 

--- a/client-v2/src/components/TextInput.tsx
+++ b/client-v2/src/components/TextInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 import moreImage from 'shared/images/icons/more.svg';
 import searchImage from 'shared/images/icons/search.svg';
 import { SmallRoundButton, ClearButtonIcon } from 'util/sharedStyles/buttons';
@@ -9,7 +9,7 @@ const InputWrapper = styled('div')`
   width: ${({ width }: { width?: number }) => width || 'auto'};
   display: flex;
   border: solid 1px #c9c9c9;
-  backgroud: #fffff;
+  background: #ffffff;
 `;
 
 const Input = styled(`input`)`

--- a/client-v2/src/components/inputs/ButtonOverlay.tsx
+++ b/client-v2/src/components/inputs/ButtonOverlay.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
+import { styled } from 'constants/theme';
 import { css } from 'styled-components';
 
 import Button from 'shared/components/input/ButtonDefault';
 
-const ButtonWithShadow = Button.extend<{ active?: boolean }>`
+const ButtonWithShadow = styled(Button)<{ active?: boolean }>`
   box-shadow: 0 1px 10px 2px rgba(0, 0, 0, 0.15);
   width: 50px;
   height: 50px;
   padding: 5px;
   border-radius: 100%;
-  background-color: #121212;
+  background-color: ${({ theme }) => theme.shared.colors.blackDark};
   transition: transform 0.15s, background-color 0.15s;
   ${({ active }) =>
     active &&
     css`
       transform: rotate(45deg);
-      background-color: #ff7f0f;
+      background-color: ${({ theme }) =>
+        theme.shared.button.backgroundColorHighlight};
       &:hover {
-        background-color: #ff983f;
+        background-color: ${({ theme }) => theme.shared.colors.orangeDark};
       }
     `};
 `;

--- a/client-v2/src/components/inputs/Dropdown.tsx
+++ b/client-v2/src/components/inputs/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 interface DropdownProps {
   current?: string | void;

--- a/client-v2/src/components/inputs/RadioButtons.tsx
+++ b/client-v2/src/components/inputs/RadioButtons.tsx
@@ -18,7 +18,7 @@ const ControlIndicator = styled('div')`
   left: 0;
   width: 18px;
   height: 18px;
-  background: #fff;
+  background: ${({ theme }) => theme.shared.base.colors.backgroundColorFocused};
   /* Check mark */
   &:after {
     position: absolute;
@@ -42,7 +42,7 @@ const ControlRadio = styled('label')<{ inline?: boolean }>`
 
   & > ${ControlIndicator} {
     border-radius: 50%;
-    border: solid 1px #c9c9c9;
+    border:  ${({ theme }) => `solid 1px ${theme.shared.input.borderColor}`};
   }
 
   /* Checked state */
@@ -57,7 +57,8 @@ const ControlRadio = styled('label')<{ inline?: boolean }>`
     ${Input}:disabled ~ ${ControlIndicator} {
       pointer-events: none;
       opacity: 0.6;
-      background: #e6e6e6;
+      background:${({ theme }) =>
+        theme.base.colors.radioButtonBackgroundDisabled};
     }
   }
 
@@ -77,17 +78,19 @@ const ControlRadio = styled('label')<{ inline?: boolean }>`
       width: 12px;
       height: 12px;
       border-radius: 50%;
-      background-color: #ff7f0f;
+      background-color: ${({ theme }) =>
+        theme.shared.base.colors.highlightColor};
     }
 
     ${Input}:hover:not(:checked) ~ ${ControlIndicator}:after {
-      background-color: #ff7f0f66;
+      background-color: ${({ theme }) =>
+        theme.shared.base.colors.highlightColor};
     }
   }
 
   /* Disabled circle colour */
   & ${Input}:disabled ~ ${ControlIndicator}:after {
-    background: #7b7b7b;
+    background:${({ theme }) => theme.shared.colors.greyMedium};
   }
 `;
 

--- a/client-v2/src/components/inputs/RadioButtons.tsx
+++ b/client-v2/src/components/inputs/RadioButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 const RadioGroup = styled('div')`
   text-align: left;

--- a/client-v2/src/components/layout/LargeSectionHeader.tsx
+++ b/client-v2/src/components/layout/LargeSectionHeader.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 export default styled('div')`
   height: 60px;

--- a/client-v2/src/components/layout/LargeSectionHeader.tsx
+++ b/client-v2/src/components/layout/LargeSectionHeader.tsx
@@ -5,6 +5,6 @@ export default styled('div')`
   padding: 10px;
   font-size: 32px;
   line-height: 40px;
-  color: #fff;
+  color: ${({ theme }) => theme.shared.base.colors.textLight};
   font-family: GHGuardianHeadline-Bold;
 `;

--- a/client-v2/src/components/layout/Overlay.tsx
+++ b/client-v2/src/components/layout/Overlay.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 export default styled('div')`
   background-color: rgba(0, 0, 0, 0.5);

--- a/client-v2/src/components/layout/SectionContainer.tsx
+++ b/client-v2/src/components/layout/SectionContainer.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 export default styled('div')`
   display: flex;

--- a/client-v2/src/components/layout/SectionContent.tsx
+++ b/client-v2/src/components/layout/SectionContent.tsx
@@ -2,7 +2,8 @@ import { styled } from 'constants/theme';
 
 export default styled('div')`
   display: flex;
-  border-right: 1px solid #c9c9c9;
+  border-right: ${({ theme }) =>
+    `solid 1px ${theme.shared.base.colors.borderColor}`};
   padding: 10px;
   flex: 1;
   align-self: start;

--- a/client-v2/src/components/layout/SectionContent.tsx
+++ b/client-v2/src/components/layout/SectionContent.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 export default styled('div')`
   display: flex;

--- a/client-v2/src/components/layout/SectionHeader.tsx
+++ b/client-v2/src/components/layout/SectionHeader.tsx
@@ -1,11 +1,12 @@
+import { styled } from '../../constants/theme';
 import LargeSectionHeader from './LargeSectionHeader';
 
-const SectionHeader = LargeSectionHeader.extend`
-  background-color: #333;
-  border-right: solid 1px #dcdcdc;
+const SectionHeader = styled(LargeSectionHeader)`
+  background-color: ${({ theme }) => theme.shared.colors.blackLight};
+  border-right: ${({ theme }) => `solid 1px ${theme.shared.colors.whiteDark}`};
 `;
 
-const SectionHeaderUnpadded = SectionHeader.extend`
+const SectionHeaderUnpadded = styled(SectionHeader)`
   padding: 0;
 `;
 

--- a/client-v2/src/components/layout/SectionHeaderWithLogo.tsx
+++ b/client-v2/src/components/layout/SectionHeaderWithLogo.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
-
+import { styled } from 'constants/theme';
 import FrontsLogo from 'images/icons/fronts-logo.svg';
 import { SectionHeaderUnpadded } from './SectionHeader';
 

--- a/client-v2/src/components/layout/SectionHeaderWithLogo.tsx
+++ b/client-v2/src/components/layout/SectionHeaderWithLogo.tsx
@@ -8,7 +8,7 @@ const SectionHeader = styled(SectionHeaderUnpadded)`
 `;
 
 const LogoTypeContainer = styled('div')`
-  background-color: #121212;
+  background-color: ${({ theme }) => theme.shared.colors.blackDark};
   display: inline-block;
   padding: 0 16px;
   height: 60px;
@@ -16,7 +16,7 @@ const LogoTypeContainer = styled('div')`
 `;
 
 const LogoContainer = styled('div')`
-  background-color: #515151;
+  background-color: ${({ theme }) => theme.shared.colors.greyMediumDark};
   position: relative;
   display: inline-block;
   vertical-align: top;

--- a/client-v2/src/components/layout/SectionsContainer.tsx
+++ b/client-v2/src/components/layout/SectionsContainer.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 export default styled('div')`
   display: flex;

--- a/client-v2/src/components/util/DropDisabler.tsx
+++ b/client-v2/src/components/util/DropDisabler.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 interface DropDisablerChildren {
   children: React.ReactNode;

--- a/client-v2/src/components/util/TextHighlighter.tsx
+++ b/client-v2/src/components/util/TextHighlighter.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { styled } from 'constants/theme';
+
 const Muted = styled('span')`
   opacity: 0.5;
 `;

--- a/client-v2/src/components/util/TextHighlighter.tsx
+++ b/client-v2/src/components/util/TextHighlighter.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components';
-
+import { styled } from 'constants/theme';
 const Muted = styled('span')`
   opacity: 0.5;
 `;

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -4,14 +4,42 @@
  *  replace: `import styled from 'styled-components';`
  *  with : `import { styled } from 'constants/theme';`
  */
-import { theme as sharedTheme } from 'shared/constants/theme';
+import { theme as shared } from 'shared/constants/theme';
 import baseStyled, { ThemedStyledInterface } from 'styled-components';
+
+const base = {
+  colors: {
+    radioButtonBackgroundDisabled: '#E6E6E6',
+    dropZone: '#D6D6D6',
+    frontListBorder: '#5E5E5E',
+    frontListLabel: shared.colors.greyMediumLight,
+    frontListButton: shared.colors.greyDark
+  }
+};
+
+const capiInterface = {
+  feedItemText: '#221133', // deep purple
+  text: shared.colors.blackDark,
+  textLight: shared.colors.greyLightPinkish,
+  textVisited: shared.colors.greyMediumLight,
+  textPlaceholder: shared.colors.greyMedium,
+  border: shared.colors.greyDark,
+  borderLight: shared.colors.greyLightPinkish,
+  backgroundDark: shared.colors.whiteDark,
+  backgroundLight: shared.colors.whiteLight,
+  backgroundWhite: shared.colors.white,
+  backgroundSelected: shared.colors.orange
+};
 
 /* Additional styling exclusive to the application
  *  should be added to the extendedTheme type object
  *  along with the shared component library theme.
  */
-const extendedTheme = { sharedTheme };
+export const theme = {
+  shared,
+  base,
+  capiInterface
+};
 
-export type Theme = typeof extendedTheme;
+export type Theme = typeof theme;
 export const styled = baseStyled as ThemedStyledInterface<Theme>;

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -31,10 +31,6 @@ const capiInterface = {
   backgroundSelected: shared.colors.orange
 };
 
-/* Additional styling exclusive to the application
- *  should be added to the extendedTheme type object
- *  along with the shared component library theme.
- */
 export const theme = {
   shared,
   base,

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -1,0 +1,17 @@
+/* Strongly-typed theme property:
+ *  The default 'styled' method from styled-components is typed with 'any'.
+ *  To use the strongly-typed theme from this file, in your components
+ *  replace: `import styled from 'styled-components';`
+ *  with : `import { styled } from 'constants/theme';`
+ */
+import { theme as sharedTheme } from 'shared/constants/theme';
+import baseStyled, { ThemedStyledInterface } from 'styled-components';
+
+/* Additional styling exclusive to the application
+ *  should be added to the extendedTheme type object
+ *  along with the shared component library theme.
+ */
+const extendedTheme = { sharedTheme };
+
+export type Theme = typeof extendedTheme;
+export const styled = baseStyled as ThemedStyledInterface<Theme>;

--- a/client-v2/src/shared/components/BasePlaceholder.tsx
+++ b/client-v2/src/shared/components/BasePlaceholder.tsx
@@ -13,7 +13,8 @@ injectGlobal`
 `;
 
 export default styled('div')`
-  background-color: ${({ theme }) => theme.base.colors.backgroundColorFocused};
+  background-color: ${({ theme }) =>
+    theme.shared.base.colors.backgroundColorFocused};
   position: relative;
   overflow: hidden;
 

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -131,7 +131,8 @@ const CollectionToggleContainer = styled('div')`
   cursor: pointer;
   :hover {
     ${ButtonCircularWithTransition} {
-      background-color: ${({ theme }) => theme.button.backgroundColorFocused};
+      background-color: ${({ theme }) =>
+        theme.shared.button.backgroundColorFocused};
     }
   }
 `;

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -72,7 +72,7 @@ const CollectionDisabledTheme = styled('div')`
 const LockedCollectionFlag = styled('span')`
   font-family: GHGuardianHeadline-Regular;
   font-size: 22px;
-  color: ${({ theme }) => theme.base.colors.text};
+  color: ${({ theme }) => theme.shared.base.colors.text};
   height: 40px;
   line-height: 40px;
   font-weight: normal;
@@ -94,11 +94,11 @@ const CollectionMetaBase = styled('span')`
   padding-right: 40px;
 `;
 
-const CollectionMeta = CollectionMetaBase.extend`
+const CollectionMeta = styled(CollectionMetaBase)`
   padding-left: 10px;
 `;
 
-const ItemCountMeta = CollectionMetaBase.extend`
+const ItemCountMeta = styled(CollectionMetaBase)`
   flex: 0;
 `;
 
@@ -115,7 +115,7 @@ const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
   ${({ isLoading, theme }) =>
     isLoading &&
     css`
-      color: ${theme.base.colors.textMuted};
+      color: ${theme.shared.base.colors.textMuted};
     `} white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -140,7 +140,7 @@ const CollectionConfigContainer = styled('div')`
   display: inline-block;
   font-family: GHGuardianHeadline-Regular;
   font-size: 22px;
-  color: ${({ theme }) => theme.base.colors.text};
+  color: ${({ theme }) => theme.shared.base.colors.text};
   height: 40px;
   line-height: 40px;
   white-space: nowrap;
@@ -154,7 +154,7 @@ const CollectionConfigText = styled('div')`
 `;
 
 const CollectionConfigTextPipe = styled('span')`
-  color: ${({ theme }) => theme.base.colors.borderColor};
+  color: ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
 const CollectionShortVerticalPinline = ShortVerticalPinline.extend`

--- a/client-v2/src/shared/components/CollectionHoverItems.tsx
+++ b/client-v2/src/shared/components/CollectionHoverItems.tsx
@@ -16,7 +16,8 @@ HoverActionsAreaOverlay.defaultProps = {
 const HideMetaDataOnToolTipDisplay = styled('div')<{
   size?: 'small' | 'default'; // Article Component size
 }>`
-  background-color: ${({ theme }) => theme.base.colors.backgroundColorFocused};
+  background-color: ${({ theme }) =>
+    theme.shared.base.colors.backgroundColorFocused};
   position: absolute;
   width: 70px;
   height: ${({ size }) => (size === 'small' ? '90%' : '180%')};

--- a/client-v2/src/shared/components/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/CollectionItemBody.tsx
@@ -12,13 +12,14 @@ export default styled('div')<{
 }>`
   display: flex;
   position: relative;
-  border-top: ${({ theme }) => `1px solid ${theme.base.colors.text}`};
+  border-top: ${({ theme }) => `1px solid ${theme.shared.base.colors.text}`};
   min-height: 35px;
   cursor: pointer;
   position: relative;
   min-height: ${({ size }) => (size === 'small' ? '35px' : '83px')};
   opacity: ${({ fade }) => (fade ? 0.5 : 1)};
-  background-color: ${({ theme }) => theme.base.colors.backgroundColorLight};
+  background-color: ${({ theme }) =>
+    theme.shared.base.colors.backgroundColorLight};
 
   ${HoverActionsAreaOverlay} {
     bottom: 0;
@@ -34,7 +35,7 @@ export default styled('div')<{
 
   :hover {
     background-color: ${({ theme }) =>
-      theme.base.colors.backgroundColorFocused};
+      theme.shared.base.colors.backgroundColorFocused};
 
     ${Thumbnail} {
       opacity: 0.2;

--- a/client-v2/src/shared/components/Fadeable.tsx
+++ b/client-v2/src/shared/components/Fadeable.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'shared/constants/theme';
 
 export default styled('div')<{
   fade?: boolean;

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -4,5 +4,6 @@ export default styled('div')`
   width: 130px;
   height: 83px;
   background-size: cover;
-  background-color: ${({ theme }) => theme.base.colors.backgroundColorFocused};
+  background-color: ${({ theme }) =>
+    theme.shared.base.colors.backgroundColorFocused};
 `;

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -29,11 +29,11 @@ const ArticleBodyContainer = styled(CollectionItemBody)<{
   border-top-color: ${({ size, pillarId, isLive, theme }) =>
     size === 'default' && pillarId && isLive
       ? getPillarColor(pillarId, isLive)
-      : theme.base.colors.borderColor};
+      : theme.shared.base.colors.borderColor};
 
   :hover {
     ${CollectionItemMetaHeading} {
-      color: ${({ theme }) => theme.base.colors.textMuted};
+      color: ${({ theme }) => theme.shared.base.colors.textMuted};
     }
   }
 `;

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -35,7 +35,7 @@ const ThumbnailPlaceholder = styled(BasePlaceholder)`
 `;
 
 const NotLiveContainer = styled(CollectionItemMetaHeading)`
-  color: ${({ theme }) => theme.base.colors.highlightColor};
+  color: ${({ theme }) => theme.shared.base.colors.highlightColor};
 `;
 
 const KickerHeading = styled(CollectionItemHeading)`

--- a/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
+++ b/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
@@ -4,7 +4,7 @@ import { ArticleComponent } from '../Article';
 import 'jest-dom/extend-expect';
 import derivedArticle from 'fixtures/derivedArticle';
 import { ThemeProvider } from 'styled-components';
-import { theme } from 'shared/constants/theme';
+import { theme } from '../../../../constants/theme';
 
 const takenDownArticle = { ...derivedArticle, ...{ isLive: false } };
 

--- a/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
@@ -20,7 +20,8 @@ export default styled('div')<{
     displayType === 'default' &&
     css`
       display: flex;
-      border-top: ${({ theme }) => `1px solid ${theme.base.colors.text}`};
+      border-top: ${({ theme }) =>
+        `1px solid ${theme.shared.base.colors.text}`};
     `}
   ${({ displayType }) =>
     displayType === 'polaroid' &&
@@ -31,7 +32,7 @@ export default styled('div')<{
   cursor: pointer;
   background-color: ${({ displayType, theme }) =>
     displayType === 'default'
-      ? theme.base.colors.backgroundColorLight
+      ? theme.shared.base.colors.backgroundColorLight
       : 'transparent'};
   opacity: ${({ fade }) => (fade ? 0.5 : 1)};
 
@@ -50,7 +51,7 @@ export default styled('div')<{
   :hover {
     background-color: ${({ displayType, theme }) =>
       displayType === 'default'
-        ? theme.base.colors.backgroundColorFocused
+        ? theme.shared.base.colors.backgroundColorFocused
         : 'transparent'};
 
       ${HoverActionsAreaOverlay} {

--- a/client-v2/src/shared/components/collectionItem/CollectionItemNotification.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemNotification.tsx
@@ -6,8 +6,8 @@ export default styled('div')`
   opacity: 1;
   position: absolute;
   right: 0;
-  color: ${({ theme }) => theme.base.colors.textDark};
+  color: ${({ theme }) => theme.shared.base.colors.textDark};
   font-size: 12px;
   font-weight: bold;
-  background-color: ${({ theme }) => theme.base.colors.backgroundColor};
+  background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
 `;

--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -15,7 +15,7 @@ export const ButtonCircularWithTransition = ButtonCircular.extend<{
 
   ${({ highlight, theme }) =>
     highlight
-      ? `background-color: ${theme.button.backgroundColorHighlight}`
+      ? `background-color: ${theme.shared.button.backgroundColorHighlight}`
       : ``};
 `;
 

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -61,12 +61,12 @@ const colorMap = {
 
 const backgroundMap = {
   disabled: {
-    default: theme.colors.greyMedium,
+    default: theme.colors.greyMediumLight,
     primary: theme.colors.orangeDark,
     muted: theme.colors.greyLight
   },
   selected: {
-    default: theme.colors.greyDark,
+    default: theme.colors.greyMediumDark,
     primary: theme.colors.orangeLight,
     muted: theme.colors.greyLight
   },
@@ -79,17 +79,17 @@ const backgroundMap = {
 
 const backgroundHoverMap = {
   disabled: {
-    default: theme.colors.greyMedium,
+    default: theme.colors.greyMediumLight,
     primary: theme.colors.orangeDark,
     muted: theme.colors.greyLight
   },
   selected: {
-    default: theme.colors.greyDark,
+    default: theme.colors.greyMediumDark,
     primary: theme.colors.orangeLight,
     muted: theme.colors.greyLight
   },
   deselected: {
-    default: theme.colors.greyDark,
+    default: theme.colors.greyMediumDark,
     primary: theme.colors.orangeLight,
     muted: theme.colors.greyLight
   }

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -32,17 +32,17 @@ const Icon = styled('img')`
 const ActionButton = ButtonCircular.extend<{ danger?: boolean }>`
   background: ${({ danger, theme }) =>
     danger
-      ? theme.button.backgroundColorHighlight
-      : theme.button.backgroundColor};
-  color: ${({ theme }) => theme.button.color};
+      ? theme.shared.button.backgroundColorHighlight
+      : theme.shared.button.backgroundColor};
+  color: ${({ theme }) => theme.shared.button.color};
   margin: 1.5px;
   margin-bottom: 2px;
   line-height: 1;
   &:hover {
     background: ${({ danger, theme }) =>
       danger
-        ? theme.button.backgroundColorHighlightFocused
-        : theme.button.backgroundColorFocused};
+        ? theme.shared.button.backgroundColorHighlightFocused
+        : theme.shared.button.backgroundColorFocused};
   }
 `;
 

--- a/client-v2/src/shared/components/input/HoverActionToolTip.tsx
+++ b/client-v2/src/shared/components/input/HoverActionToolTip.tsx
@@ -4,8 +4,8 @@ import { styled } from 'shared/constants/theme';
 const ToolTip = styled('div')<{ text: string }>`
   font-family: TS3TextSans-Bold;
   font-size: 12px;
-  color: ${({ theme }) => theme.button.color};
-  background-color: ${({ theme }) => theme.base.colors.button};
+  color: ${({ theme }) => theme.shared.button.color};
+  background-color: ${({ theme }) => theme.shared.base.colors.button};
   padding: 2px 3px;
 `;
 

--- a/client-v2/src/shared/components/input/InputBase.ts
+++ b/client-v2/src/shared/components/input/InputBase.ts
@@ -5,24 +5,24 @@ export default styled('input')<{
 }>`
   display: block;
   appearance: none;
-  height: ${props => props.theme.input.height};
-  padding: ${props => props.theme.input.paddingY}
-    ${props => props.theme.input.paddingX};
+  height: ${props => props.theme.shared.input.height};
+  padding: ${props => props.theme.shared.input.paddingY}
+    ${props => props.theme.shared.input.paddingX};
   font-size: ${props =>
     props.useHeadlineFont
-      ? props.theme.input.fontSizeHeadline
-      : props.theme.input.fontSize};
-  color: ${props => props.theme.input.color};
-  background-color: ${props => props.theme.input.backgroundColor};
-  border: 1px solid ${props => props.theme.input.borderColor};
+      ? props.theme.shared.input.fontSizeHeadline
+      : props.theme.shared.input.fontSize};
+  color: ${props => props.theme.shared.input.color};
+  background-color: ${props => props.theme.shared.input.backgroundColor};
+  border: 1px solid ${props => props.theme.shared.input.borderColor};
   width: 100%;
   background-clip: padding-box;
   ${props => props.useHeadlineFont && `font-family: GHGuardianHeadline-Medium`};
   ::placeholder {
-    color: ${props => props.theme.input.placeholderText};
+    color: ${props => props.theme.shared.input.placeholderText};
   }
   :focus {
     outline: none;
-    border: solid 1px ${props => props.theme.input.borderColorFocus};
+    border: solid 1px ${props => props.theme.shared.input.borderColorFocus};
   }
 `;

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -11,7 +11,7 @@ const CheckboxContainer = styled('div')`
 `;
 
 const Label = InputLabel.extend`
-  color: ${props => props.theme.base.colors.textMuted};
+  color: ${props => props.theme.shared.base.colors.textMuted};
 `;
 
 const Switch = styled('div')`
@@ -30,21 +30,21 @@ const CheckboxLabel = styled('label')`
   height: 24px;
   padding: 0;
   line-height: 24px;
-  border: ${({ theme }) => `2px solid ${theme.input.borderColor}`};
+  border: ${({ theme }) => `2px solid ${theme.shared.input.borderColor}`};
   border-radius: 24px;
-  background-color: ${({ theme }) => theme.input.checkboxColorInactive};
+  background-color: ${({ theme }) => theme.shared.input.checkboxColorInactive};
   transition: background-color 0.1s ease-in;
   :before {
     content: '';
     display: block;
     width: 24px;
     margin: 0px;
-    background: ${({ theme }) => theme.input.checkboxColorInactive};
+    background: ${({ theme }) => theme.shared.input.checkboxColorInactive};
     position: absolute;
     top: 0;
     bottom: 0;
     right: 16px;
-    border: ${({ theme }) => `2px solid ${theme.input.borderColor}`};
+    border: ${({ theme }) => `2px solid ${theme.shared.input.borderColor}`};
     border-radius: 24px;
     transition: all 0.1s ease-in 0s;
   }
@@ -53,10 +53,10 @@ const CheckboxLabel = styled('label')`
 const Checkbox = styled('input')`
   display: none;
   :checked + ${CheckboxLabel} {
-    background-color: ${({ theme }) => theme.input.checkboxColorActive};
+    background-color: ${({ theme }) => theme.shared.input.checkboxColorActive};
   }
   &:checked + ${CheckboxLabel}, &:checked + ${CheckboxLabel}:before {
-    border-color: ${({ theme }) => theme.input.checkboxColorActive};
+    border-color: ${({ theme }) => theme.shared.input.checkboxColorActive};
     right: 0px;
   }
 `;

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -25,8 +25,8 @@ const ImageContainer = styled('div')<{
   height: ${props => (props.size === 'small' ? '60px' : '115px')};
   background-color: ${props =>
     props.isHovering
-      ? props.theme.base.colors.placeholderLight
-      : props.theme.base.colors.placeholderDark};
+      ? props.theme.shared.base.colors.placeholderLight
+      : props.theme.shared.base.colors.placeholderDark};
   background-size: cover;
   transition: background-color 0.15s;
 `;
@@ -52,7 +52,7 @@ const IconDelete = styled('img')`
   left: 9px;
 `;
 
-const IconAdd = IconDelete.extend`
+const IconAdd = styled(IconDelete)`
   transform: rotate(45deg);
 `;
 

--- a/client-v2/src/shared/components/input/InputLabel.ts
+++ b/client-v2/src/shared/components/input/InputLabel.ts
@@ -8,9 +8,9 @@ export default styled('label')<{
   display: block;
   font-size: ${props =>
     props.size === 'sm'
-      ? props.theme.label.fontSizeSmall
-      : props.theme.label.fontSize};
-  line-height: ${props => props.theme.label.lineHeight};
+      ? props.theme.shared.label.fontSizeSmall
+      : props.theme.shared.label.fontSize};
+  line-height: ${props => props.theme.shared.label.lineHeight};
   font-weight: bold;
   ${props => !props.active && `color:`};
 `;

--- a/client-v2/src/shared/components/input/__tests__/HoverActions.spec.tsx
+++ b/client-v2/src/shared/components/input/__tests__/HoverActions.spec.tsx
@@ -13,7 +13,7 @@ import {
   HoverOphanButton
 } from '../HoverActionButtons';
 import { ThemeProvider } from 'styled-components';
-import { theme } from 'shared/constants/theme';
+import { theme } from '../../../../constants/theme';
 
 afterEach(cleanup);
 

--- a/client-v2/src/shared/components/layout/ContentContainer.ts
+++ b/client-v2/src/shared/components/layout/ContentContainer.ts
@@ -4,12 +4,12 @@ export default styled('div')<{
   setBack?: boolean;
 }>`
   background-color: ${({ setBack, theme }) =>
-    setBack ? 'transparent' : theme.base.colors.backgroundColor};
+    setBack ? 'transparent' : theme.shared.base.colors.backgroundColor};
   position: relative;
   padding: 0 10px 10px 10px;
-  box-shadow: ${({ theme }) => `0 -1px 0 ${theme.base.colors.text}`};
+  box-shadow: ${({ theme }) => `0 -1px 0 ${theme.shared.base.colors.text}`};
   border: ${({ setBack, theme }) =>
-    setBack ? 'none' : `1px solid ${theme.base.colors.borderColor}`};
+    setBack ? 'none' : `1px solid ${theme.shared.base.colors.borderColor}`};
   border-top: none;
   & + & {
     margin-top: 10px;

--- a/client-v2/src/shared/components/layout/HorizontalRule.ts
+++ b/client-v2/src/shared/components/layout/HorizontalRule.ts
@@ -3,6 +3,7 @@ import { styled } from 'shared/constants/theme';
 export default styled('div')<{ noMargin?: boolean }>`
   width: 100%;
   height: 1px;
-  border-top: ${({ theme }) => `1px solid ${theme.base.colors.borderColor}`};
+  border-top: ${({ theme }) =>
+    `1px solid ${theme.shared.base.colors.borderColor}`};
   margin: ${props => (props.noMargin ? '0' : '6px')} 0;
 `;

--- a/client-v2/src/shared/components/layout/ShortVerticalPinline.ts
+++ b/client-v2/src/shared/components/layout/ShortVerticalPinline.ts
@@ -7,5 +7,6 @@ export default styled('div')`
   top: 0;
   right: 0;
   height: 20px;
-  border-right: ${({ theme }) => `1px solid ${theme.base.colors.borderColor}`};
+  border-right: ${({ theme }) =>
+    `1px solid ${theme.shared.base.colors.borderColor}`};
 `;

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -29,7 +29,7 @@ import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaConte
 import CollectionItemNotification from '../collectionItem/CollectionItemNotification';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
-  border-top-color: ${({ theme }) => theme.base.colors.borderColor};
+  border-top-color: ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
 interface ContainerProps {

--- a/client-v2/src/shared/components/typography/ContainerHeading.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeading.ts
@@ -7,7 +7,7 @@ const ContainerHeading = styled('div')`
   line-height: 22px;
   font-weight: bold;
   font-style: normal;
-  color: ${({ theme }) => theme.base.colors.text};
+  color: ${({ theme }) => theme.shared.base.colors.text};
 `;
 
 export default ContainerHeading;

--- a/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
@@ -1,7 +1,8 @@
 import ContainerHeading from './ContainerHeading';
 
 export default ContainerHeading.extend`
-  border-bottom: ${({ theme }) => `1px solid ${theme.base.colors.borderColor}`};
+  border-bottom: ${({ theme }) =>
+    `1px solid ${theme.shared.base.colors.borderColor}`};
   height: 40px;
   line-height: 40px;
   vertical-align: middle;

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -10,8 +10,10 @@ import baseStyled, { ThemedStyledInterface } from 'styled-components';
 const colors = {
   blackDark: '#121212', // darkest
   blackLight: '#333',
-  greyDark: '#515151',
-  greyMedium: '#999999',
+  greyDark: '#444444', //
+  greyMediumDark: '#515151',
+  greyMedium: '#767676', //
+  greyMediumLight: '#999999',
   greyLight: '#A9A9A9',
   greyLightPinkish: '#C9C9C9',
   whiteDark: '#DCDCDC',
@@ -26,13 +28,13 @@ const colors = {
 const base = {
   colors: {
     text: colors.blackLight,
-    textMuted: colors.greyMedium,
+    textMuted: colors.greyMediumLight,
     textLight: colors.white,
     textDark: colors.blackDark,
     highlightColor: colors.orange,
     highlightColorFocused: colors.orangeLight,
     button: colors.blackLight,
-    buttonFocused: colors.greyDark,
+    buttonFocused: colors.greyMediumDark,
     backgroundColor: colors.whiteLight,
     backgroundColorLight: colors.white,
     backgroundColorFocused: colors.whiteMedium,

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -84,4 +84,7 @@ export const theme = {
 };
 
 export type Theme = typeof theme;
-export const styled = baseStyled as ThemedStyledInterface<Theme>;
+interface SharedTheme {
+  shared: Theme;
+}
+export const styled = baseStyled as ThemedStyledInterface<SharedTheme>;

--- a/client-v2/src/util/sharedStyles/buttons.ts
+++ b/client-v2/src/util/sharedStyles/buttons.ts
@@ -1,6 +1,6 @@
 // @flow
 
-import styled from 'styled-components';
+import { styled } from 'constants/theme';
 
 export const SmallRoundButton = styled('button')`
   appearance: none;


### PR DESCRIPTION
## What's changed?

This PR completes removal of all remaining hex codes in unshared components. The tool otherwise looks and performs the same. 

## Implementation notes

There are two 'theme' files: `shared/constants/theme` and `constants/theme` which incorporates the shared theme typings.  Please refer to these and expand on them as needed when adding colors going forward. 

Some `rgb` colors with alpha channels have not been changed. 

## Checklist

### General
- N/A 🤖 Relevant tests added 
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors) 

⚠️  I am getting the error below in local dev tools but it is not on Code. Any help understanding why would be appreciated as this doesn't seem related to any code I changed :) 
![image](https://user-images.githubusercontent.com/32312712/52223769-493a1d80-289e-11e9-9664-44a1ac2c7134.png)

- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- N/A 📷 Screenshots / GIFs of relevant UI changes included
