### PR TITLE
Drop crop

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -26,6 +26,8 @@ import { State } from 'types/State';
 import { startConfirmModal } from './ConfirmModal';
 import { capGroupSiblings } from 'shared/actions/Groups';
 import { collectionCapSelector } from 'selectors/configSelectors';
+import { getImageMetaFromValidationResponse } from 'util/form';
+import { ValidationResponse } from 'shared/util/validateImageSrc';
 
 type InsertActionCreator = (
   id: string,
@@ -289,10 +291,20 @@ const moveArticleFragment = (
   };
 };
 
+const addImageToArticleFragment = (
+  uuid: string,
+  imageData: ValidationResponse
+) =>
+  updateArticleFragmentMeta(
+    uuid,
+    getImageMetaFromValidationResponse(imageData)
+  );
+
 export {
   insertArticleFragmentWithCreate as insertArticleFragment,
   moveArticleFragment,
   updateArticleFragmentMetaWithPersist as updateArticleFragmentMeta,
   updateClipboardArticleFragmentMetaWithPersist as updateClipboardArticleFragmentMeta,
-  removeArticleFragment
+  removeArticleFragment,
+  addImageToArticleFragment
 };

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -17,7 +17,8 @@ import {
 } from './utils';
 import {
   moveArticleFragment,
-  insertArticleFragment
+  insertArticleFragment,
+  addImageToArticleFragment
 } from 'actions/ArticleFragments';
 import {
   reducer as collectionsReducer,
@@ -291,6 +292,41 @@ describe('ArticleFragments actions', () => {
         accept: null
       });
       expect(groupArticlesSelector(s1, 'a')).toEqual(['b', 'a', 'c']);
+    });
+  });
+
+  describe('insert image', () => {
+    fit('adds the correct image data', () => {
+      const s1 = root(
+        { shared: { articleFragments: { a: {} } } },
+        { type: '@@INIT' }
+      );
+
+      const src = 'http://www.images.com/image/1/master';
+      const thumb = 'http://www.images.com/image/1/thumb';
+      const origin = 'http://www.images.com/image/1';
+      const height = 3000;
+      const width = 3000;
+
+      const s2 = root(
+        s1,
+        addImageToArticleFragment('a', {
+          src,
+          thumb,
+          origin,
+          height,
+          width
+        })
+      );
+
+      expect(s2.shared.articleFragments.a.meta).toMatchObject({
+        imageReplace: true,
+        imageSrc: src,
+        imageSrcThumb: thumb,
+        imageSrcOrigin: origin,
+        imageSrcWidth: width.toString(),
+        imageSrcHeight: height.toString()
+      });
     });
   });
 });

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -6,7 +6,8 @@ import { State } from 'types/State';
 import { insertArticleFragmentFromDropEvent } from 'util/collectionUtils';
 import {
   moveArticleFragment,
-  removeArticleFragment
+  removeArticleFragment,
+  updateArticleFragmentMeta
 } from 'actions/ArticleFragments';
 import {
   editorSelectArticleFragment,
@@ -16,7 +17,10 @@ import {
   editorCloseClipboard
 } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
-import { ArticleFragment as TArticleFragment } from 'shared/types/Collection';
+import {
+  ArticleFragment as TArticleFragment,
+  ArticleFragmentMeta
+} from 'shared/types/Collection';
 import ClipboardLevel from './clipboard/ClipboardLevel';
 import ArticleFragmentLevel from './clipboard/ArticleFragmentLevel';
 import CollectionItem from './FrontsEdit/CollectionComponents/CollectionItem';
@@ -192,6 +196,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
   toggleClipboard: (open: boolean) =>
     dispatch(open ? editorOpenClipboard() : editorCloseClipboard()),
+  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) =>
+    dispatch(updateArticleFragmentMeta(id, meta)),
   dispatch
 });
 

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -42,6 +42,7 @@ import {
 } from 'util/form';
 import { CapiTextFields } from 'util/form';
 import { Dispatch } from 'types/Store';
+import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
 
 interface ComponentProps extends ContainerProps {
   articleFragmentId: string;
@@ -96,12 +97,6 @@ const ImageWrapper = styled('div')`
   transition: opacity 0.15s;
   opacity: ${(props: { faded: boolean }) => (props.faded ? 0.6 : 1)};
 `;
-
-const imageCriteria = {
-  minWidth: 400,
-  widthAspectRatio: 5,
-  heightAspectRatio: 3
-};
 
 const renderSlideshow = (
   { fields }: WrappedFieldArrayProps<ImageData>,

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -45,17 +45,22 @@ type ArticleContainerProps = ContainerProps & {
 };
 
 class CollectionItem extends React.Component<ArticleContainerProps> {
-  public onDrop = (e: React.DragEvent<HTMLElement>) => {
-    e.preventDefault();
-    e.persist();
-    validateImageEvent(e, this.props.frontId, imageCriteria)
-      .then(this.props.onImageDrop)
-      .catch(err => {
-        // swallowing errors here as the drop may well be an articleFragment
-        // rather than an image which is expected - TBD
-        // console.log('@todo:handle error', err);
-      });
-  };
+  public getDropHandler(onDrop?: (data: ValidationResponse) => void) {
+    if (!onDrop) {
+      return;
+    }
+    return (e: React.DragEvent<HTMLElement>) => {
+      e.preventDefault();
+      e.persist();
+      validateImageEvent(e, this.props.frontId, imageCriteria)
+        .then(onDrop)
+        .catch(err => {
+          // swallowing errors here as the drop may well be an articleFragment
+          // rather than an image which is expected - TBD
+          // console.log('@todo:handle error', err);
+        });
+    };
+  }
 
   public render() {
     const {
@@ -93,7 +98,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             displayType={displayType}
             notifications={notifications}
             imageDropTypes={Object.values(gridDataTransferTypes)}
-            onImageDrop={this.onDrop}
+            onImageDrop={this.getDropHandler(this.props.onImageDrop)}
           >
             {children}
           </Article>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -18,7 +18,10 @@ import {
   validateImageEvent,
   ValidationResponse
 } from 'shared/util/validateImageSrc';
-import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
+import {
+  articleFragmentImageCriteria as imageCriteria,
+  gridDataTransferTypes
+} from 'constants/image';
 
 interface ContainerProps {
   uuid: string;
@@ -81,9 +84,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
           <Article
             id={uuid}
             isUneditable={isUneditable}
-            {...getNodeProps({
-              onDrop: this.onDrop
-            })}
+            {...getNodeProps()}
             onDelete={onDelete}
             onAddToClipboard={() => onAddToClipboard(uuid)}
             onClick={() => onSelect(uuid)}
@@ -91,6 +92,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             size={size}
             displayType={displayType}
             notifications={notifications}
+            imageDropTypes={Object.values(gridDataTransferTypes)}
+            onImageDrop={this.onDrop}
           >
             {children}
           </Article>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -27,7 +27,7 @@ interface ContainerProps {
   uuid: string;
   frontId: string;
   children?: React.ReactNode;
-  getNodeProps: (extraProps?: object) => object;
+  getNodeProps: () => object;
   onSelect: (uuid: string) => void;
   onDelete: (uuid: string) => void;
   onImageDrop?: (data: ValidationResponse) => void;

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -164,7 +164,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                           onMove={this.handleMove}
                           onDrop={this.handleInsert}
                         >
-                          {(articleFragment, getAfDragProps) => {
+                          {(articleFragment, afDragProps) => {
                             collectionItemCount += 1;
                             const articleNotifications: string[] = [];
                             if (
@@ -193,8 +193,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                 uuid={articleFragment.uuid}
                                 parentId={group.uuid}
                                 isUneditable={isUneditable}
-                                getNodeProps={
-                                  !isUneditable ? getAfDragProps : () => ({})
+                                getNodeProps={() =>
+                                  !isUneditable ? afDragProps : {}
                                 }
                                 onSelect={this.props.selectArticleFragment}
                                 onDelete={() =>
@@ -211,7 +211,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                   onMove={this.handleMove}
                                   onDrop={this.handleInsert}
                                 >
-                                  {(supporting, getSupportingDragProps) => (
+                                  {(supporting, supportingDragProps) => (
                                     <CollectionItem
                                       frontId={this.props.id}
                                       uuid={supporting.uuid}
@@ -223,10 +223,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                         )
                                       }
                                       isUneditable={isUneditable}
-                                      getNodeProps={
-                                        !isUneditable
-                                          ? getSupportingDragProps
-                                          : () => ({})
+                                      getNodeProps={() =>
+                                        !isUneditable ? supportingDragProps : {}
                                       }
                                       onDelete={() =>
                                         this.props.removeSupportingCollectionItem(

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -8,7 +8,7 @@ import { Dispatch } from 'types/Store';
 import {
   removeArticleFragment,
   moveArticleFragment,
-  updateArticleFragmentMeta
+  addImageToArticleFragment
 } from 'actions/ArticleFragments';
 import { insertArticleFragmentFromDropEvent } from 'util/collectionUtils';
 import { AlsoOnDetail } from 'types/Collection';
@@ -19,8 +19,7 @@ import {
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
-  ArticleFragment as TArticleFragment,
-  ArticleFragmentMeta
+  ArticleFragment as TArticleFragment
 } from 'shared/types/Collection';
 import Collection from './CollectionComponents/Collection';
 import GroupDisplay from 'shared/components/GroupDisplay';
@@ -35,7 +34,6 @@ import { events } from 'services/GA';
 import FrontDetailView from './FrontDetailView';
 import CollectionItem from './CollectionComponents/CollectionItem';
 import { ValidationResponse } from 'shared/util/validateImageSrc';
-import { getImageMetaFromValidationResponse } from 'util/form';
 
 const FrontContainer = styled('div')`
   display: flex;
@@ -62,7 +60,7 @@ type FrontProps = FrontPropsBeforeState & {
   removeCollectionItem: (parentId: string, id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
   editorOpenCollections: (ids: string[]) => void;
-  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) => void;
+  addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   front: FrontConfig;
   articlesVisible: { [id: string]: VisibleArticlesResponse };
 };
@@ -114,16 +112,6 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
       insertArticleFragmentFromDropEvent(e, to, 'collection')
     );
   };
-
-  public addImageToArticleFragment(
-    uuid: string,
-    imageData: ValidationResponse
-  ) {
-    this.props.updateArticleFragmentMeta(
-      uuid,
-      getImageMetaFromValidationResponse(imageData)
-    );
-  }
 
   public render() {
     const { front, articlesVisible } = this.props;
@@ -185,7 +173,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                               <CollectionItem
                                 frontId={this.props.id}
                                 onImageDrop={imageData => {
-                                  this.addImageToArticleFragment(
+                                  this.props.addImageToArticleFragment(
                                     articleFragment.uuid,
                                     imageData
                                   );
@@ -295,8 +283,8 @@ const mapDispatchToProps = (
     },
     editorOpenCollections: (ids: string[]) =>
       dispatch(editorOpenCollections(ids)),
-    updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) =>
-      updateArticleFragmentMeta(id, meta)
+    addImageToArticleFragment: (id: string, response: ValidationResponse) =>
+      dispatch(addImageToArticleFragment(id, response))
   };
 };
 

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -7,7 +7,6 @@ import { CollectionItemDisplayTypes } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createSupportingArticlesSelector } from 'shared/selectors/shared';
-import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   articleFragmentId: string;
@@ -35,7 +34,6 @@ const ArticleFragmentLevel = ({
 }: Props) => (
   <Level
     arr={supporting || []}
-    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="articleFragment"
     parentId={articleFragmentId}
     type="articleFragment"
@@ -43,9 +41,9 @@ const ArticleFragmentLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
-    renderDrop={(getProps, isTarget) => (
+    renderDrop={(props, isTarget) => (
       <DropZone
-        {...getProps()}
+        {...props}
         disabled={isUneditable}
         override={isTarget}
         dropColor="hsl(0, 0%, 64%)"

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -7,6 +7,7 @@ import { CollectionItemDisplayTypes } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createSupportingArticlesSelector } from 'shared/selectors/shared';
+import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   articleFragmentId: string;
@@ -34,6 +35,7 @@ const ArticleFragmentLevel = ({
 }: Props) => (
   <Level
     arr={supporting || []}
+    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="articleFragment"
     parentId={articleFragmentId}
     type="articleFragment"
@@ -41,9 +43,9 @@ const ArticleFragmentLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
-    renderDrop={(props, isTarget) => (
+    renderDrop={(getProps, isTarget) => (
       <DropZone
-        {...props}
+        {...getProps()}
         disabled={isUneditable}
         override={isTarget}
         dropColor="hsl(0, 0%, 64%)"

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -7,6 +7,7 @@ import { CollectionItemDisplayTypes } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createSupportingArticlesSelector } from 'shared/selectors/shared';
+import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   articleFragmentId: string;
@@ -34,6 +35,7 @@ const ArticleFragmentLevel = ({
 }: Props) => (
   <Level
     arr={supporting || []}
+    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="articleFragment"
     parentId={articleFragmentId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -34,9 +34,9 @@ const ClipboardLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
-    renderDrop={(props, isTarget, index) => (
+    renderDrop={(getProps, isTarget, index) => (
       <DropZone
-        {...props}
+        {...getProps()}
         override={isTarget}
         style={{
           flexBasis: '15px',

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
+import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   children: LevelChild<ArticleFragment>;
@@ -26,6 +27,7 @@ const ClipboardLevel = ({
   onDrop
 }: Props) => (
   <Level
+    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     arr={articleFragments}
     parentType="clipboard"
     parentId="clipboard"

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -34,9 +34,9 @@ const ClipboardLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
-    renderDrop={(getProps, isTarget, index) => (
+    renderDrop={(props, isTarget, index) => (
       <DropZone
-        {...getProps()}
+        {...props}
         override={isTarget}
         style={{
           flexBasis: '15px',

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -6,6 +6,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
+import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   groupId: string;
@@ -31,6 +32,7 @@ const GroupLevel = ({
 }: Props) => (
   <Level
     arr={articleFragments}
+    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="group"
     parentId={groupId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -6,6 +6,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
+import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   groupId: string;
@@ -31,6 +32,7 @@ const GroupLevel = ({
 }: Props) => (
   <Level
     arr={articleFragments}
+    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="group"
     parentId={groupId}
     type="articleFragment"
@@ -38,8 +40,8 @@ const GroupLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
-    renderDrop={(props, isTarget) => (
-      <DropZone {...props} disabled={isUneditable} override={isTarget} />
+    renderDrop={(getProps, isTarget) => (
+      <DropZone {...getProps()} disabled={isUneditable} override={isTarget} />
     )}
   >
     {children}

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -6,7 +6,6 @@ import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
-import { gridDataTransferTypes } from 'constants/image';
 
 interface OuterProps {
   groupId: string;
@@ -32,7 +31,6 @@ const GroupLevel = ({
 }: Props) => (
   <Level
     arr={articleFragments}
-    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="group"
     parentId={groupId}
     type="articleFragment"
@@ -40,8 +38,8 @@ const GroupLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
-    renderDrop={(getProps, isTarget) => (
-      <DropZone {...getProps()} disabled={isUneditable} override={isTarget} />
+    renderDrop={(props, isTarget) => (
+      <DropZone {...props} disabled={isUneditable} override={isTarget} />
     )}
   >
     {children}

--- a/client-v2/src/constants/image.ts
+++ b/client-v2/src/constants/image.ts
@@ -1,0 +1,11 @@
+export const articleFragmentImageCriteria = {
+  minWidth: 400,
+  widthAspectRatio: 5,
+  heightAspectRatio: 3
+};
+
+export const gridDataTransferTypes = {
+  cropsData: 'application/vnd.mediaservice.crops+json',
+  gridUrl: 'application/vnd.mediaservice.kahuna.uri',
+  imageData: 'application/vnd.mediaservice.image+json'
+};

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -37,22 +37,14 @@ interface Move<T> {
   to: PosSpec;
 }
 
-type DragHandler = (e: React.DragEvent) => void;
-
 interface DropProps {
-  onDragOver: DragHandler;
-  onDrop: DragHandler;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
 }
-
-type EventProps = { [K in keyof DropProps]?: DropProps[K] };
-
-type ChildPropGetter = (
-  maybeDropProps?: EventProps
-) => DropProps & NodeChildrenProps;
 
 type LevelChild<T> = (
   node: T,
-  getChildProps: ChildPropGetter,
+  props: DropProps & NodeChildrenProps,
   index: number
 ) => React.ReactNode;
 
@@ -70,13 +62,10 @@ interface OuterProps<T> {
   onDrop: (e: React.DragEvent, to: PosSpec) => void;
   renderDrag?: (data: T) => React.ReactNode;
   renderDrop: (
-    getDropProps: (maybeDropProps?: EventProps) => DropProps,
+    props: DropProps,
     isTarget: boolean,
     index: number
   ) => React.ReactNode;
-  // any occurence of these in the data transfer will cause all dragging
-  // behaviour to be bypassed
-  blockingDataTransferTypes?: string[];
 }
 
 interface ContextProps {
@@ -105,14 +94,7 @@ class Level<T> extends React.Component<Props<T>> {
         {arr.map((node, i) => (
           <React.Fragment key={getId(node)}>
             <DropZone parentKey={this.key} index={i}>
-              {isTarget =>
-                renderDrop(
-                  (maybeDropProps: EventProps = {}) =>
-                    this.getDropProps(i, maybeDropProps),
-                  isTarget,
-                  i
-                )
-              }
+              {isTarget => renderDrop(this.getDropProps(i), isTarget, i)}
             </DropZone>
             <Node
               renderDrag={renderDrag}
@@ -121,34 +103,16 @@ class Level<T> extends React.Component<Props<T>> {
               index={i}
               data={node}
             >
-              {nodeProps =>
-                children(
-                  node,
-                  (maybeDropProps: EventProps = {}) =>
-                    this.getNodeProps(i, nodeProps, maybeDropProps),
-                  i
-                )
-              }
+              {props => children(node, this.getNodeProps(i, props), i)}
             </Node>
           </React.Fragment>
         ))}
         <DropZone parentKey={this.key} index={arr.length}>
           {isTarget =>
-            renderDrop(
-              (maybeDropProps: EventProps = {}) =>
-                this.getDropProps(arr.length, maybeDropProps),
-              isTarget,
-              arr.length
-            )
+            renderDrop(this.getDropProps(arr.length), isTarget, arr.length)
           }
         </DropZone>
       </>
-    );
-  }
-
-  private dragEventIsBlacklisted(e: React.DragEvent) {
-    return e.dataTransfer.types.some(type =>
-      (this.props.blockingDataTransferTypes || []).includes(type)
     );
   }
 
@@ -156,38 +120,23 @@ class Level<T> extends React.Component<Props<T>> {
     return i + (isNode ? getDropIndexOffset(e) : 0);
   }
 
-  private onDragOver = (
-    i: number,
-    isNode: boolean,
-    handleDragOver: DragHandler = () => {}
-  ) => (e: React.DragEvent) => {
-    e.preventDefault();
-    handleDragOver(e);
+  private onDragOver = (i: number, isNode: boolean) => (e: React.DragEvent) => {
     if (!this.props.store) {
       throw new Error(NO_STORE_ERROR);
     }
-    if ((e as any).wasHandled || this.dragEventIsBlacklisted(e)) {
+    if (e.defaultPrevented) {
       return;
     }
-    // TODO: uncool
-    (e as any).wasHandled = true;
+    e.preventDefault();
     this.props.store.update(this.key, this.getDropIndex(e, i, isNode));
   };
 
-  private onDrop = (
-    i: number,
-    isNode: boolean,
-    handleDrop: DragHandler = () => {}
-  ) => (e: React.DragEvent) => {
-    // defaultPrevented is being used as a way to communicate whether something
-    // has already prevented
-    handleDrop(e);
-    if ((e as any).wasHandled || this.dragEventIsBlacklisted(e)) {
+  private onDrop = (i: number, isNode: boolean) => (e: React.DragEvent) => {
+    if (e.defaultPrevented) {
       return;
     }
-    // TODO: uncool
-    (e as any).wasHandled = true;
 
+    e.preventDefault();
     const { onMove = () => null, onDrop = () => null } = this.props;
     const af = e.dataTransfer.getData(TRANSFER_TYPE);
 
@@ -219,24 +168,18 @@ class Level<T> extends React.Component<Props<T>> {
     }
   };
 
-  private getDropProps(i: number, maybeDropProps: EventProps) {
+  private getDropProps(i: number) {
     return {
-      ...maybeDropProps,
-      onDragOver: this.onDragOver(i, false, maybeDropProps.onDragOver),
-      onDrop: this.onDrop(i, false, maybeDropProps.onDrop)
+      onDragOver: this.onDragOver(i, false),
+      onDrop: this.onDrop(i, false)
     };
   }
 
-  private getNodeProps(
-    i: number,
-    props: NodeChildrenProps,
-    maybeDropProps: EventProps
-  ) {
+  private getNodeProps(i: number, props: NodeChildrenProps) {
     return {
-      ...maybeDropProps,
       ...props,
-      onDragOver: this.onDragOver(i, true, maybeDropProps.onDragOver),
-      onDrop: this.onDrop(i, true, maybeDropProps.onDrop)
+      onDragOver: this.onDragOver(i, true),
+      onDrop: this.onDrop(i, true)
     };
   }
 }

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -169,6 +169,7 @@ class Level<T> extends React.Component<Props<T>> {
     if ((e as any).wasHandled || this.dragEventIsBlacklisted(e)) {
       return;
     }
+    // TODO: uncool
     (e as any).wasHandled = true;
     this.props.store.update(this.key, this.getDropIndex(e, i, isNode));
   };
@@ -184,6 +185,7 @@ class Level<T> extends React.Component<Props<T>> {
     if ((e as any).wasHandled || this.dragEventIsBlacklisted(e)) {
       return;
     }
+    // TODO: uncool
     (e as any).wasHandled = true;
 
     const { onMove = () => null, onDrop = () => null } = this.props;

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -66,6 +66,9 @@ interface OuterProps<T> {
     isTarget: boolean,
     index: number
   ) => React.ReactNode;
+  // any occurence of these in the data transfer will cause all dragging
+  // behaviour to be bypassed
+  blockingDataTransferTypes?: string[];
 }
 
 interface ContextProps {
@@ -116,6 +119,12 @@ class Level<T> extends React.Component<Props<T>> {
     );
   }
 
+  private dragEventIsBlacklisted(e: React.DragEvent) {
+    return e.dataTransfer.types.some(type =>
+      (this.props.blockingDataTransferTypes || []).includes(type)
+    );
+  }
+
   private getDropIndex(e: React.DragEvent, i: number, isNode: boolean) {
     return i + (isNode ? getDropIndexOffset(e) : 0);
   }
@@ -124,7 +133,7 @@ class Level<T> extends React.Component<Props<T>> {
     if (!this.props.store) {
       throw new Error(NO_STORE_ERROR);
     }
-    if (e.defaultPrevented) {
+    if (e.defaultPrevented || this.dragEventIsBlacklisted(e)) {
       return;
     }
     e.preventDefault();
@@ -132,7 +141,7 @@ class Level<T> extends React.Component<Props<T>> {
   };
 
   private onDrop = (i: number, isNode: boolean) => (e: React.DragEvent) => {
-    if (e.defaultPrevented) {
+    if (e.defaultPrevented || this.dragEventIsBlacklisted(e)) {
       return;
     }
 

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -44,6 +44,9 @@ export default class Root extends React.Component<Props, State> {
       this.reset();
     } else {
       // because events are pooled in React we have to remove this by hand
+      // all in all this probably isn't the best solution to the problem
+      // search for `(e as any)` to see where this is set. That said it's
+      // definitely the simplest to reason about
       delete (e as any).wasHandled;
     }
   };

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -40,8 +40,11 @@ export default class Root extends React.Component<Props, State> {
   }
 
   private onDragOver = (e: React.DragEvent) => {
-    if (!e.defaultPrevented) {
+    if (!(e as any).wasHandled) {
       this.reset();
+    } else {
+      // because events are pooled in React we have to remove this by hand
+      delete (e as any).wasHandled;
     }
   };
 

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -40,14 +40,8 @@ export default class Root extends React.Component<Props, State> {
   }
 
   private onDragOver = (e: React.DragEvent) => {
-    if (!(e as any).wasHandled) {
+    if (!e.defaultPrevented) {
       this.reset();
-    } else {
-      // because events are pooled in React we have to remove this by hand
-      // all in all this probably isn't the best solution to the problem
-      // search for `(e as any)` to see where this is set. That said it's
-      // definitely the simplest to reason about
-      delete (e as any).wasHandled;
     }
   };
 

--- a/client-v2/src/lib/dnd/__tests__/dnd.spec.tsx
+++ b/client-v2/src/lib/dnd/__tests__/dnd.spec.tsx
@@ -5,6 +5,7 @@ import Level from '../Level';
 
 const createDragEvent = () => {
   const data: { [k: string]: any } = {};
+  const types: string[] = [];
   let defaultPrevented = false;
 
   return {
@@ -16,8 +17,12 @@ const createDragEvent = () => {
       defaultPrevented = true;
     },
     dataTransfer: {
+      get types() {
+        return types.slice();
+      },
       setData: (key: string, val: any) => {
         data[key] = val;
+        types.push(key);
       },
       getData: (key: string) => data[key]
     }
@@ -25,8 +30,7 @@ const createDragEvent = () => {
 };
 
 const runDrag = (type: any, data?: any, json: boolean = true) => (
-  dropProps: any,
-  inst?: any
+  dropProps: any
 ) => {
   const e = createDragEvent();
 

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -226,6 +226,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
           ) : null}
         </ContainerHeadingPinline>
         <DragIntentContainer
+          delay={300}
           onIntentConfirm={this.toggleVisibility}
           onDragIntentStart={() => {
             this.setState({ hasDragOpenIntent: true });

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -53,7 +53,7 @@ class DragIntentContainer extends React.Component<Props> {
     // all other events will fire even if not active to allow the parent
     // to reset its state that was created when drag intent was initialised
     const { delay, filterEvent } = this.props;
-    if (filterEvent && filterEvent(e)) {
+    if (!filterEvent || filterEvent(e)) {
       if (this.props.active) {
         this.props.onDragIntentStart();
         if (typeof delay !== 'undefined') {

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -1,53 +1,78 @@
 import React from 'react';
 
 type Props = {
-  onIntentConfirm: () => void;
+  onIntentConfirm?: () => void;
   onDragIntentStart: () => void;
   onDragIntentEnd: () => void;
   active: boolean;
-  className?: string;
+  delay?: number;
+  filterEvent?: (event: React.DragEvent) => boolean;
 } & React.HTMLProps<HTMLDivElement>;
 
 class DragIntentContainer extends React.Component<Props> {
+  public static defaultProps = {
+    active: true
+  };
+
   private dragTimer: number | null = null;
 
   // Keeps track of dragEvents over the Collection's toggleVisibility button
   // to determine enter/leave events
   private dragHoverDepth: number = 0;
 
-  public handleToggleButtonDragEnter = () => {
-    if (this.dragHoverDepth === 0 && this.props.active) {
-      this.registerDragIntent();
+  public handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    if (this.props.onDragEnter) {
+      this.props.onDragEnter(e);
+    }
+    if (this.dragHoverDepth === 0) {
+      this.tryRegisterDragIntent(e);
     }
     this.dragHoverDepth += 1;
   };
 
-  public handleToggleButtonDragLeave = () => {
+  public handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
     this.dragHoverDepth -= 1;
+    if (this.props.onDragLeave) {
+      this.props.onDragLeave(e);
+    }
     if (this.dragHoverDepth === 0) {
-      this.deregisterDragIntent();
+      this.tryDeregisterDragIntent();
     }
   };
 
-  public handleToggleButtonDrop = () => {
+  public handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     this.dragHoverDepth = 0;
-    this.deregisterDragIntent();
+    if (this.props.onDrop) {
+      this.props.onDrop(e);
+    }
+    this.tryDeregisterDragIntent();
   };
 
-  public registerDragIntent = () => {
+  public tryRegisterDragIntent = (e: React.DragEvent) => {
     // only register if active
     // all other events will fire even if not active to allow the parent
     // to reset its state that was created when drag intent was initialised
-    if (this.props.active) {
-      this.props.onDragIntentStart();
-      this.dragTimer = window.setTimeout(() => {
-        this.props.onIntentConfirm();
-        this.deregisterDragIntent();
-      }, 300);
+    const { delay, filterEvent } = this.props;
+    if (filterEvent && filterEvent(e)) {
+      if (this.props.active) {
+        this.props.onDragIntentStart();
+        if (typeof delay !== 'undefined') {
+          this.dragTimer = window.setTimeout(() => {
+            if (this.props.onIntentConfirm) {
+              this.props.onIntentConfirm();
+            }
+            this.tryDeregisterDragIntent();
+          }, delay);
+        } else {
+          if (this.props.onIntentConfirm) {
+            this.props.onIntentConfirm();
+          }
+        }
+      }
     }
   };
 
-  public deregisterDragIntent = () => {
+  public tryDeregisterDragIntent = () => {
     if (this.dragTimer) {
       window.clearTimeout(this.dragTimer);
     }
@@ -62,15 +87,16 @@ class DragIntentContainer extends React.Component<Props> {
       onIntentConfirm,
       onDragIntentStart,
       onDragIntentEnd,
+      filterEvent,
       ...props
     }: Props = this.props;
 
     return (
       <div
         {...props}
-        onDragEnter={this.handleToggleButtonDragEnter}
-        onDragLeave={this.handleToggleButtonDragLeave}
-        onDrop={this.handleToggleButtonDrop}
+        onDragEnter={this.handleDragEnter}
+        onDragLeave={this.handleDragLeave}
+        onDrop={this.handleDrop}
       >
         {children}
       </div>

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -6,7 +6,7 @@ type Props = {
   onDragIntentEnd: () => void;
   active: boolean;
   delay?: number;
-  filterEvent?: (event: React.DragEvent) => boolean;
+  filterRegisterEvent?: (event: React.DragEvent) => boolean;
 } & React.HTMLProps<HTMLDivElement>;
 
 class DragIntentContainer extends React.Component<Props> {
@@ -52,8 +52,8 @@ class DragIntentContainer extends React.Component<Props> {
     // only register if active
     // all other events will fire even if not active to allow the parent
     // to reset its state that was created when drag intent was initialised
-    const { delay, filterEvent } = this.props;
-    if (!filterEvent || filterEvent(e)) {
+    const { delay, filterRegisterEvent } = this.props;
+    if (!filterRegisterEvent || filterRegisterEvent(e)) {
       if (this.props.active) {
         this.props.onDragIntentStart();
         if (typeof delay !== 'undefined') {
@@ -84,10 +84,11 @@ class DragIntentContainer extends React.Component<Props> {
     const {
       children,
       active, // active prop must be destructured here so it's not passed into div props
+      onDrop,
       onIntentConfirm,
       onDragIntentStart,
       onDragIntentEnd,
-      filterEvent,
+      filterRegisterEvent,
       ...props
     }: Props = this.props;
 

--- a/client-v2/src/shared/components/__tests__/DragIntentContainer.spec.tsx
+++ b/client-v2/src/shared/components/__tests__/DragIntentContainer.spec.tsx
@@ -11,6 +11,7 @@ describe('DragIntentContainer', () => {
     const onIntentConfirm = jest.fn();
     const DragIntent = (
       <DragIntentContainer
+        delay={300}
         onIntentConfirm={onIntentConfirm}
         onDragIntentStart={onDragIntentStart}
         onDragIntentEnd={() => {}}
@@ -34,6 +35,7 @@ describe('DragIntentContainer', () => {
     const onIntentConfirm = jest.fn();
     const DragIntent = (
       <DragIntentContainer
+        delay={300}
         onIntentConfirm={onIntentConfirm}
         onDragIntentStart={() => {}}
         onDragIntentEnd={() => {}}
@@ -55,6 +57,7 @@ describe('DragIntentContainer', () => {
     const onDragIntentEnd = jest.fn();
     const DragIntent = (
       <DragIntentContainer
+        delay={300}
         onIntentConfirm={() => {}}
         onDragIntentStart={() => {}}
         onDragIntentEnd={onDragIntentEnd}
@@ -77,6 +80,7 @@ describe('DragIntentContainer', () => {
     const onDragIntentEnd = jest.fn();
     const DragIntent = (
       <DragIntentContainer
+        delay={300}
         onIntentConfirm={onIntentConfirm}
         onDragIntentStart={() => {}}
         onDragIntentEnd={onDragIntentEnd}
@@ -99,6 +103,7 @@ describe('DragIntentContainer', () => {
     const onIntentConfirm = jest.fn();
     const DragIntent = (
       <DragIntentContainer
+        delay={300}
         onIntentConfirm={onIntentConfirm}
         onDragIntentStart={onDragIntentStart}
         onDragIntentEnd={() => {}}
@@ -112,6 +117,26 @@ describe('DragIntentContainer', () => {
     const { getByText } = render(DragIntent);
     fireEvent.dragEnter(getByText('Child'));
     jest.runOnlyPendingTimers();
+    expect(onDragIntentStart).not.toBeCalled();
+    expect(onIntentConfirm).not.toBeCalled();
+  });
+  it('runs synchronously without delay', async () => {
+    const onDragIntentStart = jest.fn();
+    const onIntentConfirm = jest.fn();
+    const DragIntent = (
+      <DragIntentContainer
+        onIntentConfirm={onIntentConfirm}
+        onDragIntentStart={onDragIntentStart}
+        onDragIntentEnd={() => {}}
+        active={false}
+      >
+        <span>
+          <span>Child</span>
+        </span>
+      </DragIntentContainer>
+    );
+    const { getByText } = render(DragIntent);
+    fireEvent.dragEnter(getByText('Child'));
     expect(onDragIntentStart).not.toBeCalled();
     expect(onIntentConfirm).not.toBeCalled();
   });

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -64,7 +64,7 @@ type ComponentProps = {
   size?: CollectionItemSizes;
   notifications?: string[];
   children: React.ReactNode;
-  imageDropTypes: string[];
+  imageDropTypes?: string[];
   onImageDrop?: (e: React.DragEvent<HTMLElement>) => void;
 } & ContainerProps;
 

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -103,13 +103,18 @@ class ArticleComponent extends React.Component<ComponentProps> {
       children,
       isUneditable,
       imageDropTypes = [],
-      onImageDrop = () => {}
+      onImageDrop
     } = this.props;
     const ArticleBody = articleBodyComponentMap[displayType];
     const getOverlayEventProps = () => ({
       onDelete,
       onAddToClipboard
     });
+
+    const dragEventHasImageData = (e: React.DragEvent) =>
+      e.dataTransfer.types.some(dataTransferType =>
+        imageDropTypes.includes(dataTransferType)
+      );
 
     return (
       <CollectionItemContainer
@@ -128,14 +133,15 @@ class ArticleComponent extends React.Component<ComponentProps> {
       >
         {article && (
           <DragIntentContainer
-            filterEvent={e => {
-              return e.dataTransfer.types.some(dataTransferType =>
-                imageDropTypes.includes(dataTransferType)
-              );
-            }}
+            active={!!onImageDrop}
+            filterRegisterEvent={dragEventHasImageData}
             onDragIntentStart={() => this.setIsHovered(true)}
             onDragIntentEnd={() => this.setIsHovered(false)}
-            onDrop={onImageDrop}
+            onDrop={e => {
+              if (dragEventHasImageData(e)) {
+                onImageDrop && onImageDrop(e);
+              }
+            }}
           >
             <ArticleBodyContainer
               data-testid="article-body"

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -138,8 +138,8 @@ class ArticleComponent extends React.Component<ComponentProps> {
             onDragIntentStart={() => this.setIsHovered(true)}
             onDragIntentEnd={() => this.setIsHovered(false)}
             onDrop={e => {
-              if (dragEventHasImageData(e)) {
-                onImageDrop && onImageDrop(e);
+              if (dragEventHasImageData(e) && onImageDrop) {
+                onImageDrop(e);
               }
             }}
           >

--- a/client-v2/src/shared/components/collectionItem/CollectionItemContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemContainer.tsx
@@ -1,5 +1,5 @@
 import { styled } from 'shared/constants/theme';
 
 export default styled('div')`
-  position: 'relative';
+  position: relative;
 `;

--- a/client-v2/src/shared/util/__tests__/validateImageSrc.spec.ts
+++ b/client-v2/src/shared/util/__tests__/validateImageSrc.spec.ts
@@ -65,7 +65,7 @@ describe('Validate images', () => {
 
     it('unknown domain', done => {
       validateImageSrc('http://another-host/image.png').then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/images must come/i);
           done();
@@ -78,7 +78,7 @@ describe('Validate images', () => {
     it("fails if the image can't be found", done => {
       ImageMock.shouldError = true;
       validateImageSrc(getPath('this_image_doesnt_exists__promised.png')).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/could not be found/i);
           done();
@@ -92,7 +92,7 @@ describe('Validate images', () => {
       };
       const path = getPath('square.png');
       validateImageSrc(path, 'front', criteria).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/cannot be more/i);
           done();
@@ -105,7 +105,7 @@ describe('Validate images', () => {
         minWidth: 200
       };
       validateImageSrc(getPath('square.png'), 'front', criteria).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/cannot be less/i);
           done();
@@ -120,7 +120,7 @@ describe('Validate images', () => {
       };
 
       validateImageSrc(getPath('square.png'), 'front', criteria).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/aspect ratio/i);
           done();
@@ -188,7 +188,7 @@ describe('Validate images', () => {
       validateImageSrc(
         'http://grid.co.uk/1234567890123456789012345678901234567890'
       ).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/unable to locate/i);
           done();
@@ -209,7 +209,7 @@ describe('Validate images', () => {
           'http://grid.co.uk/1234567890123456789012345678901234567890?crop=image_crop',
           'front'
         ).then(
-          err => done.fail(err as Error),
+          err => done.fail(err.toString()),
           err => {
             expect(err.message).toMatch(/does not have a valid crop/i);
             done();
@@ -244,7 +244,7 @@ describe('Validate images', () => {
             heightAspectRatio: 4
           }
         ).then(
-          err => done.fail(err as Error),
+          err => done.fail(err.toString()),
           err => {
             expect(err.message).toMatch(/does not have a valid crop/i);
             done();
@@ -307,7 +307,7 @@ describe('Validate images', () => {
         validateImageSrc(
           'http://grid.co.uk/1234567890123456789012345678901234567890'
         ).then(
-          err => done.fail(err as Error),
+          err => done.fail(err.toString()),
           err => {
             expect(err.message).toMatch(/does not have a valid crop/i);
             done();
@@ -344,7 +344,7 @@ describe('Validate images', () => {
             heightAspectRatio: 4
           }
         ).then(
-          err => done.fail(err as Error),
+          err => done.fail(err.toString()),
           err => {
             expect(err.message).toMatch(/does not have a valid crop/i);
             done();
@@ -442,7 +442,7 @@ describe('Validate images', () => {
       grid.gridInstance.getCropFromEvent = () => null;
 
       validateImageEvent('front' as any, {} as any).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/invalid image/i);
           done();
@@ -464,7 +464,7 @@ describe('Validate images', () => {
       validateImageEvent(dragEvent, 'front', {
         maxWidth: 500
       }).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/does not have a valid asset/i);
           done();
@@ -485,7 +485,7 @@ describe('Validate images', () => {
         widthAspectRatio: 4,
         heightAspectRatio: 1
       }).then(
-        err => done.fail(err as Error),
+        err => done.fail(err.toString()),
         err => {
           expect(err.message).toMatch(/aspect ratio/i);
           done();

--- a/client-v2/src/shared/util/validateImageSrc.ts
+++ b/client-v2/src/shared/util/validateImageSrc.ts
@@ -212,7 +212,7 @@ function validateImageSrc(
   src: string,
   frontId?: string,
   criteria?: Criteria
-): Promise<ValidationResponse | Error> {
+): Promise<ValidationResponse> {
   if (!src) {
     return Promise.reject(new Error('Missing image'));
   }
@@ -246,7 +246,7 @@ function validateMediaItem(
   imageOrigin: string,
   frontId: string,
   criteria?: Criteria
-): Promise<ValidationResponse | Error> {
+): Promise<ValidationResponse> {
   return getSuitableImageDetails([crop], crop.id, criteria || {})
     .then(asset => {
       const newImageDetails = asset;
@@ -268,7 +268,7 @@ function validateImageEvent(
   event: DragEvent | React.DragEvent<HTMLElement>,
   frontId: string,
   criteria?: Criteria
-): Promise<ValidationResponse | Error> {
+): Promise<ValidationResponse> {
   const mediaItem = grid.gridInstance.getCropFromEvent(event);
   const imageOrigin = grid.gridInstance.getGridUrlFromEvent(event);
 

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -130,6 +130,18 @@ const formToMetaFieldMap: { [fieldName: string]: string } = {
   imageCutoutSrcOrigin: 'cutoutImage'
 };
 
+export const getImageMetaFromValidationResponse = (
+  image: ImageData,
+  hideImage?: boolean
+) => ({
+  imageReplace: !!image.src && !hideImage,
+  imageSrc: image.src,
+  imageSrcThumb: image.thumb,
+  imageSrcWidth: intToStr(image.width),
+  imageSrcHeight: intToStr(image.height),
+  imageSrcOrigin: image.origin
+});
+
 export const getArticleFragmentMetaFromFormValues = (
   state: State,
   formName: string,
@@ -158,12 +170,7 @@ export const getArticleFragmentMetaFromFormValues = (
       headline: getStringField(values.headline),
       trailText: getStringField(values.trailText),
       byline: getStringField(values.byline),
-      imageReplace: !!primaryImage.src && !values.imageHide,
-      imageSrc: primaryImage.src,
-      imageSrcThumb: primaryImage.thumb,
-      imageSrcWidth: intToStr(primaryImage.width),
-      imageSrcHeight: intToStr(primaryImage.height),
-      imageSrcOrigin: primaryImage.origin,
+      ...getImageMetaFromValidationResponse(primaryImage, values.imageHide),
       imageCutoutSrc: cutoutImage.src,
       imageCutoutSrcWidth: intToStr(cutoutImage.width),
       imageCutoutSrcHeight: intToStr(cutoutImage.height),


### PR DESCRIPTION
## What's changed?

This allows dropping of grid crops on to Collection Items

## Implementation notes

I've extended `DragIntentContainer` to tell me when things are hovered over immediately as it works quite nicely and the logic is already baked in there. This may be a touch confusing (especially given the name of the component)!

I've not done any of the checks yet but thought I'd get this out for people to look at.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
  - This interacts a lot with article dropping but I've tested that a lot and seems to work well
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
