### PR TITLE
Memoize the open fronts selector

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -15,8 +15,10 @@ import {
   selectIsClipboardOpen,
   editorOpenClipboard,
   editorCloseAllOverviews,
-  editorOpenAllOverviews
+  editorOpenAllOverviews,
+  selectEditorFrontsByPriority
 } from '../frontsUIBundle';
+import initialState from 'fixtures/initialState';
 import { Action } from 'types/Action';
 
 type State = ReturnType<typeof innerReducer>;
@@ -28,6 +30,21 @@ const reducer = (state: State | undefined, action: Action) => ({
 });
 
 describe('frontsUIBundle', () => {
+  describe('selectors', () => {
+    it('should select editor fronts by priority', () => {
+      expect(
+        selectEditorFrontsByPriority(initialState, { priority: 'commercial' })
+          .length
+      ).toEqual(1);
+    });
+    it('should memoize editor fronts by priority', () => {
+      expect(
+        selectEditorFrontsByPriority(initialState, { priority: 'commercial' })
+      ).toBe(
+        selectEditorFrontsByPriority(initialState, { priority: 'commercial' })
+      );
+    });
+  });
   describe('reducer', () => {
     it('should add a front to the open editor fronts', () => {
       const state = reducer(undefined, editorOpenFront('exampleFront') as any);

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -18,6 +18,8 @@ import {
 } from 'types/Action';
 import { State as GlobalState } from 'types/State';
 import { events } from 'services/GA';
+import { getFronts } from 'selectors/frontsSelectors';
+import { createSelector } from 'reselect';
 
 const EDITOR_OPEN_FRONT = 'EDITOR_OPEN_FRONT';
 const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
@@ -166,18 +168,22 @@ const selectIsFrontOverviewOpen = <T extends { editor: State }>(
   frontId: string
 ) => !state.editor.closedOverviews.includes(frontId);
 
-const selectEditorFrontsByPriority = <
-  T extends { editor: State; fronts: GlobalState['fronts'] }
->(
-  state: T,
-  priority: string
-) => {
-  const frontsInConfig = state.fronts.frontsConfig.data.fronts;
-  return state.editor.frontIds.filter(frontId => {
-    const frontConfig = frontsInConfig[frontId];
-    return frontConfig && frontConfig.priority === priority;
-  });
-};
+const selectPriority = (
+  _: GlobalState,
+  { priority }: { priority: string }
+): string => priority;
+
+const selectEditorFrontsByPriority = createSelector(
+  getFronts,
+  selectEditorFronts,
+  selectPriority,
+  (fronts, openFrontIds, priority) => {
+    return openFrontIds.filter(frontId => {
+      const frontConfig = fronts[frontId];
+      return frontConfig && frontConfig.priority === priority;
+    });
+  }
+);
 
 const selectEditorArticleFragment = <T extends { editor: State }>(
   state: T,

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -79,10 +79,9 @@ class FrontsEdit extends React.Component<Props> {
 const mapStateToProps = (state: State, props: Props) => ({
   error: state.error,
   staleFronts: state.staleFronts,
-  frontIds: selectEditorFrontsByPriority(
-    state,
-    props.match.params.priority || ''
-  )
+  frontIds: selectEditorFrontsByPriority(state, {
+    priority: props.match.params.priority || ''
+  })
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) =>

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -650,7 +650,7 @@ const state = {
   unpublishedChanges: {},
   clipboard: ['56a3b407-741c-439f-a678-175abea44a9f'],
   editor: {
-    frontIds: [],
+    frontIds: ['sc-johnson-partner-zone'],
     collectionIds: [],
     selectedArticleFragments: {},
     closedOverviews: [],

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -279,6 +279,7 @@ const visibleFrontArticlesSelector = createSelector(
 
 export {
   getFront,
+  getFronts,
   getFrontsConfig,
   getCollectionConfig,
   frontsConfigSelector,


### PR DESCRIPTION
## What's changed?

This PR memoizes the open fronts selector. Previously, the unmemoized selector would force a top-down rerender of the Edit route component. These rerenders no longer occur.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included (N/A)
