### PR TITLE
Fix direction of circular caret button for Collection opening/closing

### DIFF
--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -11,7 +11,7 @@ export const ButtonCircularWithTransition = ButtonCircular.extend<{
   display: inline-block;
   text-align: center;
   padding: 0;
-  transform: rotate(-90deg);
+  transform: rotate(0deg);
 
   ${({ highlight, theme }) =>
     highlight
@@ -37,7 +37,7 @@ export default ({
     highlight={preActive}
     style={{
       transform: active
-        ? 'rotate(0deg)'
+        ? 'rotate(-180deg)'
         : preActive
         ? 'rotate(-45deg)'
         : undefined


### PR DESCRIPTION
## What's changed?

Button Caret now: 

- points up to click to close close collection.
- points down to click to open collection. 
- Retains brief rotation when dragging article fragment over to open collection and drop
<img src="https://user-images.githubusercontent.com/32312712/52476352-35403580-2b96-11e9-9fff-c46185c69a98.png" width="200"/>


## Implementation notes

Will probably have to be adjusted to point left/right for the collapse/expand implementations once that UX is finalised. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
