### PR TITLE
Remove redundant config usage

### DIFF
--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -65,15 +65,15 @@ object CollectionService {
 
   def getStoriesForCollectionStages(collectionId: String, collection: CollectionJson): (Seq[Story], Seq[Story]) = {
     val liveStages = Some(collection.live).map(getStoriesForStage).getOrElse(Seq())
-
+    val draftStages = collection.draft.map(getStoriesForStage).getOrElse(liveStages)
     (
       liveStages,
-      collection.draft.map(getStoriesForStage).getOrElse(liveStages)
+      draftStages
     )
   }
 
-  def getStoriesForStage(stage: List[Trail]): Seq[Story] = {
-    stage.map { article =>
+  def getStoriesForStage(trailsInStage: List[Trail]): Seq[Story] = {
+    trailsInStage.map { article =>
       val maybeGroup = for {
         meta <- article.meta
         group <- meta.group


### PR DESCRIPTION
## What's changed?

This is a minor refactor of the collection and stories getter logic, to remove some redundant code.

## Implementation notes

We now only need the collection config to determine the collection `type`, and this dependency could be removed if we passed that in some other way. This might matter because the collection config is _large_ -- around 200kb at the time of writing post-gzip -- and every time we read from the collections endpoint we're parsing this file for a tiny subset of the data it contains. It'd be nice to avoid that if possible.

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A)
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included (N/A)
