### PR TITLE
Add Collapse All button to Collection Overview

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -42,7 +42,10 @@ import {
 import { recordUnpublishedChanges } from 'actions/UnpublishedChanges';
 import difference from 'lodash/difference';
 import { selectArticlesInCollections } from 'shared/selectors/collection';
-import { editorOpenCollections } from 'bundles/frontsUIBundle';
+import {
+  editorOpenCollections,
+  editorCloseCollections
+} from 'bundles/frontsUIBundle';
 import flatten from 'lodash/flatten';
 
 function getCollections(collectionIds: string[]): ThunkResult<Promise<void>> {
@@ -199,6 +202,12 @@ const openCollectionsAndFetchTheirArticles = (
   return dispatch(getArticlesForCollections(collectionIds, itemSet));
 };
 
+const closeCollections = (collectionIds: string[]): ThunkResult<void> => {
+  return dispatch => {
+    return dispatch(editorCloseCollections(collectionIds));
+  };
+};
+
 function getVisibleArticles(
   collection: Collection,
   state: State,
@@ -219,6 +228,7 @@ export {
   getCollections,
   getArticlesForCollections,
   openCollectionsAndFetchTheirArticles,
+  closeCollections,
   fetchArticles,
   updateCollection
 };

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -9,7 +9,10 @@ import { CollectionItemSets } from 'shared/types/Collection';
 import { styled } from 'constants/theme';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
-import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
+import {
+  openCollectionsAndFetchTheirArticles,
+  closeCollections
+} from 'actions/Collections';
 
 interface FrontContainerProps {
   id: string;
@@ -19,6 +22,7 @@ interface FrontContainerProps {
 type FrontCollectionOverviewProps = FrontContainerProps & {
   front: FrontConfig;
   openAllCollections: (collections: string[]) => void;
+  closeAllCollections: (collections: string[]) => void;
 };
 
 const Container = styled(ContentContainer)`
@@ -33,7 +37,8 @@ const FrontCollectionsOverview = ({
   id,
   front,
   browsingStage,
-  openAllCollections
+  openAllCollections,
+  closeAllCollections
 }: FrontCollectionOverviewProps) => (
   <Container setBack>
     <ContainerHeadingPinline>
@@ -41,10 +46,18 @@ const FrontCollectionsOverview = ({
       <button
         onClick={e => {
           e.preventDefault();
+          closeAllCollections(front.collections);
+        }}
+      >
+        close all
+      </button>
+      <button
+        onClick={e => {
+          e.preventDefault();
           openAllCollections(front.collections);
         }}
       >
-        toggle
+        open all
       </button>
     </ContainerHeadingPinline>
     {front.collections.map(collectionId => (
@@ -69,7 +82,9 @@ const mapDispatchToProps = (
   openAllCollections: (collections: string[]) =>
     dispatch(
       openCollectionsAndFetchTheirArticles(collections, props.browsingStage)
-    )
+    ),
+  closeAllCollections: (collections: string[]) =>
+    dispatch(closeCollections(collections))
 });
 
 export default connect(

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -7,12 +7,12 @@ import CollectionOverview from './CollectionOverview';
 import { connect } from 'react-redux';
 import { CollectionItemSets } from 'shared/types/Collection';
 import { styled } from 'constants/theme';
+import ButtonCircularCaret, {
+  ButtonCircularWithTransition
+} from 'shared/components/input/ButtonCircularCaret';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
-import {
-  openCollectionsAndFetchTheirArticles,
-  closeCollections
-} from 'actions/Collections';
+import { closeCollections } from 'actions/Collections';
 
 interface FrontContainerProps {
   id: string;
@@ -21,9 +21,12 @@ interface FrontContainerProps {
 
 type FrontCollectionOverviewProps = FrontContainerProps & {
   front: FrontConfig;
-  openAllCollections: (collections: string[]) => void;
   closeAllCollections: (collections: string[]) => void;
 };
+interface CollectionOverviewCollapseAllButtonProps {
+  front: FrontConfig;
+  closeAllCollections: (collections: string[]) => void;
+}
 
 const Container = styled(ContentContainer)`
   display: flex;
@@ -33,33 +36,58 @@ const Container = styled(ContentContainer)`
   width: 380px;
 `;
 
+const CollapseAllButtonContainer = styled('div')`
+  margin-top: 10px;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  :hover {
+    ${ButtonCircularWithTransition} {
+      background-color: ${({ theme }) =>
+        theme.shared.button.backgroundColorFocused};
+    }
+  }
+`;
+
+const CollapseAllDiv = styled('div')`
+  cursor: pointer;
+  font-family: TS3TextSans-Bold;
+  font-size: 14px;
+`;
+
+const CollapseAllLabel = styled('div')`
+  display: inline-block;
+`;
+
+const CollapseAllButton = ({
+  front,
+  closeAllCollections
+}: CollectionOverviewCollapseAllButtonProps) => (
+  <CollapseAllDiv
+    onClick={e => {
+      e.preventDefault();
+      closeAllCollections(front.collections);
+    }}
+  >
+    <ButtonCircularCaret small={true} active={true} preActive={false} />{' '}
+    <CollapseAllLabel>Collapse all</CollapseAllLabel>
+  </CollapseAllDiv>
+);
+
 const FrontCollectionsOverview = ({
   id,
   front,
   browsingStage,
-  openAllCollections,
   closeAllCollections
 }: FrontCollectionOverviewProps) => (
   <Container setBack>
-    <ContainerHeadingPinline>
-      Overview
-      <button
-        onClick={e => {
-          e.preventDefault();
-          closeAllCollections(front.collections);
-        }}
-      >
-        close all
-      </button>
-      <button
-        onClick={e => {
-          e.preventDefault();
-          openAllCollections(front.collections);
-        }}
-      >
-        open all
-      </button>
-    </ContainerHeadingPinline>
+    <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
+    <CollapseAllButtonContainer>
+      <CollapseAllButton
+        front={front}
+        closeAllCollections={closeAllCollections}
+      />
+    </CollapseAllButtonContainer>
     {front.collections.map(collectionId => (
       <CollectionOverview
         frontId={id}
@@ -79,10 +107,6 @@ const mapDispatchToProps = (
   dispatch: Dispatch,
   props: FrontContainerProps
 ) => ({
-  openAllCollections: (collections: string[]) =>
-    dispatch(
-      openCollectionsAndFetchTheirArticles(collections, props.browsingStage)
-    ),
   closeAllCollections: (collections: string[]) =>
     dispatch(closeCollections(collections))
 });

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { State } from 'types/State';
+import { Dispatch } from 'types/Store';
 import { getFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
 import CollectionOverview from './CollectionOverview';
@@ -8,6 +9,7 @@ import { CollectionItemSets } from 'shared/types/Collection';
 import { styled } from 'constants/theme';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
+import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
 interface FrontContainerProps {
   id: string;
@@ -16,6 +18,7 @@ interface FrontContainerProps {
 
 type FrontCollectionOverviewProps = FrontContainerProps & {
   front: FrontConfig;
+  openAllCollections: (collections: string[]) => void;
 };
 
 const Container = styled(ContentContainer)`
@@ -29,10 +32,21 @@ const Container = styled(ContentContainer)`
 const FrontCollectionsOverview = ({
   id,
   front,
-  browsingStage
+  browsingStage,
+  openAllCollections
 }: FrontCollectionOverviewProps) => (
   <Container setBack>
-    <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
+    <ContainerHeadingPinline>
+      Overview
+      <button
+        onClick={e => {
+          e.preventDefault();
+          openAllCollections(front.collections);
+        }}
+      >
+        toggle
+      </button>
+    </ContainerHeadingPinline>
     {front.collections.map(collectionId => (
       <CollectionOverview
         frontId={id}
@@ -48,4 +62,17 @@ const mapStateToProps = (state: State, props: FrontContainerProps) => ({
   front: getFront(state, props.id)
 });
 
-export default connect(mapStateToProps)(FrontCollectionsOverview);
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+  props: FrontContainerProps
+) => ({
+  openAllCollections: (collections: string[]) =>
+    dispatch(
+      openCollectionsAndFetchTheirArticles(collections, props.browsingStage)
+    )
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(FrontCollectionsOverview);

--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -6,12 +6,15 @@ import ButtonCircular from './ButtonCircular';
 
 export const ButtonCircularWithTransition = ButtonCircular.extend<{
   highlight?: boolean;
+  small?: boolean;
 }>`
   transition: transform 0.15s;
   display: inline-block;
   text-align: center;
   padding: 0;
   transform: rotate(0deg);
+  height: ${({ small }) => (small ? '18px' : undefined)};
+  width: ${({ small }) => (small ? '18px' : undefined)};
 
   ${({ highlight, theme }) =>
     highlight
@@ -19,21 +22,29 @@ export const ButtonCircularWithTransition = ButtonCircular.extend<{
       : ``};
 `;
 
-const CaretImg = styled('img')`
-  width: 18px;
+const CaretImg = styled('img')<{
+  small?: boolean;
+}>`
+  width: ${({ small }) => (small ? '14px' : '18px')};
   display: inline-block;
-  vertical-align: middle;
 `;
+
+interface ButtonCircularCaretWithTransitionProps {
+  active: boolean;
+  preActive: boolean;
+  small?: boolean;
+}
 
 export default ({
   active,
   preActive,
+  small,
   ...props
-}: { active: boolean; preActive: boolean } & React.HTMLAttributes<
-  HTMLButtonElement
->) => (
+}: ButtonCircularCaretWithTransitionProps &
+  React.HTMLAttributes<HTMLButtonElement>) => (
   <ButtonCircularWithTransition
     {...props}
+    small={small}
     highlight={preActive}
     style={{
       transform: active
@@ -43,6 +54,6 @@ export default ({
         : undefined
     }}
   >
-    <CaretImg src={caretIcon} alt="" />
+    <CaretImg src={caretIcon} alt="" small={small} />
   </ButtonCircularWithTransition>
 );


### PR DESCRIPTION
## What's changed?

Users can now close all open collections at the click of a button form the Overview panel.
 Clicking it again with no open Collections does nothing. (ignore pink highlighting on headline - that is just highlighting captured by mistake)

![kapture 2019-02-08 at 17 20 24](https://user-images.githubusercontent.com/32312712/52494644-6df80300-2bc6-11e9-8cbe-18e94f9a875c.gif)


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
