### PR TITLE
Add Collapse All button to Collection Overview

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -42,7 +42,10 @@ import {
 import { recordUnpublishedChanges } from 'actions/UnpublishedChanges';
 import difference from 'lodash/difference';
 import { selectArticlesInCollections } from 'shared/selectors/collection';
-import { editorOpenCollections } from 'bundles/frontsUIBundle';
+import {
+  editorOpenCollections,
+  editorCloseCollections
+} from 'bundles/frontsUIBundle';
 import flatten from 'lodash/flatten';
 
 function getCollections(collectionIds: string[]): ThunkResult<Promise<void>> {
@@ -199,6 +202,12 @@ const openCollectionsAndFetchTheirArticles = (
   return dispatch(getArticlesForCollections(collectionIds, itemSet));
 };
 
+const closeCollections = (collectionIds: string[]): ThunkResult<void> => {
+  return dispatch => {
+    return dispatch(editorCloseCollections(collectionIds));
+  };
+};
+
 function getVisibleArticles(
   collection: Collection,
   state: State,
@@ -219,6 +228,7 @@ export {
   getCollections,
   getArticlesForCollections,
   openCollectionsAndFetchTheirArticles,
+  closeCollections,
   fetchArticles,
   updateCollection
 };

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { styled } from 'constants/theme';
 import { State } from 'types/State';
+import { Dispatch } from 'types/Store';
 import { getFront } from 'selectors/frontsSelectors';
+import { closeCollections } from 'actions/Collections';
 import { FrontConfig } from 'types/FaciaApi';
 import CollectionOverview from './CollectionOverview';
-import { connect } from 'react-redux';
 import { CollectionItemSets } from 'shared/types/Collection';
-import { styled } from 'constants/theme';
+import ButtonCircularCaret, {
+  ButtonCircularWithTransition
+} from 'shared/components/input/ButtonCircularCaret';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 
@@ -16,7 +21,12 @@ interface FrontContainerProps {
 
 type FrontCollectionOverviewProps = FrontContainerProps & {
   front: FrontConfig;
+  closeAllCollections: (collections: string[]) => void;
 };
+interface CollectionOverviewCollapseAllButtonProps {
+  front: FrontConfig;
+  closeAllCollections: (collections: string[]) => void;
+}
 
 const Container = styled(ContentContainer)`
   display: flex;
@@ -26,13 +36,58 @@ const Container = styled(ContentContainer)`
   width: 380px;
 `;
 
+const CollapseAllButtonContainer = styled('div')`
+  margin-top: 10px;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  :hover {
+    ${ButtonCircularWithTransition} {
+      background-color: ${({ theme }) =>
+        theme.shared.button.backgroundColorFocused};
+    }
+  }
+`;
+
+const CollapseAllDiv = styled('div')`
+  cursor: pointer;
+  font-family: TS3TextSans-Bold;
+  font-size: 14px;
+`;
+
+const CollapseAllLabel = styled('div')`
+  display: inline-block;
+`;
+
+const CollapseAllButton = ({
+  front,
+  closeAllCollections
+}: CollectionOverviewCollapseAllButtonProps) => (
+  <CollapseAllDiv
+    onClick={e => {
+      e.preventDefault();
+      closeAllCollections(front.collections);
+    }}
+  >
+    <ButtonCircularCaret small={true} active={true} preActive={false} />{' '}
+    <CollapseAllLabel>Collapse all</CollapseAllLabel>
+  </CollapseAllDiv>
+);
+
 const FrontCollectionsOverview = ({
   id,
   front,
-  browsingStage
+  browsingStage,
+  closeAllCollections
 }: FrontCollectionOverviewProps) => (
   <Container setBack>
     <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
+    <CollapseAllButtonContainer>
+      <CollapseAllButton
+        front={front}
+        closeAllCollections={closeAllCollections}
+      />
+    </CollapseAllButtonContainer>
     {front.collections.map(collectionId => (
       <CollectionOverview
         frontId={id}
@@ -48,4 +103,15 @@ const mapStateToProps = (state: State, props: FrontContainerProps) => ({
   front: getFront(state, props.id)
 });
 
-export default connect(mapStateToProps)(FrontCollectionsOverview);
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+  props: FrontContainerProps
+) => ({
+  closeAllCollections: (collections: string[]) =>
+    dispatch(closeCollections(collections))
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(FrontCollectionsOverview);

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -8,11 +8,12 @@ import { closeCollections } from 'actions/Collections';
 import { FrontConfig } from 'types/FaciaApi';
 import CollectionOverview from './CollectionOverview';
 import { CollectionItemSets } from 'shared/types/Collection';
+import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
+import ContentContainer from 'shared/components/layout/ContentContainer';
+import ButtonCircularWithLabel from 'shared/components/input/ButtonCircularWithLabel';
 import ButtonCircularCaret, {
   ButtonCircularWithTransition
 } from 'shared/components/input/ButtonCircularCaret';
-import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
-import ContentContainer from 'shared/components/layout/ContentContainer';
 
 interface FrontContainerProps {
   id: string;
@@ -23,10 +24,6 @@ type FrontCollectionOverviewProps = FrontContainerProps & {
   front: FrontConfig;
   closeAllCollections: (collections: string[]) => void;
 };
-interface CollectionOverviewCollapseAllButtonProps {
-  front: FrontConfig;
-  closeAllCollections: (collections: string[]) => void;
-}
 
 const Container = styled(ContentContainer)`
   display: flex;
@@ -36,11 +33,14 @@ const Container = styled(ContentContainer)`
   width: 380px;
 `;
 
-const CollapseAllButtonContainer = styled('div')`
+const ContainerMeta = styled('div')`
   margin-top: 10px;
   width: 100%;
   display: flex;
   justify-content: flex-end;
+`;
+
+const CollapseAllButton = styled(ButtonCircularWithLabel)`
   :hover {
     ${ButtonCircularWithTransition} {
       background-color: ${({ theme }) =>
@@ -48,31 +48,6 @@ const CollapseAllButtonContainer = styled('div')`
     }
   }
 `;
-
-const CollapseAllDiv = styled('div')`
-  cursor: pointer;
-  font-family: TS3TextSans-Bold;
-  font-size: 14px;
-`;
-
-const CollapseAllLabel = styled('div')`
-  display: inline-block;
-`;
-
-const CollapseAllButton = ({
-  front,
-  closeAllCollections
-}: CollectionOverviewCollapseAllButtonProps) => (
-  <CollapseAllDiv
-    onClick={e => {
-      e.preventDefault();
-      closeAllCollections(front.collections);
-    }}
-  >
-    <ButtonCircularCaret small={true} active={true} preActive={false} />{' '}
-    <CollapseAllLabel>Collapse all</CollapseAllLabel>
-  </CollapseAllDiv>
-);
 
 const FrontCollectionsOverview = ({
   id,
@@ -82,12 +57,17 @@ const FrontCollectionsOverview = ({
 }: FrontCollectionOverviewProps) => (
   <Container setBack>
     <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
-    <CollapseAllButtonContainer>
+    <ContainerMeta>
       <CollapseAllButton
-        front={front}
-        closeAllCollections={closeAllCollections}
-      />
-    </CollapseAllButtonContainer>
+        onClick={e => {
+          e.preventDefault();
+          closeAllCollections(front.collections);
+        }}
+        label={'Collapse all'}
+      >
+        <ButtonCircularCaret small active preActive={false} />
+      </CollapseAllButton>
+    </ContainerMeta>
     {front.collections.map(collectionId => (
       <CollectionOverview
         frontId={id}

--- a/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularCaret.tsx
@@ -6,12 +6,15 @@ import ButtonCircular from './ButtonCircular';
 
 export const ButtonCircularWithTransition = ButtonCircular.extend<{
   highlight?: boolean;
+  small?: boolean;
 }>`
   transition: transform 0.15s;
   display: inline-block;
   text-align: center;
   padding: 0;
   transform: rotate(0deg);
+  height: ${({ small }) => (small ? '18px' : undefined)};
+  width: ${({ small }) => (small ? '18px' : undefined)};
 
   ${({ highlight, theme }) =>
     highlight
@@ -19,21 +22,29 @@ export const ButtonCircularWithTransition = ButtonCircular.extend<{
       : ``};
 `;
 
-const CaretImg = styled('img')`
-  width: 18px;
+const CaretImg = styled('img')<{
+  small?: boolean;
+}>`
+  width: ${({ small }) => (small ? '14px' : '18px')};
   display: inline-block;
-  vertical-align: middle;
 `;
+
+interface ButtonCircularCaretWithTransitionProps {
+  active: boolean;
+  preActive: boolean;
+  small?: boolean;
+}
 
 export default ({
   active,
   preActive,
+  small,
   ...props
-}: { active: boolean; preActive: boolean } & React.HTMLAttributes<
-  HTMLButtonElement
->) => (
+}: ButtonCircularCaretWithTransitionProps &
+  React.HTMLAttributes<HTMLButtonElement>) => (
   <ButtonCircularWithTransition
     {...props}
+    small={small}
     highlight={preActive}
     style={{
       transform: active
@@ -43,6 +54,6 @@ export default ({
         : undefined
     }}
   >
-    <CaretImg src={caretIcon} alt="" />
+    <CaretImg src={caretIcon} alt="" small={small} />
   </ButtonCircularWithTransition>
 );

--- a/client-v2/src/shared/components/input/ButtonCircularWithLabel.tsx
+++ b/client-v2/src/shared/components/input/ButtonCircularWithLabel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { styled } from 'shared/constants/theme';
+
+interface ContainerButtonWithLabelProps {
+  onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const ContainerButtonDiv = styled('div')`
+  cursor: pointer;
+  font-family: TS3TextSans-Bold;
+  font-size: 14px;
+`;
+
+const ContainerButtonLabel = styled('div')`
+  display: inline-block;
+  vertical-align: top;
+`;
+
+export default ({
+  onClick,
+  label,
+  className,
+  children
+}: ContainerButtonWithLabelProps) => (
+  <ContainerButtonDiv className={className} onClick={onClick}>
+    {children} <ContainerButtonLabel>{label}</ContainerButtonLabel>
+  </ContainerButtonDiv>
+);


### PR DESCRIPTION
## What's changed?

Users can now close all open collections at the click of a button form the Overview panel.
 Clicking it again with no open Collections does nothing. (ignore pink highlighting on headline - that is just highlighting captured by mistake)

![kapture 2019-02-08 at 17 20 24](https://user-images.githubusercontent.com/32312712/52494644-6df80300-2bc6-11e9-8cbe-18e94f9a875c.gif)


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
