### PR TITLE
Fix CAPI flicker

### DIFF
--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -59,6 +59,10 @@ const RefreshButton = styled.button`
   &:hover {
     color: ${({ theme }) => theme.shared.base.colors.buttonFocused};
   }
+
+  &:disabled {
+    color: ${({ theme }) => theme.shared.base.colors.textMuted};
+  }
 `;
 
 const FeedsContainerWrapper = styled('div')`
@@ -163,13 +167,23 @@ class FeedsContainer extends React.Component<
       this.runSearch
     );
 
+  public get isLoading() {
+    return (
+      (this.state.capiFeedIndex === 0 && this.props.liveLoading) ||
+      (this.state.capiFeedIndex === 1 && this.props.previewLoading)
+    );
+  }
+
   public renderFixedContent = () => {
     if (!this.state.displaySearchFilters) {
       return (
         <ResultsHeadingContainer>
           <Title>Latest</Title>
-          <RefreshButton onClick={() => this.runSearchAndRestartPolling()}>
-            Refresh
+          <RefreshButton
+            disabled={this.isLoading}
+            onClick={() => this.runSearchAndRestartPolling()}
+          >
+            {this.isLoading ? 'Loading' : 'Refresh'}
           </RefreshButton>
           <StageSelectionContainer>
             <RadioGroup>
@@ -198,9 +212,7 @@ class FeedsContainer extends React.Component<
       liveArticles,
       previewArticles,
       liveError,
-      liveLoading,
-      previewError,
-      previewLoading
+      previewError
     } = this.props;
 
     return (
@@ -212,17 +224,9 @@ class FeedsContainer extends React.Component<
           onUpdate={this.handleParamsUpdate}
         >
           {this.state.capiFeedIndex === 0 ? (
-            <Feed
-              loading={liveLoading}
-              error={liveError}
-              articles={liveArticles}
-            />
+            <Feed error={liveError} articles={liveArticles} />
           ) : (
-            <Feed
-              loading={previewLoading}
-              error={previewError}
-              articles={previewArticles}
-            />
+            <Feed error={previewError} articles={previewArticles} />
           )}
         </SearchInput>
       </FeedsContainerWrapper>

--- a/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
@@ -9,7 +9,6 @@ const getId = (internalPageCode: string | number | undefined) =>
 interface FeedProps {
   articles?: CapiArticle[];
   error: string | null;
-  loading: boolean;
 }
 
 interface ErrorDisplayProps {
@@ -20,53 +19,43 @@ interface ErrorDisplayProps {
 const ErrorDisplay = ({ error, children }: ErrorDisplayProps) =>
   error ? <div>{error}</div> : <>{children}</>;
 
-interface LoaderDisplayProps {
-  children: React.ReactNode;
-  loading: boolean;
-}
-
-const LoaderDisplay = ({ loading, children }: LoaderDisplayProps) =>
-  loading ? <div>Loading!</div> : <>{children}</>;
-
 const NoResults = styled('div')`
   margin: 4px;
 `;
 
-const Feed = ({ articles = [], error, loading }: FeedProps) => (
+const Feed = ({ articles = [], error }: FeedProps) => (
   <ErrorDisplay error={error}>
-    <LoaderDisplay loading={loading}>
-      {articles.length ? (
-        articles
-          .filter(result => result.webTitle)
-          .map(
-            ({
-              id,
-              webTitle,
-              webUrl,
-              webPublicationDate,
-              sectionName,
-              fields,
-              pillarId
-            }) => (
-              <FeedItem
-                id={id}
-                key={webUrl}
-                title={webTitle}
-                href={webUrl}
-                publicationDate={webPublicationDate}
-                sectionName={sectionName}
-                pillarId={pillarId}
-                internalPageCode={fields && getId(fields.internalPageCode)}
-                firstPublicationDate={fields.firstPublicationDate}
-                isLive={!fields.isLive || fields.isLive === 'true'}
-                scheduledPublicationDate={fields.scheduledPublicationDate}
-              />
-            )
+    {articles.length ? (
+      articles
+        .filter(result => result.webTitle)
+        .map(
+          ({
+            id,
+            webTitle,
+            webUrl,
+            webPublicationDate,
+            sectionName,
+            fields,
+            pillarId
+          }) => (
+            <FeedItem
+              id={id}
+              key={webUrl}
+              title={webTitle}
+              href={webUrl}
+              publicationDate={webPublicationDate}
+              sectionName={sectionName}
+              pillarId={pillarId}
+              internalPageCode={fields && getId(fields.internalPageCode)}
+              firstPublicationDate={fields.firstPublicationDate}
+              isLive={!fields.isLive || fields.isLive === 'true'}
+              scheduledPublicationDate={fields.scheduledPublicationDate}
+            />
           )
-      ) : (
-        <NoResults>No results found</NoResults>
-      )}
-    </LoaderDisplay>
+        )
+    ) : (
+      <NoResults>No results found</NoResults>
+    )}
   </ErrorDisplay>
 );
 


### PR DESCRIPTION
## What's changed?

This fixes CAPI flickering when polling by changing how loading states are displayed in the feed. Before, loading would be represented by removing all the articles and showing "Loading!" in their place for the duration of the fetch request.

Now, the _Refresh_ button changes it's text do "Loading" and becomes disabled. This gives a more useful queue without removing the articles from the DOM.

![kapture 2019-02-18 at 11 31 38](https://user-images.githubusercontent.com/1652187/52948219-c8385700-3370-11e9-9da3-276096502b79.gif)

## Implementation notes

N/A

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
