### PR TITLE
Add FETCH_SUCCESS_IGNORE action for polling

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -69,7 +69,6 @@ function getCollections(
         returnOnlyUpdatedCollections
       );
       const collectionResponses = await fetchCollections(params);
-
       // TODO: test that this works!
       // find all collections missing in the response and ensure their 'fetch'
       // status is reset
@@ -77,17 +76,10 @@ function getCollections(
         collectionResponses.map(cr => cr.id),
         collectionIds
       );
-
-      // TODO: test the boolean in the second parameter
-      // this will mark the data as fetched but will allows us to not have
-      // to supply any data and just use the previous data
       const missingActions = missingCollections.map(id =>
-        collectionActions.fetchSuccess(
-          {
-            id
-          },
-          true
-        )
+        collectionActions.fetchSuccessIgnore({
+          id
+        })
       );
       const actions = collectionResponses.map(collectionResponse => {
         const {

--- a/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
@@ -20,6 +20,7 @@ describe('createAsyncResourceBundle', () => {
       expect(actionNames).toEqual({
         fetchStart: 'FETCH_START',
         fetchSuccess: 'FETCH_SUCCESS',
+        fetchSuccessIgnore: 'FETCH_SUCCESS_IGNORE',
         fetchError: 'FETCH_ERROR',
         updateStart: 'UPDATE_START',
         updateSuccess: 'UPDATE_SUCCESS',
@@ -43,6 +44,11 @@ describe('createAsyncResourceBundle', () => {
       expect(actions.fetchSuccess({ data: 'exampleData' })).toEqual({
         entity: 'books',
         type: 'FETCH_SUCCESS',
+        payload: { data: { data: 'exampleData' }, time: 1337 }
+      });
+      expect(actions.fetchSuccessIgnore({ data: 'exampleData' })).toEqual({
+        entity: 'books',
+        type: 'FETCH_SUCCESS_IGNORE',
         payload: { data: { data: 'exampleData' }, time: 1337 }
       });
       expect(actions.fetchError('Something went wrong')).toEqual({
@@ -164,7 +170,7 @@ describe('createAsyncResourceBundle', () => {
       describe('Success action handler', () => {
         it('should merge data and mark the state as not loading when a success action is dispatched', () => {
           const newState = reducer(
-            { ...initialState, loading: true },
+            { ...initialState },
             actions.fetchSuccess({ uuid: { id: 'uuid', author: 'Mark Twain' } })
           );
           expect(newState.loadingIds).toEqual([]);
@@ -190,7 +196,7 @@ describe('createAsyncResourceBundle', () => {
             indexById: true
           });
           const newState = bundle.reducer(
-            { ...initialState, loading: true },
+            { ...initialState },
             bundle.actions.fetchSuccess([
               { id: 'uuid', author: 'Mark Twain' },
               { id: 'uuid2', author: 'Elizabeth Gaskell' }
@@ -201,6 +207,20 @@ describe('createAsyncResourceBundle', () => {
             uuid: { id: 'uuid', author: 'Mark Twain' },
             uuid2: { id: 'uuid2', author: 'Elizabeth Gaskell' }
           });
+        });
+      });
+      describe('Success Ignore action handler', () => {
+        const newState = reducer(
+          { ...initialState, loadingIds: ['uuid'] },
+          actions.fetchSuccessIgnore({
+            uuid: { id: 'uuid', author: 'Mark Twain' }
+          })
+        );
+        it('should return initial state data when a successIgnore action is dispatched', () => {
+          expect(newState.data).toEqual(initialState.data);
+        });
+        it('should clear ID data from loadingIds when a successIgnore action is dispatched', () => {
+          expect(newState.loadingIds).toEqual([]);
         });
       });
       describe('Error action handler', () => {


### PR DESCRIPTION
## What's changed?

Creates a new Action FETCH_SUCCESS_IGNORE that will clear the loading ids from collection state and return original state data for collections that exhibit no changes and return null data during collection polling.
 
## Implementation notes

Replaces a boolean flag on FETCH_SUCESS

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
