### PR TITLE
Expand clipboard drop zone to fill container

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -42,6 +42,13 @@ const ClipboardTitle = styled.h2`
 
 const ClipboardBody = styled.div`
   padding: 10px;
+  flex-basis: 100%;
+`;
+
+const StyledDragIntentContainer = styled(DragIntentContainer)`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 `;
 
 interface ClipboardProps {
@@ -93,9 +100,8 @@ class Clipboard extends React.Component<ClipboardProps> {
 
   public render() {
     return (
-      <DragIntentContainer
+      <StyledDragIntentContainer
         active={!this.props.isClipboardOpen}
-        style={{ height: '100%' }}
         onDragIntentStart={() => this.setState({ preActive: true })}
         onDragIntentEnd={() => this.setState({ preActive: false })}
         onIntentConfirm={() => this.props.toggleClipboard(true)}
@@ -182,7 +188,7 @@ class Clipboard extends React.Component<ClipboardProps> {
             </Root>
           )}
         </ClipboardBody>
-      </DragIntentContainer>
+      </StyledDragIntentContainer>
     );
   }
 }

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -43,6 +43,7 @@ const ClipboardTitle = styled.h2`
 const ClipboardBody = styled.div`
   padding: 10px;
   flex-basis: 100%;
+  display: flex;
 `;
 
 const StyledDragIntentContainer = styled(DragIntentContainer)`

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -5,6 +5,7 @@ type Props = {
   onDragIntentStart: () => void;
   onDragIntentEnd: () => void;
   active: boolean;
+  className?: string;
 } & React.HTMLProps<HTMLDivElement>;
 
 class DragIntentContainer extends React.Component<Props> {


### PR DESCRIPTION
## What's changed?

The clipboard drop zone had been ensmallened at some previous point. This PR re-embiggens it.

![clipboard-zone](https://user-images.githubusercontent.com/7767575/53334792-b2d3a780-38f1-11e9-86f6-8d12475579b2.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A)
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE (N/A)

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
