### PR TITLE
Avoid rerendering the collection tree when selecting articles for edit

### DIFF
--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -14,11 +14,17 @@ import {
   RemoveClipboardArticleFragment
 } from 'types/Action';
 
+export const REMOVE_CLIPBOARD_ARTICLE_FRAGMENT =
+  'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT';
+export const UPDATE_CLIPBOARD_CONTENT = 'UPDATE_CLIPBOARD_CONTENT';
+export const INSERT_CLIPBOARD_ARTICLE_FRAGMENT =
+  'INSERT_CLIPBOARD_ARTICLE_FRAGMENT';
+
 function updateClipboardContent(
   clipboardContent: string[] = []
 ): UpdateClipboardContent {
   return {
-    type: 'UPDATE_CLIPBOARD_CONTENT',
+    type: UPDATE_CLIPBOARD_CONTENT,
     payload: clipboardContent
   };
 }
@@ -62,7 +68,7 @@ const insertClipboardArticleFragment = (
   index: number,
   articleFragmentId: string
 ): InsertClipboardArticleFragment => ({
-  type: 'INSERT_CLIPBOARD_ARTICLE_FRAGMENT',
+  type: INSERT_CLIPBOARD_ARTICLE_FRAGMENT,
   payload: {
     id,
     index,
@@ -74,7 +80,7 @@ const removeClipboardArticleFragment = (
   id: string,
   articleFragmentId: string
 ): RemoveClipboardArticleFragment => ({
-  type: 'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT',
+  type: REMOVE_CLIPBOARD_ARTICLE_FRAGMENT,
   payload: {
     id,
     articleFragmentId

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -20,6 +20,10 @@ import {
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import { Action } from 'types/Action';
+import {
+  removeSupportingArticleFragment,
+  removeGroupArticleFragment
+} from 'shared/actions/ArticleFragments';
 
 type State = ReturnType<typeof innerReducer>;
 
@@ -63,6 +67,48 @@ describe('frontsUIBundle', () => {
         editorClearOpenFronts()
       );
       expect(selectEditorFronts(state)).toEqual([]);
+    });
+    it('should clear the article fragment selection when selected article fragments are removed from a front', () => {
+      const state = reducer(
+        {
+          selectedArticleFragments: {
+            frontId: { id: 'articleFragmentId', isSupporting: false }
+          }
+        } as any,
+        removeGroupArticleFragment('collectionId', 'articleFragmentId')
+      );
+      expect(state.editor.selectedArticleFragments.frontId).toBe(undefined);
+    });
+    describe('Clearing article selection in response to persistence events', () => {
+      const stateWithSelectedArticleFragments = {
+        selectedArticleFragments: {
+          frontId: { id: 'articleFragmentId', isSupporting: false }
+        }
+      } as any;
+      it("should not clear the article fragment selection when selected article fragments aren't in the front", () => {
+        const state = reducer(
+          stateWithSelectedArticleFragments,
+          removeGroupArticleFragment('collectionId', 'anotherArticleFragmentId')
+        );
+        expect(state.editor).toBe(stateWithSelectedArticleFragments);
+      });
+      it('should clear the article fragment selection when selected supporting article fragments are removed from a front', () => {
+        const state = reducer(
+          stateWithSelectedArticleFragments,
+          removeSupportingArticleFragment('collectionId', 'articleFragmentId')
+        );
+        expect(state.editor.selectedArticleFragments.frontId).toBe(undefined);
+      });
+      it("should not clear the article fragment selection when selected supporting article fragments aren't in the front", () => {
+        const state = reducer(
+          stateWithSelectedArticleFragments,
+          removeSupportingArticleFragment(
+            'collectionId',
+            'anotherArticleFragmentId'
+          )
+        );
+        expect(state.editor).toBe(stateWithSelectedArticleFragments);
+      });
     });
     it('should set the fronts to the open editor fronts', () => {
       const state = reducer(

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -24,6 +24,7 @@ import {
   removeSupportingArticleFragment,
   removeGroupArticleFragment
 } from 'shared/actions/ArticleFragments';
+import { removeClipboardArticleFragment } from 'actions/Clipboard';
 
 type State = ReturnType<typeof innerReducer>;
 
@@ -103,6 +104,23 @@ describe('frontsUIBundle', () => {
         const state = reducer(
           stateWithSelectedArticleFragments,
           removeSupportingArticleFragment(
+            'collectionId',
+            'anotherArticleFragmentId'
+          )
+        );
+        expect(state.editor).toBe(stateWithSelectedArticleFragments);
+      });
+      it('should clear the article fragment selection when selected clipboard article fragments are removed from a front', () => {
+        const state = reducer(
+          stateWithSelectedArticleFragments,
+          removeClipboardArticleFragment('collectionId', 'articleFragmentId')
+        );
+        expect(state.editor.selectedArticleFragments.frontId).toBe(undefined);
+      });
+      it("should not clear the article fragment selection when selected clipboard article fragments aren't in the front", () => {
+        const state = reducer(
+          stateWithSelectedArticleFragments,
+          removeClipboardArticleFragment(
             'collectionId',
             'anotherArticleFragmentId'
           )

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -20,6 +20,10 @@ import { State as GlobalState } from 'types/State';
 import { events } from 'services/GA';
 import { getFronts } from 'selectors/frontsSelectors';
 import { createSelector } from 'reselect';
+import {
+  REMOVE_GROUP_ARTICLE_FRAGMENT,
+  REMOVE_SUPPORTING_ARTICLE_FRAGMENT
+} from 'shared/actions/ArticleFragments';
 
 const EDITOR_OPEN_FRONT = 'EDITOR_OPEN_FRONT';
 const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
@@ -198,6 +202,14 @@ const defaultState = {
   selectedArticleFragments: {}
 };
 
+const clearArticleFragmentSelection = (state: State, frontId: string) => ({
+  ...state,
+  selectedArticleFragments: {
+    ...state.selectedArticleFragments,
+    [frontId]: undefined
+  }
+});
+
 const reducer = (state: State = defaultState, action: Action): State => {
   switch (action.type) {
     case EDITOR_OPEN_FRONT: {
@@ -254,13 +266,23 @@ const reducer = (state: State = defaultState, action: Action): State => {
       };
     }
     case EDITOR_CLEAR_ARTICLE_FRAGMENT_SELECTION: {
-      return {
-        ...state,
-        selectedArticleFragments: {
-          ...state.selectedArticleFragments,
-          [action.payload.frontId]: undefined
+      return clearArticleFragmentSelection(state, action.payload.frontId);
+    }
+    case REMOVE_SUPPORTING_ARTICLE_FRAGMENT:
+    case REMOVE_GROUP_ARTICLE_FRAGMENT: {
+      const articleFragmentId = action.payload.articleFragmentId;
+      const selectedFrontId = Object.keys(state.selectedArticleFragments).find(
+        frontId => {
+          const selectedArticleFragmentData =
+            state.selectedArticleFragments[frontId];
+          return selectedArticleFragmentData
+            ? selectedArticleFragmentData.id === articleFragmentId
+            : false;
         }
-      };
+      );
+      return selectedFrontId
+        ? clearArticleFragmentSelection(state, selectedFrontId)
+        : state;
     }
     case EDITOR_OPEN_CLIPBOARD: {
       return {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -24,6 +24,7 @@ import {
   REMOVE_GROUP_ARTICLE_FRAGMENT,
   REMOVE_SUPPORTING_ARTICLE_FRAGMENT
 } from 'shared/actions/ArticleFragments';
+import { REMOVE_CLIPBOARD_ARTICLE_FRAGMENT } from 'actions/Clipboard';
 
 const EDITOR_OPEN_FRONT = 'EDITOR_OPEN_FRONT';
 const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
@@ -269,7 +270,8 @@ const reducer = (state: State = defaultState, action: Action): State => {
       return clearArticleFragmentSelection(state, action.payload.frontId);
     }
     case REMOVE_SUPPORTING_ARTICLE_FRAGMENT:
-    case REMOVE_GROUP_ARTICLE_FRAGMENT: {
+    case REMOVE_GROUP_ARTICLE_FRAGMENT:
+    case REMOVE_CLIPBOARD_ARTICLE_FRAGMENT: {
       const articleFragmentId = action.payload.articleFragmentId;
       const selectedFrontId = Object.keys(state.selectedArticleFragments).find(
         frontId => {

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -10,7 +10,6 @@ import {
 } from 'actions/ArticleFragments';
 import {
   editorSelectArticleFragment,
-  selectEditorArticleFragment,
   editorClearArticleFragmentSelection,
   selectIsClipboardOpen,
   editorOpenClipboard,
@@ -53,7 +52,6 @@ const StyledDragIntentContainer = styled(DragIntentContainer)`
 `;
 
 interface ClipboardProps {
-  selectedArticleFragment: { id: string; isSupporting: boolean } | void;
   selectArticleFragment: (id: string, isSupporting?: boolean) => void;
   clearArticleFragmentSelection: () => void;
   removeCollectionItem: (id: string) => void;
@@ -78,25 +76,6 @@ class Clipboard extends React.Component<ClipboardProps> {
 
   public handleInsert = (e: React.DragEvent, to: PosSpec) => {
     this.props.dispatch(insertArticleFragmentFromDropEvent(e, to, 'clipboard'));
-  };
-
-  public removeCollectionItem = (id: string) => {
-    this.props.removeCollectionItem(id);
-    this.clearArticleFragmentSelectionIfNeeded(id);
-  };
-
-  public removeSupportingCollectionItem = (parentId: string, id: string) => {
-    this.props.removeSupportingCollectionItem(parentId, id);
-    this.clearArticleFragmentSelectionIfNeeded(id);
-  };
-
-  public clearArticleFragmentSelectionIfNeeded = (id: string) => {
-    if (
-      this.props.selectedArticleFragment &&
-      id === this.props.selectedArticleFragment.id
-    ) {
-      this.props.clearArticleFragmentSelection();
-    }
   };
 
   public render() {
@@ -140,16 +119,12 @@ class Clipboard extends React.Component<ClipboardProps> {
                   <CollectionItem
                     uuid={articleFragment.uuid}
                     parentId={clipboardId}
+                    frontId={clipboardId}
                     getNodeProps={() => afProps}
                     displayType="polaroid"
                     onSelect={this.props.selectArticleFragment}
-                    isSelected={
-                      !this.props.selectedArticleFragment ||
-                      this.props.selectedArticleFragment.id ===
-                        articleFragment.uuid
-                    }
                     onDelete={() =>
-                      this.removeCollectionItem(articleFragment.uuid)
+                      this.props.removeCollectionItem(articleFragment.uuid)
                     }
                     {...afProps}
                   >
@@ -162,6 +137,7 @@ class Clipboard extends React.Component<ClipboardProps> {
                       {(supporting, sProps) => (
                         <CollectionItem
                           uuid={supporting.uuid}
+                          frontId={clipboardId}
                           parentId={articleFragment.uuid}
                           getNodeProps={() => sProps}
                           size="small"
@@ -169,13 +145,8 @@ class Clipboard extends React.Component<ClipboardProps> {
                           onSelect={id =>
                             this.props.selectArticleFragment(id, true)
                           }
-                          isSelected={
-                            !this.props.selectedArticleFragment ||
-                            this.props.selectedArticleFragment.id ===
-                              supporting.uuid
-                          }
                           onDelete={() =>
-                            this.removeSupportingCollectionItem(
+                            this.props.removeSupportingCollectionItem(
                               articleFragment.uuid,
                               supporting.uuid
                             )
@@ -195,7 +166,6 @@ class Clipboard extends React.Component<ClipboardProps> {
 }
 
 const mapStateToProps = (state: State) => ({
-  selectedArticleFragment: selectEditorArticleFragment(state, clipboardId),
   isClipboardOpen: selectIsClipboardOpen(state)
 });
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -13,10 +13,11 @@ import {
 import SnapLink from 'shared/components/snapLink/SnapLink';
 import { insertArticleFragment } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
+import { selectEditorArticleFragment } from 'bundles/frontsUIBundle';
 
 interface ContainerProps {
-  isSelected?: boolean;
   uuid: string;
+  frontId: string;
   children?: React.ReactNode;
   getNodeProps: () => object;
   onSelect: (uuid: string) => void;
@@ -31,6 +32,7 @@ interface ContainerProps {
 type ArticleContainerProps = ContainerProps & {
   onAddToClipboard: (uuid: string) => void;
   type: CollectionItemTypes;
+  isSelected: boolean;
 };
 
 const CollectionItem = ({
@@ -97,9 +99,18 @@ const CollectionItem = ({
 
 const createMapStateToProps = () => {
   const selectType = createCollectionItemTypeSelector();
-  return (state: State, props: ContainerProps) => ({
-    type: selectType(selectSharedState(state), props.uuid)
-  });
+  return (state: State, props: ContainerProps) => {
+    const selectArticleFragmentData = selectEditorArticleFragment(
+      state,
+      props.frontId
+    );
+    return {
+      type: selectType(selectSharedState(state), props.uuid),
+      isSelected:
+        !!selectArticleFragmentData &&
+        selectArticleFragmentData.id === props.uuid
+    };
+  };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -100,15 +100,15 @@ const CollectionItem = ({
 const createMapStateToProps = () => {
   const selectType = createCollectionItemTypeSelector();
   return (state: State, props: ContainerProps) => {
-    const selectArticleFragmentData = selectEditorArticleFragment(
+    const selectedArticleFragmentData = selectEditorArticleFragment(
       state,
       props.frontId
     );
     return {
       type: selectType(selectSharedState(state), props.uuid),
       isSelected:
-        !!selectArticleFragmentData &&
-        selectArticleFragmentData.id === props.uuid
+        !selectedArticleFragmentData ||
+        selectedArticleFragmentData.id === props.uuid
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -6,7 +6,6 @@ import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
 import {
-  updateArticleFragmentMeta,
   removeArticleFragment,
   moveArticleFragment
 } from 'actions/ArticleFragments';
@@ -14,19 +13,14 @@ import { insertArticleFragmentFromDropEvent } from 'util/collectionUtils';
 import { AlsoOnDetail } from 'types/Collection';
 import {
   editorSelectArticleFragment,
-  selectEditorArticleFragment,
   editorClearArticleFragmentSelection,
   editorOpenCollections
 } from 'bundles/frontsUIBundle';
 import {
-  ArticleFragmentMeta,
   CollectionItemSets,
   ArticleFragment as TArticleFragment
 } from 'shared/types/Collection';
 import Collection from './CollectionComponents/Collection';
-import CollectionItem from './CollectionComponents/CollectionItem';
-import ArticleFragmentForm from './ArticleFragmentForm';
-import FrontCollectionsOverview from './FrontCollectionsOverview';
 import GroupDisplay from 'shared/components/GroupDisplay';
 import ArticleFragmentLevel from 'components/clipboard/ArticleFragmentLevel';
 import GroupLevel from 'components/clipboard/GroupLevel';
@@ -36,6 +30,8 @@ import { visibleFrontArticlesSelector } from 'selectors/frontsSelectors';
 import { VisibleArticlesResponse } from 'types/FaciaApi';
 import { initialiseFront } from 'actions/Fronts';
 import { events } from 'services/GA';
+import FrontDetailView from './FrontDetailView';
+import CollectionItem from './CollectionComponents/CollectionItem';
 
 const FrontContainer = styled('div')`
   display: flex;
@@ -55,8 +51,6 @@ interface FrontPropsBeforeState {
 }
 
 type FrontProps = FrontPropsBeforeState & {
-  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) => void;
-  selectedArticleFragment: { id: string; isSupporting: boolean } | void;
   dispatch: Dispatch;
   initialiseFront: () => void;
   selectArticleFragment: (id: string, isSupporting?: boolean) => void;
@@ -116,27 +110,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
     );
   };
 
-  public removeCollectionItem(parentId: string, id: string) {
-    this.props.removeCollectionItem(parentId, id);
-    this.clearArticleFragmentSelectionIfNeeded(id);
-  }
-
-  public removeSupportingCollectionItem(parentId: string, id: string) {
-    this.props.removeSupportingCollectionItem(parentId, id);
-    this.clearArticleFragmentSelectionIfNeeded(id);
-  }
-
-  public clearArticleFragmentSelectionIfNeeded(id: string) {
-    if (
-      this.props.selectedArticleFragment &&
-      id === this.props.selectedArticleFragment.id
-    ) {
-      this.props.clearArticleFragmentSelection();
-    }
-  }
-
   public render() {
-    const { selectedArticleFragment, front, articlesVisible } = this.props;
+    const { front, articlesVisible } = this.props;
     return (
       <React.Fragment>
         <div
@@ -193,6 +168,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                             }
                             return (
                               <CollectionItem
+                                frontId={this.props.id}
                                 uuid={articleFragment.uuid}
                                 parentId={group.uuid}
                                 isUneditable={isUneditable}
@@ -201,15 +177,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                 }
                                 onSelect={this.props.selectArticleFragment}
                                 onDelete={() =>
-                                  this.removeCollectionItem(
+                                  this.props.removeCollectionItem(
                                     group.uuid,
                                     articleFragment.uuid
                                   )
-                                }
-                                isSelected={
-                                  !selectedArticleFragment ||
-                                  selectedArticleFragment.id ===
-                                    articleFragment.uuid
                                 }
                                 articleNotifications={articleNotifications}
                               >
@@ -221,6 +192,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                 >
                                   {(supporting, supportingDragProps) => (
                                     <CollectionItem
+                                      frontId={this.props.id}
                                       uuid={supporting.uuid}
                                       parentId={articleFragment.uuid}
                                       onSelect={id =>
@@ -233,13 +205,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                       getNodeProps={() =>
                                         !isUneditable ? supportingDragProps : {}
                                       }
-                                      isSelected={
-                                        !selectedArticleFragment ||
-                                        selectedArticleFragment.id ===
-                                          supporting.uuid
-                                      }
                                       onDelete={() =>
-                                        this.removeSupportingCollectionItem(
+                                        this.props.removeSupportingCollectionItem(
                                           articleFragment.uuid,
                                           supporting.uuid
                                         )
@@ -260,28 +227,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
             </Root>
           </FrontContentContainer>
           <FrontContentContainer>
-            {selectedArticleFragment ? (
-              <ArticleFragmentForm
-                articleFragmentId={selectedArticleFragment.id}
-                isSupporting={selectedArticleFragment.isSupporting}
-                key={selectedArticleFragment.id}
-                form={selectedArticleFragment.id}
-                frontId={this.props.id}
-                onSave={(meta: ArticleFragmentMeta) => {
-                  this.props.updateArticleFragmentMeta(
-                    selectedArticleFragment.id,
-                    meta
-                  );
-                  this.props.clearArticleFragmentSelection();
-                }}
-                onCancel={this.props.clearArticleFragmentSelection}
-              />
-            ) : (
-              <FrontCollectionsOverview
-                id={this.props.id}
-                browsingStage={this.props.browsingStage}
-              />
-            )}
+            <FrontDetailView
+              id={this.props.id}
+              browsingStage={this.props.browsingStage}
+            />
           </FrontContentContainer>
         </FrontContainer>
       </React.Fragment>
@@ -291,7 +240,6 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
 
 const mapStateToProps = (state: State, props: FrontPropsBeforeState) => ({
   unpublishedChanges: state.unpublishedChanges,
-  selectedArticleFragment: selectEditorArticleFragment(state, props.id),
   front: getFront(state, props.id),
   articlesVisible: visibleFrontArticlesSelector(state, {
     collectionSet: props.browsingStage
@@ -304,8 +252,6 @@ const mapDispatchToProps = (
 ) => {
   return {
     dispatch,
-    updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) =>
-      dispatch(updateArticleFragmentMeta(id, meta)),
     initialiseFront: () =>
       dispatch(initialiseFront(props.id, props.browsingStage)),
     selectArticleFragment: (

--- a/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import ArticleFragmentForm from './ArticleFragmentForm';
+import FrontCollectionsOverview from './FrontCollectionsOverview';
+import { connect } from 'react-redux';
+import {
+  ArticleFragmentMeta,
+  CollectionItemSets
+} from 'shared/types/Collection';
+import { updateArticleFragmentMeta } from 'actions/ArticleFragments';
+import {
+  editorClearArticleFragmentSelection,
+  selectEditorArticleFragment
+} from 'bundles/frontsUIBundle';
+import { Dispatch } from 'types/Store';
+import { State } from 'types/State';
+
+interface ContainerProps {
+  id: string;
+  browsingStage: CollectionItemSets;
+}
+
+interface ComponentProps extends ContainerProps {
+  selectedArticleFragment: { id: string; isSupporting: boolean } | void;
+  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) => void;
+  clearArticleFragmentSelection: (id: string) => void;
+}
+
+const FrontsDetailView = ({
+  selectedArticleFragment,
+  id,
+  browsingStage,
+  clearArticleFragmentSelection
+}: ComponentProps) =>
+  selectedArticleFragment ? (
+    <ArticleFragmentForm
+      articleFragmentId={selectedArticleFragment.id}
+      isSupporting={selectedArticleFragment.isSupporting}
+      key={selectedArticleFragment.id}
+      form={selectedArticleFragment.id}
+      frontId={id}
+      onSave={(meta: ArticleFragmentMeta) => {
+        updateArticleFragmentMeta(selectedArticleFragment.id, meta);
+        clearArticleFragmentSelection(id);
+      }}
+      onCancel={() => clearArticleFragmentSelection(id)}
+    />
+  ) : (
+    <FrontCollectionsOverview id={id} browsingStage={browsingStage} />
+  );
+
+const mapStateToProps = (state: State, props: ContainerProps) => ({
+  selectedArticleFragment: selectEditorArticleFragment(state, props.id)
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) =>
+    dispatch(updateArticleFragmentMeta(id, meta)),
+  clearArticleFragmentSelection: (frontId: string) =>
+    dispatch(editorClearArticleFragmentSelection(frontId))
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(FrontsDetailView);

--- a/client-v2/src/reducers/clipboardReducer.ts
+++ b/client-v2/src/reducers/clipboardReducer.ts
@@ -2,6 +2,11 @@ import { Action } from 'types/Action';
 import { insertAndDedupeSiblings } from 'shared/util/insertAndDedupeSiblings';
 import { State as SharedState } from '../shared/types/State';
 import { articleFragmentsSelector } from 'shared/selectors/shared';
+import {
+  INSERT_CLIPBOARD_ARTICLE_FRAGMENT,
+  REMOVE_CLIPBOARD_ARTICLE_FRAGMENT,
+  UPDATE_CLIPBOARD_CONTENT
+} from 'actions/Clipboard';
 
 type State = string[];
 
@@ -11,14 +16,14 @@ const clipboard = (
   prevSharedState: SharedState
 ): State => {
   switch (action.type) {
-    case 'UPDATE_CLIPBOARD_CONTENT': {
+    case UPDATE_CLIPBOARD_CONTENT: {
       const { payload } = action;
       return payload;
     }
-    case 'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT': {
+    case REMOVE_CLIPBOARD_ARTICLE_FRAGMENT: {
       return state.filter(id => id !== action.payload.articleFragmentId);
     }
-    case 'INSERT_CLIPBOARD_ARTICLE_FRAGMENT': {
+    case INSERT_CLIPBOARD_ARTICLE_FRAGMENT: {
       return insertAndDedupeSiblings(
         state,
         [action.payload.articleFragmentId],

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -267,11 +267,13 @@ const visibleArticlesSelector = createSelector(
   }
 );
 
+const defaultVisibleFrontArticles = {};
+
 const visibleFrontArticlesSelector = createSelector(
   [collectionVisibilitiesSelector, collectionSetSelector],
   (collectionVisibilities, collectionSet) => {
     if (collectionSet === 'previously') {
-      return {};
+      return defaultVisibleFrontArticles;
     }
     return collectionVisibilities[collectionSet];
   }

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -16,12 +16,24 @@ import { createLinkSnap, createLatestSnap } from 'shared/util/snap';
 import { getIdFromURL } from 'util/CAPIUtils';
 import { isValidURL } from 'shared/util/url';
 
+export const UPDATE_ARTICLE_FRAGMENT_META =
+  'SHARED/UPDATE_ARTICLE_FRAGMENT_META';
+export const ARTICLE_FRAGMENTS_RECEIVED = 'SHARED/ARTICLE_FRAGMENTS_RECEIVED';
+export const REMOVE_GROUP_ARTICLE_FRAGMENT =
+  'SHARED/REMOVE_GROUP_ARTICLE_FRAGMENT';
+export const REMOVE_SUPPORTING_ARTICLE_FRAGMENT =
+  'SHARED/REMOVE_SUPPORTING_ARTICLE_FRAGMENT';
+export const INSERT_GROUP_ARTICLE_FRAGMENT =
+  'SHARED/INSERT_GROUP_ARTICLE_FRAGMENT';
+export const INSERT_SUPPORTING_ARTICLE_FRAGMENT =
+  'SHARED/INSERT_SUPPORTING_ARTICLE_FRAGMENT';
+
 function updateArticleFragmentMeta(
   id: string,
   meta: ArticleFragmentMeta
 ): UpdateArticleFragmentMeta {
   return {
-    type: 'SHARED/UPDATE_ARTICLE_FRAGMENT_META',
+    type: UPDATE_ARTICLE_FRAGMENT_META,
     payload: {
       id,
       meta
@@ -42,7 +54,7 @@ function articleFragmentsReceived(
     ? keyBy(articleFragments, ({ uuid }) => uuid)
     : articleFragments;
   return {
-    type: 'SHARED/ARTICLE_FRAGMENTS_RECEIVED',
+    type: ARTICLE_FRAGMENTS_RECEIVED,
     payload
   };
 }
@@ -52,7 +64,7 @@ function removeGroupArticleFragment(
   articleFragmentId: string
 ): RemoveGroupArticleFragment {
   return {
-    type: 'SHARED/REMOVE_GROUP_ARTICLE_FRAGMENT',
+    type: REMOVE_GROUP_ARTICLE_FRAGMENT,
     payload: {
       id,
       articleFragmentId
@@ -65,7 +77,7 @@ function removeSupportingArticleFragment(
   articleFragmentId: string
 ): RemoveSupportingArticleFragment {
   return {
-    type: 'SHARED/REMOVE_SUPPORTING_ARTICLE_FRAGMENT',
+    type: REMOVE_SUPPORTING_ARTICLE_FRAGMENT,
     payload: {
       id,
       articleFragmentId
@@ -78,7 +90,7 @@ const insertGroupArticleFragment = (
   index: number,
   articleFragmentId: string
 ): InsertGroupArticleFragment => ({
-  type: 'SHARED/INSERT_GROUP_ARTICLE_FRAGMENT',
+  type: INSERT_GROUP_ARTICLE_FRAGMENT,
   payload: {
     id,
     index,
@@ -91,7 +103,7 @@ const insertSupportingArticleFragment = (
   index: number,
   articleFragmentId: string
 ): InsertSupportingArticleFragment => ({
-  type: 'SHARED/INSERT_SUPPORTING_ARTICLE_FRAGMENT',
+  type: INSERT_SUPPORTING_ARTICLE_FRAGMENT,
   payload: {
     id,
     index,

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -2,6 +2,12 @@ import { Action } from '../types/Action';
 import { insertAndDedupeSiblings } from '../util/insertAndDedupeSiblings';
 import { State } from './sharedReducer';
 import { articleFragmentsSelector } from 'shared/selectors/shared';
+import {
+  UPDATE_ARTICLE_FRAGMENT_META,
+  ARTICLE_FRAGMENTS_RECEIVED,
+  REMOVE_SUPPORTING_ARTICLE_FRAGMENT,
+  INSERT_SUPPORTING_ARTICLE_FRAGMENT
+} from 'shared/actions/ArticleFragments';
 
 const articleFragments = (
   state: State['articleFragments'] = {},
@@ -9,7 +15,7 @@ const articleFragments = (
   prevSharedState: State
 ) => {
   switch (action.type) {
-    case 'SHARED/UPDATE_ARTICLE_FRAGMENT_META': {
+    case UPDATE_ARTICLE_FRAGMENT_META: {
       const { id } = action.payload;
       return {
         ...state,
@@ -22,11 +28,11 @@ const articleFragments = (
         }
       };
     }
-    case 'SHARED/ARTICLE_FRAGMENTS_RECEIVED': {
+    case ARTICLE_FRAGMENTS_RECEIVED: {
       const { payload } = action;
       return Object.assign({}, state, payload);
     }
-    case 'SHARED/REMOVE_SUPPORTING_ARTICLE_FRAGMENT': {
+    case REMOVE_SUPPORTING_ARTICLE_FRAGMENT: {
       const articleFragment = state[action.payload.id];
       return {
         ...state,
@@ -41,7 +47,7 @@ const articleFragments = (
         }
       };
     }
-    case 'SHARED/INSERT_SUPPORTING_ARTICLE_FRAGMENT': {
+    case INSERT_SUPPORTING_ARTICLE_FRAGMENT: {
       const { id, articleFragmentId, index } = action.payload;
       const targetArticleFragment = state[id];
       const insertedArticleFragment = state[articleFragmentId];


### PR DESCRIPTION
## What's changed?

At the moment, we rerender the entire collection tree when collection items are selected for edit. This is expensive, and you can feel the jank when the form opens on large fronts. This PR should fix the issue -- we now only render the articles that are changing state.

## Implementation notes

This was a nice candidate for a refactor, as it DRYed up code across the Fronts and Clipboard components. I've also const-ified the relevant action names where necessary to allow us to depend on them outside of their reducer context, which is probably a good thing in any case!

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included (N/A)
