### PR TITLE
Add escaping to config

### DIFF
--- a/app/views/V2App/app.scala.html
+++ b/app/views/V2App/app.scala.html
@@ -40,11 +40,7 @@ String)
 
 <body>
     <div class="wrap" id="react-mount"></div>
-
-    <script type="application/json" id="config">
-            @Html(clientConfigJson)
-        </script>
-
+    <div id="config" data-value="@clientConfigJson"></div>
     <script src="@jsLocation" type="application/javascript"></script>
 </body>
 

--- a/client-v2/integration/server/index.html
+++ b/client-v2/integration/server/index.html
@@ -43,61 +43,66 @@
         >Business - BBC News</a
       >
     </div>
-    <script type="application/json" id="config">
-      {
-        "dev": true,
-        "env": "code",
-        "editions": ["uk", "us", "au"],
-        "email": "richard.beddington@guardian.co.uk",
-        "avatarUrl": "https://lh3.googleusercontent.com/-ZbWEH5tBZWU/AAAAAAAAAAI/AAAAAAAAAAA/ABtNlbDL_UpljZgqBjPvw4n0SmYiLD0amw/mo/photo.jpg",
-        "firstName": "Richard",
-        "lastName": "Beddington",
-        "sentryPublicDSN": "https://4527e03d554a4962ae99a7481e9278ff@app.getsentry.com/35467",
-        "mediaBaseUrl": "https://media.gutools.co.uk",
-        "apiBaseUrl": "https://api.media.test.dev-gutools.co.uk",
-        "switches": {
-          "facia-tool-allow-breaking-news-for-all": false,
-          "facia-tool-permissions-access": true,
-          "facia-tool-allow-edit-editorial-fronts-for-all": false,
-          "facia-tool-allow-config-for-all": false,
-          "facia-tool-allow-launch-editorial-fronts-for-all": false,
-          "facia-tool-allow-launch-commercial-fronts-for-all": false,
-          "facia-tool-sparklines": true,
-          "facia-tool-draft-content": true,
-          "facia-tool-disable": false
+    <div id="config"></div>
+    <script>
+      const config = document.getElementById('config');
+
+      config.dataset.value = JSON.stringify({
+        dev: true,
+        env: 'code',
+        editions: ['uk', 'us', 'au'],
+        email: 'richard.beddington@guardian.co.uk',
+        avatarUrl:
+          'https://lh3.googleusercontent.com/-ZbWEH5tBZWU/AAAAAAAAAAI/AAAAAAAAAAA/ABtNlbDL_UpljZgqBjPvw4n0SmYiLD0amw/mo/photo.jpg',
+        firstName: 'Richard',
+        lastName: 'Beddington',
+        sentryPublicDSN:
+          'https://4527e03d554a4962ae99a7481e9278ff@app.getsentry.com/35467',
+        mediaBaseUrl: 'https://media.gutools.co.uk',
+        apiBaseUrl: 'https://api.media.test.dev-gutools.co.uk',
+        switches: {
+          'facia-tool-allow-breaking-news-for-all': false,
+          'facia-tool-permissions-access': true,
+          'facia-tool-allow-edit-editorial-fronts-for-all': false,
+          'facia-tool-allow-config-for-all': false,
+          'facia-tool-allow-launch-editorial-fronts-for-all': false,
+          'facia-tool-allow-launch-commercial-fronts-for-all': false,
+          'facia-tool-sparklines': true,
+          'facia-tool-draft-content': true,
+          'facia-tool-disable': false
         },
-        "acl": {
-          "fronts": { "breaking-news": false },
-          "permissions": { "configure-config": true }
+        acl: {
+          fronts: { 'breaking-news': false },
+          permissions: { 'configure-config': true }
         },
-        "collectionCap": 20,
-        "navListCap": 40,
-        "navListType": "nav/list",
-        "collectionMetadata": [
-          { "type": "Canonical" },
-          { "type": "Special" },
-          { "type": "Breaking" },
-          { "type": "Branded" }
+        collectionCap: 20,
+        navListCap: 40,
+        navListType: 'nav/list',
+        collectionMetadata: [
+          { type: 'Canonical' },
+          { type: 'Special' },
+          { type: 'Breaking' },
+          { type: 'Branded' }
         ],
-        "clipboardArticles": [
+        clipboardArticles: [
           {
-            "id": "internal-code/page/5224281",
-            "frontPublicationDate": 1540381197498,
-            "meta": {
-              "supporting": [
+            id: 'internal-code/page/5224281',
+            frontPublicationDate: 1540381197498,
+            meta: {
+              supporting: [
                 {
-                  "id": "internal-code/page/2309422",
-                  "frontPublicationDate": 1540379258808,
-                  "meta": {}
+                  id: 'internal-code/page/2309422',
+                  frontPublicationDate: 1540379258808,
+                  meta: {}
                 }
               ]
             }
           }
         ],
-        "frontIds": ["test/front"],
-        "capiLiveUrl": "/api/live/",
-        "capiPreviewUrl": "/api/preview/"
-      }
+        frontIds: ['test/front'],
+        capiLiveUrl: '/api/live/',
+        capiPreviewUrl: '/api/preview/'
+      });
     </script>
     <script src="/dist/app.bundle.js"></script>
   </body>

--- a/client-v2/src/util/extractConfigFromPage.ts
+++ b/client-v2/src/util/extractConfigFromPage.ts
@@ -7,7 +7,7 @@ export default () => {
     throw new Error('Missing config');
   }
 
-  const json: Config = JSON.parse(configEl.innerHTML);
+  const json: Config = JSON.parse(configEl.dataset.value || '');
 
   return json;
 };


### PR DESCRIPTION
## What's changed?

Before this change `</script>` tags left in anything that made it to the `config` would close the config script tag and allow arbitrary scripts to be added to the body on page load.

This PR leaves the config JSON escaped as we print it to the DOM to stop this from happening.

## Implementation notes

When reading from an DOM attribute the DOM parser will unescape the escaped JSON and gives us our config JSON with the HTML tags in it as expected. We solve any XSS possibility in the app using #549.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
