### PR TITLE
Fix dedupe when flattening a drops supporting articles to sibling in the targets supporting articles

### DIFF
--- a/client-v2/src/shared/util/__tests__/insertAndDedupeSiblings.spec.ts
+++ b/client-v2/src/shared/util/__tests__/insertAndDedupeSiblings.spec.ts
@@ -24,6 +24,12 @@ const articleFragmentMap = {
     id: '3', // same as c
     meta: {},
     frontPublicationDate: 0
+  },
+  e: {
+    uuid: 'e',
+    id: '2', // same as b
+    meta: {},
+    frontPublicationDate: 0
   }
 };
 
@@ -77,5 +83,17 @@ describe('insertAndDedupeSiblings', () => {
     expect(
       insertAndDedupeSiblings(['a', 'c'], ['d'], 1, articleFragmentMap, false)
     ).toEqual(['a']);
+  });
+
+  it('takes multiple insertions and only dedupes existing', () => {
+    expect(
+      insertAndDedupeSiblings(['a', 'b', 'c'], ['d', 'e'], 1, articleFragmentMap)
+    ).toEqual(['a', 'd', 'e']);
+  });
+
+  it('takes multiple insertions with duplicates and keeps the first', () => {
+    expect(
+      insertAndDedupeSiblings(['a', 'c'], ['b', 'e'], 1, articleFragmentMap)
+    ).toEqual(['a', 'b', 'c']);
   });
 });

--- a/client-v2/src/shared/util/__tests__/insertAndDedupeSiblings.spec.ts
+++ b/client-v2/src/shared/util/__tests__/insertAndDedupeSiblings.spec.ts
@@ -87,7 +87,12 @@ describe('insertAndDedupeSiblings', () => {
 
   it('takes multiple insertions and only dedupes existing', () => {
     expect(
-      insertAndDedupeSiblings(['a', 'b', 'c'], ['d', 'e'], 1, articleFragmentMap)
+      insertAndDedupeSiblings(
+        ['a', 'b', 'c'],
+        ['d', 'e'],
+        1,
+        articleFragmentMap
+      )
     ).toEqual(['a', 'd', 'e']);
   });
 

--- a/client-v2/src/shared/util/insertAndDedupeSiblings.ts
+++ b/client-v2/src/shared/util/insertAndDedupeSiblings.ts
@@ -22,7 +22,7 @@ export const insertAndDedupeSiblings = (
   );
 
   const isAnInsertedItem = (i: number) =>
-    i >= index && i < (index + insertionUUIDs.length);
+    i >= index && i < index + insertionUUIDs.length;
 
   // the filter alone should be enough here but just in case any of the
   // insertions were duplicates then run `uniqBy` over and dedupe again

--- a/client-v2/src/shared/util/insertAndDedupeSiblings.ts
+++ b/client-v2/src/shared/util/insertAndDedupeSiblings.ts
@@ -21,6 +21,9 @@ export const insertAndDedupeSiblings = (
     id => articleFragmentMap[id]
   );
 
+  const isAnInsertedItem = (i: number) =>
+    i >= index && i < (index + insertionUUIDs.length);
+
   // the filter alone should be enough here but just in case any of the
   // insertions were duplicates then run `uniqBy` over and dedupe again
   return uniqBy(
@@ -29,7 +32,7 @@ export const insertAndDedupeSiblings = (
         // keep anything that doesn't match on id or is the item we just
         // inserted
         !insertionIDs.includes(siblingArticleFragment.id) ||
-        (isInsertionGroup && i === index)
+        (isInsertionGroup && isAnInsertedItem(i))
     ),
     ({ id: dedupeKey }) => dedupeKey
   ).map(({ uuid }) => uuid);


### PR DESCRIPTION
## What's changed?

Supporting articles get flattened and we end up inserting multiple article fragments on one level occasionally as a result.

E.g. when dragging an article with supporting articles into a supporting position, the dragged parent article is added as a supporting article of the target article (as is normal) but also the supporting articles from the _dragged_ article are also added as supporting articles, following after their parent. (This may need reading a few times to get!). I've called this "flattening".

Prior to this PR, if any of those supporting articles (the ones that had been to be adjacent to their sibling) were duplicates in their new position, both them and their duplicate counterparts that existed as a supporting article in the target _prior_ to the drop would be removed, instead of keeping one of them (specifically the newer ones)

This changes that and adds a couple of tests around here.

## Implementation notes

N/A

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
