### PR TITLE
Add fork-ts plugin

### DIFF
--- a/client-v2/config/webpack.config.common.js
+++ b/client-v2/config/webpack.config.common.js
@@ -3,7 +3,7 @@ const TSConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 // https://github.com/Igorbek/typescript-plugin-styled-components
 const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
 const styledComponentsTransformer = createStyledComponentsTransformer();
-
+var ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
   entry: './src/index.tsx',
@@ -11,6 +11,7 @@ module.exports = {
     path: path.resolve(__dirname, '../../public/client-v2/dist'),
     filename: 'app.bundle.js'
   },
+  plugins: [new ForkTsCheckerWebpackPlugin()],
   module: {
     rules: [
       {
@@ -41,5 +42,9 @@ module.exports = {
     modules: [path.resolve(__dirname, 'src'), 'node_modules'],
     plugins: [new TSConfigPathsPlugin()],
     extensions: ['.ts', '.tsx', '.js']
+  },
+  stats: {
+    // See https://github.com/TypeStrong/ts-loader#loader-options
+    warningsFilter: /export .* was not found in/
   }
 };

--- a/client-v2/config/webpack.config.common.js
+++ b/client-v2/config/webpack.config.common.js
@@ -3,7 +3,7 @@ const TSConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 // https://github.com/Igorbek/typescript-plugin-styled-components
 const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
 const styledComponentsTransformer = createStyledComponentsTransformer();
-var ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
   entry: './src/index.tsx',

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -50,6 +50,7 @@
     "express": "^4.16.4",
     "fetch-mock": "^6.4.2",
     "file-loader": "^1.1.11",
+    "fork-ts-checker-webpack-plugin": "^0.5.2",
     "jest": "^23.6.0",
     "jest-dom": "^2.1.0",
     "markdown-toc": "^1.2.0",

--- a/client-v2/tsconfig.json
+++ b/client-v2/tsconfig.json
@@ -12,7 +12,8 @@
     "sourceMap": true,
     "baseUrl": "src",
     "strict": true,
-    "outDir": "../../public/client-v2/dist"
+    "outDir": "../../public/client-v2/dist",
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## What's changed?

At the moment, our build step during development takes a while - between 5 and 7 seconds. To speed things up, this PR adds https://github.com/Realytics/fork-ts-checker-webpack-plugin and disables typechecking during transpilation. Typechecking happens via this plugin in a separate thread.

This speeds both parts of the process up -- our builds now run in under a second, and we get typechecking results slightly after. An error during typechecking still fails a build, so we're still typesafe  in CI 👍 

Before (build time):
![screen shot 2019-03-05 at 09 19 43](https://user-images.githubusercontent.com/7767575/53794592-2d22ae00-3f28-11e9-8a52-73be991d9d4b.png)

After (build time, then typechecking time):
![screen shot 2019-03-05 at 08 59 56](https://user-images.githubusercontent.com/7767575/53794595-2eec7180-3f28-11e9-9765-63130f7985eb.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A)
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
