### PR TITLE
Add live/dead indicators to articles in capi feed

### DIFF
--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -81,7 +81,7 @@ const ResultsHeadingContainer = styled('div')`
 
 const getCapiFieldsToShow = (isPreview: boolean) => {
   const defaultFieldsToShow =
-    'internalPageCode,trailText,firstPublicationDate,isLive';
+    'internalPageCode,trailText,firstPublicationDate,isLive,liveBloggingNow';
 
   if (!isPreview) {
     return defaultFieldsToShow;

--- a/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
@@ -36,7 +36,8 @@ const Feed = ({ articles = [], error }: FeedProps) => (
             webPublicationDate,
             sectionName,
             fields,
-            pillarId
+            pillarId,
+            frontsMeta
           }) => (
             <FeedItem
               id={id}
@@ -50,6 +51,7 @@ const Feed = ({ articles = [], error }: FeedProps) => (
               firstPublicationDate={fields.firstPublicationDate}
               isLive={!fields.isLive || fields.isLive === 'true'}
               scheduledPublicationDate={fields.scheduledPublicationDate}
+              tone={frontsMeta.tone}
             />
           )
         )

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -114,6 +114,7 @@ interface FeedItemProps {
   isLive: boolean;
   onAddToClipboard: (id: string) => void;
   scheduledPublicationDate?: string;
+  tone?: string;
 }
 
 const dragStart = (
@@ -121,6 +122,26 @@ const dragStart = (
   event: React.DragEvent<HTMLDivElement>
 ) => {
   event.dataTransfer.setData('capi', href || '');
+};
+
+const getArticleLabel = (
+  firstPublicationDate: string | undefined,
+  sectionName: string,
+  isLive: boolean,
+  tone?: string
+) => {
+  if (!isLive) {
+    if (firstPublicationDate) {
+      return notLiveLabels.takenDown;
+    }
+    return notLiveLabels.draft;
+  }
+
+  if (tone === 'dead' || tone === 'live') {
+    return startCase(tone);
+  }
+
+  return startCase(sectionName);
 };
 
 const FeedItem = ({
@@ -134,7 +155,8 @@ const FeedItem = ({
   firstPublicationDate,
   isLive,
   onAddToClipboard = noop,
-  scheduledPublicationDate
+  scheduledPublicationDate,
+  tone
 }: FeedItemProps) => (
   <Container
     data-testid="feed-item"
@@ -154,11 +176,7 @@ const FeedItem = ({
               styleTheme.capiInterface.textLight
           }}
         >
-          {isLive && startCase(sectionName)}
-          {!isLive &&
-            (firstPublicationDate
-              ? notLiveLabels.takendDown
-              : notLiveLabels.draft)}
+          {getArticleLabel(firstPublicationDate, sectionName, isLive, tone)}
         </Tone>
         {scheduledPublicationDate && (
           <ScheduledPublication>

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -19,6 +19,7 @@ import {
 import { insertArticleFragment } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import { getPaths } from 'util/paths';
+import { liveBlogTones } from 'constants/fronts';
 
 const LinkContainer = styled('div')`
   background-color: ${({ theme }) => theme.capiInterface.backgroundLight};
@@ -137,8 +138,8 @@ const getArticleLabel = (
     return notLiveLabels.draft;
   }
 
-  if (tone === 'dead' || tone === 'live') {
-    return 'Live';
+  if (tone === liveBlogTones.dead || tone === liveBlogTones.live) {
+    return startCase(liveBlogTones.live);
   }
 
   return startCase(sectionName);
@@ -172,7 +173,7 @@ const FeedItem = ({
         <Tone
           style={{
             color:
-              getPillarColor(pillarId, isLive, tone === 'dead') ||
+              getPillarColor(pillarId, isLive, tone === liveBlogTones.dead) ||
               styleTheme.capiInterface.textLight
           }}
         >

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -138,7 +138,7 @@ const getArticleLabel = (
   }
 
   if (tone === 'dead' || tone === 'live') {
-    return startCase(tone);
+    return 'Live';
   }
 
   return startCase(sectionName);
@@ -172,7 +172,7 @@ const FeedItem = ({
         <Tone
           style={{
             color:
-              getPillarColor(pillarId, isLive) ||
+              getPillarColor(pillarId, isLive, tone === 'dead') ||
               styleTheme.capiInterface.textLight
           }}
         >

--- a/client-v2/src/constants/fronts.ts
+++ b/client-v2/src/constants/fronts.ts
@@ -19,6 +19,11 @@ export const notLiveLabels: { [key: string]: string } = {
   takenDown: 'Taken Down'
 };
 
+export const liveBlogTones: { [key: string]: string } = {
+  dead: 'dead',
+  live: 'live'
+};
+
 export const detectPressFailureMs = 10000;
 
 export const noOfOpenCollectionsOnFirstLoad = 3;

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -18,7 +18,8 @@ import ImagePlaceholder from '../ImagePlaceholder';
 import TextPlaceholder from '../TextPlaceholder';
 
 const PillaredSection = styled('span')<{ pillar?: string; isLive?: boolean }>`
-  color: ${({ pillar, isLive }) => getPillarColor(pillar, isLive) || 'inherit'};
+  color: ${({ pillar, isLive }) =>
+    getPillarColor(pillar, isLive || true) || 'inherit'};
   font-size: 13px;
   font-weight: bold;
 `;

--- a/client-v2/src/shared/util/getPillarColor.ts
+++ b/client-v2/src/shared/util/getPillarColor.ts
@@ -1,3 +1,5 @@
+import { theme } from 'constants/theme';
+
 const pillarColorMap = {
   'pillar/news': '#c70000',
   'pillar/sport': '#0084c6',
@@ -7,15 +9,21 @@ const pillarColorMap = {
 } as { [pillar: string]: string };
 
 const noPillarColour = '#221133';
+const deadLiveBlogColour = theme.shared.colors.greyMediumDark;
 
 export const notLiveColour = '#ff7f0f';
 
 export const getPillarColor = (
   pillar: string | undefined,
-  isLive?: boolean
+  isLive?: boolean,
+  deadLiveBlog?: boolean
 ) => {
   if (!isLive) {
     return notLiveColour;
+  }
+
+  if (deadLiveBlog) {
+    return deadLiveBlogColour;
   }
 
   if (!pillar) {

--- a/client-v2/src/shared/util/getPillarColor.ts
+++ b/client-v2/src/shared/util/getPillarColor.ts
@@ -15,7 +15,7 @@ export const notLiveColour = '#ff7f0f';
 
 export const getPillarColor = (
   pillar: string | undefined,
-  isLive?: boolean,
+  isLive: boolean,
   deadLiveBlog?: boolean
 ) => {
   if (!isLive) {

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -136,9 +136,7 @@ interface CapiArticle {
       showMainVideo: boolean;
       showQuotedHeadline: boolean;
     };
-    frontsMeta?: {
-      tone?: string;
-    };
+    tone?: string;
   };
 }
 


### PR DESCRIPTION
## What's changed?

Indicate whether live blog is live/dead in capi feed. Unlike in the old tool we are not showing these in collections themselves because we are not polling for changes so information is potentially stale. 
![screen shot 2019-03-08 at 11 20 30](https://user-images.githubusercontent.com/3066534/54025977-2d26e600-4194-11e9-9ef6-b5f79555742d.png)

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
