### PR TITLE
Feed trail image

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -112,7 +112,7 @@ class Clipboard extends React.Component<ClipboardProps> {
                 display: 'flex',
                 flexDirection: 'column',
                 height: '100%',
-                width: '160px'
+                width: '140px'
               }}
             >
               <ClipboardLevel

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -13,7 +13,7 @@ const FeedSectionContainer = styled('div')`
 `;
 
 const FeedWrapper = styled('div')`
-  width: 389px;
+  width: 409px;
   padding-right: 10px;
   margin-right: 10px;
   border-right: ${({ theme }) =>

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -81,7 +81,7 @@ const ResultsHeadingContainer = styled('div')`
 
 const getCapiFieldsToShow = (isPreview: boolean) => {
   const defaultFieldsToShow =
-    'internalPageCode,trailText,firstPublicationDate,isLive,liveBloggingNow';
+    'internalPageCode,trailText,firstPublicationDate,isLive,thumbnail,secureThumbnail,liveBloggingNow';
 
   if (!isPreview) {
     return defaultFieldsToShow;

--- a/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { styled } from 'constants/theme';
 import FeedItem from './FeedItem';
 import { CapiArticle } from 'types/Capi';
+import { getThumbnail } from 'util/CAPIUtils';
 
 const getId = (internalPageCode: string | number | undefined) =>
   `internal-code/page/${internalPageCode}`;
@@ -28,33 +29,25 @@ const Feed = ({ articles = [], error }: FeedProps) => (
     {articles.length ? (
       articles
         .filter(result => result.webTitle)
-        .map(
-          ({
-            id,
-            webTitle,
-            webUrl,
-            webPublicationDate,
-            sectionName,
-            fields,
-            pillarId,
-            frontsMeta
-          }) => (
-            <FeedItem
-              id={id}
-              key={webUrl}
-              title={webTitle}
-              href={webUrl}
-              publicationDate={webPublicationDate}
-              sectionName={sectionName}
-              pillarId={pillarId}
-              internalPageCode={fields && getId(fields.internalPageCode)}
-              firstPublicationDate={fields.firstPublicationDate}
-              isLive={!fields.isLive || fields.isLive === 'true'}
-              scheduledPublicationDate={fields.scheduledPublicationDate}
-              tone={frontsMeta.tone}
-            />
-          )
-        )
+        .map(article => (
+          <FeedItem
+            id={article.id}
+            key={article.webUrl}
+            title={article.webTitle}
+            href={article.webUrl}
+            publicationDate={article.webPublicationDate}
+            sectionName={article.sectionName}
+            pillarId={article.pillarId}
+            internalPageCode={
+              article.fields && getId(article.fields.internalPageCode)
+            }
+            firstPublicationDate={article.fields.firstPublicationDate}
+            isLive={!article.fields.isLive || article.fields.isLive === 'true'}
+            scheduledPublicationDate={article.fields.scheduledPublicationDate}
+            thumbnail={getThumbnail(article, article.frontsMeta.defaults)}
+            tone={article.frontsMeta.tone}
+          />
+        ))
     ) : (
       <NoResults>No results found</NoResults>
     )}

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -100,8 +100,8 @@ const Tone = styled('div')`
 `;
 
 const Body = styled('div')`
-  width: calc(100% - 170px);
-  padding-left: 4px;
+  width: calc(100% - 163px);
+  padding-left: 1px;
 `;
 
 interface FeedItemProps {

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -20,6 +20,7 @@ import { insertArticleFragment } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import { getPaths } from 'util/paths';
 import { liveBlogTones } from 'constants/fronts';
+import { ThumbnailSmall } from 'shared/components/Thumbnail';
 
 const LinkContainer = styled('div')`
   background-color: ${({ theme }) => theme.capiInterface.backgroundLight};
@@ -80,7 +81,7 @@ const VisitedWrapper = styled.a`
 const MetaContainer = styled('div')`
   position: relative;
   width: 80px;
-  padding: 0px 8px;
+  padding: 0px 2px;
 `;
 
 const FirstPublished = styled('div')`
@@ -99,8 +100,8 @@ const Tone = styled('div')`
 `;
 
 const Body = styled('div')`
-  width: calc(100% - 80px);
-  padding-left: 10px;
+  width: calc(100% - 170px);
+  padding-left: 4px;
 `;
 
 interface FeedItemProps {
@@ -116,6 +117,7 @@ interface FeedItemProps {
   onAddToClipboard: (id: string) => void;
   scheduledPublicationDate?: string;
   tone?: string;
+  thumbnail?: string;
 }
 
 const dragStart = (
@@ -157,7 +159,8 @@ const FeedItem = ({
   isLive,
   onAddToClipboard = noop,
   scheduledPublicationDate,
-  tone
+  tone,
+  thumbnail
 }: FeedItemProps) => (
   <Container
     data-testid="feed-item"
@@ -197,6 +200,11 @@ const FeedItem = ({
       <Body>
         <Title data-testid="headline">{title}</Title>
       </Body>
+      <ThumbnailSmall
+        style={{
+          backgroundImage: `url('${thumbnail}')`
+        }}
+      />
     </VisitedWrapper>
     <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
       <HoverActionsButtonWrapper

--- a/client-v2/src/shared/components/PolaroidThumbnail.tsx
+++ b/client-v2/src/shared/components/PolaroidThumbnail.tsx
@@ -3,5 +3,4 @@ import Thumbnail from './Thumbnail';
 
 export default styled(Thumbnail)`
   width: 100%;
-  height: 108px;
 `;

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -1,9 +1,20 @@
 import { styled } from 'shared/constants/theme';
 
-export default styled('div')`
-  width: 130px;
-  height: 83px;
+const ThumbnailBase = styled('div')`
   background-size: cover;
   background-color: ${({ theme }) =>
     theme.shared.base.colors.backgroundColorFocused};
+`;
+
+const ThumbnailSmall = styled(ThumbnailBase)`
+  width: 83px;
+  height: 50px;
+  margin: 3px 5px 3px 5px;
+`;
+
+export { ThumbnailSmall };
+
+export default styled(ThumbnailBase)`
+  width: 130px;
+  height: 83px;
 `;

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -43,7 +43,7 @@ const ArticlePolaroidComponent = ({
     <>
       {size === 'default' &&
         (displayPlaceholders ? (
-          <ImagePlaceholder height={108} />
+          <ImagePlaceholder height={84} />
         ) : (
           <PolaroidThumbnail
             style={{


### PR DESCRIPTION
## What's changed?

Displays article trail pics in capi feed, reduces the clipboard size to make way for a slightly wider feed and adjusts some padding for the same purpose as well as per @akemitakagi's instructions.

## Implementation notes
![Screenshot 2019-03-11 at 15 19 16](https://user-images.githubusercontent.com/3066534/54135140-2c4eb800-4411-11e9-867d-cc9617379ca5.png)



_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
