### PR TITLE
Fix form bugs

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -117,6 +117,9 @@ const renderSlideshow = (
   </>
 );
 
+const getInputId = (articleFragmentId: string, label: string) =>
+  `${articleFragmentId}-${label}`;
+
 const formComponent: React.StatelessComponent<Props> = ({
   change,
   kickerOptions,
@@ -133,7 +136,8 @@ const formComponent: React.StatelessComponent<Props> = ({
   reset,
   showKickerTag,
   showKickerSection,
-  frontId
+  frontId,
+  articleFragmentId
 }) => (
   <FormContainer onSubmit={handleSubmit}>
     <CollectionHeadingPinline>
@@ -163,6 +167,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="isBoosted"
           component={InputCheckboxToggle}
           label="Boost"
+          id={getInputId(articleFragmentId, 'boost')}
           type="checkbox"
         />
         <ConditionalField
@@ -170,6 +175,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="showQuotedHeadline"
           component={InputCheckboxToggle}
           label="Quote headline"
+          id={getInputId(articleFragmentId, 'quote-headline')}
           type="checkbox"
         />
         <ConditionalField
@@ -177,12 +183,14 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="showBoostedHeadline"
           component={InputCheckboxToggle}
           label="Large headline"
+          id={getInputId(articleFragmentId, 'large-headline')}
           type="checkbox"
         />
         <ConditionalField
           permittedFields={editableFields}
           name="showLivePlayable"
           component={InputCheckboxToggle}
+          id={getInputId(articleFragmentId, 'show-updates')}
           label="Show updates"
           type="checkbox"
         />
@@ -191,6 +199,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="showMainVideo"
           component={InputCheckboxToggle}
           label="Show video"
+          id={getInputId(articleFragmentId, 'show-video')}
           type="checkbox"
         />
         <ConditionalField
@@ -264,6 +273,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="isBreaking"
           component={InputCheckboxToggle}
           label="Breaking News"
+          id={getInputId(articleFragmentId, 'breaking-news')}
           type="checkbox"
         />
         <ConditionalField
@@ -271,6 +281,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="showByline"
           component={InputCheckboxToggle}
           label="Show Byline"
+          id={getInputId(articleFragmentId, 'show-byline')}
           type="checkbox"
         />
         {showByline && (
@@ -312,6 +323,7 @@ const formComponent: React.StatelessComponent<Props> = ({
                 name="imageHide"
                 component={InputCheckboxToggle}
                 label="Hide media"
+                id={getInputId(articleFragmentId, 'hide-media')}
                 type="checkbox"
                 default={false}
               />
@@ -344,6 +356,7 @@ const formComponent: React.StatelessComponent<Props> = ({
                 name="imageCutoutReplace"
                 component={InputCheckboxToggle}
                 label="Use cutout"
+                id={getInputId(articleFragmentId, 'use-cutout')}
                 type="checkbox"
                 default={false}
               />
@@ -363,6 +376,7 @@ const formComponent: React.StatelessComponent<Props> = ({
           name="imageSlideshowReplace"
           component={InputCheckboxToggle}
           label="Slideshow"
+          id={getInputId(articleFragmentId, 'slideshow')}
           type="checkbox"
         />
       </InputGroup>

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -77,7 +77,7 @@ export default ({
         <Switch>
           <Checkbox
             type="checkbox"
-            onClick={() => onChange(!inputRest.checked)}
+            onChange={() => onChange(!inputRest.checked)}
             {...inputRest}
             {...rest}
             id={label}

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -63,10 +63,12 @@ const Checkbox = styled('input')`
 
 type Props = {
   label?: string;
+  id: string;
 } & WrappedFieldProps;
 
 export default ({
   label,
+  id,
   input: { onChange, ...inputRest },
   ...rest
 }: Props) => (
@@ -80,9 +82,9 @@ export default ({
             onChange={() => onChange(!inputRest.checked)}
             {...inputRest}
             {...rest}
-            id={label}
+            id={id}
           />
-          <CheckboxLabel htmlFor={label} />
+          <CheckboxLabel htmlFor={id} />
         </Switch>
       </CheckboxContainer>
     </InputContainer>


### PR DESCRIPTION
Previously, two forms open at the same time would trigger the first form's checkboxes when the user clicked on either. This is because they shared ids. 🙃This is no longer the case.

This PR also removes the warning re: onChange handler in development mode 😄 

## Checklist

### General
- [ ] 🤖 Relevant tests added (N/A)
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included (N/A)
