### PR TITLE
Open preview in the same tab each time

### DIFF
--- a/app/commands/V2GetCollectionsCommand.scala
+++ b/app/commands/V2GetCollectionsCommand.scala
@@ -1,0 +1,29 @@
+package commands
+
+import scala.concurrent.{ExecutionContext, Future}
+import services.{CollectionService, CollectionAndStoriesResponse}
+import controllers.{CollectionSpec}
+
+case class V2GetCollectionsCommand(
+    collectionService: CollectionService,
+    collectionSpecs: List[CollectionSpec]
+)(
+    implicit ec: ExecutionContext
+) {
+  import V2GetCollectionsCommand._
+  def process(): Future[List[CollectionAndStoriesResponse]] =
+    collectionService
+      .fetchCollectionsAndStoriesVisible(collectionSpecs.map(_.id))
+      .map(keepOnlyNewerCollectionData(collectionSpecs, _))
+}
+
+object V2GetCollectionsCommand {
+  def keepOnlyNewerCollectionData(
+      specs: List[CollectionSpec],
+      responses: List[Option[CollectionAndStoriesResponse]]
+  ): List[CollectionAndStoriesResponse] =
+    for {
+      (Some(response), spec) <- responses.zip(specs)
+      if response.wasUpdatedAfter(spec.lastUpdated)
+    } yield response
+}

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -22,14 +22,14 @@ object CollectionSpec {
 case class CollectionSpec(id: String, lastUpdated: Option[Long], `type`: String)
 
 class FaciaToolV2Controller(
-                             val acl: Acl,
-                             val structuredLogger: StructuredLogger,
-                             val faciaPress: FaciaPress,
-                             val updateActions: UpdateActions,
-                             val configAgent: ConfigAgent,
-                             val collectionService: CollectionService,
-                             val deps: BaseFaciaControllerComponents
-                           )(implicit ec: ExecutionContext)
+                           val acl: Acl,
+                           val structuredLogger: StructuredLogger,
+                           val faciaPress: FaciaPress,
+                           val updateActions: UpdateActions,
+                           val configAgent: ConfigAgent,
+                           val collectionService: CollectionService,
+                           val deps: BaseFaciaControllerComponents
+                         )(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with ModifyCollectionsPermissionsCheck with Logging {
 
     def getCollections() =

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -9,33 +9,70 @@ import services._
 import updates._
 import util.Acl
 import permissions.ModifyCollectionsPermissionsCheck
+import org.joda.time.{DateTime}
 import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 
+object GetCollectionRequest {
+  implicit val jsonFormat = Json.format[GetCollectionRequest]
+}
+
+case class GetCollectionRequest(
+                                 collectionSpecs: Seq[CollectionSpec]
+                               )
+
+case class CollectionSpec(id: String, `type`: String, lastUpdated: Option[Int])
+
 class FaciaToolV2Controller(
-                           val acl: Acl,
-                           val structuredLogger: StructuredLogger,
-                           val faciaPress: FaciaPress,
-                           val updateActions: UpdateActions,
-                           val configAgent: ConfigAgent,
-                           val collectionService: CollectionService,
-                           val deps: BaseFaciaControllerComponents
-                         )(implicit ec: ExecutionContext)
+                             val acl: Acl,
+                             val structuredLogger: StructuredLogger,
+                             val faciaPress: FaciaPress,
+                             val updateActions: UpdateActions,
+                             val configAgent: ConfigAgent,
+                             val collectionService: CollectionService,
+                             val deps: BaseFaciaControllerComponents
+                           )(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with ModifyCollectionsPermissionsCheck with Logging {
 
-  def getCollections(): Action[AnyContent] = AccessAPIAuthAction.async { implicit request =>
-    val collectionIds = request.queryString.getOrElse("ids", Seq()).toList
+  def getCollections() = AccessAPIAuthAction(parse.json[GetCollectionRequest]).async { implicit request =>
+
+    val collectionSpecs = request.body.collectionSpecs.toList
+    val collectionIds = collectionSpecs.map(_.id)
+
     val collectionPriorities = collectionIds.flatMap(configAgent.getFrontsPermissionsPriorityByCollectionId(_)).toSet
+
+
+    //TODO write tests
 
     withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
       val collections = collectionService.fetchCollectionsAndStoriesVisible(collectionIds)
 
-      collections.map(c => NoCache {
-        Ok(Json.toJson(c)).as("application/json")
-      })
+      // if spec includes lastUpdated timestamp, then this will only return the server data if it is more recent than the spec timestamp
+      def getNewerServerData(collectionAndStoriesResponse: CollectionAndStoriesResponse) = {
+        val id = collectionAndStoriesResponse.id
+        val lastUpdated = collectionAndStoriesResponse.collection.lastUpdated
+        val spec = collectionSpecs.find(spec => spec.id == id)
+
+        // .getOrElse ensures that if lastUpdated does not exist, it will always be less, and the server data will always be returned.
+        spec.flatMap(s => if (s.lastUpdated.getOrElse(-1) < lastUpdated.getMillis()) Some(collectionAndStoriesResponse) else None)
+      }
+      collections.map(c =>
+        c.map(_.flatMap(response => getNewerServerData(response)))).map(c =>
+        NoCache {
+          Ok(Json.toJson(c)).as("application/json")
+        })
+
+//      collections.map(c => NoCache {
+//        c.map(collectionAndStoriesResponse => collectionAndStoriesResponse match {
+//          case Some(response) => getNewerServerData(response)
+//          case None => None
+//        })
+//        Ok(Json.toJson(c)).as("application/json")
+//      })
     }
+
   }
 
   def collectionEdits() = AccessAPIAuthAction.async { implicit request =>

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -19,7 +19,7 @@ object CollectionSpec {
   implicit val jsonFormat = Json.format[CollectionSpec]
 }
 
-case class CollectionSpec(id: String, lastUpdated: Option[Long], `type`: String)
+case class CollectionSpec(id: String, lastUpdated: Option[Long])
 
 class FaciaToolV2Controller(
                            val acl: Acl,

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -14,16 +14,11 @@ import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-
-object GetCollectionRequest {
-  implicit val jsonFormat = Json.format[GetCollectionRequest]
+object CollectionSpec {
+  implicit val jsonFormat = Json.format[CollectionSpec]
 }
 
-case class GetCollectionRequest(
-                                 collectionSpecs: Seq[CollectionSpec]
-                               )
-
-case class CollectionSpec(id: String, `type`: String, lastUpdated: Option[Int])
+case class CollectionSpec(id: String, lastUpdated: Option[Long], `type`: String)
 
 class FaciaToolV2Controller(
                              val acl: Acl,
@@ -36,44 +31,37 @@ class FaciaToolV2Controller(
                            )(implicit ec: ExecutionContext)
   extends BaseFaciaController(deps) with ModifyCollectionsPermissionsCheck with Logging {
 
-  def getCollections() = AccessAPIAuthAction(parse.json[GetCollectionRequest]).async { implicit request =>
+    def getCollections() =
+    AccessAPIAuthAction(parse.json[Seq[CollectionSpec]]).async {
+      implicit request =>
+        val collectionSpecs = request.body.toList
+        val collectionIds = collectionSpecs.map(_.id)
+        val collectionPriorities = collectionIds
+          .flatMap(configAgent.getFrontsPermissionsPriorityByCollectionId(_))
+          .toSet
 
-    val collectionSpecs = request.body.collectionSpecs.toList
-    val collectionIds = collectionSpecs.map(_.id)
+        //TODO write tests
 
-    val collectionPriorities = collectionIds.flatMap(configAgent.getFrontsPermissionsPriorityByCollectionId(_)).toSet
-
-
-    //TODO write tests
-
-    withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
-      val collections = collectionService.fetchCollectionsAndStoriesVisible(collectionIds)
-
-      // if spec includes lastUpdated timestamp, then this will only return the server data if it is more recent than the spec timestamp
-      def getNewerServerData(collectionAndStoriesResponse: CollectionAndStoriesResponse) = {
-        val id = collectionAndStoriesResponse.id
-        val lastUpdated = collectionAndStoriesResponse.collection.lastUpdated
-        val spec = collectionSpecs.find(spec => spec.id == id)
-
-        // .getOrElse ensures that if lastUpdated does not exist, it will always be less, and the server data will always be returned.
-        spec.flatMap(s => if (s.lastUpdated.getOrElse(-1) < lastUpdated.getMillis()) Some(collectionAndStoriesResponse) else None)
-      }
-      collections.map(c =>
-        c.map(_.flatMap(response => getNewerServerData(response)))).map(c =>
-        NoCache {
-          Ok(Json.toJson(c)).as("application/json")
-        })
-
-//      collections.map(c => NoCache {
-//        c.map(collectionAndStoriesResponse => collectionAndStoriesResponse match {
-//          case Some(response) => getNewerServerData(response)
-//          case None => None
-//        })
-//        Ok(Json.toJson(c)).as("application/json")
-//      })
+        withModifyGroupPermissionForCollections(collectionPriorities, Set()) {
+          collectionService
+            .fetchCollectionsAndStoriesVisible(collectionIds)
+            .map(
+              collectionResponses =>
+                NoCache {
+                  val list = collectionResponses.zip(collectionSpecs).flatMap {
+                    case (response, spec) =>
+                      // getOrElse ensures that if lastUpdated does not exist,
+                      // it will always be less, and the server data will always
+                      // be returned
+                      response.filter(
+                        _.wasUpdatedAfter(spec.lastUpdated.getOrElse(-1L))
+                      )
+                  }
+                  Ok(Json.toJson(list)).as("application/json")
+                }
+            )
+        }
     }
-
-  }
 
   def collectionEdits() = AccessAPIAuthAction.async { implicit request =>
 

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -1,20 +1,18 @@
 package controllers
 
 import play.api.libs.json.Json
-import services.{ContainerService}
-import slices.{Story}
+import services.{ ContainerService }
+import slices.{ Story }
 
 object StoriesVisibleRequest {
   implicit val jsonFormat = Json.format[StoriesVisibleRequest]
 }
 
 case class StoriesVisibleRequest(
-                                  stories: Seq[Story]
-                                )
+  stories: Seq[Story]
+)
 
-class StoriesVisibleController(
-                                val containerService: ContainerService,
-                                val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
+class StoriesVisibleController(val containerService: ContainerService, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
   def storiesVisible(containerType: String) = AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
     val storiesVisible = containerService.getStoriesVisible(containerType, request.body.stories)
 

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -1,18 +1,20 @@
 package controllers
 
 import play.api.libs.json.Json
-import services.{ ContainerService }
-import slices.{ Story }
+import services.{ContainerService}
+import slices.{Story}
 
 object StoriesVisibleRequest {
   implicit val jsonFormat = Json.format[StoriesVisibleRequest]
 }
 
 case class StoriesVisibleRequest(
-  stories: Seq[Story]
-)
+                                  stories: Seq[Story]
+                                )
 
-class StoriesVisibleController(val containerService: ContainerService, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
+class StoriesVisibleController(
+                                val containerService: ContainerService,
+                                val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
   def storiesVisible(containerType: String) = AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
     val storiesVisible = containerService.getStoriesVisible(containerType, request.body.stories)
 

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -13,7 +13,7 @@ object StoriesVisibleByStage {
   implicit val jsonFormat = Json.format[StoriesVisibleByStage]
 }
 
-case class CollectionAndStoriesResponse(collection: CollectionJson, storiesVisibleByStage: Option[StoriesVisibleByStage])
+case class CollectionAndStoriesResponse(id: String, collection: CollectionJson, storiesVisibleByStage: Option[StoriesVisibleByStage])
 
 object CollectionAndStoriesResponse {
   implicit val jsonFormat = Json.format[CollectionAndStoriesResponse]
@@ -30,7 +30,7 @@ class CollectionService(frontsApi: FrontsApi, containerService: ContainerService
     frontsApi.amazonClient.config.flatMap { config =>
       val futures = collectionIds.map { collectionId => fetchCollection(collectionId).flatMap {
           case Some(collection) => {
-            val collectionAndStoriesResponse = CollectionAndStoriesResponse(collection,
+            val collectionAndStoriesResponse = CollectionAndStoriesResponse(collectionId, collection,
               CollectionService.getStoriesVisibleByStage(
                 collectionId,
                 collection,

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -13,7 +13,9 @@ object StoriesVisibleByStage {
   implicit val jsonFormat = Json.format[StoriesVisibleByStage]
 }
 
-case class CollectionAndStoriesResponse(id: String, collection: CollectionJson, storiesVisibleByStage: Option[StoriesVisibleByStage])
+case class CollectionAndStoriesResponse(id: String, collection: CollectionJson, storiesVisibleByStage: Option[StoriesVisibleByStage]) {
+  def wasUpdatedAfter(millis: Long) = collection.lastUpdated.getMillis() > millis
+}
 
 object CollectionAndStoriesResponse {
   implicit val jsonFormat = Json.format[CollectionAndStoriesResponse]

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -14,7 +14,10 @@ object StoriesVisibleByStage {
 }
 
 case class CollectionAndStoriesResponse(id: String, collection: CollectionJson, storiesVisibleByStage: Option[StoriesVisibleByStage]) {
-  def wasUpdatedAfter(millis: Long) = collection.lastUpdated.getMillis() > millis
+  // getOrElse ensures that if millis is None
+  // this method will return true assuming i.e. that it was updatedAfter no time
+  def wasUpdatedAfter(millis: Option[Long]): Boolean =
+    collection.lastUpdated.getMillis() > millis.getOrElse(-1L)
 }
 
 object CollectionAndStoriesResponse {

--- a/client-v2/config/webpack.config.common.js
+++ b/client-v2/config/webpack.config.common.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack')
 const TSConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 // https://github.com/Igorbek/typescript-plugin-styled-components
 const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
@@ -20,8 +21,8 @@ module.exports = {
         loader: 'ts-loader',
         exclude: /node_modules/,
         options: {
-          getCustomTransformers: () => ({ 
-            before: [styledComponentsTransformer] 
+          getCustomTransformers: () => ({
+            before: [styledComponentsTransformer]
           })
         }
       },
@@ -38,6 +39,7 @@ module.exports = {
       }
     ]
   },
+  plugins: [new webpack.EnvironmentPlugin(['BUILD_ENV'])],
   resolve: {
     modules: [path.resolve(__dirname, 'src'), 'node_modules'],
     plugins: [new TSConfigPathsPlugin()],

--- a/client-v2/config/webpack.config.common.js
+++ b/client-v2/config/webpack.config.common.js
@@ -1,8 +1,9 @@
 const path = require('path');
-const webpack = require('webpack')
+const webpack = require('webpack');
 const TSConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 // https://github.com/Igorbek/typescript-plugin-styled-components
-const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
+const createStyledComponentsTransformer = require('typescript-plugin-styled-components')
+  .default;
 const styledComponentsTransformer = createStyledComponentsTransformer();
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
@@ -12,7 +13,10 @@ module.exports = {
     path: path.resolve(__dirname, '../../public/client-v2/dist'),
     filename: 'app.bundle.js'
   },
-  plugins: [new ForkTsCheckerWebpackPlugin()],
+  plugins: [
+    new webpack.EnvironmentPlugin(['BUILD_ENV']),
+    new ForkTsCheckerWebpackPlugin()
+  ],
   module: {
     rules: [
       {
@@ -35,11 +39,10 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
+        use: ['style-loader', 'css-loader']
       }
     ]
   },
-  plugins: [new webpack.EnvironmentPlugin(['BUILD_ENV'])],
   resolve: {
     modules: [path.resolve(__dirname, 'src'), 'node_modules'],
     plugins: [new TSConfigPathsPlugin()],

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const express = require('express');
+const bodyParser = require('body-parser')
 const port = 3456;
 
 const config = require('../fixtures/config');
@@ -20,6 +21,7 @@ module.exports = async () =>
   new Promise((res, rej) => {
     const app = express();
 
+    app.use(bodyParser.json())
     app.get('/v2/*', (_, res) =>
       res.sendFile(path.join(__dirname, './index.html'))
     );
@@ -116,9 +118,10 @@ module.exports = async () =>
 
     app.get('/config', (_, res) => res.json(config));
     app.get('/collection/:id', (_, res) => res.json(collection));
-    app.get('/collections*', (_, res) =>
+    app.post('/collections*', (req, res) =>
       res.json([
         {
+          id: req.body[0].id,
           collection,
           storiesVisibleByStage: {
             live: { desktop: 4, mobile: 4 },
@@ -135,12 +138,12 @@ module.exports = async () =>
         req.params[0].includes('bbc') // prevents error messages from External Snap Link fixture
           ? res.json('')
           : res.sendFile(
-              path.join(
-                __dirname,
-                '../../../public/client-v2/dist',
-                req.params.file
-              )
+            path.join(
+              __dirname,
+              '../../../public/client-v2/dist',
+              req.params.file
             )
+          )
     );
 
     // this catches update requests and pretends they went through ok

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -14,7 +14,7 @@
     "dev-server": "yarn compileWithBabel $(yarn bin)/webpack-dev-server --config config/webpack.config.dev.js",
     "dev": "yarn install && yarn dev-server --open",
     "test": "yarn jest",
-    "test-integration": "yarn build && node ./integration/run.js",
+    "test-integration": "BUILD_ENV=integration yarn build && node ./integration/run.js",
     "run-checks": "yarn test && yarn lint"
   },
   "devDependencies": {
@@ -86,6 +86,7 @@
     "@types/redux-thunk": "^2.1.0",
     "@types/uuid": "^3.4.4",
     "babel-polyfill": "^6.26.0",
+    "body-parser": "^1.18.3",
     "date-fns": "^1.29.0",
     "downshift": "^3.1.7",
     "enzyme": "^3.7.0",

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -255,7 +255,7 @@ const moveArticleFragment = (
 ): ThunkResult<void> => {
   return (dispatch: Dispatch, getState) => {
     const removeActionCreator =
-      from && getRemoveActionCreatorFromType(from.type);
+      from && getRemoveActionCreatorFromType(from.type, persistTo);
     const insertActionCreator = getInsertionActionCreatorFromType(
       to.type,
       persistTo

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -34,10 +34,7 @@ import {
 import { groupsReceived } from 'shared/actions/Groups';
 import { recordVisibleArticles } from 'actions/Fronts';
 import { actions as collectionActions } from 'shared/bundles/collectionsBundle';
-import {
-  getCollectionConfig,
-  collectionsInOpenFrontsSelector
-} from 'selectors/frontsSelectors';
+import { getCollectionConfig } from 'selectors/frontsSelectors';
 import { State } from 'types/State';
 import { Dispatch, ThunkResult } from 'types/Store';
 import { frontStages, collectionItemSets } from 'constants/fronts';
@@ -54,7 +51,10 @@ import {
   editorCloseCollections
 } from 'bundles/frontsUIBundle';
 import flatten from 'lodash/flatten';
-import { collectionParamsSelector } from 'selectors/collectionSelectors';
+import {
+  collectionParamsSelector,
+  collectionsInOpenFrontsSelector
+} from 'selectors/collectionSelectors';
 import uniq from 'lodash/uniq';
 
 const articlesInCollection = createAllArticlesInCollectionSelector();

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -206,7 +206,6 @@ const fetchArticles = (articleIds: string[]) => async (dispatch: Dispatch) => {
   }
 };
 
-// ref
 const getArticlesForCollections = (
   collectionIds: string[],
   itemSet: CollectionItemSets

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -72,7 +72,6 @@ function getCollections(
         returnOnlyUpdatedCollections
       );
       const collectionResponses = await fetchCollections(params);
-
       // TODO: test that this works!
       // find all collections missing in the response and ensure their 'fetch'
       // status is reset
@@ -80,17 +79,10 @@ function getCollections(
         collectionResponses.map(cr => cr.id),
         collectionIds
       );
-
-      // TODO: test the boolean in the second parameter
-      // this will mark the data as fetched but will allows us to not have
-      // to supply any data and just use the previous data
       const missingActions = missingCollections.map(id =>
-        collectionActions.fetchSuccess(
-          {
-            id
-          },
-          true
-        )
+        collectionActions.fetchSuccessIgnore({
+          id
+        })
       );
       const actions = collectionResponses.map(collectionResponse => {
         const {

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -59,7 +59,6 @@ function fetchStaleOpenCollections(): ThunkResult<Promise<void>> {
   };
 }
 
-// TEST TODO
 function getCollections(
   collectionIds: string[],
   returnOnlyUpdatedCollections: boolean = false
@@ -131,7 +130,6 @@ function getCollections(
       });
       dispatch(batchActions(flatten(actions)));
     } catch (error) {
-      console.log('ERRR', error);
       dispatch(collectionActions.fetchError(error, collectionIds));
     }
   };

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -72,25 +72,29 @@ function getCollections(
         returnOnlyUpdatedCollections
       );
       const collectionResponses = await fetchCollections(params);
-      const actions = collectionResponses.map((collectionResponse, index) => {
-        const collectionId = collectionIds[index];
+      
+      // TODO: test that this works!
+      // find all collections missing in the response and ensure their 'fetch'
+      // status is reset
+      const missingCollections = difference(collectionResponses.map(cr => cr.id), collectionIds);
+
+      // TODO: test the boolean in the second parameter
+      // this will mark the data as fetched but will allows us to not have
+      // to supply any data and just use the previous data
+      const missingActions = missingCollections.map(id => collectionActions.fetchSuccess(
+        {
+          id
+        },
+        true
+      ))
+      const actions = collectionResponses.map(collectionResponse => {
+        const { id: collectionId, collection: collectionWithoutId,
+          storiesVisibleByStage } = collectionResponse;
         const collectionConfig = getCollectionConfig(getState(), collectionId);
-        if (!collectionResponse) {
-          if (collectionId) {
-            return collectionActions.fetchSuccess({
-              id: collectionId,
-              displayName: collectionConfig.description,
-              type: collectionConfig.type
-            });
-          }
-          return collectionActions.fetchError(
-            `No collection returned in collections request for id ${
-              collectionIds[index]
-            }`,
-            collectionIds[index]
-          );
-        }
-        const { collection, storiesVisibleByStage } = collectionResponse;
+        const collection = {
+          ...collectionWithoutId,
+          id: collectionId
+        };
         const collectionWithNestedArticles = combineCollectionWithConfig(
           collectionConfig,
           collection
@@ -128,7 +132,7 @@ function getCollections(
           )
         ];
       });
-      dispatch(batchActions(flatten(actions)));
+      dispatch(batchActions(flatten([...actions, ...missingActions])));
     } catch (error) {
       dispatch(collectionActions.fetchError(error, collectionIds));
     }
@@ -155,7 +159,7 @@ function updateCollection(collection: Collection): ThunkResult<Promise<void>> {
         collection.id
       );
       await updateCollectionFromApi(collection.id, denormalisedCollection);
-      dispatch(collectionActions.updateSuccess(collection.id, collection));
+      dispatch(collectionActions.updateSuccess(collection.id));
       const visibleArticles = await getVisibleArticles(
         collection,
         getState(),
@@ -202,7 +206,7 @@ const fetchArticles = (articleIds: string[]) => async (dispatch: Dispatch) => {
   }
 };
 
-//ref
+// ref
 const getArticlesForCollections = (
   collectionIds: string[],
   itemSet: CollectionItemSets

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -61,7 +61,9 @@ function selectParamsAndFetchCollections(
   return async (dispatch: Dispatch, getState: () => State) => {
     const state = getState();
     const params = collectionIds.map(id => {
-      const maybeCollection = selectCollection(state, { collectionId: id });
+      const maybeCollection = selectCollection(selectSharedState(state), {
+        collectionId: id
+      });
       const config = getCollectionConfig(state, id);
       if (!maybeCollection) {
         throw new Error(`Collection ID ${id} does not exist in state`);

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -72,28 +72,36 @@ function getCollections(
         returnOnlyUpdatedCollections
       );
       const collectionResponses = await fetchCollections(params);
-      
+
       // TODO: test that this works!
       // find all collections missing in the response and ensure their 'fetch'
       // status is reset
-      const missingCollections = difference(collectionResponses.map(cr => cr.id), collectionIds);
+      const missingCollections = difference(
+        collectionResponses.map(cr => cr.id),
+        collectionIds
+      );
 
       // TODO: test the boolean in the second parameter
       // this will mark the data as fetched but will allows us to not have
       // to supply any data and just use the previous data
-      const missingActions = missingCollections.map(id => collectionActions.fetchSuccess(
-        {
-          id
-        },
-        true
-      ))
+      const missingActions = missingCollections.map(id =>
+        collectionActions.fetchSuccess(
+          {
+            id
+          },
+          true
+        )
+      );
       const actions = collectionResponses.map(collectionResponse => {
-        const { id: collectionId, collection: collectionWithoutId,
-          storiesVisibleByStage } = collectionResponse;
-        const collectionConfig = getCollectionConfig(getState(), collectionId);
+        const {
+          id,
+          collection: collectionWithoutId,
+          storiesVisibleByStage
+        } = collectionResponse;
+        const collectionConfig = getCollectionConfig(getState(), id);
         const collection = {
           ...collectionWithoutId,
-          id: collectionId
+          id
         };
         const collectionWithNestedArticles = combineCollectionWithConfig(
           collectionConfig,

--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -18,6 +18,7 @@ import { frontStages, noOfOpenCollectionsOnFirstLoad } from 'constants/fronts';
 import { State } from 'types/State';
 import { editorOpenCollections } from 'bundles/frontsUIBundle';
 import { events } from 'services/GA';
+import { collectionParamsSelector } from 'selectors/collectionSelectors';
 
 function fetchLastPressedSuccess(frontId: string, datePressed: string): Action {
   return {
@@ -103,12 +104,15 @@ function publishCollection(
         dispatch(getCollections([collectionId]));
 
         return new Promise(resolve => setTimeout(resolve, 10000))
-          .then(() =>
-            Promise.all([
-              dispatch(getCollectionApi(collectionId)),
+          .then(() => {
+            const [params] = collectionParamsSelector(getState(), [
+              collectionId
+            ]);
+            return Promise.all([
+              getCollectionApi(params),
               fetchLastPressedApi(frontId)
-            ])
-          )
+            ]);
+          })
           .then(([collectionResponse, lastPressed]) => {
             const lastPressedInMilliseconds = new Date(lastPressed).getTime();
             dispatch(

--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -105,7 +105,7 @@ function publishCollection(
         return new Promise(resolve => setTimeout(resolve, 10000))
           .then(() =>
             Promise.all([
-              getCollectionApi(collectionId),
+              dispatch(getCollectionApi(collectionId)),
               fetchLastPressedApi(frontId)
             ])
           )

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -66,7 +66,7 @@ describe('Collection actions', () => {
         }
       });
       expect(actions[1]).toEqual(
-        collectionActions.updateSuccess('exampleCollection', collection)
+        collectionActions.updateSuccess('exampleCollection')
       );
     });
   });
@@ -80,11 +80,7 @@ describe('Collection actions', () => {
 
     it('should add fetched Collections to the store', async () => {
       const collectionIds = ['testCollection1', 'testCollection2'];
-      fetchMock.post('/collections', getCollectionsThunkFaciaApiResponse, {
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      fetchMock.post('/collections', getCollectionsThunkFaciaApiResponse);
       await store.dispatch(getCollections(collectionIds) as any);
       expect(store.getState().shared.collections.data).toEqual({
         exampleCollection: {
@@ -135,12 +131,7 @@ describe('Collection actions', () => {
       const collectionIds = ['testCollection1', 'testCollection2'];
       const request = fetchMock.post(
         '/collections',
-        getCollectionsThunkFaciaApiResponse,
-        {
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }
+        getCollectionsThunkFaciaApiResponse
       );
       await store.dispatch(getCollections(collectionIds) as any);
       const result = request.lastOptions().body;
@@ -153,12 +144,7 @@ describe('Collection actions', () => {
       const collectionIds = ['testCollection1', 'testCollection2'];
       const request = fetchMock.post(
         '/collections',
-        getCollectionsThunkFaciaApiResponse,
-        {
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }
+        getCollectionsThunkFaciaApiResponse
       );
       await store.dispatch(getCollections(collectionIds, true) as any);
       const result = request.lastOptions().body;

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -136,8 +136,8 @@ describe('Collection actions', () => {
       await store.dispatch(getCollections(collectionIds) as any);
       const result = request.lastOptions().body;
       expect(JSON.parse(result as string)).toEqual([
-        { id: 'testCollection1', type: 'type' },
-        { id: 'testCollection2', type: 'type' }
+        { id: 'testCollection1' },
+        { id: 'testCollection2' }
       ]);
     });
     it('should send collection id, type and lastUpdated in request body when returnOnlyUpdatedCollection is true', async () => {
@@ -149,8 +149,8 @@ describe('Collection actions', () => {
       await store.dispatch(getCollections(collectionIds, true) as any);
       const result = request.lastOptions().body;
       expect(JSON.parse(result as string)).toEqual([
-        { id: 'testCollection1', type: 'type', lastUpdated: 1547479667115 },
-        { id: 'testCollection2', type: 'type', lastUpdated: 1547479667115 }
+        { id: 'testCollection1', lastUpdated: 1547479667115 },
+        { id: 'testCollection2', lastUpdated: 1547479667115 }
       ]);
     });
   });

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -11,6 +11,7 @@ import {
 import {
   getArticlesForCollections,
   updateCollection,
+  getCollections, // TODO ADD TEST
   fetchArticles
 } from '../Collections';
 

--- a/client-v2/src/actions/__tests__/Fronts.spec.ts
+++ b/client-v2/src/actions/__tests__/Fronts.spec.ts
@@ -37,7 +37,6 @@ describe('Fronts actions', () => {
 
       const state = store.getState();
       const sharedState = selectSharedState(state);
-      console.log(sharedState);
       const collectionIds = [
         'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
         '4ab657ff-c105-4292-af23-cda00457b6b7',

--- a/client-v2/src/actions/__tests__/Fronts.spec.ts
+++ b/client-v2/src/actions/__tests__/Fronts.spec.ts
@@ -15,10 +15,11 @@ describe('Fronts actions', () => {
   describe('initialiseFront', () => {
     afterEach(() => fetchMock.flush());
     it('should fetch all of the front collections, mark <n> first collections as open, and fetch articles for <n> first collections', async () => {
-      fetchMock.once(
-        '/collections?ids=e59785e9-ba82-48d8-b79a-0a80b2f9f808&ids=4ab657ff-c105-4292-af23-cda00457b6b7&ids=c7f48719-6cbc-4024-ae92-1b5f9f6c0c99',
-        scJohnsonPartnerZoneCollection
-      );
+      fetchMock.postOnce('/collections', scJohnsonPartnerZoneCollection, {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
       fetchMock.post('begin:/stories-visible', {
         desktop: 2,
         mobile: 4
@@ -36,6 +37,7 @@ describe('Fronts actions', () => {
 
       const state = store.getState();
       const sharedState = selectSharedState(state);
+      console.log(sharedState);
       const collectionIds = [
         'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
         '4ab657ff-c105-4292-af23-cda00457b6b7',
@@ -47,11 +49,17 @@ describe('Fronts actions', () => {
         true
       );
       // The collections and articles should be fetched
+
+      // TODO this selectArticalsInCollections returns internal code pages which means we cannot use it with articleFragmentSelector
+      //  This worked previously because selectArticles in Collection was returning an empty array which was erroneous - TODO
       expect(
         selectArticlesInCollections(sharedState, {
           collectionIds,
           itemSet: 'draft'
-        }).every(_ => !!articleFragmentSelector(sharedState, _))
+        }).every(_ => {
+          console.log(_);
+          return !!articleFragmentSelector(sharedState, _);
+        })
       ).toBe(true);
     });
   });

--- a/client-v2/src/actions/__tests__/Fronts.spec.ts
+++ b/client-v2/src/actions/__tests__/Fronts.spec.ts
@@ -15,11 +15,7 @@ describe('Fronts actions', () => {
   describe('initialiseFront', () => {
     afterEach(() => fetchMock.flush());
     it('should fetch all of the front collections, mark <n> first collections as open, and fetch articles for <n> first collections', async () => {
-      fetchMock.postOnce('/collections', scJohnsonPartnerZoneCollection, {
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      fetchMock.postOnce('/collections', scJohnsonPartnerZoneCollection);
       fetchMock.post('begin:/stories-visible', {
         desktop: 2,
         mobile: 4
@@ -55,10 +51,7 @@ describe('Fronts actions', () => {
         selectArticlesInCollections(sharedState, {
           collectionIds,
           itemSet: 'draft'
-        }).every(_ => {
-          console.log(_);
-          return !!articleFragmentSelector(sharedState, _);
-        })
+        }).every(_ => !!articleFragmentSelector(sharedState, _))
       ).toBe(true);
     });
   });

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -107,6 +107,12 @@ const ImageWrapper = styled('div')`
   opacity: ${(props: { faded: boolean }) => (props.faded ? 0.6 : 1)};
 `;
 
+const CollectionEditedError = styled.div`
+  background-color: yellow;
+  margin-bottom: 1em;
+  padding: 1em;
+`;
+
 const renderSlideshow = (
   { fields }: WrappedFieldArrayProps<ImageData>,
   frontId: string
@@ -177,261 +183,266 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             >
               Cancel
             </Button>
-            <Button onClick={handleSubmit} disabled={pristine} size="l">
+            <Button
+              onClick={handleSubmit}
+              disabled={pristine || !articleExists}
+              size="l"
+            >
               Save
             </Button>
           </ButtonContainer>
         </CollectionHeadingPinline>
-        {articleExists ? (
-          <FormContent>
-            <InputGroup>
-              <ConditionalField
-                permittedFields={editableFields}
-                name="headline"
-                label="Headline"
-                placeholder={articleCapiFieldValues.headline}
-                component={InputTextArea}
-                useHeadlineFont
-                rows="2"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="isBoosted"
-                component={InputCheckboxToggle}
-                label="Boost"
-                id={getInputId(articleFragmentId, 'boost')}
-                type="checkbox"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="showQuotedHeadline"
-                component={InputCheckboxToggle}
-                label="Quote headline"
-                id={getInputId(articleFragmentId, 'quote-headline')}
-                type="checkbox"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="showBoostedHeadline"
-                component={InputCheckboxToggle}
-                label="Large headline"
-                id={getInputId(articleFragmentId, 'large-headline')}
-                type="checkbox"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="showLivePlayable"
-                component={InputCheckboxToggle}
-                label="Show updates"
-                id={getInputId(articleFragmentId, 'show-updates')}
-                type="checkbox"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="showMainVideo"
-                component={InputCheckboxToggle}
-                label="Show video"
-                id={getInputId(articleFragmentId, 'show-video')}
-                type="checkbox"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="customKicker"
-                label="Kicker"
-                component={InputText}
-                placeholder="Add custom kicker"
-                useHeadlineFont
-                format={value => {
-                  if (showKickerTag) {
-                    return kickerOptions.webTitle;
-                  }
-                  if (showKickerSection) {
-                    return kickerOptions.sectionName;
-                  }
-                  return value;
-                }}
-                onChange={e => {
-                  change('showKickerCustom', true);
-                  change('showKickerTag', false);
-                  change('showKickerSection', false);
-                  if (e) {
-                    change('customKicker', e.target.value);
-                  }
-                }}
-              />
-              <ConditionalComponent
-                name="customKicker"
-                permittedNames={editableFields}
-              >
-                {kickerOptions.webTitle && (
-                  <Field
-                    permittedFields={editableFields}
-                    name="showKickerTag"
-                    component={InputButton}
-                    buttonText={kickerOptions.webTitle}
-                    selected={showKickerTag}
-                    onClick={() => {
-                      if (!showKickerTag) {
-                        change('showKickerTag', true);
-                        change('showKickerSection', false);
-                        change('showKickerCustom', false);
-                      } else {
-                        change('showKickerTag', false);
-                      }
-                    }}
-                  />
-                )}
-                {kickerOptions.sectionName && (
-                  <Field
-                    permittedFields={editableFields}
-                    name="showKickerSection"
-                    component={InputButton}
-                    selected={showKickerSection}
-                    buttonText={kickerOptions.sectionName}
-                    onClick={() => {
-                      if (!showKickerSection) {
-                        change('showKickerSection', true);
-                        change('showKickerTag', false);
-                        change('showKickerCustom', false);
-                      } else {
-                        change('showKickerSection', false);
-                      }
-                    }}
-                  />
-                )}
-              </ConditionalComponent>
-              <ConditionalField
-                permittedFields={editableFields}
-                name="isBreaking"
-                component={InputCheckboxToggle}
-                label="Breaking News"
-                id={getInputId(articleFragmentId, 'breaking-news')}
-                type="checkbox"
-              />
-              <ConditionalField
-                permittedFields={editableFields}
-                name="showByline"
-                component={InputCheckboxToggle}
-                label="Show Byline"
-                id={getInputId(articleFragmentId, 'show-byline')}
-                type="checkbox"
-              />
-              {showByline && (
-                <ConditionalField
+        {!articleExists && (
+          <CollectionEditedError>
+            {this.state.lastKnownCollectionId &&
+              `This collection has been edited by ${this.props.getLastUpdatedBy(
+                this.state.lastKnownCollectionId
+              )} since you started editing this article. Your changes have not been saved.`}
+          </CollectionEditedError>
+        )}
+        <FormContent>
+          <InputGroup>
+            <ConditionalField
+              permittedFields={editableFields}
+              name="headline"
+              label="Headline"
+              placeholder={articleCapiFieldValues.headline}
+              component={InputTextArea}
+              useHeadlineFont
+              rows="2"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="isBoosted"
+              component={InputCheckboxToggle}
+              label="Boost"
+              id={getInputId(articleFragmentId, 'boost')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showQuotedHeadline"
+              component={InputCheckboxToggle}
+              label="Quote headline"
+              id={getInputId(articleFragmentId, 'quote-headline')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showBoostedHeadline"
+              component={InputCheckboxToggle}
+              label="Large headline"
+              id={getInputId(articleFragmentId, 'large-headline')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showLivePlayable"
+              component={InputCheckboxToggle}
+              label="Show updates"
+              id={getInputId(articleFragmentId, 'show-updates')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showMainVideo"
+              component={InputCheckboxToggle}
+              label="Show video"
+              id={getInputId(articleFragmentId, 'show-video')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="customKicker"
+              label="Kicker"
+              component={InputText}
+              placeholder="Add custom kicker"
+              useHeadlineFont
+              format={value => {
+                if (showKickerTag) {
+                  return kickerOptions.webTitle;
+                }
+                if (showKickerSection) {
+                  return kickerOptions.sectionName;
+                }
+                return value;
+              }}
+              onChange={e => {
+                change('showKickerCustom', true);
+                change('showKickerTag', false);
+                change('showKickerSection', false);
+                if (e) {
+                  change('customKicker', e.target.value);
+                }
+              }}
+            />
+            <ConditionalComponent
+              name="customKicker"
+              permittedNames={editableFields}
+            >
+              {kickerOptions.webTitle && (
+                <Field
                   permittedFields={editableFields}
-                  name="byline"
-                  label="Byline"
-                  component={InputText}
-                  placeholder={articleCapiFieldValues.byline}
-                  useHeadlineFont
+                  name="showKickerTag"
+                  component={InputButton}
+                  buttonText={kickerOptions.webTitle}
+                  selected={showKickerTag}
+                  onClick={() => {
+                    if (!showKickerTag) {
+                      change('showKickerTag', true);
+                      change('showKickerSection', false);
+                      change('showKickerCustom', false);
+                    } else {
+                      change('showKickerTag', false);
+                    }
+                  }}
                 />
               )}
+              {kickerOptions.sectionName && (
+                <Field
+                  permittedFields={editableFields}
+                  name="showKickerSection"
+                  component={InputButton}
+                  selected={showKickerSection}
+                  buttonText={kickerOptions.sectionName}
+                  onClick={() => {
+                    if (!showKickerSection) {
+                      change('showKickerSection', true);
+                      change('showKickerTag', false);
+                      change('showKickerCustom', false);
+                    } else {
+                      change('showKickerSection', false);
+                    }
+                  }}
+                />
+              )}
+            </ConditionalComponent>
+            <ConditionalField
+              permittedFields={editableFields}
+              name="isBreaking"
+              component={InputCheckboxToggle}
+              label="Breaking News"
+              id={getInputId(articleFragmentId, 'breaking-news')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showByline"
+              component={InputCheckboxToggle}
+              label="Show Byline"
+              id={getInputId(articleFragmentId, 'show-byline')}
+              type="checkbox"
+            />
+            {showByline && (
               <ConditionalField
                 permittedFields={editableFields}
-                name="trailText"
-                label="Trail text"
-                component={InputTextArea}
-                placeholder={articleCapiFieldValues.trailText}
+                name="byline"
+                label="Byline"
+                component={InputText}
+                placeholder={articleCapiFieldValues.byline}
+                useHeadlineFont
               />
-            </InputGroup>
-            <RowContainer>
-              <Row>
-                <Col>
-                  <ImageWrapper faded={imageHide}>
-                    <ConditionalField
-                      permittedFields={editableFields}
-                      name="primaryImage"
-                      component={InputImage}
-                      disabled={imageHide}
-                      criteria={imageCriteria}
-                      frontId={frontId}
-                    />
-                  </ImageWrapper>
-                </Col>
-                <Col>
-                  <InputGroup>
-                    <ConditionalField
-                      permittedFields={editableFields}
-                      name="imageHide"
-                      component={InputCheckboxToggle}
-                      label="Hide media"
-                      id={getInputId(articleFragmentId, 'hide-media')}
-                      type="checkbox"
-                      default={false}
-                    />
-                  </InputGroup>
-                </Col>
-              </Row>
-              <ConditionalComponent
-                permittedNames={editableFields}
-                name={['primaryImage', 'imageHide']}
-              >
-                <HorizontalRule />
-              </ConditionalComponent>
-              <Row>
-                <Col>
-                  <ImageWrapper faded={!imageCutoutReplace}>
-                    <ConditionalField
-                      permittedFields={editableFields}
-                      name="cutoutImage"
-                      component={InputImage}
-                      disabled={imageHide}
-                      criteria={imageCriteria}
-                      frontId={frontId}
-                    />
-                  </ImageWrapper>
-                </Col>
-                <Col>
-                  <InputGroup>
-                    <ConditionalField
-                      permittedFields={editableFields}
-                      name="imageCutoutReplace"
-                      component={InputCheckboxToggle}
-                      label="Use cutout"
-                      id={getInputId(articleFragmentId, 'use-cutout')}
-                      type="checkbox"
-                      default={false}
-                    />
-                  </InputGroup>
-                </Col>
-              </Row>
-            </RowContainer>
+            )}
+            <ConditionalField
+              permittedFields={editableFields}
+              name="trailText"
+              label="Trail text"
+              component={InputTextArea}
+              placeholder={articleCapiFieldValues.trailText}
+            />
+          </InputGroup>
+          <RowContainer>
+            <Row>
+              <Col>
+                <ImageWrapper faded={imageHide}>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="primaryImage"
+                    component={InputImage}
+                    disabled={imageHide}
+                    criteria={imageCriteria}
+                    frontId={frontId}
+                  />
+                </ImageWrapper>
+              </Col>
+              <Col>
+                <InputGroup>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="imageHide"
+                    component={InputCheckboxToggle}
+                    label="Hide media"
+                    id={getInputId(articleFragmentId, 'hide-media')}
+                    type="checkbox"
+                    default={false}
+                  />
+                </InputGroup>
+              </Col>
+            </Row>
             <ConditionalComponent
               permittedNames={editableFields}
-              name={['cutoutImage', 'imageCutoutReplace']}
+              name={['primaryImage', 'imageHide']}
             >
               <HorizontalRule />
             </ConditionalComponent>
-            <InputGroup>
-              <ConditionalField
-                permittedFields={editableFields}
-                name="imageSlideshowReplace"
-                component={InputCheckboxToggle}
-                label="Slideshow"
-                id={getInputId(articleFragmentId, 'slideshow')}
-                type="checkbox"
-              />
-            </InputGroup>
-            {imageSlideshowReplace && (
-              <RowContainer>
-                <SlideshowRow>
-                  <FieldArray<WrappedFieldArrayProps<ImageData>>
-                    name="slideshow"
-                    component={(args: WrappedFieldArrayProps<ImageData>) =>
-                      renderSlideshow(args, frontId)
-                    }
+            <Row>
+              <Col>
+                <ImageWrapper faded={!imageCutoutReplace}>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="cutoutImage"
+                    component={InputImage}
+                    disabled={imageHide}
+                    criteria={imageCriteria}
+                    frontId={frontId}
                   />
-                </SlideshowRow>
-                <SlideshowLabel>Drag and drop up to five images</SlideshowLabel>
-              </RowContainer>
-            )}
-          </FormContent>
-        ) : (
-          this.state.lastKnownCollectionId &&
-          `This collection has been edited by ${this.props.getLastUpdatedBy(
-            this.state.lastKnownCollectionId
-          )} since you started editing this article. Your changes have not been saved.`
-        )}
+                </ImageWrapper>
+              </Col>
+              <Col>
+                <InputGroup>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="imageCutoutReplace"
+                    component={InputCheckboxToggle}
+                    label="Use cutout"
+                    id={getInputId(articleFragmentId, 'use-cutout')}
+                    type="checkbox"
+                    default={false}
+                  />
+                </InputGroup>
+              </Col>
+            </Row>
+          </RowContainer>
+          <ConditionalComponent
+            permittedNames={editableFields}
+            name={['cutoutImage', 'imageCutoutReplace']}
+          >
+            <HorizontalRule />
+          </ConditionalComponent>
+          <InputGroup>
+            <ConditionalField
+              permittedFields={editableFields}
+              name="imageSlideshowReplace"
+              component={InputCheckboxToggle}
+              label="Slideshow"
+              id={getInputId(articleFragmentId, 'slideshow')}
+              type="checkbox"
+            />
+          </InputGroup>
+          {imageSlideshowReplace && (
+            <RowContainer>
+              <SlideshowRow>
+                <FieldArray<WrappedFieldArrayProps<ImageData>>
+                  name="slideshow"
+                  component={(args: WrappedFieldArrayProps<ImageData>) =>
+                    renderSlideshow(args, frontId)
+                  }
+                />
+              </SlideshowRow>
+              <SlideshowLabel>Drag and drop up to five images</SlideshowLabel>
+            </RowContainer>
+          )}
+        </FormContent>
       </FormContainer>
     );
   }
@@ -443,7 +454,6 @@ const ArticleFragmentForm = reduxForm<
   {}
 >({
   destroyOnUnmount: false,
-  enableReinitialize: true,
   onSubmit: (
     values: ArticleFragmentFormData,
     dispatch: Dispatch,
@@ -472,7 +482,7 @@ interface ContainerProps {
   imageHide: boolean;
   kickerOptions: ArticleTag;
   showByline: boolean;
-  editableFields: string[];
+  editableFields?: string[];
   showKickerTag: boolean;
   showKickerSection: boolean;
   articleCapiFieldValues: CapiTextFields;
@@ -535,9 +545,8 @@ const createMapStateToProps = () => {
       articleCapiFieldValues: getCapiValuesForArticleTextFields(
         externalArticle
       ),
-      editableFields: article
-        ? selectFormFields(state, article.uuid, isSupporting)
-        : [],
+      editableFields:
+        article && selectFormFields(state, article.uuid, isSupporting),
       kickerOptions: article
         ? articleTagSelector(selectSharedState(state), articleFragmentId)
         : {},

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -106,8 +106,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
                   this.props.frontId
                 }`}
-                target="_blank"
-                rel="noopener noreferrer"
+                target="preview"
               >
                 <Button size="l">Preview</Button>
               </a>

--- a/client-v2/src/components/inputs/ConditionalField.tsx
+++ b/client-v2/src/components/inputs/ConditionalField.tsx
@@ -4,7 +4,7 @@ import ConditionalComponent from 'components/layout/ConditionalComponent';
 import { BaseFieldProps } from 'redux-form';
 
 interface Props extends BaseFieldProps {
-  permittedFields: string[];
+  permittedFields?: string[];
 }
 
 const ConditionalField = <P extends {}>(props: Props & P) => (

--- a/client-v2/src/components/layout/ConditionalComponent.tsx
+++ b/client-v2/src/components/layout/ConditionalComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export interface ConditionalComponentProps {
   name: string | string[];
-  permittedNames: string[];
+  permittedNames?: string[];
 }
 
 /**
@@ -15,7 +15,7 @@ const ConditionalComponent: React.StatelessComponent<
 > = ({ name, permittedNames, children }): React.ReactElement<any> | null => {
   const names = Array.isArray(name) ? name : [name];
   for (const nameIndex in names) {
-    if (permittedNames.indexOf(names[nameIndex]) !== -1) {
+    if (!permittedNames || permittedNames.indexOf(names[nameIndex]) !== -1) {
       return children ? <>{children}</> : null;
     }
   }

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -1,26 +1,49 @@
 export const scJohnsonPartnerZoneCollection = [
   {
-    live: [],
-    draft: [
-      { id: 'internal-code/page/5607373', frontPublicationDate: 1547479659039 },
-      { id: 'internal-code/page/5607569', frontPublicationDate: 1547479662461 }
-    ],
-    lastUpdated: 1547479662508,
-    updatedBy: 'Jonathon Herbert',
-    updatedEmail: 'jonathon.herbert@guardian.co.uk',
-    displayName: 'sc johnson partner zone',
-    previously: []
+    collection: {
+      id: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
+      live: [],
+      draft: [
+        {
+          id: 'internal-code/page/5607373',
+          frontPublicationDate: 1547479659039
+        },
+        {
+          id: 'internal-code/page/5607569',
+          frontPublicationDate: 1547479662461
+        }
+      ],
+      lastUpdated: 1547479662508,
+      updatedBy: 'Jonathon Herbert',
+      updatedEmail: 'jonathon.herbert@guardian.co.uk',
+      displayName: 'sc johnson partner zone',
+      previously: []
+    },
+    storiesVisibleByStage: {
+      live: { desktop: 4, mobile: 4 },
+      draft: { desktop: 4, mobile: 4 }
+    }
   },
   {
-    live: [],
-    draft: [
-      { id: 'internal-code/page/5607569', frontPublicationDate: 1547479667072 }
-    ],
-    lastUpdated: 1547479667115,
-    updatedBy: 'Jonathon Herbert',
-    updatedEmail: 'jonathon.herbert@guardian.co.uk',
-    displayName: 'popular in sustainable business',
-    previously: []
+    collection: {
+      id: '4ab657ff-c105-4292-af23-cda00457b6b7',
+      live: [],
+      draft: [
+        {
+          id: 'internal-code/page/5607569',
+          frontPublicationDate: 1547479667072
+        }
+      ],
+      lastUpdated: 1547479667115,
+      updatedBy: 'Jonathon Herbert',
+      updatedEmail: 'jonathon.herbert@guardian.co.uk',
+      displayName: 'popular in sustainable business',
+      previously: []
+    },
+    storiesVisibleByStage: {
+      live: { desktop: 4, mobile: 4 },
+      draft: { desktop: 4, mobile: 4 }
+    }
   },
   null
 ];

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -50,8 +50,8 @@ export const scJohnsonPartnerZoneCollection = [
 
 export const getCollectionsThunkFaciaApiResponse = [
   {
+    id: 'testCollection1',
     collection: {
-      id: 'testCollection1',
       displayName: 'testCollection1',
       live: ['abc', 'def'],
       draft: [],
@@ -65,8 +65,8 @@ export const getCollectionsThunkFaciaApiResponse = [
     }
   },
   {
+    id: 'testCollection2',
     collection: {
-      id: 'testCollection2',
       displayName: 'testCollection2',
       live: ['abc'],
       draft: ['def'],

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -47,3 +47,36 @@ export const scJohnsonPartnerZoneCollection = [
   },
   null
 ];
+
+export const getCollectionsThunkFaciaApiResponse = [
+  {
+    collection: {
+      id: 'testCollection1',
+      displayName: 'testCollection1',
+      live: ['abc', 'def'],
+      draft: [],
+      lastUpdated: 1547479667115,
+      previously: undefined,
+      type: 'type'
+    },
+    storiesVisibleByStage: {
+      live: { desktop: 4, mobile: 4 },
+      draft: { desktop: 4, mobile: 4 }
+    }
+  },
+  {
+    collection: {
+      id: 'testCollection2',
+      displayName: 'testCollection2',
+      live: ['abc'],
+      draft: ['def'],
+      lastUpdated: 1547479667115,
+      previously: undefined,
+      type: 'type'
+    },
+    storiesVisibleByStage: {
+      live: { desktop: 4, mobile: 4 },
+      draft: { desktop: 4, mobile: 4 }
+    }
+  }
+];

--- a/client-v2/src/fixtures/frontsConfig.ts
+++ b/client-v2/src/fixtures/frontsConfig.ts
@@ -8,6 +8,11 @@ const frontsConfig: { data: FrontsConfig } = {
         collections: ['collection1'],
         priority: 'editorial'
       },
+      editorialFront2: {
+        id: 'editorialFront2',
+        collections: ['collection6'],
+        priority: 'editorial'
+      },
       commercialFront: {
         id: 'commercialFront',
         collections: ['collection1'],

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -14,6 +14,7 @@ import { Dispatch } from 'types/Store';
 import Modal from 'react-modal';
 import { init as initGA } from 'services/GA';
 import { init } from 'keyboard-shortcuts/init';
+import pollingConfig from 'util/pollingConfig';
 
 initGA();
 
@@ -43,6 +44,7 @@ if (config.frontIds) {
 // @ts-ignore unbind is not used yet but can be used for removed all the
 // keyboard events
 const unbind = init(store);
+pollingConfig(store);
 
 const reactMount = document.getElementById('react-mount');
 

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -45,7 +45,9 @@ if (config.frontIds) {
 // keyboard events
 const unbind = init(store);
 
-pollingConfig(store);
+if (process.env.BUILD_ENV !== 'integration') {
+  pollingConfig(store);
+}
 
 const reactMount = document.getElementById('react-mount');
 

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -44,6 +44,7 @@ if (config.frontIds) {
 // @ts-ignore unbind is not used yet but can be used for removed all the
 // keyboard events
 const unbind = init(store);
+
 pollingConfig(store);
 
 const reactMount = document.getElementById('react-mount');

--- a/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
@@ -137,6 +137,20 @@ describe('createAsyncResourceBundle', () => {
         id: '2'
       });
     });
+    it('should provide a selector to select whether a resource is loading for the first time', () => {
+      const bundle = createAsyncResourceBundle('books', {
+        indexById: true
+      });
+      const state = {
+        books: { data: { '1': { id: '1' } }, loadingIds: ['1', '2'] }
+      };
+      expect(bundle.selectors.selectIsLoadingInitialDataById(state, '1')).toBe(
+        false
+      );
+      expect(bundle.selectors.selectIsLoadingInitialDataById(state, '2')).toBe(
+        true
+      );
+    });
   });
 
   describe('Reducer', () => {

--- a/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
@@ -20,6 +20,7 @@ describe('createAsyncResourceBundle', () => {
       expect(actionNames).toEqual({
         fetchStart: 'FETCH_START',
         fetchSuccess: 'FETCH_SUCCESS',
+        fetchSuccessIgnore: 'FETCH_SUCCESS_IGNORE',
         fetchError: 'FETCH_ERROR',
         updateStart: 'UPDATE_START',
         updateSuccess: 'UPDATE_SUCCESS',
@@ -43,6 +44,11 @@ describe('createAsyncResourceBundle', () => {
       expect(actions.fetchSuccess({ data: 'exampleData' })).toEqual({
         entity: 'books',
         type: 'FETCH_SUCCESS',
+        payload: { data: { data: 'exampleData' }, time: 1337 }
+      });
+      expect(actions.fetchSuccessIgnore({ data: 'exampleData' })).toEqual({
+        entity: 'books',
+        type: 'FETCH_SUCCESS_IGNORE',
         payload: { data: { data: 'exampleData' }, time: 1337 }
       });
       expect(actions.fetchError('Something went wrong')).toEqual({
@@ -164,7 +170,7 @@ describe('createAsyncResourceBundle', () => {
       describe('Success action handler', () => {
         it('should merge data and mark the state as not loading when a success action is dispatched', () => {
           const newState = reducer(
-            { ...initialState, loading: true },
+            { ...initialState },
             actions.fetchSuccess({ uuid: { id: 'uuid', author: 'Mark Twain' } })
           );
           expect(newState.loadingIds).toEqual([]);
@@ -190,7 +196,7 @@ describe('createAsyncResourceBundle', () => {
             indexById: true
           });
           const newState = bundle.reducer(
-            { ...initialState, loading: true },
+            { ...initialState },
             bundle.actions.fetchSuccess([
               { id: 'uuid', author: 'Mark Twain' },
               { id: 'uuid2', author: 'Elizabeth Gaskell' }
@@ -201,6 +207,20 @@ describe('createAsyncResourceBundle', () => {
             uuid: { id: 'uuid', author: 'Mark Twain' },
             uuid2: { id: 'uuid2', author: 'Elizabeth Gaskell' }
           });
+        });
+      });
+      describe('Success Ignore action handler', () => {
+        const newState = reducer(
+          { ...initialState, loadingIds: ['uuid'] },
+          actions.fetchSuccessIgnore({
+            uuid: { id: 'uuid', author: 'Mark Twain' }
+          })
+        );
+        it('should return initial state data when a successIgnore action is dispatched', () => {
+          expect(newState.data).toEqual(initialState.data);
+        });
+        it('should clear ID data from loadingIds when a successIgnore action is dispatched', () => {
+          expect(newState.loadingIds).toEqual([]);
         });
       });
       describe('Error action handler', () => {

--- a/client-v2/src/lib/createAsyncResourceBundle/index.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/index.ts
@@ -20,7 +20,11 @@ interface FetchStartAction {
 interface FetchSuccessAction<Resource> {
   entity: string;
   type: 'FETCH_SUCCESS';
-  payload: { data: Resource | Resource[] | any; time: number };
+  payload: {
+    data: Resource | Resource[] | any;
+    time: number;
+    ignoreIncomingData: boolean;
+  };
 }
 
 interface FetchErrorAction {
@@ -204,11 +208,12 @@ function createAsyncResourceBundle<Resource>(
   });
 
   const fetchSuccessAction = (
-    data: Resource | Resource[] | any
+    data: Resource | Resource[] | any,
+    ignoreIncomingData: boolean = false
   ): FetchSuccessAction<Resource> => ({
     entity: entityName,
     type: FETCH_SUCCESS,
-    payload: { data, time: Date.now() }
+    payload: { data, time: Date.now(), ignoreIncomingData }
   });
 
   const fetchErrorAction = (
@@ -228,7 +233,7 @@ function createAsyncResourceBundle<Resource>(
 
   const updateSuccessAction = (
     id: string,
-    data: Resource
+    data?: Resource
   ): UpdateSuccessAction<Resource> => ({
     entity: entityName,
     type: UPDATE_SUCCESS,
@@ -262,7 +267,9 @@ function createAsyncResourceBundle<Resource>(
         case FETCH_SUCCESS: {
           return {
             ...state,
-            data: !indexById
+            data: action.payload.ignoreIncomingData
+              ? state.data
+              : !indexById
               ? action.payload.data
               : applyNewData(state.data, action.payload.data, entityName),
             lastFetch: action.payload.time,

--- a/client-v2/src/lib/createAsyncResourceBundle/index.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/index.ts
@@ -198,6 +198,10 @@ function createAsyncResourceBundle<Resource>(
   const selectById = (state: RootState, id: string): Resource | undefined =>
     selectLocalState(state).data[id];
 
+  const selectIsLoadingInitialDataById = (state: RootState, id: string) =>
+    !selectById(state, id) &&
+    selectLocalState(state).loadingIds.indexOf(id) !== -1;
+
   const selectAll = (state: RootState) => selectLocalState(state).data;
 
   const initialState: State<Resource> = {
@@ -394,6 +398,7 @@ function createAsyncResourceBundle<Resource>(
       selectLastFetch,
       selectIsLoading,
       selectIsLoadingById,
+      selectIsLoadingInitialDataById,
       selectById,
       selectAll
     }

--- a/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
@@ -1,7 +1,8 @@
 import {
   isCollectionBackfilledSelector,
   isCollectionLockedSelector,
-  createCollectionHasUnsavedArticleEditsWarningSelector
+  createCollectionHasUnsavedArticleEditsWarningSelector,
+  collectionsInOpenFrontsSelector
 } from 'selectors/collectionSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 
@@ -87,5 +88,44 @@ describe('Validating Front Collection configuration metadata', () => {
         'collection2'
       )
     ).toEqual(false);
+  });
+});
+
+describe('Selecting collections on all open Fronts', () => {
+  it('return correct collections for one open Front', () => {
+    expect(
+      collectionsInOpenFrontsSelector({
+        fronts: {
+          frontsConfig
+        },
+        editor: {
+          frontIds: ['editorialFront']
+        }
+      } as any)
+    ).toEqual(['collection1']);
+  });
+  it('return correct collections for multiple open Fronts', () => {
+    expect(
+      collectionsInOpenFrontsSelector({
+        fronts: {
+          frontsConfig
+        },
+        editor: {
+          frontIds: ['editorialFront', 'editorialFront2']
+        }
+      } as any)
+    ).toEqual(['collection1', 'collection6']);
+  });
+  it('return enpty array for no open Fronts', () => {
+    expect(
+      collectionsInOpenFrontsSelector({
+        fronts: {
+          frontsConfig
+        },
+        editor: {
+          frontIds: []
+        }
+      } as any)
+    ).toEqual([]);
   });
 });

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -1,8 +1,7 @@
 import {
   getFrontsWithPriority,
   alsoOnFrontSelector,
-  lastPressedSelector,
-  collectionsInOpenFrontsSelector
+  lastPressedSelector
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';
@@ -103,45 +102,6 @@ describe('Filtering fronts correctly', () => {
 const allFronts = editorialFrontsInConfig
   .concat(additionalEditorialFronts)
   .concat(trainingFronts.concat(commercialFronts));
-
-describe('Selecting collections on all open Fronts', () => {
-  it('return correct collections for one open Front', () => {
-    expect(
-      collectionsInOpenFrontsSelector({
-        fronts: {
-          frontsConfig
-        },
-        editor: {
-          frontIds: ['editorialFront']
-        }
-      } as any)
-    ).toEqual(['collection1']);
-  });
-  it('return correct collections for multiple open Fronts', () => {
-    expect(
-      collectionsInOpenFrontsSelector({
-        fronts: {
-          frontsConfig
-        },
-        editor: {
-          frontIds: ['editorialFront', 'editorialFront2']
-        }
-      } as any)
-    ).toEqual(['collection1', 'collection6']);
-  });
-  it('return enpty array for no open Fronts', () => {
-    expect(
-      collectionsInOpenFrontsSelector({
-        fronts: {
-          frontsConfig
-        },
-        editor: {
-          frontIds: []
-        }
-      } as any)
-    ).toEqual([]);
-  });
-});
 
 describe('Selecting which front collection is also on correctly', () => {
   it('fills in also details for all collections on a front', () => {

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -2,7 +2,7 @@ import {
   getFrontsWithPriority,
   alsoOnFrontSelector,
   lastPressedSelector,
-  collectionsInOpenFrontsSelector // Write Test
+  collectionsInOpenFrontsSelector
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -1,17 +1,15 @@
 import {
   getFrontsWithPriority,
   alsoOnFrontSelector,
-  lastPressedSelector
+  lastPressedSelector,
+  collectionsInOpenFrontsSelector // Write Test
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';
 
 const editorialFrontsInConfig: FrontConfig[] = [
-  {
-    collections: ['collection1'],
-    id: 'editorialFront',
-    priority: 'editorial'
-  }
+  { collections: ['collection1'], id: 'editorialFront', priority: 'editorial' },
+  { collections: ['collection6'], id: 'editorialFront2', priority: 'editorial' }
 ];
 
 const additionalEditorialFronts: FrontConfig[] = [
@@ -105,6 +103,45 @@ describe('Filtering fronts correctly', () => {
 const allFronts = editorialFrontsInConfig
   .concat(additionalEditorialFronts)
   .concat(trainingFronts.concat(commercialFronts));
+
+describe('Selecting collections on all open Fronts', () => {
+  it('return correct collections for one open Front', () => {
+    expect(
+      collectionsInOpenFrontsSelector({
+        fronts: {
+          frontsConfig
+        },
+        editor: {
+          frontIds: ['editorialFront']
+        }
+      } as any)
+    ).toEqual(['collection1']);
+  });
+  it('return correct collections for multiple open Fronts', () => {
+    expect(
+      collectionsInOpenFrontsSelector({
+        fronts: {
+          frontsConfig
+        },
+        editor: {
+          frontIds: ['editorialFront', 'editorialFront2']
+        }
+      } as any)
+    ).toEqual(['collection1', 'collection6']);
+  });
+  it('return enpty array for no open Fronts', () => {
+    expect(
+      collectionsInOpenFrontsSelector({
+        fronts: {
+          frontsConfig
+        },
+        editor: {
+          frontIds: []
+        }
+      } as any)
+    ).toEqual([]);
+  });
+});
 
 describe('Selecting which front collection is also on correctly', () => {
   it('fills in also details for all collections on a front', () => {

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -1,5 +1,5 @@
 import { State } from 'types/State';
-import { getCollectionConfig } from './frontsSelectors';
+import { getCollectionConfig, getFront } from './frontsSelectors';
 import {
   selectSharedState,
   createArticlesInCollectionSelector,
@@ -7,6 +7,8 @@ import {
 } from 'shared/selectors/shared';
 import { isDirty } from 'redux-form';
 import { CollectionItemSets } from 'shared/types/Collection';
+import { selectEditorFronts } from 'bundles/frontsUIBundle';
+import flatten from 'lodash/flatten';
 
 const selectCollection = createCollectionSelector();
 
@@ -38,6 +40,14 @@ function collectionParamsSelector(
   return params;
 }
 
+const collectionsInOpenFrontsSelector = (state: State): string[] => {
+  const openFrontIds = selectEditorFronts(state);
+  const openFronts = openFrontIds
+    .map(frontId => getFront(state, frontId))
+    .filter(Boolean); // TODO How do we want to handle non-existent frontconfigs?
+  return flatten(openFronts.map(front => front.collections));
+};
+
 const isCollectionLockedSelector = (state: State, id: string): boolean =>
   !!getCollectionConfig(state, id).uneditable;
 
@@ -65,5 +75,6 @@ export {
   collectionParamsSelector,
   isCollectionLockedSelector,
   isCollectionBackfilledSelector,
+  collectionsInOpenFrontsSelector,
   collectionHasUnsavedArticleEditsWarningSelector as createCollectionHasUnsavedArticleEditsWarningSelector
 };

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -14,15 +14,15 @@ function collectionParamsSelector(
   state: State,
   collectionIds: string[],
   returnOnlyUpdatedCollections: boolean = false
-): Array<{ id: string; type: string; lastUpdated?: number }> {
+): Array<{ id: string; lastUpdated?: number }> {
   const params = collectionIds.map(id => {
     const config = getCollectionConfig(state, id);
     if (!config) {
       throw new Error(`Collection ID ${id} does not exist in config`);
     }
-    const type = config.type;
+
     if (!returnOnlyUpdatedCollections) {
-      return { id, type };
+      return { id };
     }
 
     const maybeCollection = selectCollection(selectSharedState(state), {
@@ -32,7 +32,7 @@ function collectionParamsSelector(
       throw new Error(`Collection ID ${id} does not exist in state`);
     }
     const lastUpdated = maybeCollection.lastUpdated;
-    return { id, type, lastUpdated };
+    return { id, lastUpdated };
   });
 
   return params;

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -10,13 +10,11 @@ import { CollectionItemSets } from 'shared/types/Collection';
 
 const selectCollection = createCollectionSelector();
 
-// TODO Test
 function collectionParamsSelector(
   state: State,
   collectionIds: string[],
   returnOnlyUpdatedCollections: boolean = false
 ): Array<{ id: string; type: string; lastUpdated?: number }> {
-  console.log('return only', returnOnlyUpdatedCollections);
   const params = collectionIds.map(id => {
     const config = getCollectionConfig(state, id);
     if (!config) {

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -2,10 +2,43 @@ import { State } from 'types/State';
 import { getCollectionConfig } from './frontsSelectors';
 import {
   selectSharedState,
-  createArticlesInCollectionSelector
+  createArticlesInCollectionSelector,
+  createCollectionSelector
 } from 'shared/selectors/shared';
 import { isDirty } from 'redux-form';
 import { CollectionItemSets } from 'shared/types/Collection';
+
+const selectCollection = createCollectionSelector();
+
+// TODO Test
+function collectionParamsSelector(
+  state: State,
+  collectionIds: string[],
+  returnOnlyUpdatedCollections: boolean = false
+): Array<{ id: string; type: string; lastUpdated?: number }> {
+  console.log('return only', returnOnlyUpdatedCollections);
+  const params = collectionIds.map(id => {
+    const config = getCollectionConfig(state, id);
+    if (!config) {
+      throw new Error(`Collection ID ${id} does not exist in config`);
+    }
+    const type = config.type;
+    if (!returnOnlyUpdatedCollections) {
+      return { id, type };
+    }
+
+    const maybeCollection = selectCollection(selectSharedState(state), {
+      collectionId: id
+    });
+    if (!maybeCollection) {
+      throw new Error(`Collection ID ${id} does not exist in state`);
+    }
+    const lastUpdated = maybeCollection.lastUpdated;
+    return { id, type, lastUpdated };
+  });
+
+  return params;
+}
 
 const isCollectionLockedSelector = (state: State, id: string): boolean =>
   !!getCollectionConfig(state, id).uneditable;
@@ -31,6 +64,7 @@ const collectionHasUnsavedArticleEditsWarningSelector = () => {
 };
 
 export {
+  collectionParamsSelector,
   isCollectionLockedSelector,
   isCollectionBackfilledSelector,
   collectionHasUnsavedArticleEditsWarningSelector as createCollectionHasUnsavedArticleEditsWarningSelector

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -45,7 +45,9 @@ const getFrontsByPriority = createSelector(
 // TODO test
 const collectionsInOpenFrontsSelector = (state: State): string[] => {
   const openFrontIds = selectEditorFronts(state);
-  const openFronts = openFrontIds.map(frontId => getFront(state, frontId));
+  const openFronts = openFrontIds
+    .map(frontId => getFront(state, frontId))
+    .filter(Boolean); // TODO How do we want to handle non-existent frontconfigs?
   return flatten(openFronts.map(front => front.collections));
 };
 

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -5,8 +5,6 @@ import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
 import { breakingNewsFrontId } from 'constants/fronts';
 import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
-import { selectEditorFronts } from 'bundles/frontsUIBundle';
-import flatten from 'lodash/flatten';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
 
@@ -22,9 +20,8 @@ interface FrontsByPriority {
   [id: string]: FrontConfig[];
 }
 
-function getFronts(state: State): FrontConfigMap {
-  return frontsConfigSelectors.selectAll(state).fronts || {};
-}
+const getFronts = (state: State): FrontConfigMap =>
+  frontsConfigSelectors.selectAll(state).fronts || {};
 
 const getFront = (state: State, id: string) => getFronts(state)[id];
 
@@ -42,14 +39,6 @@ const getFrontsByPriority = createSelector(
         };
       }, {})
 );
-
-const collectionsInOpenFrontsSelector = (state: State): string[] => {
-  const openFrontIds = selectEditorFronts(state);
-  const openFronts = openFrontIds
-    .map(frontId => getFront(state, frontId))
-    .filter(Boolean); // TODO How do we want to handle non-existent frontconfigs?
-  return flatten(openFronts.map(front => front.collections));
-};
 
 const prioritySelector = (state: State, { priority }: { priority: string }) =>
   priority;
@@ -299,7 +288,6 @@ export {
   collectionConfigsSelector,
   frontsIdsSelector,
   getFrontsWithPriority,
-  collectionsInOpenFrontsSelector,
   alsoOnFrontSelector,
   createAlsoOnSelector,
   lastPressedSelector,

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -22,8 +22,9 @@ interface FrontsByPriority {
   [id: string]: FrontConfig[];
 }
 
-const getFronts = (state: State): FrontConfigMap =>
-  frontsConfigSelectors.selectAll(state).fronts || {};
+function getFronts(state: State): FrontConfigMap {
+  return frontsConfigSelectors.selectAll(state).fronts || {};
+}
 
 const getFront = (state: State, id: string) => getFronts(state)[id];
 

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -5,6 +5,8 @@ import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
 import { breakingNewsFrontId } from 'constants/fronts';
 import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
+import { selectEditorFronts } from 'bundles/frontsUIBundle';
+import flatten from 'lodash/flatten';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
 
@@ -39,6 +41,13 @@ const getFrontsByPriority = createSelector(
         };
       }, {})
 );
+
+// TODO test
+const collectionsInOpenFrontsSelector = (state: State): string[] => {
+  const openFrontIds = selectEditorFronts(state);
+  const openFronts = openFrontIds.map(frontId => getFront(state, frontId));
+  return flatten(openFronts.map(front => front.collections));
+};
 
 const prioritySelector = (state: State, { priority }: { priority: string }) =>
   priority;
@@ -288,6 +297,7 @@ export {
   collectionConfigsSelector,
   frontsIdsSelector,
   getFrontsWithPriority,
+  collectionsInOpenFrontsSelector,
   alsoOnFrontSelector,
   createAlsoOnSelector,
   lastPressedSelector,

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -42,7 +42,6 @@ const getFrontsByPriority = createSelector(
       }, {})
 );
 
-// TODO test
 const collectionsInOpenFrontsSelector = (state: State): string[] => {
   const openFrontIds = selectEditorFronts(state);
   const openFronts = openFrontIds

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -19,10 +19,8 @@ import { CapiArticle } from 'types/Capi';
 import chunk from 'lodash/chunk';
 import { CAPISearchQueryReponse } from './capiQuery';
 import flatMap from 'lodash/flatMap';
-import { State } from 'types/State';
 import { Dispatch, ThunkResult } from 'types/Store';
-import { selectParamsAndFetchCollection } from 'actions/Collections';
-import { collection } from 'shared/fixtures/shared';
+import { selectParamsAndFetchCollections } from 'actions/Collections';
 
 function fetchFrontsConfig(): Promise<FrontsConfig> {
   return pandaFetch('/config', {
@@ -189,18 +187,22 @@ async function saveOpenFrontIds(frontIds?: string[]): Promise<void> {
   }
 }
 
-async function getCollection(
+function getCollection(
   collectionId: string
-): Promise<CollectionResponse> {
-  const collections = await getCollections([collectionId]); //collections: {id: string;type: string;lastUpdated?: number | undefined;}[]):
-  const [collection] = collections;
-  if (!collection) {
-    throw new Error(`Collection with id ${collectionId} not found`);
-  }
-  return collection;
+): ThunkResult<Promise<CollectionResponse>> {
+  return async (dispatch: Dispatch) => {
+    const [collection] = await dispatch(
+      selectParamsAndFetchCollections([collectionId], false)
+    );
+
+    if (!collection) {
+      throw new Error(`Collection with id ${collectionId} not found`);
+    }
+    return collection;
+  };
 }
 
-async function getCollections(
+async function getCollections( // fetchCollections
   collections: Array<{ id: string; type: string; lastUpdated?: number }>
 ): Promise<Array<CollectionResponse>> {
   const response = await pandaFetch(`/collections`, {

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -200,7 +200,7 @@ async function getCollection(collectionId: {
 
 async function getCollections( // fetchCollections
   collections: Array<{ id: string; type: string; lastUpdated?: number }>
-): Promise<Array<CollectionResponse>> {
+): Promise<CollectionResponse[]> {
   const response = await pandaFetch('/collections', {
     body: JSON.stringify(collections),
     method: 'POST',

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -187,7 +187,6 @@ async function saveOpenFrontIds(frontIds?: string[]): Promise<void> {
 
 async function getCollection(collectionId: {
   id: string;
-  type: string;
   lastUpdated?: number;
 }): Promise<CollectionResponse> {
   const [collection] = await getCollections([collectionId]);
@@ -199,7 +198,7 @@ async function getCollection(collectionId: {
 }
 
 async function getCollections( // fetchCollections
-  collections: Array<{ id: string; type: string; lastUpdated?: number }>
+  collections: Array<{ id: string; lastUpdated?: number }>
 ): Promise<CollectionResponse[]> {
   const response = await pandaFetch('/collections', {
     body: JSON.stringify(collections),

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -19,8 +19,6 @@ import { CapiArticle } from 'types/Capi';
 import chunk from 'lodash/chunk';
 import { CAPISearchQueryReponse } from './capiQuery';
 import flatMap from 'lodash/flatMap';
-import { Dispatch, ThunkResult } from 'types/Store';
-import { selectParamsAndFetchCollections } from 'actions/Collections';
 
 function fetchFrontsConfig(): Promise<FrontsConfig> {
   return pandaFetch('/config', {
@@ -187,27 +185,28 @@ async function saveOpenFrontIds(frontIds?: string[]): Promise<void> {
   }
 }
 
-function getCollection(
-  collectionId: string
-): ThunkResult<Promise<CollectionResponse>> {
-  return async (dispatch: Dispatch) => {
-    const [collection] = await dispatch(
-      selectParamsAndFetchCollections([collectionId], false)
-    );
+async function getCollection(collectionId: {
+  id: string;
+  type: string;
+  lastUpdated?: number;
+}): Promise<CollectionResponse> {
+  const [collection] = await getCollections([collectionId]);
 
-    if (!collection) {
-      throw new Error(`Collection with id ${collectionId} not found`);
-    }
-    return collection;
-  };
+  if (!collection) {
+    throw new Error(`Collection with id ${collectionId} not found`);
+  }
+  return collection;
 }
 
 async function getCollections( // fetchCollections
   collections: Array<{ id: string; type: string; lastUpdated?: number }>
 ): Promise<Array<CollectionResponse>> {
-  const response = await pandaFetch(`/collections`, {
+  const response = await pandaFetch('/collections', {
     body: JSON.stringify(collections),
-    method: 'post',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
     credentials: 'same-origin'
   });
   return await response.json();

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -9,7 +9,8 @@ import {
   InsertSupportingArticleFragment,
   RemoveGroupArticleFragment,
   RemoveSupportingArticleFragment,
-  UpdateArticleFragmentMeta
+  UpdateArticleFragmentMeta,
+  ClearArticleFragments
 } from 'shared/types/Action';
 import { createFragment } from 'shared/util/articleFragment';
 import { createLinkSnap, createLatestSnap } from 'shared/util/snap';
@@ -19,6 +20,7 @@ import { isValidURL } from 'shared/util/url';
 export const UPDATE_ARTICLE_FRAGMENT_META =
   'SHARED/UPDATE_ARTICLE_FRAGMENT_META';
 export const ARTICLE_FRAGMENTS_RECEIVED = 'SHARED/ARTICLE_FRAGMENTS_RECEIVED';
+export const CLEAR_ARTICLE_FRAGMENTS = 'SHARED/CLEAR_ARTICLE_FRAGMENTS';
 export const REMOVE_GROUP_ARTICLE_FRAGMENT =
   'SHARED/REMOVE_GROUP_ARTICLE_FRAGMENT';
 export const REMOVE_SUPPORTING_ARTICLE_FRAGMENT =
@@ -56,6 +58,15 @@ function articleFragmentsReceived(
   return {
     type: ARTICLE_FRAGMENTS_RECEIVED,
     payload
+  };
+}
+
+function clearArticleFragments(ids: string[]): ClearArticleFragments {
+  return {
+    type: 'SHARED/CLEAR_ARTICLE_FRAGMENTS',
+    payload: {
+      ids
+    }
   };
 }
 
@@ -189,5 +200,6 @@ export {
   insertSupportingArticleFragment,
   removeGroupArticleFragment,
   removeSupportingArticleFragment,
-  createArticleFragment
+  createArticleFragment,
+  clearArticleFragments
 };

--- a/client-v2/src/shared/bundles/collectionsBundle.ts
+++ b/client-v2/src/shared/bundles/collectionsBundle.ts
@@ -15,7 +15,7 @@ const collectionSelectors = {
   selectParentCollectionOfArticleFragment: (
     state: SharedState,
     articleFragmentId: string
-  ) => {
+  ): string | null => {
     let collectionId: null | string = null;
     Object.keys(state.collections.data).some(id =>
       ['live', 'draft', 'previously'].some(stage => {

--- a/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
+++ b/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
@@ -59,7 +59,21 @@ describe('Article component ', () => {
     expect(getByTestId('article-body')).not.toHaveTextContent('Draft');
   });
 
-  it('should render loading placeholders when the isLoading prop is true', () => {
+  it('should render loading placeholders when the isLoading prop is true and there is not article', () => {
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <ArticleComponent
+          children={<React.Fragment />}
+          article={undefined}
+          id="ea1"
+          isLoading={true}
+        />
+      </ThemeProvider>
+    );
+    expect(() => getByTestId('loading-placeholder')).toThrow();
+  });
+
+  it('should not render loading placeholders when the isLoading prop is true but the article is present', () => {
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>
         <ArticleComponent
@@ -72,6 +86,7 @@ describe('Article component ', () => {
     );
     expect(getByTestId('loading-placeholder')).toBeTruthy();
   });
+
   it('should not render loading placeholders when the isLoading prop is false or not present', () => {
     let renderResult = render(
       <ThemeProvider theme={theme}>

--- a/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
+++ b/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
@@ -70,7 +70,7 @@ describe('Article component ', () => {
         />
       </ThemeProvider>
     );
-    expect(() => getByTestId('loading-placeholder')).toThrow();
+    expect(getByTestId('loading-placeholder')).toBeTruthy();
   });
 
   it('should not render loading placeholders when the isLoading prop is true but the article is present', () => {

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -530,10 +530,26 @@ const stateWithCollection: any = {
           exampleCollection: {
             displayName: 'Example Collection',
             type: 'type'
+          },
+          testCollection1: {
+            displayName: 'testCollection',
+            type: 'type'
+          },
+          testCollection2: {
+            displayName: 'testCollection',
+            type: 'type'
           }
         }
-      }
-    }
+      },
+      lastError: null,
+      error: null,
+      lastFetch: 1547474511048,
+      loading: false,
+      loadingIds: [],
+      updatingIds: []
+    },
+    lastPressed: {},
+    collectionVisibility: { draft: {}, live: {} }
   },
   shared: {
     collections: {
@@ -554,7 +570,13 @@ const stateWithCollection: any = {
           previously: undefined,
           type: 'type'
         }
-      }
+      },
+      lastError: null,
+      error: null,
+      lastFetch: null,
+      loading: false,
+      loadingIds: [],
+      updatingIds: []
     },
     groups: {
       abc: {

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -5,6 +5,7 @@ import { articleFragmentsSelector } from 'shared/selectors/shared';
 import {
   UPDATE_ARTICLE_FRAGMENT_META,
   ARTICLE_FRAGMENTS_RECEIVED,
+  CLEAR_ARTICLE_FRAGMENTS,
   REMOVE_SUPPORTING_ARTICLE_FRAGMENT,
   INSERT_SUPPORTING_ARTICLE_FRAGMENT
 } from 'shared/actions/ArticleFragments';
@@ -27,6 +28,12 @@ const articleFragments = (
           }
         }
       };
+    }
+    case CLEAR_ARTICLE_FRAGMENTS: {
+      return action.payload.ids.reduce((newState, id) => {
+        const { [id]: omit, ...rest } = newState;
+        return rest;
+      }, state);
     }
     case ARTICLE_FRAGMENTS_RECEIVED: {
       const { payload } = action;
@@ -51,6 +58,12 @@ const articleFragments = (
       const { id, articleFragmentId, index } = action.payload;
       const targetArticleFragment = state[id];
       const insertedArticleFragment = state[articleFragmentId];
+
+      if (!insertedArticleFragment) {
+        // this may have happened if we've purged after a poll
+        return state;
+      }
+
       const supporting = insertAndDedupeSiblings(
         targetArticleFragment.meta.supporting || [],
         [

--- a/client-v2/src/shared/reducers/groupsReducer.ts
+++ b/client-v2/src/shared/reducers/groupsReducer.ts
@@ -38,6 +38,12 @@ const groups = (
       const { id, index, articleFragmentId } = action.payload;
       const articleFragmentsMap = articleFragmentsSelector(prevSharedState);
       const groupSiblings = groupSiblingsSelector(prevSharedState, id);
+
+      if (!articleFragmentsMap[articleFragmentId]) {
+        // this may have happened if we've purged after a poll
+        return state;
+      }
+
       const dedupedSiblings = groupSiblings.reduce(
         (acc, sibling) => ({
           ...acc,

--- a/client-v2/src/shared/selectors/collection.ts
+++ b/client-v2/src/shared/selectors/collection.ts
@@ -16,13 +16,14 @@ export const selectArticlesInCollections = createSelector(
       itemSet
     }: { collectionIds: string[]; itemSet: CollectionItemSets }
   ) =>
-    collectionIds.map(_ =>
-      selectArticleIdsInCollection(state, {
-        collectionId: _,
-        collectionSet: itemSet
-      })
-        .map(articleId => articleFragmentSelector(state, articleId))
-        .map(article => article.id)
+    collectionIds.map(
+      _ =>
+        selectArticleIdsInCollection(state, {
+          collectionId: _,
+          collectionSet: itemSet
+        })
+          .map(articleId => articleFragmentSelector(state, articleId))
+          .map(article => article.id) // TODO WHY IS THIS WORKING? should it not retrun the UUID?
     ),
   articleIds => uniq(flatten(articleIds))
 );

--- a/client-v2/src/shared/selectors/collection.ts
+++ b/client-v2/src/shared/selectors/collection.ts
@@ -8,6 +8,7 @@ import { articleFragmentSelector } from '../selectors/shared';
 
 const selectArticleIdsInCollection = createArticlesInCollectionSelector();
 
+// Does not return UUIDs. Returns interal page codes for fetching articleFragments
 export const selectArticlesInCollections = createSelector(
   (
     state: State,
@@ -16,14 +17,13 @@ export const selectArticlesInCollections = createSelector(
       itemSet
     }: { collectionIds: string[]; itemSet: CollectionItemSets }
   ) =>
-    collectionIds.map(
-      _ =>
-        selectArticleIdsInCollection(state, {
-          collectionId: _,
-          collectionSet: itemSet
-        })
-          .map(articleId => articleFragmentSelector(state, articleId))
-          .map(article => article.id) // TODO WHY IS THIS WORKING? should it not retrun the UUID?
+    collectionIds.map(_ =>
+      selectArticleIdsInCollection(state, {
+        collectionId: _,
+        collectionSet: itemSet
+      })
+        .map(articleId => articleFragmentSelector(state, articleId))
+        .map(article => article.id)
     ),
   articleIds => uniq(flatten(articleIds))
 );

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -13,6 +13,7 @@ import {
   ArticleTag
 } from '../types/Collection';
 import { State } from '../types/State';
+import { collectionItemSets } from 'constants/fronts';
 
 // Selects the shared part of the application state mounted at its default point, '.shared'.
 const selectSharedState = (rootState: any): State => rootState.shared;
@@ -292,7 +293,7 @@ const createAllArticlesInCollectionSelector = () => {
     collectionIds.reduce(
       (acc, id) => [
         ...acc,
-        ...(['live', 'draft', 'previously'] as CollectionItemSets[]).reduce(
+        ...Object.values(collectionItemSets).reduce(
           (acc1, collectionSet) => [
             ...acc1,
             ...articlesInCollection(state, {

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -285,6 +285,28 @@ const createArticlesInCollectionSelector = () => {
     });
 };
 
+const createAllArticlesInCollectionSelector = () => {
+  const articlesInCollection = createArticlesInCollectionSelector();
+
+  return (state: State, collectionIds: string[]) =>
+    collectionIds.reduce(
+      (acc, id) => [
+        ...acc,
+        ...(['live', 'draft', 'previously'] as CollectionItemSets[]).reduce(
+          (acc1, collectionSet) => [
+            ...acc1,
+            ...articlesInCollection(state, {
+              collectionId: id,
+              collectionSet
+            })
+          ],
+          [] as string[]
+        )
+      ],
+      [] as string[]
+    );
+};
+
 const articleFragmentIdSelector = (
   _: unknown,
   { articleFragmentId }: { articleFragmentId: string }
@@ -401,6 +423,7 @@ export {
   articleFragmentsFromRootStateSelector,
   createArticlesInCollectionGroupSelector,
   createArticlesInCollectionSelector,
+  createAllArticlesInCollectionSelector,
   createGroupArticlesSelector,
   createSupportingArticlesSelector,
   createCollectionSelector,

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -11,6 +11,10 @@ interface ArticleFragmentsReceived {
   type: 'SHARED/ARTICLE_FRAGMENTS_RECEIVED';
   payload: { [id: string]: ArticleFragment };
 }
+interface ClearArticleFragments {
+  type: 'SHARED/CLEAR_ARTICLE_FRAGMENTS';
+  payload: { ids: string[] };
+}
 interface GroupsReceived {
   type: 'SHARED/GROUPS_RECEIVED';
   payload: { [id: string]: Group };
@@ -70,6 +74,7 @@ type Action =
   | Actions<ExternalArticle>
   | Actions<Collection>
   | ArticleFragmentsReceived
+  | ClearArticleFragments
   | UpdateArticleFragmentMeta
   | CapGroupSiblings;
 
@@ -80,6 +85,7 @@ export {
   RemoveGroupArticleFragment,
   RemoveSupportingArticleFragment,
   ArticleFragmentsReceived,
+  ClearArticleFragments,
   UpdateArticleFragmentMeta,
   InsertArticleFragmentPayload,
   RemoveArticleFragmentPayload,

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -1,6 +1,6 @@
 import { PriorityName } from './Priority';
 import { $Diff } from 'utility-types';
-import { CollectionWithNestedArticles } from 'shared/types/Collection';
+import { CollectionFromResponse } from 'shared/types/Collection';
 
 interface FrontConfigResponse {
   collections: string[];
@@ -86,7 +86,8 @@ interface ArticleDetails {
 }
 
 interface CollectionResponse {
-  collection: CollectionWithNestedArticles;
+  id: string;
+  collection: CollectionFromResponse;
   storiesVisibleByStage: {
     live: VisibleArticlesResponse;
     draft: VisibleArticlesResponse;

--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -2,6 +2,11 @@ import { fetchStaleOpenCollections } from 'actions/Collections';
 import { Dispatch } from 'types/Store';
 import { Store } from 'types/Store';
 
+/**
+ * TODO: do we want to check if there are any collectionUpdates going out here
+ * could there be a race condition where we try to update a collection and poll
+ * at the same time and the poll overwrites the update
+ */
 export default (store: Store) =>
   setInterval(
     () => (store.dispatch as Dispatch)(fetchStaleOpenCollections()),

--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -1,0 +1,9 @@
+import { fetchStaleOpenCollections } from 'actions/Collections';
+import { Dispatch } from 'types/Store';
+import { Store } from 'types/Store';
+
+export default (store: Store) =>
+  setInterval(
+    () => (store.dispatch as Dispatch)(fetchStaleOpenCollections()),
+    10000
+  );

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -99,16 +99,19 @@ const persistCollectionOnEdit = (
           (act.meta.key ? act.payload[act.meta.key] : act.payload.id)
       )
     );
-    const collectionIds: string[] = articleFragmentIds.reduce((acc, id) => {
-      const collectionId = selectors.selectParentCollectionOfArticleFragment(
-        selectSharedState(store.getState()),
-        id
-      );
-      if (!collectionId) {
-        return acc;
-      }
-      return acc.concat(collectionId);
-    }, []);
+    const collectionIds: string[] = articleFragmentIds.reduce(
+      (acc, id) => {
+        const collectionId = selectors.selectParentCollectionOfArticleFragment(
+          selectSharedState(store.getState()),
+          id
+        );
+        if (!collectionId) {
+          return acc;
+        }
+        return acc.concat(collectionId);
+      },
+      [] as string[]
+    );
     return collectionIds;
   };
 

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -1467,7 +1467,7 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-each@^1.0.0:
+async-each@^1.0.0, async-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
   integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
@@ -2397,7 +2397,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.0, braces@^2.3.1:
+braces@^2.3.0, braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
@@ -2752,6 +2752,25 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3:
     upath "^1.0.5"
   optionalDependencies:
     fsevents "^1.2.2"
+
+chokidar@^2.0.4:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.0"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
 chownr@^1.0.1:
   version "1.1.1"
@@ -4436,6 +4455,18 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+fork-ts-checker-webpack-plugin@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-0.5.2.tgz#a73b3630bd0a69409a6e4824e54c03a62fe82d8f"
+  integrity sha512-a5IG+xXyKnpruI0CP/anyRLAoxWtp3lzdG6flxicANnoSzz64b12dJ7ASAVRrI2OaWwZR2JyBaMHFQqInhWhIw==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    tapable "^1.0.0"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -4501,6 +4532,14 @@ fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
+
+fsevents@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
@@ -7025,6 +7064,11 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -8202,7 +8246,7 @@ readable-stream@^3.0.6:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readdirp@^2.0.0:
+readdirp@^2.0.0, readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
   integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
@@ -9958,6 +10002,11 @@ upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
+
+upath@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
+  integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
 uri-js@^4.2.2:
   version "4.2.2"

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -2342,7 +2342,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-body-parser@1.18.3:
+body-parser@1.18.3, body-parser@^1.18.3:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   integrity sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=

--- a/conf/routes
+++ b/conf/routes
@@ -43,6 +43,8 @@ GET         /front/lastmodified/*path                controllers.PressController
 GET         /front/lastmodifiedstatus/:stage/*path   controllers.PressController.getLastModifiedStatus(stage, path)
 
 GET         /collection/*collectionId                controllers.FaciaToolController.getCollection(collectionId)
+# The below endpoint is a GET but it was decided to send params in the body as they were more than just ids
+# a pragmatic decision if not a semantic one
 POST        /collections                             controllers.FaciaToolV2Controller.getCollections
 POST        /edits                                   controllers.FaciaToolController.collectionEdits
 POST        /v2Edits                                 controllers.FaciaToolV2Controller.collectionEdits

--- a/conf/routes
+++ b/conf/routes
@@ -43,7 +43,7 @@ GET         /front/lastmodified/*path                controllers.PressController
 GET         /front/lastmodifiedstatus/:stage/*path   controllers.PressController.getLastModifiedStatus(stage, path)
 
 GET         /collection/*collectionId                controllers.FaciaToolController.getCollection(collectionId)
-GET         /collections                             controllers.FaciaToolV2Controller.getCollections
+POST        /collections                             controllers.FaciaToolV2Controller.getCollections
 POST        /edits                                   controllers.FaciaToolController.collectionEdits
 POST        /v2Edits                                 controllers.FaciaToolV2Controller.collectionEdits
 GET         /config                                  controllers.FaciaToolController.getConfig

--- a/test/commands/V2GetCollectionsCommandTest.scala
+++ b/test/commands/V2GetCollectionsCommandTest.scala
@@ -13,7 +13,7 @@ class V2GetCollectionsCommandTest extends FreeSpec with Matchers {
   val tomorrow = now.plusDays(1)
 
   private def createCollectionSpec(id: String, lastUpdated: Option[Long] = None) = {
-    CollectionSpec(id, lastUpdated, "type")
+    CollectionSpec(id, lastUpdated)
   }
 
   private def createCollectionJson(lastUpdated: DateTime) = {

--- a/test/commands/V2GetCollectionsCommandTest.scala
+++ b/test/commands/V2GetCollectionsCommandTest.scala
@@ -1,0 +1,81 @@
+package commands
+
+import com.gu.facia.client.models.{CollectionJson}
+import controllers.CollectionSpec
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+import services.{CollectionAndStoriesResponse}
+
+
+class V2GetCollectionsCommandTest extends FreeSpec with Matchers {
+  val now = new DateTime()
+  val yesterday = now.minusDays(1)
+  val tomorrow = now.plusDays(1)
+
+  private def createCollectionSpec(id: String, lastUpdated: Option[Long] = None) = {
+    CollectionSpec(id, lastUpdated, "type")
+  }
+
+  private def createCollectionJson(lastUpdated: DateTime) = {
+    CollectionJson(
+      live = List(),
+      draft = None,
+      treats = None,
+      lastUpdated = lastUpdated,
+      updatedBy = "",
+      updatedEmail = "",
+      displayName = None,
+      href = None,
+      previously = None
+    )
+  }
+
+  private def createCollectionAndStoriesResponse(id: String, lastUpdated: DateTime): CollectionAndStoriesResponse = {
+    CollectionAndStoriesResponse(id, createCollectionJson(lastUpdated), None)
+  }
+
+  "keepOnlyNewerCollectionData" - {
+    "should return all collection response data if CollectionSpecs has no lastUpdated key" in {
+      val specs = List(
+        createCollectionSpec("id1"),
+        createCollectionSpec("id2")
+      )
+      val responses = List(
+        Some(createCollectionAndStoriesResponse("id1", now)),
+        Some(createCollectionAndStoriesResponse("id2", yesterday))
+      )
+      V2GetCollectionsCommand.keepOnlyNewerCollectionData(specs, responses) should be(responses.flatten)
+    }
+
+    "should return only collection response data when CollectionResponse has more recent lastUpdated data than CollectionSpecs" in {
+      val specs = List(
+        createCollectionSpec("id1", Some(now.getMillis())),
+        createCollectionSpec("id2", Some(now.getMillis())),
+        createCollectionSpec("id3", Some(now.getMillis()))
+      )
+      val responses = List(
+        Some(createCollectionAndStoriesResponse("id1", now)),
+        Some(createCollectionAndStoriesResponse("id2", yesterday)),
+        Some(createCollectionAndStoriesResponse("id3", tomorrow))
+      )
+      V2GetCollectionsCommand.keepOnlyNewerCollectionData(specs, responses) should be(List(
+        createCollectionAndStoriesResponse("id3", tomorrow)
+      ))
+    }
+
+    "should return an empty list when all CollectionResponse items have older lastUpdated data than CollectionSpecs" in {
+      val specs = List(
+        createCollectionSpec("id1", Some(now.getMillis())),
+        createCollectionSpec("id2", Some(now.getMillis())),
+        createCollectionSpec("id3", Some(now.getMillis()))
+      )
+      val responses = List(
+        Some(createCollectionAndStoriesResponse("id1", yesterday)),
+        Some(createCollectionAndStoriesResponse("id2", yesterday)),
+        Some(createCollectionAndStoriesResponse("id3", yesterday))
+      )
+      V2GetCollectionsCommand.keepOnlyNewerCollectionData(specs, responses) should be(List())
+    }
+  }
+
+}


### PR DESCRIPTION
## What's changed?

As above this change ensures we open preview in the same tab each time.

Trello: https://trello.com/c/as78uUIU/466-when-previewing-v2-launches-a-new-window-each-time-whereas-v1-updates-the-existing-open-preview-window

## Implementation notes

To get this to work you need to specify a `target` with any custom name and remove `noopener` and `noreferrer`. I think in this case that's fine as we're linking to our own tools.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
