### PR TITLE
Ensure preview opens in the same tab each time

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -106,8 +106,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
                   this.props.frontId
                 }`}
-                target="_blank"
-                rel="noopener noreferrer"
+                target="preview"
               >
                 <Button size="l">Preview</Button>
               </a>


### PR DESCRIPTION
## What's changed?

As above this change ensures we open preview in the same tab each time.

Trello: https://trello.com/c/as78uUIU/466-when-previewing-v2-launches-a-new-window-each-time-whereas-v1-updates-the-existing-open-preview-window

## Implementation notes

To get this to work you need to specify a `target` with any custom name and remove `noopener` and `noreferrer`. I think in this case that's fine as we're linking to our own tools.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
