### PR TITLE
Proxy return same status code as CAPI

### DIFF
--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -55,7 +55,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
         logger.error(s"Request to capi preview with url $url failed with response $response, ${response.body}")
       }
       Cached(60) {
-        Ok(rewriteBody(response.body)).as("application/javascript")
+        Status(response.status)(rewriteBody(response.body)).as("application/javascript")
       }
     }
   }
@@ -76,7 +76,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
         logger.error(s"Request to live capi with url $url failed with response $response, ${response.body}")
       }
       Cached(60) {
-        Ok(rewriteBody(response.body)).as("application/javascript")
+        Status(response.status)(rewriteBody(response.body)).as("application/javascript")
       }
     }
   }


### PR DESCRIPTION
## What's changed?

Ensure the client receives errors from CAPI rather than a 200 when CAPI returns non-200s

## Implementation notes

I _think_ this is how to do it and it all seems to be working ok, I've just not had any errors from CAPI and testing a controller seems _arduous_.

Will also check on CODE first.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
