### PR TITLE
Expand clipboard drop zone to fill area

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -52,6 +52,7 @@ const ClipboardBody = styled.div`
 const StyledDragIntentContainer = styled(DragIntentContainer)`
   display: flex;
   flex-direction: column;
+  height: 100%;
 `;
 
 interface ClipboardProps {


### PR DESCRIPTION
## What's changed?

Restores the clipboard target area, which has shrunk as a result of an element above the flex area not having height: 100%.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
