### PR TITLE
Quick fixes for front list

### DIFF
--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -55,7 +55,10 @@ const FrontsContainer = styled(SectionContainer)<{
   overflow-x: scroll;
   transition: transform 0.15s;
   ${({ makeRoomForExtraHeader }) =>
-    makeRoomForExtraHeader && 'transform: translate3d(0, 60px, 0)'}
+    makeRoomForExtraHeader &&
+    `
+    transform: translate3d(0, 60px, 0);
+    height: calc(100% - 60px)`}
 `;
 
 class FrontsEdit extends React.Component<Props> {

--- a/client-v2/src/util/__tests__/storeMiddleware.spec.ts
+++ b/client-v2/src/util/__tests__/storeMiddleware.spec.ts
@@ -79,7 +79,40 @@ describe('Store middleware', () => {
     });
     it("should call the persist function with the state's open front ids if it receives an action the correct persistTo property", () => {
       const store = mockStore({
-        editor: { frontIds: ['front1', 'front2'] }
+        editor: { frontIds: ['front1', 'front2'] },
+        fronts: {
+          frontsConfig: {
+            data: {
+              fronts: {
+                front1: {},
+                front2: {}
+              }
+            }
+          }
+        }
+      });
+      store.dispatch({
+        type: 'ARBITRARY_ACTION',
+        meta: {
+          persistTo: 'openFrontIds'
+        }
+      });
+      expect(persistFrontIdsSpy.mock.calls.length).toBe(1);
+      expect(persistFrontIdsSpy.mock.calls[0][0]).toEqual(['front1', 'front2']);
+    });
+    it('should not include fronts that are no longer in the state', () => {
+      const store = mockStore({
+        editor: { frontIds: ['front1', 'front2', 'notInState'] },
+        fronts: {
+          frontsConfig: {
+            data: {
+              fronts: {
+                front1: {},
+                front2: {}
+              }
+            }
+          }
+        }
       });
       store.dispatch({
         type: 'ARBITRARY_ACTION',

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -12,6 +12,7 @@ import { selectSharedState } from 'shared/selectors/shared';
 import { saveOpenFrontIds } from 'services/faciaApi';
 import { NestedArticleFragment } from 'shared/types/Collection';
 import { denormaliseClipboard } from 'util/clipboardUtils';
+import { getFront } from 'selectors/frontsSelectors';
 
 const updateStateFromUrlChange: Middleware<{}, State, Dispatch> = ({
   dispatch,
@@ -201,7 +202,12 @@ const persistOpenFrontsOnEdit: (
     return next(action);
   }
   const result = next(action);
-  const frontIds = selectEditorFrontIds(store.getState());
+  const state = store.getState();
+  const frontIds = selectEditorFrontIds(state).filter(
+    // Only persist fronts that exist in the state, clearing out
+    // fronts that have been changed or deleted.
+    frontId => !!getFront(state, frontId)
+  );
   // Now they're in the state, persist the relevant front ids.
   persistFrontIds(frontIds);
   return result;


### PR DESCRIPTION
## What's changed?

A few quick fixes for some issues with the current front menu --
- The scrollbar at the bottom of the main fronts area disappeared when the menu was open
- We weren't checking that fronts were present in the state when we persisted them, which means old fronts can hang about in dynamo indefinitely

Thanks for checking this out, @harpreetpurewal !

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
