### PR TITLE
Remove link from also on front listing

### DIFF
--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -83,9 +83,7 @@ class CollectionNotification extends React.Component<
           {this.state.showFrontDetails && (
             <AlsoOnLinksWrapper>
               {alsoOn.fronts.map(front => (
-                <div key={front.id}>
-                  <a href={`/v2/${front.priority}/${front.id}`}>{front.id}</a>
-                </div>
+                <div key={front.id}>{front.id}</div>
               ))}
             </AlsoOnLinksWrapper>
           )}


### PR DESCRIPTION
## What's changed?

Remove the linking in the fronts list for 'also-on', which was misleading -- the routes it was linking too do not exist (yet!)

<img width="128" alt="Screenshot 2019-03-13 at 16 39 00" src="https://user-images.githubusercontent.com/7767575/54297329-9355a380-45ae-11e9-9806-a8a525d69c97.png">
to

<img width="128" alt="Screenshot 2019-03-13 at 16 38 43" src="https://user-images.githubusercontent.com/7767575/54297338-96509400-45ae-11e9-9f4e-4bddacda9cc8.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
