### PR TITLE
Front last refreshed

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -45,7 +45,7 @@ const FrontsHeaderText = styled('span')`
 const SectionContentMetaContainer = styled('div')`
   display: flex;
   flex-shrink: 0;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin-bottom: 10px;
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import distanceInWords from 'date-fns/distance_in_words';
 import startCase from 'lodash/startCase';
 import { styled } from 'constants/theme';
 import { Dispatch } from 'types/Store';
@@ -12,11 +11,7 @@ import { frontStages } from 'constants/fronts';
 import { FrontConfig } from 'types/FaciaApi';
 import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
-import {
-  getFront,
-  createAlsoOnSelector,
-  lastPressedSelector
-} from 'selectors/frontsSelectors';
+import { getFront, createAlsoOnSelector } from 'selectors/frontsSelectors';
 import Front from './Front';
 import { FrontSectionHeader } from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';
@@ -58,9 +53,6 @@ const StageSelectButtons = styled('div')`
   color: ${({ theme }) => theme.shared.colors.blackDark};
   padding: 0px 30px;
 `;
-const LastPressed = styled('span')`
-  font-size: 14px;
-`;
 
 const CollapseAllButton = styled(ButtonRoundedWithLabel)`
   & svg {
@@ -85,7 +77,6 @@ interface FrontsContainerProps {
 type FrontsComponentProps = FrontsContainerProps & {
   selectedFront: FrontConfig;
   alsoOn: { [id: string]: AlsoOnDetail };
-  lastPressed: string | null;
   frontsActions: {
     fetchLastPressed: (frontId: string) => void;
     editorCloseFront: (frontId: string) => void;
@@ -102,12 +93,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
   public state = {
     collectionSet: frontStages.draft
   };
-
-  public componentDidMount() {
-    if (!this.props.lastPressed) {
-      this.props.frontsActions.fetchLastPressed(this.props.frontId);
-    }
-  }
 
   public handleCollectionSetSelect(key: string) {
     this.setState({
@@ -159,13 +144,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
         </>
         <SectionContent direction="column">
           <SectionContentMetaContainer>
-            <LastPressed>
-              {this.props.lastPressed &&
-                `Last refreshed ${distanceInWords(
-                  new Date(this.props.lastPressed),
-                  Date.now()
-                )} ago`}
-            </LastPressed>
             <CollapseAllButton
               onClick={e => {
                 e.preventDefault();
@@ -195,8 +173,7 @@ const createMapStateToProps = () => {
   const alsoOnSelector = createAlsoOnSelector();
   return (state: State, props: FrontsContainerProps) => ({
     selectedFront: getFront(state, props.frontId),
-    alsoOn: alsoOnSelector(state, props.frontId),
-    lastPressed: lastPressedSelector(state, props.frontId)
+    alsoOn: alsoOnSelector(state, props.frontId)
   });
 };
 

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -1,7 +1,6 @@
 import {
   getFrontsWithPriority,
-  alsoOnFrontSelector,
-  lastPressedSelector
+  alsoOnFrontSelector
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';
@@ -82,20 +81,6 @@ describe('Filtering fronts correctly', () => {
         'commercial'
       )
     ).toEqual(commercialFronts);
-  });
-  it('gets the last press date for a given front and stage', () => {
-    expect(
-      lastPressedSelector(
-        {
-          fronts: {
-            lastPressed: {
-              exampleId: '2018-05-24T09:42:20.580Z'
-            }
-          }
-        } as any,
-        'exampleId'
-      )
-    ).toEqual('2018-05-24T09:42:20.580Z');
   });
 });
 

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -255,9 +255,6 @@ const createAlsoOnSelector = () =>
     alsoOnFrontSelector
   );
 
-const lastPressedSelector = (state: State, frontId: string): string | null =>
-  state.fronts.lastPressed[frontId] || null;
-
 const clipboardSelector = (state: State) => state.clipboard;
 
 const visibleArticlesSelector = createSelector(
@@ -290,7 +287,6 @@ export {
   getFrontsWithPriority,
   alsoOnFrontSelector,
   createAlsoOnSelector,
-  lastPressedSelector,
   hasUnpublishedChangesSelector,
   clipboardSelector,
   visibleArticlesSelector,


### PR DESCRIPTION
## What's changed?

After talking to Harpreet we decided that the whole concept of pressing fronts is so complicated that we shouldn't be displaying the pressed date or a `Refresh` button above a front anymore. Users still get alerts if a front is failing to press and central prod can use the troubleshooting tool to diagnose issues. 
![Screenshot 2019-03-15 at 09 07 17](https://user-images.githubusercontent.com/3066534/54420393-c8bed600-4701-11e9-8026-c8a55a481ae3.png)

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
