### PR TITLE
Fix issue with new component ref

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -113,10 +113,11 @@ const CollectionEditedError = styled.div`
   padding: 1em;
 `;
 
-const renderSlideshow = (
-  { fields }: WrappedFieldArrayProps<ImageData>,
-  frontId: string
-) => (
+type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
+  frontId: string;
+};
+
+const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
   <>
     {fields.map((name, index) => (
       <Col key={`${name}-${index}`}>
@@ -432,11 +433,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           {imageSlideshowReplace && (
             <RowContainer>
               <SlideshowRow>
-                <FieldArray<WrappedFieldArrayProps<ImageData>>
+                <FieldArray<RenderSlideshowProps>
                   name="slideshow"
-                  component={(args: WrappedFieldArrayProps<ImageData>) =>
-                    renderSlideshow(args, frontId)
-                  }
+                  frontId={frontId}
+                  component={RenderSlideshow}
                 />
               </SlideshowRow>
               <SlideshowLabel>Drag and drop up to five images</SlideshowLabel>


### PR DESCRIPTION
## What's changed?

This fixes a bug where ReduxForm would infinitely recurse, registering and unregistering fields when the slideshow button was clicked. We have no idea why this wasn't breaking before but we presume that giving the same function reference each time fixes this - and it seems to!

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
