### PR TITLE
Provide path for migration of user data

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -65,7 +65,7 @@ class AppComponents(context: Context) extends BaseFaciaControllerComponents(cont
   val pressController = new PressController(dynamo, this)
   val v2App = new V2App(isDev, acl, dynamo, this)
   val faciaToolV2 = new FaciaToolV2Controller(acl, structuredLogger, faciaPress, updateActions, configAgent, collectionService, this)
-  val userDataController = new UserDataController(dynamo, this)
+  val userDataController = new UserDataController(frontsApi, dynamo, this)
   val gridProxy = new GridProxy(this)
   val loggingFilter = new LoggingFilter
 

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -30,6 +30,7 @@ case class Defaults(
   collectionMetadata: Iterable[Metadata],
   clipboardArticles: Option[List[Trail]],
   frontIds: Option[List[String]],
+  frontIdsByPriority: Option[Map[String, List[String]]],
   capiLiveUrl: String = "",
   capiPreviewUrl: String = ""
 )
@@ -64,6 +65,7 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
         Metadata.tags.map{
           case (_, meta) => meta
         },
+        None,
         None,
         None
       )))

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -36,8 +36,6 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
       _.asOpt[List[String]])
     val maybeFrontIdsByPriority: Option[Map[String, List[String]]] = request.body.asJson.flatMap(
       _.asOpt[Map[String, List[String]]])
-    Logger.info(maybeFrontIds.toString)
-    Logger.info(maybeFrontIdsByPriority.toString)
     (maybeFrontIds, maybeFrontIdsByPriority) match {
       case (Some(frontIds), _) =>
         Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('frontIds -> frontIds)))
@@ -70,7 +68,6 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
       })
     }
     result.map(data => {
-      Logger.info(data.toString)
       Ok
     })
   }

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -3,10 +3,13 @@ package controllers
 import com.gu.facia.client.models.Trail
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
-import services.Dynamo
+import services.{Dynamo, FrontsApi}
 import model.UserData
+import play.api.Logger
 
-class UserDataController(dynamo: Dynamo, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
   import model.UserData._
 
   private lazy val userDataTable = Table[UserData](config.faciatool.userDataTable)
@@ -28,18 +31,48 @@ class UserDataController(dynamo: Dynamo, val deps: BaseFaciaControllerComponents
   }
 
   def putFrontIds() = APIAuthAction { request =>
-
-    val frontIds: Option[List[String]] = request.body.asJson.flatMap(jsValue =>
-      jsValue.asOpt[List[String]])
-
-    frontIds match {
-      case Some(ids) => {
-        val userEmail = request.user.email
-        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('frontIds -> ids)))
+    // We handle both cases here, because of the migration from a list to a map by priority
+    val maybeFrontIds: Option[List[String]] = request.body.asJson.flatMap(
+      _.asOpt[List[String]])
+    val maybeFrontIdsByPriority: Option[Map[String, List[String]]] = request.body.asJson.flatMap(
+      _.asOpt[Map[String, List[String]]])
+    Logger.info(maybeFrontIds.toString)
+    Logger.info(maybeFrontIdsByPriority.toString)
+    (maybeFrontIds, maybeFrontIdsByPriority) match {
+      case (Some(frontIds), _) =>
+        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('frontIds -> frontIds)))
         Ok
-      }
-      case None => BadRequest
+      case (_, Some(frontIdsByPriority)) =>
+        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('frontIdsByPriority -> frontIdsByPriority)))
+        Ok
+      case _ => BadRequest
     }
+  }
+
+  def migrateUserData() = AccessAPIAuthAction.async {
+    val result = frontsApi.amazonClient.config.flatMap { config =>
+      val maybeUserData = Scanamo.exec(dynamo.client)(userDataTable.scan)
+      Future.successful(maybeUserData.filter(_.isRight).map {
+        case Right(userData) =>
+          val frontIds = userData.frontIds.getOrElse(List.empty[String])
+          val frontIdsByPriority = frontIds.foldLeft(Map.empty[String, List[String]])((acc, frontId) => {
+            val maybeAcc = for {
+              front <- config.fronts.get(frontId)
+              priority <- front.priority
+            } yield {
+              val frontIdsByCurrentPriority = acc.getOrElse(priority, List.empty[String])
+              acc + (priority -> (frontIdsByCurrentPriority :+ frontId))
+            }
+            maybeAcc.getOrElse(acc)
+          })
+          Scanamo.exec(dynamo.client)(userDataTable.update('email -> userData.email, set('frontIdsByPriority -> frontIdsByPriority)))
+          Map(userData.email -> frontIdsByPriority)
+      })
+    }
+    result.map(data => {
+      Logger.info(data.toString)
+      Ok
+    })
   }
 }
 

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -58,8 +58,8 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
           val frontIdsByPriority = frontIds.foldLeft(Map.empty[String, List[String]])((acc, frontId) => {
             val maybeAcc = for {
               front <- config.fronts.get(frontId)
-              priority <- front.priority
             } yield {
+              val priority = front.priority.getOrElse("editorial")
               val frontIdsByCurrentPriority = acc.getOrElse(priority, List.empty[String])
               acc + (priority -> (frontIdsByCurrentPriority :+ frontId))
             }

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -36,7 +36,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
 
     val userEmail: String = req.user.email
 
-    val record: Option[UserData] = Scanamo.exec(dynamo.client)(
+    val maybeUserData: Option[UserData] = Scanamo.exec(dynamo.client)(
       userDataTable.get('email -> userEmail)).flatMap(_.right.toOption)
 
     val conf = Defaults(
@@ -58,8 +58,9 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
       Metadata.tags.map {
         case (_, meta) => meta
       },
-      record.map(record => record.clipboardArticles.getOrElse(List())),
-      record.map(record => record.frontIds.getOrElse(List())),
+      maybeUserData.map(_.clipboardArticles.getOrElse(List())),
+      maybeUserData.map(_.frontIds.getOrElse(List())),
+      maybeUserData.map(_.frontIdsByPriority.getOrElse(Map())),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
     )

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -17,4 +17,8 @@ object UserData {
     }
   )(Json.stringify(_))
 }
-case class UserData(email: String, clipboardArticles: Option[List[Trail]], frontIds: Option[List[String]])
+case class UserData(
+                     email: String,
+                     clipboardArticles: Option[List[Trail]],
+                     frontIds: Option[List[String]],
+                     frontIdsByPriority: Option[Map[String, List[String]]])

--- a/conf/routes
+++ b/conf/routes
@@ -55,8 +55,9 @@ GET         /metadata                                controllers.FaciaToolContro
 POST        /treats/*collectionId                    controllers.FaciaToolController.treatEdits(collectionId)
 
 PUT        /userdata/clipboard                       controllers.UserDataController.putClipboardContent()
-
 PUT        /userdata/frontIds                        controllers.UserDataController.putFrontIds()
+# For temporary internal use -- migrates user data to a new format
+PUT        /userdata/migrate                         controllers.UserDataController.migrateUserData()
 
 # endpoints for proxying https
 GET         /api/preview/*path                       controllers.FaciaContentApiProxy.capiPreview(path)

--- a/conf/routes
+++ b/conf/routes
@@ -56,6 +56,7 @@ POST        /treats/*collectionId                    controllers.FaciaToolContro
 
 PUT        /userdata/clipboard                       controllers.UserDataController.putClipboardContent()
 PUT        /userdata/frontIds                        controllers.UserDataController.putFrontIds()
+PUT        /userdata/frontIdsByPriority              controllers.UserDataController.putFrontIdsByPriority()
 # For temporary internal use -- migrates user data to a new format
 PUT        /userdata/migrate                         controllers.UserDataController.migrateUserData()
 


### PR DESCRIPTION
## What's changed?

This PR exposes a temporary /userdata/migrate route to allow us to trigger the migration of user data from one format to another. It'll be necessary to migrate our list of frontIds to a new format that keys them by priority.

It also readies the endpoint that writes this data to accept both formats for the new client.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
