### PR TITLE
Rv fronts width

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -6,7 +6,6 @@ import {
   editorSetOpenFronts,
   editorOpenCollections,
   editorCloseCollections,
-  selectEditorFrontIds,
   selectIsCollectionOpen,
   editorCloseOverview,
   selectIsFrontOverviewOpen,
@@ -26,6 +25,7 @@ import {
 } from 'shared/actions/ArticleFragments';
 import { removeClipboardArticleFragment } from 'actions/Clipboard';
 import { State as GlobalState } from 'types/State';
+import { selectEditorFrontIds } from 'selectors/frontsSelectors';
 
 type State = ReturnType<typeof innerReducer>;
 

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -22,7 +22,7 @@ import {
 } from 'types/Action';
 import { State as GlobalState } from 'types/State';
 import { events } from 'services/GA';
-import { getFronts } from 'selectors/frontsSelectors';
+import { getFronts, selectEditorFrontIds } from 'selectors/frontsSelectors';
 import { createSelector } from 'reselect';
 import {
   REMOVE_GROUP_ARTICLE_FRAGMENT,
@@ -194,7 +194,6 @@ interface State {
 const selectIsCurrentFrontsMenuOpen = (state: GlobalState) =>
   state.editor.showOpenFrontsMenu;
 
-const selectEditorFrontIds = (state: GlobalState) => state.editor.frontIds;
 const selectIsCollectionOpen = <T extends { editor: State }>(
   state: T,
   collectionId: string
@@ -418,7 +417,6 @@ export {
   editorSelectArticleFragment,
   editorClearArticleFragmentSelection,
   selectIsCurrentFrontsMenuOpen,
-  selectEditorFrontIds,
   selectEditorFrontsByPriority,
   selectEditorArticleFragment,
   selectIsCollectionOpen,

--- a/client-v2/src/components/FeedSectionHeader.tsx
+++ b/client-v2/src/components/FeedSectionHeader.tsx
@@ -9,12 +9,12 @@ import { State } from 'types/State';
 import {
   selectIsCurrentFrontsMenuOpen,
   editorShowOpenFrontsMenu,
-  editorHideOpenFrontsMenu,
-  selectEditorFrontIds
+  editorHideOpenFrontsMenu
 } from 'bundles/frontsUIBundle';
 import { Dispatch } from 'types/Store';
 import FadeTransition from './transitions/FadeTransition';
 import { MoreIcon } from 'shared/components/icons/Icons';
+import { selectEditorFrontIds } from 'selectors/frontsSelectors';
 
 const FeedbackButton = Button.extend<{
   href: string;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -6,7 +6,7 @@ import CollectionNotification from 'components/CollectionNotification';
 import Button from 'shared/components/input/ButtonDefault';
 import { AlsoOnDetail } from 'types/Collection';
 import { publishCollection } from 'actions/Fronts';
-import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
+import { hasUnpublishedChangesSelector, hasMultipleFrontsOpenSelector } from 'selectors/frontsSelectors';
 import { isCollectionLockedSelector } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
@@ -39,6 +39,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   displayEditWarning: boolean;
   isCollectionLocked: boolean;
   isOpen: boolean;
+  hasMultipleFrontsOpen: boolean
   onChangeOpenState: (id: string, isOpen: boolean) => void;
 };
 
@@ -55,7 +56,8 @@ const Collection = ({
   displayEditWarning,
   isCollectionLocked,
   isOpen,
-  onChangeOpenState
+  onChangeOpenState,
+  hasMultipleFrontsOpen
 }: CollectionProps) => {
   const isUneditable =
     isCollectionLocked || browsingStage !== collectionItemSets.draft;
@@ -68,6 +70,7 @@ const Collection = ({
       isUneditable={isUneditable}
       isLocked={isCollectionLocked}
       isOpen={isOpen}
+      hasMultipleFrontsOpen={isOpen}
       onChangeOpenState={() => onChangeOpenState(id, isOpen)}
       headlineContent={
         hasUnpublishedChanges &&
@@ -110,7 +113,8 @@ const createMapStateToProps = () => {
     displayEditWarning: editWarningSelector(selectSharedState(state), {
       collectionId: id
     }),
-    isOpen: selectIsCollectionOpen(state, id)
+    isOpen: selectIsCollectionOpen(state, id),
+    hasMultipleFrontsOpen: hasMultipleFrontsOpenSelector(state)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -6,7 +6,10 @@ import CollectionNotification from 'components/CollectionNotification';
 import Button from 'shared/components/input/ButtonDefault';
 import { AlsoOnDetail } from 'types/Collection';
 import { publishCollection } from 'actions/Fronts';
-import { hasUnpublishedChangesSelector, hasMultipleFrontsOpenSelector } from 'selectors/frontsSelectors';
+import {
+  hasUnpublishedChangesSelector,
+  hasMultipleFrontsOpenSelector
+} from 'selectors/frontsSelectors';
 import { isCollectionLockedSelector } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
@@ -39,7 +42,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   displayEditWarning: boolean;
   isCollectionLocked: boolean;
   isOpen: boolean;
-  hasMultipleFrontsOpen: boolean
+  hasMultipleFrontsOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
 };
 
@@ -70,7 +73,7 @@ const Collection = ({
       isUneditable={isUneditable}
       isLocked={isCollectionLocked}
       isOpen={isOpen}
-      hasMultipleFrontsOpen={isOpen}
+      hasMultipleFrontsOpen={hasMultipleFrontsOpen}
       onChangeOpenState={() => onChangeOpenState(id, isOpen)}
       headlineContent={
         hasUnpublishedChanges &&

--- a/client-v2/src/containers/FrontsList.ts
+++ b/client-v2/src/containers/FrontsList.ts
@@ -1,10 +1,12 @@
 import { connect } from 'react-redux';
 import { match, withRouter, RouteComponentProps } from 'react-router';
 
-import { selectEditorFrontIds } from 'bundles/frontsUIBundle';
 import { State } from '../types/State';
 import FrontList from '../components/FrontList';
-import { getFrontsWithPriority } from '../selectors/frontsSelectors';
+import {
+  getFrontsWithPriority,
+  selectEditorFrontIds
+} from '../selectors/frontsSelectors';
 
 type Props = {
   match: match<{ priority: string }>;

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -1,5 +1,9 @@
 import { State } from 'types/State';
-import { getCollectionConfig, getFront } from './frontsSelectors';
+import {
+  getCollectionConfig,
+  getFront,
+  selectEditorFrontIds
+} from './frontsSelectors';
 import {
   selectSharedState,
   createArticlesInCollectionSelector,
@@ -7,7 +11,6 @@ import {
 } from 'shared/selectors/shared';
 import { isDirty } from 'redux-form';
 import { CollectionItemSets } from 'shared/types/Collection';
-import { selectEditorFrontIds } from 'bundles/frontsUIBundle';
 import flatten from 'lodash/flatten';
 
 const selectCollection = createCollectionSelector();

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -5,7 +5,6 @@ import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
 import { breakingNewsFrontId } from 'constants/fronts';
 import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
-import { selectEditorFrontIds } from 'bundles/frontsUIBundle';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
 
@@ -20,6 +19,8 @@ interface CollectionConfigMap {
 interface FrontsByPriority {
   [id: string]: FrontConfig[];
 }
+
+const selectEditorFrontIds = (state: State) => state.editor.frontIds;
 
 const getFronts = (state: State): FrontConfigMap =>
   frontsConfigSelectors.selectAll(state).fronts || {};
@@ -161,8 +162,7 @@ const getCollectionConfigs = (
 
 const hasMultipleFrontsOpenSelector = createSelector(
   selectEditorFrontIds,
-  (frontIds) => {
-    console.log({frontIds});
+  frontIds => {
     return frontIds.length > 1;
   }
 );
@@ -304,5 +304,6 @@ export {
   clipboardSelector,
   visibleArticlesSelector,
   visibleFrontArticlesSelector,
-  hasMultipleFrontsOpenSelector
+  hasMultipleFrontsOpenSelector,
+  selectEditorFrontIds
 };

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -5,6 +5,7 @@ import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
 import { breakingNewsFrontId } from 'constants/fronts';
 import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
+import { selectEditorFrontIds } from 'bundles/frontsUIBundle';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
 
@@ -158,6 +159,14 @@ const getCollectionConfigs = (
   return [];
 };
 
+const hasMultipleFrontsOpenSelector = createSelector(
+  selectEditorFrontIds,
+  (frontIds) => {
+    console.log({frontIds});
+    return frontIds.length > 1;
+  }
+);
+
 const getUnpublishedChangesStatus = (
   collectionId: string,
   unpublishedChanges: { [id: string]: boolean }
@@ -294,5 +303,6 @@ export {
   hasUnpublishedChangesSelector,
   clipboardSelector,
   visibleArticlesSelector,
-  visibleFrontArticlesSelector
+  visibleFrontArticlesSelector,
+  hasMultipleFrontsOpenSelector
 };

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -43,6 +43,7 @@ type Props = ContainerProps & {
   isUneditable?: boolean;
   isLocked?: boolean;
   isOpen?: boolean;
+  hasMultipleFrontsOpen?: boolean;
   onChangeOpenState?: (isOpen: boolean) => void;
 };
 
@@ -52,7 +53,6 @@ interface CollectionState {
 
 const CollectionContainer = ContentContainer.extend`
   flex: 1;
-  width: 600px;
 `;
 
 const HeadlineContentContainer = styled('span')`
@@ -189,12 +189,17 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       metaContent,
       isUneditable,
       isLocked,
-      children
+      hasMultipleFrontsOpen,
+      children,
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
 
+    console.log({hasMultipleFrontsOpen});
     return (
-      <CollectionContainer id={collection && createCollectionId(collection)}>
+      <CollectionContainer
+        style={{ width: hasMultipleFrontsOpen ? '510px' : '590px' }}
+        id={collection && createCollectionId(collection)}
+       >
         <ContainerHeadingPinline>
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText isLoading={!collection}>

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -51,8 +51,12 @@ interface CollectionState {
   hasDragOpenIntent: boolean;
 }
 
-const CollectionContainer = ContentContainer.extend`
+const CollectionContainer = ContentContainer.extend<{
+  hasMultipleFrontsOpen?: boolean;
+}>`
   flex: 1;
+  width: ${({ hasMultipleFrontsOpen }) =>
+    hasMultipleFrontsOpen ? '510px' : '590px'};
 `;
 
 const HeadlineContentContainer = styled('span')`
@@ -190,16 +194,15 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       isUneditable,
       isLocked,
       hasMultipleFrontsOpen,
-      children,
+      children
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
 
-    console.log({hasMultipleFrontsOpen});
     return (
       <CollectionContainer
-        style={{ width: hasMultipleFrontsOpen ? '510px' : '590px' }}
         id={collection && createCollectionId(collection)}
-       >
+        hasMultipleFrontsOpen={hasMultipleFrontsOpen}
+      >
         <ContainerHeadingPinline>
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText isLoading={!collection}>

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -5,14 +5,13 @@ import { Dispatch } from 'types/Store';
 import { BATCH } from 'redux-batched-actions';
 import { Action, ActionPersistMeta } from 'types/Action';
 import { selectors } from 'shared/bundles/collectionsBundle';
-import { selectEditorFrontIds } from 'bundles/frontsUIBundle';
 import { updateCollection } from 'actions/Collections';
 import { updateClipboard } from 'actions/Clipboard';
 import { selectSharedState } from 'shared/selectors/shared';
 import { saveOpenFrontIds } from 'services/faciaApi';
 import { NestedArticleFragment } from 'shared/types/Collection';
 import { denormaliseClipboard } from 'util/clipboardUtils';
-import { getFront } from 'selectors/frontsSelectors';
+import { getFront, selectEditorFrontIds } from 'selectors/frontsSelectors';
 
 const updateStateFromUrlChange: Middleware<{}, State, Dispatch> = ({
   dispatch,


### PR DESCRIPTION
## What's changed?
Display narrower fronts if we have more than one front open to make it easier to see many at once on a screen.
![Screenshot 2019-03-15 at 11 46 05](https://user-images.githubusercontent.com/3066534/54431139-81464300-471d-11e9-835c-708481fa0bab.png)
![Screenshot 2019-03-15 at 11 46 30](https://user-images.githubusercontent.com/3066534/54431149-86a38d80-471d-11e9-928f-60048db8ddee.png)

## Implementation notes
Needed to move the frontsIds selector from the frontsUIBundle to frontsSelectors because it was causing circular decencies there. Probably worth looking into looking at how we split selectors in these two files in more detail.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
