### PR TITLE
Aligns adding Grid images in Article Fragment edit form with Composer UX/UI

### DIFF
--- a/client-v2/config/setupTest.js
+++ b/client-v2/config/setupTest.js
@@ -4,4 +4,7 @@ const Adapter = require('enzyme-adapter-react-16');
 enzyme.configure({ adapter: new Adapter() });
 
 // ensure google tracking tag is there so as not to see console errors
-window.gtag = () => { };
+window.gtag = () => {};
+
+// ensures pageConfig data is mocked in all tests
+jest.mock('util/extractConfigFromPage.ts');

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -124,7 +124,7 @@ const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
         <Field<InputImageContainerProps>
           name={name}
           component={InputImage}
-          size="small"
+          small
           criteria={imageCriteria}
           frontId={frontId}
         />

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import Raven from 'raven-js';
 import { BrowserRouter } from 'react-router-dom';
 import configureStore from 'util/configureStore';
-import extractConfigFromPage from 'util/extractConfigFromPage';
+import pageConfig from 'util/extractConfigFromPage';
 import App from 'components/App';
 import { configReceived } from 'actions/Config';
 import { editorSetOpenFronts } from 'bundles/frontsUIBundle';
@@ -19,27 +19,28 @@ import pollingConfig from 'util/pollingConfig';
 initGA();
 
 const store = configureStore();
-const config = extractConfigFromPage();
 
 // publish uncaught errors to sentry.io
-if (config.env.toUpperCase() !== 'DEV' && config.sentryPublicDSN) {
+if (pageConfig.env.toUpperCase() !== 'DEV' && pageConfig.sentryPublicDSN) {
   const sentryOptions = {
     tags: {
       stack: 'cms-fronts',
-      stage: config.env.toUpperCase(),
+      stage: pageConfig.env.toUpperCase(),
       app: 'facia-tool-v2'
     }
   };
 
-  Raven.config(config.sentryPublicDSN, sentryOptions).install();
+  Raven.config(pageConfig.sentryPublicDSN, sentryOptions).install();
 }
 
-store.dispatch(configReceived(config));
-if (config.frontIds) {
-  store.dispatch(editorSetOpenFronts(config.frontIds));
+store.dispatch(configReceived(pageConfig));
+if (pageConfig.frontIds) {
+  store.dispatch(editorSetOpenFronts(pageConfig.frontIds));
 }
 
-(store.dispatch as Dispatch)(storeClipboardContent(config.clipboardArticles));
+(store.dispatch as Dispatch)(
+  storeClipboardContent(pageConfig.clipboardArticles)
+);
 
 // @ts-ignore unbind is not used yet but can be used for removed all the
 // keyboard events

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -73,7 +73,7 @@ const events = {
     // collectionId: string,
     method: ImageAdditionMethod
   ) =>
-    gtag('event', `imageAdded${method}`, {
+    gtag('event', `imageAdded: ${method}`, {
       // collection_id: collectionId,
       front_id: frontId,
       method

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -34,6 +34,9 @@ const init = () => {
   });
 };
 
+type ImageAdditionMethod = 'drop' | 'paste' | 'click to modal';
+
+// NOTE: you are unable to set custom dimensions on events, so the final gtag argument {} being passed in below are not currently working.
 const events = {
   addFront: (frontId: string) =>
     gtag('event', 'add_front', {
@@ -64,6 +67,16 @@ const events = {
     gtag('event', 'collection_published', {
       collection_id: collectionId,
       front_id: frontId
+    }),
+  imageAdded: (
+    frontId: string,
+    // collectionId: string,
+    method: ImageAdditionMethod
+  ) =>
+    gtag('event', `imageAdded${method}`, {
+      // collection_id: collectionId,
+      front_id: frontId,
+      method
     })
 };
 

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -162,6 +162,20 @@ const LockedPadlockIcon = ({
   </svg>
 );
 
+const AddImageIcon = ({
+  fill = theme.colors.white,
+  size = 'm',
+  title = 'Add mage'
+}: IconProps) => (
+  <svg width={mapSize(size)} height={mapSize(size)} viewBox="0 0 22 22">
+    <title>{title}</title>
+    <path
+      fill={fill}
+      d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H3v16h16V11h-3zM5 19l3-4 2 3 3-4 4 5H5z"
+    />
+  </svg>
+);
+
 export {
   DownCaretIcon,
   RubbishBinIcon,
@@ -169,5 +183,6 @@ export {
   MoreIcon, // tapered +
   ClearIcon, // tapered x
   LockedPadlockIcon,
-  MagnifyingGlassIcon
+  MagnifyingGlassIcon,
+  AddImageIcon
 };

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -11,7 +11,8 @@ import DragIntentContainer from '../DragIntentContainer';
 import { GridModal } from 'components/GridModal';
 import {
   validateImageEvent,
-  validateMediaItem
+  validateMediaItem,
+  validateImageSrc
 } from '../../util/validateImageSrc';
 import { gridUrlSelector } from 'selectors/configSelectors';
 import { State } from 'types/State';
@@ -45,7 +46,7 @@ const AddImageViaGridModalButton = styled(ButtonDefault)`
   }
 `;
 
-const AddImageViaUrlInput = styled('div')`
+const AddImageViaUrlInput = styled(InputContainer)`
   padding: 11px 5px 5px 5px;
   height: 50%;
   background-color: ${props => props.theme.shared.colors.greyLight};
@@ -96,12 +97,14 @@ type ComponentProps = InputImageContainerProps &
 interface ComponentState {
   isHovering: boolean;
   modalOpen: boolean;
+  imageSrc: string;
 }
 
 class InputImage extends React.Component<ComponentProps, ComponentState> {
   public state = {
     isHovering: false,
-    modalOpen: false
+    modalOpen: false,
+    imageSrc: ''
   };
 
   public handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -115,6 +118,34 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
         console.log('@todo:handle error', err);
       });
   };
+
+  public handlePasteImgSrcInputChange = (
+    e: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({ imageSrc: e.currentTarget.value });
+  };
+
+  public handlePasteImgSrcInputSubmit = (e: React.KeyboardEvent) => {
+    e.persist();
+    if (e.keyCode === 13) {
+      validateImageSrc(
+        //crop???
+        this.state.imageSrc,
+        this.props.frontId,
+        this.props.criteria
+      )
+        .then(mediaItem => {
+          this.props.input.onChange(mediaItem);
+        })
+        .catch(err => {
+          alert(err);
+          // tslint:disable-next-line no-console
+          console.log('@todo:handle error', err);
+        });
+      this.setState({ imageSrc: '' });
+    }
+  };
+
   public handleAdd = () => {
     // @todo: grid integration
   };
@@ -218,13 +249,20 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                   priority="muted"
                   onClick={this.openModal}
                 >
-                  {/* <IconAdd src={crossIcon} onClick={this.handleAdd} />{' '} */}
                   <Label size="sm">Add image</Label>
                 </AddImageViaGridModalButton>
 
                 <AddImageViaUrlInput>
-                  <ImageUrlInput placeholder={'Paste URL or embed code'} />
-                  {/* <InputLabel>Paste</InputLabel> */}
+                  <ImageUrlInput
+                    name="paste-url"
+                    placeholder="Paste URL or embed code"
+                    defaultValue={this.state.imageSrc}
+                    onKeyDown={this.handlePasteImgSrcInputSubmit}
+                    onChange={this.handlePasteImgSrcInputChange}
+                  />
+                  <InputLabel hidden htmlFor="paste-url">
+                    Paste URL or embed code
+                  </InputLabel>
                 </AddImageViaUrlInput>
               </>
             )}

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-import { styled } from 'shared/constants/theme';
+import { theme, styled } from 'shared/constants/theme';
 import { connect } from 'react-redux';
 import { WrappedFieldProps } from 'redux-form';
 
 import ButtonDefault from './ButtonDefault';
 import InputContainer from './InputContainer';
+import InputBase from './InputBase';
+import InputLabel from './InputLabel';
+import DragIntentContainer from '../DragIntentContainer';
+import { GridModal } from 'components/GridModal';
 import {
   validateImageEvent,
   validateMediaItem
 } from '../../util/validateImageSrc';
-import { GridModal } from 'components/GridModal';
 import { gridUrlSelector } from 'selectors/configSelectors';
 import { State } from 'types/State';
 import { GridData, Criteria } from 'shared/types/Grid';
@@ -17,18 +20,47 @@ import { RubbishBinIcon } from '../icons/Icons';
 
 const ImageContainer = styled('div')<{
   size?: 'small';
-  isHovering: boolean;
+  isHovering?: boolean;
 }>`
   position: relative;
   width: 100%;
   max-width: ${props => (props.size === 'small' ? '100px' : '180px')};
   height: ${props => (props.size === 'small' ? '60px' : '115px')};
-  background-color: ${props =>
-    props.isHovering
-      ? props.theme.shared.base.colors.placeholderLight
-      : props.theme.shared.base.colors.placeholderDark};
   background-size: cover;
   transition: background-color 0.15s;
+  border-left: ${props =>
+    props.isHovering
+      ? `4px solid ${theme.base.colors.highlightColor}`
+      : 'none'};
+`;
+
+const AddImageViaGridModalButton = styled(ButtonDefault)`
+  height: 50%;
+  width: 100%;
+  border-bottom: ${props =>
+    `1px solid ${props.theme.shared.base.colors.backgroundColor}`};
+  background-color: ${props => props.theme.shared.colors.greyLight};
+  :hover {
+    background-color: ${props => props.theme.shared.colors.greyLightPinkish};
+  }
+`;
+
+const AddImageViaUrlInput = styled('div')`
+  padding: 11px 5px 5px 5px;
+  height: 50%;
+  background-color: ${props => props.theme.shared.colors.greyLight};
+`;
+
+const ImageUrlInput = styled(InputBase)`
+  ::placeholder {
+    font-size: 12px;
+  }
+`;
+
+const Label = styled(InputLabel)`
+  cursor: pointer;
+  display: inline-block;
+  color: ${props => props.theme.shared.base.colors.text};
 `;
 
 const ButtonDelete = styled(ButtonDefault)`
@@ -72,16 +104,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     modalOpen: false
   };
 
-  public handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    this.setState({ isHovering: true });
-  };
-  public handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    this.setState({ isHovering: false });
-  };
-  public handleDragOver = (e: React.DragEvent<HTMLDivElement>) =>
-    e.preventDefault();
   public handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.persist();
@@ -161,32 +183,53 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
           onClose={this.closeModal}
           onMessage={this.onMessage}
         />
-        <ImageContainer
-          onClick={this.openModal}
-          onDragEnter={this.handleDragEnter}
-          onDragLeave={this.handleDragLeave}
-          onDragOver={this.handleDragOver}
-          onDrop={this.handleDrop}
-          isHovering={this.state.isHovering}
-          {...this.props}
-          style={{
-            backgroundImage:
-              this.props.input.value && `url(${this.props.input.value.thumb}`
-          }}
+        <DragIntentContainer
+          active
+          onIntentConfirm={() => this.setState({ isHovering: true })}
+          onDragIntentStart={() => this.setState({ isHovering: true })}
+          onDragIntentEnd={() => this.setState({ isHovering: false })}
         >
-          <ButtonDelete type="button" priority="primary">
-            {this.props.input.value ? (
-              <IconDelete
-                onClick={event => {
-                  event.stopPropagation();
-                  this.clearField();
-                }}
-              >
-                <RubbishBinIcon size={'s'} />
-              </IconDelete>
-            ) : null}
-          </ButtonDelete>
-        </ImageContainer>
+          <ImageContainer
+            onDrop={this.handleDrop}
+            isHovering={this.state.isHovering}
+            {...this.props}
+            style={{
+              backgroundImage:
+                this.props.input.value && `url(${this.props.input.value.thumb}`
+            }}
+          >
+            {!!this.props.input.value && !!this.props.input.value.thumb ? (
+              <ButtonDelete type="button" priority="primary">
+                {this.props.input.value ? (
+                  <IconDelete
+                    onClick={event => {
+                      event.stopPropagation();
+                      this.clearField();
+                    }}
+                  >
+                    <RubbishBinIcon size={'s'} />
+                  </IconDelete>
+                ) : null}
+              </ButtonDelete>
+            ) : (
+              <>
+                <AddImageViaGridModalButton
+                  type="button"
+                  priority="muted"
+                  onClick={this.openModal}
+                >
+                  {/* <IconAdd src={crossIcon} onClick={this.handleAdd} />{' '} */}
+                  <Label size="sm">Add image</Label>
+                </AddImageViaGridModalButton>
+
+                <AddImageViaUrlInput>
+                  <ImageUrlInput placeholder={'Paste URL or embed code'} />
+                  {/* <InputLabel>Paste</InputLabel> */}
+                </AddImageViaUrlInput>
+              </>
+            )}
+          </ImageContainer>
+        </DragIntentContainer>
       </InputContainer>
     );
   }

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -17,7 +17,7 @@ import {
 import { gridUrlSelector } from 'selectors/configSelectors';
 import { State } from 'types/State';
 import { GridData, Criteria } from 'shared/types/Grid';
-import { RubbishBinIcon } from '../icons/Icons';
+import { RubbishBinIcon, AddImageIcon } from '../icons/Icons';
 
 const ImageContainer = styled('div')<{
   size?: 'small';
@@ -61,7 +61,9 @@ const ImageUrlInput = styled(InputBase)`
 const Label = styled(InputLabel)`
   cursor: pointer;
   display: inline-block;
-  color: ${props => props.theme.shared.base.colors.text};
+  color: ${props => props.theme.shared.base.colors.textLight};
+  padding-inline-start: 5px;
+  vertical-align: super;
 `;
 
 const ButtonDelete = styled(ButtonDefault)`
@@ -239,7 +241,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                       this.clearField();
                     }}
                   >
-                    <RubbishBinIcon size={'s'} />
+                    <RubbishBinIcon size="s" />
                   </IconDelete>
                 ) : null}
               </ButtonDelete>
@@ -250,6 +252,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                   priority="muted"
                   onClick={this.openModal}
                 >
+                  <AddImageIcon size="l" />
                   <Label size="sm">Add image</Label>
                 </AddImageViaGridModalButton>
 

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { theme, styled } from 'shared/constants/theme';
 import { connect } from 'react-redux';
 import { WrappedFieldProps } from 'redux-form';
+import { events } from 'services/GA';
 
 import ButtonDefault from './ButtonDefault';
 import InputContainer from './InputContainer';
@@ -110,6 +111,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   };
 
   public handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    events.imageAdded(this.props.frontId, 'drop');
     e.preventDefault();
     e.persist();
     validateImageEvent(e, this.props.frontId, this.props.criteria)
@@ -129,6 +131,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   };
 
   public handlePasteImgSrcInputSubmit = (e: React.KeyboardEvent) => {
+    events.imageAdded(this.props.frontId, 'paste');
     e.persist();
     if (e.keyCode === 13) {
       e.preventDefault();
@@ -188,6 +191,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       this.props.criteria
     )
       .then(mediaItem => {
+        events.imageAdded(this.props.frontId, 'click to modal');
         this.props.input.onChange(mediaItem);
       })
       .catch(err => {

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -21,13 +21,13 @@ import { GridData, Criteria } from 'shared/types/Grid';
 import { RubbishBinIcon, AddImageIcon } from '../icons/Icons';
 
 const ImageContainer = styled('div')<{
-  size?: 'small';
+  small?: boolean;
   isHovering?: boolean;
 }>`
   position: relative;
   width: 100%;
-  max-width: ${props => (props.size === 'small' ? '100px' : '180px')};
-  height: ${props => (props.size === 'small' ? '60px' : '115px')};
+  max-width: ${props => (props.small ? '100px' : '180px')};
+  height: ${props => (props.small ? '60px' : '115px')};
   background-size: cover;
   transition: background-color 0.15s;
   border-left: ${props =>
@@ -36,8 +36,11 @@ const ImageContainer = styled('div')<{
       : 'none'};
 `;
 
-const AddImageViaGridModalButton = styled(ButtonDefault)`
-  height: 50%;
+const AddImageViaGridModalButton = styled(ButtonDefault)<{
+  small?: boolean;
+}>`
+  height: ${props => (!!props.small ? '100%' : '50%')};
+  background-size: cover;
   width: 100%;
   border-bottom: ${props =>
     `1px solid ${props.theme.shared.base.colors.backgroundColor}`};
@@ -91,7 +94,7 @@ const IconDelete = styled('div')`
 export interface InputImageContainerProps {
   frontId: string;
   criteria?: Criteria;
-  size?: 'small';
+  small?: boolean;
 }
 
 type ComponentProps = InputImageContainerProps &
@@ -212,7 +215,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   };
 
   public render() {
-    const gridSearchUrl = `${this.props.gridUrl}?cropType=landscape`;
+    const { small, input, gridUrl } = this.props;
+    const gridSearchUrl = `${gridUrl}?cropType=landscape`;
     return (
       <InputContainer>
         <GridModal
@@ -230,15 +234,14 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
           <ImageContainer
             onDrop={this.handleDrop}
             isHovering={this.state.isHovering}
-            {...this.props}
+            small={small}
             style={{
-              backgroundImage:
-                this.props.input.value && `url(${this.props.input.value.thumb}`
+              backgroundImage: input.value && `url(${input.value.thumb}`
             }}
           >
-            {!!this.props.input.value && !!this.props.input.value.thumb ? (
+            {!!input.value && !!input.value.thumb ? (
               <ButtonDelete type="button" priority="primary">
-                {this.props.input.value ? (
+                {input.value ? (
                   <IconDelete
                     onClick={event => {
                       event.stopPropagation();
@@ -255,23 +258,26 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                   type="button"
                   priority="muted"
                   onClick={this.openModal}
+                  small={small}
                 >
                   <AddImageIcon size="l" />
-                  <Label size="sm">Add image</Label>
+                  {!!small ? null : <Label size="sm">Add image</Label>}
                 </AddImageViaGridModalButton>
 
-                <AddImageViaUrlInput>
-                  <ImageUrlInput
-                    name="paste-url"
-                    placeholder="Paste URL or embed code"
-                    defaultValue={this.state.imageSrc}
-                    onKeyDown={this.handlePasteImgSrcInputSubmit}
-                    onChange={this.handlePasteImgSrcInputChange}
-                  />
-                  <InputLabel hidden htmlFor="paste-url">
-                    Paste URL or embed code
-                  </InputLabel>
-                </AddImageViaUrlInput>
+                {!!small ? null : (
+                  <AddImageViaUrlInput>
+                    <ImageUrlInput
+                      name="paste-url"
+                      placeholder=" Paste crop url from Grid"
+                      defaultValue={this.state.imageSrc}
+                      onKeyDown={this.handlePasteImgSrcInputSubmit}
+                      onChange={this.handlePasteImgSrcInputChange}
+                    />
+                    <InputLabel hidden htmlFor="paste-url">
+                      Paste crop url from Grid
+                    </InputLabel>
+                  </AddImageViaUrlInput>
+                )}
               </>
             )}
           </ImageContainer>

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -122,14 +122,15 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   public handlePasteImgSrcInputChange = (
     e: React.FormEvent<HTMLInputElement>
   ) => {
+    e.preventDefault();
     this.setState({ imageSrc: e.currentTarget.value });
   };
 
   public handlePasteImgSrcInputSubmit = (e: React.KeyboardEvent) => {
     e.persist();
     if (e.keyCode === 13) {
+      e.preventDefault();
       validateImageSrc(
-        //crop???
         this.state.imageSrc,
         this.props.frontId,
         this.props.criteria

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -73,10 +73,10 @@ const Label = styled(InputLabel)`
 const ButtonDelete = styled(ButtonDefault)`
   position: absolute;
   display: block;
-  top: 6px;
-  right: 6px;
-  height: 32px;
-  width: 32px;
+  top: 2px;
+  right: 2px;
+  height: 24px;
+  width: 24px;
   text-align: center;
   padding: 0;
   border-radius: 24px;
@@ -87,8 +87,8 @@ const IconDelete = styled('div')`
   position: absolute;
   height: 14px;
   width: 14px;
-  top: 9px;
-  left: 9px;
+  top: 5px;
+  left: 5px;
 `;
 
 export interface InputImageContainerProps {

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -70,25 +70,29 @@ const Label = styled(InputLabel)`
   vertical-align: super;
 `;
 
-const ButtonDelete = styled(ButtonDefault)`
+const ButtonDelete = styled(ButtonDefault)<{
+  small?: boolean;
+}>`
   position: absolute;
   display: block;
-  top: 2px;
-  right: 2px;
-  height: 24px;
-  width: 24px;
+  top: ${props => (props.small ? '2px' : '6px')};
+  right: ${props => (props.small ? '2px' : '6px')};
+  height: ${props => (props.small ? '24px' : '32px')};
+  width: ${props => (props.small ? '24px' : '32px')};
   text-align: center;
   padding: 0;
   border-radius: 24px;
 `;
 
-const IconDelete = styled('div')`
+const IconDelete = styled('div')<{
+  small?: boolean;
+}>`
   display: block;
   position: absolute;
   height: 14px;
   width: 14px;
-  top: 5px;
-  left: 5px;
+  top: ${props => (props.small ? '5px' : '9px')};
+  left: ${props => (props.small ? '5px' : '9px')};
 `;
 
 export interface InputImageContainerProps {
@@ -237,9 +241,10 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
             }}
           >
             {!!input.value && !!input.value.thumb ? (
-              <ButtonDelete type="button" priority="primary">
+              <ButtonDelete type="button" priority="primary" small={small}>
                 {input.value ? (
                   <IconDelete
+                    small={small}
                     onClick={event => {
                       event.stopPropagation();
                       this.clearField();

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -126,17 +126,17 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       });
   };
 
-  public handlePasteImgSrcInputChange = (
-    e: React.FormEvent<HTMLInputElement>
-  ) => {
+  public handlePasteImgSrcChange = (e: React.FormEvent<HTMLInputElement>) => {
     e.preventDefault();
     this.setState({ imageSrc: e.currentTarget.value });
   };
 
-  public handlePasteImgSrcInputSubmit = (e: React.KeyboardEvent) => {
+  public handlePasteImgSrcSubmit = (keyCode: number) => (
+    e: React.KeyboardEvent
+  ) => {
     events.imageAdded(this.props.frontId, 'paste');
     e.persist();
-    if (e.keyCode === 13) {
+    if (e.keyCode === keyCode) {
       e.preventDefault();
       validateImageSrc(
         this.state.imageSrc,
@@ -155,9 +155,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     }
   };
 
-  public handleAdd = () => {
-    // @todo: grid integration
-  };
   public clearField = () => this.props.input.onChange(null);
 
   public validMessage(data: GridData) {
@@ -270,8 +267,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                       name="paste-url"
                       placeholder=" Paste crop url from Grid"
                       defaultValue={this.state.imageSrc}
-                      onKeyDown={this.handlePasteImgSrcInputSubmit}
-                      onChange={this.handlePasteImgSrcInputChange}
+                      onKeyDown={this.handlePasteImgSrcSubmit(13)}
+                      onChange={this.handlePasteImgSrcChange}
                     />
                     <InputLabel hidden htmlFor="paste-url">
                       Paste crop url from Grid

--- a/client-v2/src/shared/components/input/InputLabel.ts
+++ b/client-v2/src/shared/components/input/InputLabel.ts
@@ -3,9 +3,10 @@ import { styled } from 'shared/constants/theme';
 export default styled('label')<{
   size?: 'sm';
   active?: boolean;
+  hidden?: boolean;
   for?: string;
 }>`
-  display: block;
+  display: ${props => (props.hidden ? 'none' : 'block')};
   font-size: ${props =>
     props.size === 'sm'
       ? props.theme.shared.label.fontSizeSmall

--- a/client-v2/src/shared/constants/url.ts
+++ b/client-v2/src/shared/constants/url.ts
@@ -1,3 +1,4 @@
+import pageConfig from 'util/extractConfigFromPage';
 export default {
   base: {
     mainDomain: 'www.theguardian.com',
@@ -5,7 +6,7 @@ export default {
     previewDomain: 'preview.gutools.co.uk'
   },
   media: {
-    apiBaseUrl: '/api.grid',
+    apiBaseUrl: pageConfig.apiBaseUrl,
     mediaBaseUrl: 'http://media',
     usageBaseUrl: '/api/usage',
     imgIXDomainExpr: /^https:\/\/i\.guim\.co\.uk\/img\/static\//,

--- a/client-v2/src/util/__mocks__/extractConfigFromPage.ts
+++ b/client-v2/src/util/__mocks__/extractConfigFromPage.ts
@@ -1,0 +1,7 @@
+import config from 'fixtures/config';
+
+const pageConfig = () => {
+  return config;
+};
+
+export default pageConfig();

--- a/client-v2/src/util/extractConfigFromPage.ts
+++ b/client-v2/src/util/extractConfigFromPage.ts
@@ -1,6 +1,6 @@
 import { Config } from 'types/Config';
 
-export default () => {
+const pageConfig = () => {
   const configEl = document.getElementById('config');
 
   if (!configEl) {
@@ -11,3 +11,5 @@ export default () => {
 
   return json;
 };
+
+export default pageConfig();


### PR DESCRIPTION
## What's changed?

Adding Grid images in Article Fragment edit form now looks and functions more closely to the Composer UX/UI. 

Large images can be added via dragging, clicking to modal, or pasting a Grid crop Url. 
Small images can only be added via dragging and clicking. 

Rubbish bin delete button on small images should perhaps be smaller so looping in @akemitakagi for her thoughts.   

![Kapture 2019-03-13 at 16 42 26](https://user-images.githubusercontent.com/32312712/54442214-2836d900-4736-11e9-8845-242254e143f2.gif)
![image](https://user-images.githubusercontent.com/32312712/54442159-0ccbce00-4736-11e9-8478-870756c75d47.png)

## Implementation notes

@akash1810 helped me add GA to track how many people are using the drag, click or paste option, as there was a question of whether we need to be supporting the pasting of Grid urls. Unable to check this works in CODE so will review in GA once merged. 

Adding images via a URL requires validating the image's source and fetching data from the Grid API. The API base url is different for CODE and PROD, so is pulled dynamically from the page config in the document. This works fine at runtime, but I needed to mock the utility module in Jest config for tests to pass.  If someone has a better way to do this please let me know.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
