### PR TITLE
Ensure Modal overlays appear on top of everything

### DIFF
--- a/client-v2/src/components/ConfirmModal.tsx
+++ b/client-v2/src/components/ConfirmModal.tsx
@@ -56,7 +56,8 @@ const ConfirmModal = ({
   <StyledModal
     style={{
       overlay: {
-        backgroundColor: 'rgba(0, 0, 0, 0.75)'
+        backgroundColor: 'rgba(0, 0, 0, 0.75)',
+        zIndex: 1000
       }
     }}
     isOpen={isOpen}

--- a/client-v2/src/components/GridModal.tsx
+++ b/client-v2/src/components/GridModal.tsx
@@ -47,7 +47,14 @@ const ImageContainer = styled('div')`
 
 export const GridModal = ({ isOpen, url, onMessage, onClose }: ModalProps) => (
   <React.Fragment>
-    <StyledModal isOpen={isOpen}>
+    <StyledModal
+      isOpen={isOpen}
+      style={{
+        overlay: {
+          zIndex: 900
+        }
+      }}
+    >
       <ModalButton type="button" priority="primary" onClick={onClose}>
         <ImageContainer>
           <CloseIcon />


### PR DESCRIPTION
## What's changed?

Noticed a couple z-index issues with the Grid iframe Modal (see images). This PR ensures both the GridModal and the ConfirmModal appear on top of everything else (even the Front's menu)
![Screenshot 2019-03-18 at 09 38 33](https://user-images.githubusercontent.com/32312712/54525625-8947f200-496c-11e9-840a-77be8b09a0a7.png)
![Screenshot 2019-03-18 at 09 38 16](https://user-images.githubusercontent.com/32312712/54525627-8baa4c00-496c-11e9-9b24-4f39d815b230.png)



## Implementation notes

Added z-indexes.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
