### PR TITLE
Revert "Proxy return same status code as CAPI"

### DIFF
--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -55,7 +55,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
         logger.error(s"Request to capi preview with url $url failed with response $response, ${response.body}")
       }
       Cached(60) {
-        Status(response.status)(rewriteBody(response.body)).as("application/javascript")
+        Ok(rewriteBody(response.body)).as("application/javascript")
       }
     }
   }
@@ -76,7 +76,7 @@ class FaciaContentApiProxy(val deps: BaseFaciaControllerComponents)(implicit ec:
         logger.error(s"Request to live capi with url $url failed with response $response, ${response.body}")
       }
       Cached(60) {
-        Status(response.status)(rewriteBody(response.body)).as("application/javascript")
+        Ok(rewriteBody(response.body)).as("application/javascript")
       }
     }
   }


### PR DESCRIPTION
Reverts guardian/facia-tool#616

This PR causes issues in v1 - we get errors in capi if there are e.g. open quotes in our search terms, we don't wait for the user to finish typing before making a request so we get yellow error messages in v1 as the user is typing a search term. 

Let's fix this by making a separate search endpoint for v2 and debounce capi search requests to avoid these error messages in v2.