### PR TITLE
Fix width of feed item headline

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -101,7 +101,7 @@ const Tone = styled('div')`
 `;
 
 const Body = styled('div')`
-  width: calc(100% - 163px);
+  width: 213px;
   padding-left: 8px;
 `;
 


### PR DESCRIPTION
## What's changed?

Fix the width of feed item headline so that it fills the same space even for short headlines and trail images stay aligned 

Before: 
![Screenshot 2019-03-20 at 11 05 56](https://user-images.githubusercontent.com/3066534/54679953-81b95200-4b00-11e9-8d3f-7336fd136791.png)

After: 
![Screenshot 2019-03-20 at 11 06 58](https://user-images.githubusercontent.com/3066534/54679958-867e0600-4b00-11e9-89c4-46293068fcaf.png)


## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
