### PR TITLE
A few minor styling tweaks

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -101,7 +101,7 @@ const Tone = styled('div')`
 
 const Body = styled('div')`
   width: calc(100% - 163px);
-  padding-left: 1px;
+  padding-left: 8px;
 `;
 
 interface FeedItemProps {

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -62,7 +62,6 @@ const Container = styled.div`
   font-size: 14px;
   min-height: 2.5em;
   margin-top: 0.75em;
-  margin-right: 0.75em;
   padding: 0.55em 0.75em;
   text-align: left;
   text-decoration: none;

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -43,7 +43,7 @@ const Container = styled(ContentContainer)<ContainerProps>`
 `;
 
 const ContainerBody = styled.div`
-  width: 380px;
+  width: 360px;
 `;
 
 const FrontCollectionsOverview = ({

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -24,6 +24,7 @@ import { theme as sharedTheme } from 'shared/constants/theme';
 
 const FrontHeader = styled(FrontSectionHeader)`
   display: flex;
+  border-right: 1px solid #767676;
 `;
 
 const FrontHeaderMeta = styled('div')`
@@ -33,7 +34,6 @@ const FrontHeaderMeta = styled('div')`
   font-family: TS3TextSans;
   font-size: 14px;
   white-space: nowrap;
-  border-right: 1px solid #767676;
 `;
 
 const FrontsHeaderText = styled('span')`


### PR DESCRIPTION
## What's changed?

A few minor styling things: 

Corrected padding on feed articles

<img width="256" alt="Screenshot 2019-03-20 at 13 31 59" src="https://user-images.githubusercontent.com/7767575/54688721-137f8a00-4b16-11e9-824a-e43d4a4e9348.png">

Small pinline between fronts

<img width="209" alt="Screenshot 2019-03-20 at 13 32 14" src="https://user-images.githubusercontent.com/7767575/54688708-0b274f00-4b16-11e9-858f-805c58163e61.png">

Collection overview items now fill out their parent

<img width="408" alt="Screenshot 2019-03-20 at 13 32 43" src="https://user-images.githubusercontent.com/7767575/54688649-efbc4400-4b15-11e9-8933-c405f4f559de.png">

(red pen not included)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
