### PR TITLE
End the font madness

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -29,52 +29,47 @@ import ConfirmModal from './ConfirmModal';
 // tslint:disable:no-unused-expression
 injectGlobal`
   @font-face {
-    font-family: GHGuardianHeadline-Bold
+    font-family: GHGuardianHeadline;
     src: url(${GHGuardianHeadlineBoldWoff2}) format('woff2'),
       url(${GHGuardianHeadlineBoldWoff}) format('woff'),
       url(${GHGuardianHeadlineBoldTtf}) format('truetype');
-
-    font-style: 'bold',
-    font-weight: 800
+    font-weight: bold;
+    font-weight: 600 800;
   }
 
   @font-face {
-    font-family: GHGuardianHeadline-Regular
+    font-family: GHGuardianHeadline;
     src: url(${GHGuardianHeadlineRegularWoff2}) format('woff2'),
       url(${GHGuardianHeadlineRegularWoff}) format('woff'),
       url(${GHGuardianHeadlineRegularTtf}) format('truetype');
-
-     font-style: 'normal',
-     font-weight: 'normal'
+    font-style: normal;
+    font-weight: 100 400;
   }
 
   @font-face {
-    font-family: GHGuardianHeadline-Medium
+    font-family: GHGuardianHeadline;
     src: url(${GHGuardianHeadlineMediumWoff2}) format('woff2'),
       url(${GHGuardianHeadlineMediumWoff}) format('woff'),
       url(${GHGuardianHeadlineMediumTtf}) format('truetype');
-
-    font-style: 'bold',
-    font-weight: 800
+    font-weight: 500;
   }
 
   @font-face {
-    font-family: TS3TextSans
+    font-family: TS3TextSans;
     src: url(${GuardianTextSansWoff2}) format('woff2'),
       url(${GuardianTextSansWoff}) format('woff'),
       url(${GuardianTextSansTtf}) format('truetype');
-
-    font-style: 'normal',
-    font-weight: 'normal'
+    font-style: normal;
+    font-weight: 100 400;
   }
 
   @font-face {
-    font-family: TS3TextSans-Bold
+    font-family: TS3TextSans;
     src: url(${GuardianTextSansBoldWoff2}) format('woff2'),
       url(${GuardianTextSansTtfBold}) format('truetype'),
       url(${GuardianTextSansBoldWoff}) format('woff');
-    font-style: 'normal',
-    font-weight: 'normal'
+    font-weight: bold;
+    font-weight: 500 800;
   }
 
   html, body {

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -40,7 +40,8 @@ interface FeedsContainerState {
 const Title = styled.h1`
   margin: 2px 0 0;
   vertical-align: top;
-  font-family: GHGuardianHeadline-Medium;
+  font-family: GHGuardianHeadline;
+  font-weight: 500;
   font-size: 20px;
   min-width: 80px;
 `;

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -63,7 +63,7 @@ const Container = styled('div')`
 const Title = styled(`h2`)`
   margin: 2px 0 0;
   vertical-align: top;
-  font-family: GHGuardianHeadline-Medium;
+  font-family: GHGuardianHeadline;
   font-size: 16px;
   font-weight: 500;
 `;
@@ -96,7 +96,8 @@ const ScheduledPublication = styled(FirstPublished)`
 const Tone = styled('div')`
   padding-top: 2px;
   font-size: 12px;
-  font-family: TS3TextSans-Bold;
+  font-family: TS3TextSans;
+  font-weight: bold;
 `;
 
 const Body = styled('div')`

--- a/client-v2/src/components/inputs/RadioButtons.tsx
+++ b/client-v2/src/components/inputs/RadioButtons.tsx
@@ -33,7 +33,8 @@ const ControlRadio = styled('label')<{ inline?: boolean }>`
   padding-left: 24px;
   padding-top: 3px;
   cursor: pointer;
-  font-family: TS3TextSans-Bold;
+  font-family: TS3TextSans;
+  font-weight: bold;
   font-size: 12px;
 
   & + & {

--- a/client-v2/src/components/layout/LargeSectionHeader.tsx
+++ b/client-v2/src/components/layout/LargeSectionHeader.tsx
@@ -6,5 +6,6 @@ export default styled('div')`
   font-size: 32px;
   line-height: 40px;
   color: ${({ theme }) => theme.shared.base.colors.textLight};
-  font-family: GHGuardianHeadline-Bold;
+  font-family: GHGuardianHeadline;
+  font-weight: bold;
 `;

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -75,13 +75,11 @@ const CollectionDisabledTheme = styled('div')`
 `;
 
 const LockedCollectionFlag = styled('span')`
-  font-family: GHGuardianHeadline-Regular;
+  font-family: GHGuardianHeadline;
   font-size: 22px;
   color: ${({ theme }) => theme.shared.base.colors.text};
   height: 40px;
   line-height: 40px;
-  font-weight: normal;
-  font-style: normal;
 `;
 
 const CollectionMetaContainer = styled('div')`
@@ -144,7 +142,7 @@ const CollectionToggleContainer = styled('div')`
 
 const CollectionConfigContainer = styled('div')`
   display: inline-block;
-  font-family: GHGuardianHeadline-Regular;
+  font-family: GHGuardianHeadline;
   font-size: 22px;
   color: ${({ theme }) => theme.shared.base.colors.text};
   height: 40px;

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -41,7 +41,8 @@ const NotLiveContainer = styled(CollectionItemMetaHeading)`
 `;
 
 const KickerHeading = styled(CollectionItemHeading)`
-  font-family: GHGuardianHeadline-Bold;
+  font-family: GHGuardianHeadline;
+  font-weight: bold;
   padding-right: 3px;
 `;
 

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -3,7 +3,8 @@ import { styled } from 'shared/constants/theme';
 import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 
 const Wrapper = styled('span')`
-  font-family: GhGuardianHeadline-Medium;
+  font-family: GHGuardianHeadline;
+  font-weight: 500;
   padding-top: 2px;
   font-size: 16px;
 `;

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaHeading.tsx
@@ -3,5 +3,6 @@ import { styled } from 'shared/constants/theme';
 export default styled('div')`
   padding-top: 2px;
   font-size: 12px;
-  font-family: TS3TextSans-Bold;
+  font-family: TS3TextSans;
+  font-weight: bold;
 `;

--- a/client-v2/src/shared/components/input/ButtonRoundedWithLabel.tsx
+++ b/client-v2/src/shared/components/input/ButtonRoundedWithLabel.tsx
@@ -10,7 +10,8 @@ interface ContainerButtonWithLabelProps {
 
 const ContainerButton = styled('button')`
   cursor: pointer;
-  font-family: TS3TextSans-Bold;
+  font-family: TS3TextSans;
+  font-weight: bold;
   font-size: 12px;
   padding: 0 6px 0 8px;
   border: ${({ theme }) => `solid 1px ${theme.shared.colors.greyMediumLight}`};

--- a/client-v2/src/shared/components/input/HoverActionToolTip.tsx
+++ b/client-v2/src/shared/components/input/HoverActionToolTip.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { styled } from 'shared/constants/theme';
 
 const ToolTip = styled('div')<{ text: string }>`
-  font-family: TS3TextSans-Bold;
+  font-family: TS3TextSans;
+  font-weight: bold;
   font-size: 12px;
   color: ${({ theme }) => theme.shared.button.color};
   background-color: ${({ theme }) => theme.shared.base.colors.button};

--- a/client-v2/src/shared/components/input/InputBase.ts
+++ b/client-v2/src/shared/components/input/InputBase.ts
@@ -17,7 +17,9 @@ export default styled('input')<{
   border: 1px solid ${props => props.theme.shared.input.borderColor};
   width: 100%;
   background-clip: padding-box;
-  ${props => props.useHeadlineFont && `font-family: GHGuardianHeadline-Medium`};
+  ${props =>
+    props.useHeadlineFont &&
+    `font-family: GHGuardianHeadline; font-weight: 500`};
   ::placeholder {
     color: ${props => props.theme.shared.input.placeholderText};
   }

--- a/client-v2/src/shared/components/typography/ContainerHeading.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeading.ts
@@ -2,11 +2,10 @@ import { styled } from 'shared/constants/theme';
 
 const ContainerHeading = styled('div')`
   display: flex;
-  font-family: GHGuardianHeadline-Bold;
+  font-family: GHGuardianHeadline;
+  font-weight: bold;
   font-size: 22px;
   line-height: 22px;
-  font-weight: bold;
-  font-style: normal;
   color: ${({ theme }) => theme.shared.base.colors.text};
 `;
 


### PR DESCRIPTION
## What's changed?

The current implementation of webfonts for this project (_my_ implementation!) is gross -- we have a family of fonts for each weight, and developers adding fonts have been rightly confused, leading to some odd rendering as browsers try and synthesis font weights. This PR corrects that behaviour. To see the change, add `font-synthesis: none` in the current tool and see the difference between what we've specified and what the browser makes up.

Obviously I would have known none of this without @paperboyo -- thanks!

E.g. before, the uncouth and belligerent made-up fonts

<img width="280" alt="Screenshot 2019-03-20 at 14 20 54" src="https://user-images.githubusercontent.com/7767575/54691677-935c2300-4b1b-11e9-8c98-392c10fde22f.png">

After, the tasteful and well-mannered actual fonts

<img width="280" alt="Screenshot 2019-03-20 at 14 20 34" src="https://user-images.githubusercontent.com/7767575/54691604-7293cd80-4b1b-11e9-920e-7f33739c1b05.png">


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
