### PR TITLE
Discard button

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -3,7 +3,11 @@ import {
   getArticlesBatched,
   getCollections as fetchCollections,
   updateCollection as updateCollectionFromApi,
-  fetchVisibleArticles
+  discardDraftChangesToCollection as discardDraftChangesToCollectionApi,
+  fetchVisibleArticles,
+  fetchLastPressed as fetchLastPressedApi,
+  publishCollection as publishCollectionApi,
+  getCollection as getCollectionApi
 } from 'services/faciaApi';
 import { VisibleArticlesResponse } from 'types/FaciaApi';
 import {
@@ -59,11 +63,6 @@ import {
 import flatten from 'lodash/flatten';
 import { createCollectionsInOpenFrontsSelector } from 'selectors/collectionSelectors';
 import uniq from 'lodash/uniq';
-import {
-  fetchLastPressed as fetchLastPressedApi,
-  publishCollection as publishCollectionApi,
-  getCollection as getCollectionApi
-} from 'services/faciaApi';
 import { recordUnpublishedChanges } from 'actions/UnpublishedChanges';
 import { isFrontStale } from 'util/frontsUtils';
 import { visibleArticlesSelector } from 'selectors/frontsSelectors';
@@ -390,6 +389,18 @@ function publishCollection(
   };
 }
 
+function discardDraftChangesToCollection(
+  collectionId: string
+): ThunkResult<Promise<void | string[]>> {
+  return (dispatch: Dispatch, getState: () => State) => {
+    return discardDraftChangesToCollectionApi(collectionId)
+      .then(() => dispatch(getCollections([collectionId])))
+      .catch(() => {
+        // @todo: implement once error handling is done
+      });
+  };
+}
+
 export {
   getCollections,
   getArticlesForCollections,
@@ -399,5 +410,6 @@ export {
   fetchArticles,
   updateCollection,
   initialiseCollectionsForFront,
-  publishCollection
+  publishCollection,
+  discardDraftChangesToCollection
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -5,7 +5,10 @@ import CollectionDisplay from 'shared/components/Collection';
 import CollectionNotification from 'components/CollectionNotification';
 import Button from 'shared/components/input/ButtonDefault';
 import { AlsoOnDetail } from 'types/Collection';
-import { publishCollection } from 'actions/Collections';
+import {
+  publishCollection,
+  discardDraftChangesToCollection
+} from 'actions/Collections';
 import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
 import { isCollectionLockedSelector } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
@@ -35,6 +38,9 @@ interface CollectionPropsBeforeState {
 
 type CollectionProps = CollectionPropsBeforeState & {
   publishCollection: (collectionId: string, frontId: string) => Promise<void>;
+  discardDraftChangesToCollection: (
+    collectionId: string
+  ) => Promise<void | string[]>;
   hasUnpublishedChanges: boolean;
   canPublish: boolean;
   groups: Group[];
@@ -59,7 +65,8 @@ const Collection = ({
   isCollectionLocked,
   isOpen,
   onChangeOpenState,
-  hasMultipleFrontsOpen
+  hasMultipleFrontsOpen,
+  discardDraftChangesToCollection: discardDraftChanges
 }: CollectionProps) => {
   const isUneditable =
     isCollectionLocked || browsingStage !== collectionItemSets.draft;
@@ -77,13 +84,22 @@ const Collection = ({
       headlineContent={
         hasUnpublishedChanges &&
         canPublish && (
-          <Button
-            size="l"
-            priority="primary"
-            onClick={() => publish(id, frontId)}
-          >
-            Launch
-          </Button>
+          <React.Fragment>
+            <Button
+              size="l"
+              priority="default"
+              onClick={() => discardDraftChanges(id)}
+            >
+              Discard
+            </Button>
+            <Button
+              size="l"
+              priority="primary"
+              onClick={() => publish(id, frontId)}
+            >
+              Launch
+            </Button>
+          </React.Fragment>
         )
       }
       metaContent={
@@ -129,6 +145,8 @@ const mapDispatchToProps = (
 ) => ({
   publishCollection: (id: string, frontId: string) =>
     dispatch(publishCollection(id, frontId)),
+  discardDraftChangesToCollection: (id: string) =>
+    dispatch(discardDraftChangesToCollection(id)),
   onChangeOpenState: (id: string, isOpen: boolean) => {
     if (isOpen) {
       dispatch(editorCloseCollections(id));

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -100,6 +100,27 @@ async function fetchVisibleArticles(
   }
 }
 
+async function discardDraftChangesToCollection(
+  collectionId: string
+): Promise<void> {
+  // The server does not respond with JSON
+  try {
+    await pandaFetch(`/collection/discard/${collectionId}`, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify({ collectionId })
+    });
+  } catch (response) {
+    throw new Error(
+      `Tried to discard changes to collection with id ${collectionId}, but the server responded with ${
+        response.status
+      }: ${response.body}`
+    );
+  }
+}
 async function publishCollection(collectionId: string): Promise<void> {
   // The server does not respond with JSON
   try {
@@ -316,5 +337,6 @@ export {
   saveClipboard,
   saveOpenFrontIds,
   getCapiUriForContentIds,
-  fetchVisibleArticles
+  fetchVisibleArticles,
+  discardDraftChangesToCollection
 };

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -143,7 +143,7 @@ const CollectionToggleContainer = styled('div')`
 const CollectionConfigContainer = styled('div')`
   display: inline-block;
   font-family: GHGuardianHeadline;
-  font-size: 22px;
+  font-size: 15px;
   color: ${({ theme }) => theme.shared.base.colors.text};
   height: 40px;
   line-height: 40px;


### PR DESCRIPTION
## What's changed?

We have a discard button which erases all changes made to draft after the article was launched last.

 @harpreetpurewal and @akemitakagi I had to make the collection metadata text smaller to fit the discard button in. 

I think we are going to have to think the way we display collection metadata anyway because currently we display only one metadata tag, we should have space to display multiple. Perhaps just adjust the front according to how many tags we have?

![Screenshot 2019-03-20 at 14 29 03](https://user-images.githubusercontent.com/3066534/54692491-05813780-4b1d-11e9-8480-540570ccb528.png)


## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
