### PR TITLE
Header fixes

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -5,7 +5,6 @@ import DropDisabler from './util/DropDisabler';
 
 import { theme as styleTheme, styled } from 'constants/theme';
 import { priorities } from 'constants/priorities';
-import SectionHeaderWithLogo from './layout/SectionHeaderWithLogo';
 import GHGuardianHeadlineBoldTtf from '../fonts/headline/GHGuardianHeadline-Bold.ttf';
 import GHGuardianHeadlineBoldWoff from '../fonts/headline/GHGuardianHeadline-Bold.woff';
 import GHGuardianHeadlineBoldWoff2 from '../fonts/headline/GHGuardianHeadline-Bold.woff2';
@@ -89,13 +88,6 @@ const AppContainer = styled('div')`
   width: 100%;
 `;
 
-const BackgroundHeader = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-`;
-
 export const frontsEditPath = `/:priority(${Object.keys(priorities).join(
   '|'
 )})/:frontId?`;
@@ -104,9 +96,6 @@ const App = () => (
   <ThemeProvider theme={styleTheme}>
     <DropDisabler>
       <AppContainer>
-        <BackgroundHeader>
-          <SectionHeaderWithLogo />
-        </BackgroundHeader>
         <Switch>
           <Route exact path={frontsEditPath} component={FrontsEdit} />
           <Route exact path="/" component={Home} />

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -49,6 +49,7 @@ const FrontsContainer = styled(SectionContainer)<{
   makeRoomForExtraHeader: boolean;
 }>`
   height: 100%;
+  overflow-y: hidden;
   overflow-x: scroll;
   transition: transform 0.15s;
   ${({ makeRoomForExtraHeader }) =>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -35,8 +35,11 @@ import CollectionItem from './CollectionComponents/CollectionItem';
 import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 
+// min-height required here to display scrollbar in Firefox:
+// https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
 const FrontContainer = styled('div')`
   display: flex;
+  min-height: 0;
 `;
 
 const FrontContentContainer = styled('div')`


### PR DESCRIPTION
## What's changed?

Fixes a couple of issues with the header:
- Removes the weird black header on the right when we only have one front open. When we have only one front open we still get a lot extra space appearing on the right. Had a quick chat with @harpreetpurewal and we decided fixing this is not a priority. 
- Adds correct scrollbars to firefox so we scroll overview and collections separately rather than the whole front along with it's header!

Before: 
![Screenshot 2019-03-21 at 12 12 07](https://user-images.githubusercontent.com/3066534/54751344-9534ed80-4bd2-11e9-814c-6e0a3fd2a33f.png)

After: 
![Screenshot 2019-03-21 at 12 11 58](https://user-images.githubusercontent.com/3066534/54751352-9a923800-4bd2-11e9-84d5-dc0b6943454b.png)



## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
