### PR TITLE
Ellipsis for current front menu

### DIFF
--- a/client-v2/src/components/CurrentFrontsList.tsx
+++ b/client-v2/src/components/CurrentFrontsList.tsx
@@ -50,11 +50,14 @@ const NoFronts = styled(FrontTabList)`
 
 const FrontTab = styled('div')<{ isDragging: boolean }>`
   display: inline-block;
+  max-width: 250px;
   vertical-align: top;
   height: 100%;
   line-height: 60px;
   padding: 0 22px;
   font-size: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   background-color: ${({ isDragging }) =>
     isDragging
       ? themeConstants.shared.colors.blackDark
@@ -85,19 +88,23 @@ class Component extends React.Component<ComponentProps> {
             >
               {this.props.fronts.map((front, index) => (
                 <Draggable key={front.id} draggableId={front.id} index={index}>
-                  {(provided, snapshot) => (
-                    <FrontTab
-                      innerRef={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                      style={provided.draggableProps.style}
-                      isDragging={snapshot.isDragging}
-                      key={front.id}
-                      onClick={() => this.scrollToFront(front.id)}
-                    >
-                      {startCase(front.id)}
-                    </FrontTab>
-                  )}
+                  {(provided, snapshot) => {
+                    const title = startCase(front.id);
+                    return (
+                      <FrontTab
+                        title={title}
+                        innerRef={provided.innerRef}
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
+                        style={provided.draggableProps.style}
+                        isDragging={snapshot.isDragging}
+                        key={front.id}
+                        onClick={() => this.scrollToFront(front.id)}
+                      >
+                        {title}
+                      </FrontTab>
+                    );
+                  }}
                 </Draggable>
               ))}
               {dropProvided.placeholder}


### PR DESCRIPTION
## What's changed?

Not much. Long fronts were little painful in the menu. But no more! There's also the full title if you hover, to disambiguate.

<img width="738" alt="Screenshot 2019-03-22 at 17 43 06" src="https://user-images.githubusercontent.com/7767575/54842525-02777a00-4cca-11e9-814a-279f41ade748.png">


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
