### PR TITLE
Ellipsis and flex basis for collection titles

### DIFF
--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -63,6 +63,7 @@ const HeadlineContentContainer = styled('span')`
   position: relative;
   right: -11px;
   line-height: 0px;
+  display: flex;
 `;
 
 const CollectionDisabledTheme = styled('div')`
@@ -107,13 +108,13 @@ const ItemCountMeta = styled(CollectionMetaBase)`
 
 const CollectionHeadlineWithConfigContainer = styled('div')`
   flex-grow: 1;
-  max-width: calc(100% - 95px);
   display: flex;
+  min-width: 0;
+  flex-basis: 100%;
 `;
 
 const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
   display: inline-block;
-  max-width: 400px;
   white-space: nowrap;
   ${({ isLoading, theme }) =>
     isLoading &&
@@ -195,7 +196,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       children
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
-
+    const displayName = collection ? collection.displayName : 'Loading';
     return (
       <CollectionContainer
         id={collection && createCollectionId(collection)}
@@ -203,8 +204,8 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       >
         <ContainerHeadingPinline>
           <CollectionHeadlineWithConfigContainer>
-            <CollectionHeadingText isLoading={!collection}>
-              {collection ? collection.displayName : 'Loading'}
+            <CollectionHeadingText isLoading={!collection} title={displayName}>
+              {displayName}
             </CollectionHeadingText>
             <CollectionConfigContainer>
               {oc(collection).metadata[0].type() ? (


### PR DESCRIPTION
## What's changed?

Long collection names were jostling for space with our launch and discard buttons., e.g.

<img width="533" alt="Screenshot 2019-03-22 at 17 44 37" src="https://user-images.githubusercontent.com/7767575/54842624-47031580-4cca-11e9-8478-8eaed3e91d20.png">

This PR adds some fancy flexbox-ness to ensure that there's room for everything, taking advantage of the additional space as content is removed:
<img width="600" alt="Screenshot 2019-03-22 at 17 33 10" src="https://user-images.githubusercontent.com/7767575/54842644-52564100-4cca-11e9-9492-cf83b7f63b4a.png">
<img width="600" alt="Screenshot 2019-03-22 at 17 33 27" src="https://user-images.githubusercontent.com/7767575/54842653-5b471280-4cca-11e9-8d3d-bee20e3ab05f.png">
<img width="600" alt="Screenshot 2019-03-22 at 17 33 54" src="https://user-images.githubusercontent.com/7767575/54842659-626e2080-4cca-11e9-803e-62909caff44a.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
