### PR TITLE
Add a grey background header

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -4,6 +4,7 @@ import { Switch, Route } from 'react-router-dom';
 import DropDisabler from './util/DropDisabler';
 
 import { theme as styleTheme, styled } from 'constants/theme';
+import SectionHeaderWithLogo from './layout/SectionHeaderWithLogo';
 import GHGuardianHeadlineBoldTtf from '../fonts/headline/GHGuardianHeadline-Bold.ttf';
 import GHGuardianHeadlineBoldWoff from '../fonts/headline/GHGuardianHeadline-Bold.woff';
 import GHGuardianHeadlineBoldWoff2 from '../fonts/headline/GHGuardianHeadline-Bold.woff2';
@@ -88,10 +89,20 @@ const AppContainer = styled('div')`
   width: 100%;
 `;
 
+const BackgroundHeader = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;
+
 const App = () => (
   <ThemeProvider theme={styleTheme}>
     <DropDisabler>
       <AppContainer>
+        <BackgroundHeader>
+          <SectionHeaderWithLogo greyHeader={true} />
+        </BackgroundHeader>
         <Switch>
           <Route exact path={frontsEdit} component={FrontsEdit} />
           <Route exact path="/" component={Home} />

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -13,7 +13,7 @@ import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
 import { getFront, createAlsoOnSelector } from 'selectors/frontsSelectors';
 import Front from './Front';
-import { FrontSectionHeader } from '../layout/SectionHeader';
+import SectionHeader from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';
 import { CollectionItemSets, Collection } from 'shared/types/Collection';
 import { toTitleCase } from 'util/stringUtils';
@@ -22,7 +22,7 @@ import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLab
 import { DownCaretIcon } from 'shared/components/icons/Icons';
 import { theme as sharedTheme } from 'shared/constants/theme';
 
-const FrontHeader = styled(FrontSectionHeader)`
+const FrontHeader = styled(SectionHeader)`
   display: flex;
   border-right: 1px solid #767676;
 `;
@@ -109,7 +109,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     return (
       <FrontsContainer>
         <>
-          <FrontHeader>
+          <FrontHeader greyHeader={true}>
             <FrontsHeaderText>
               {this.props.selectedFront &&
                 startCase(this.props.selectedFront.id)}

--- a/client-v2/src/components/layout/SectionHeader.tsx
+++ b/client-v2/src/components/layout/SectionHeader.tsx
@@ -1,27 +1,24 @@
 import { styled } from '../../constants/theme';
 import LargeSectionHeader from './LargeSectionHeader';
 
-const SectionHeaderBase = styled(LargeSectionHeader)<{
+const SectionHeader = styled(LargeSectionHeader)<{
   includeBorder?: boolean;
+  greyHeader?: boolean;
 }>`
   border-right: ${({ theme, includeBorder }) =>
     `solid 1px ${
       includeBorder ? theme.shared.colors.whiteDark : 'transparent'
     }`};
-`;
-
-const SectionHeader = styled(SectionHeaderBase)`
-  background-color: ${({ theme }) => theme.shared.colors.blackLight};
+  background-color: ${({ theme, greyHeader }) =>
+    greyHeader
+      ? theme.shared.colors.greyVeryLight
+      : theme.shared.colors.blackDark};
 `;
 
 const SectionHeaderUnpadded = styled(SectionHeader)`
   padding: 0;
 `;
 
-const FrontSectionHeader = styled(SectionHeaderBase)`
-  background-color: ${({ theme }) => theme.shared.colors.greyVeryLight};
-`;
-
-export { SectionHeaderUnpadded, FrontSectionHeader };
+export { SectionHeaderUnpadded };
 
 export default SectionHeader;

--- a/client-v2/src/components/layout/SectionHeaderWithLogo.tsx
+++ b/client-v2/src/components/layout/SectionHeaderWithLogo.tsx
@@ -17,12 +17,14 @@ const LogoTypeContainer = styled('div')`
 
 export default ({
   children,
-  includeBorder
+  includeBorder,
+  greyHeader
 }: {
   children?: React.ReactNode;
   includeBorder?: boolean;
+  greyHeader?: boolean;
 }) => (
-  <SectionHeader includeBorder={includeBorder}>
+  <SectionHeader greyHeader={greyHeader} includeBorder={includeBorder}>
     <LogoTypeContainer>F</LogoTypeContainer>
     {children}
   </SectionHeader>


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

I've added the background header back in but now with a grey background colour. 
![Screenshot 2019-03-25 at 08 49 11](https://user-images.githubusercontent.com/3066534/54906333-fadaef80-4eda-11e9-9149-51e198b0db5f.png)
![Screenshot 2019-03-25 at 08 48 49](https://user-images.githubusercontent.com/3066534/54906345-00383a00-4edb-11e9-88db-241c7a4996e8.png)
![Screenshot 2019-03-25 at 08 48 38](https://user-images.githubusercontent.com/3066534/54906366-0a5a3880-4edb-11e9-83d0-f4ddd20cccf0.png)

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
