### PR TITLE
Add unique names for live/draft toggles

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -129,7 +129,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                     <RadioButton
                       inline
                       key={key}
-                      name="frontStages"
+                      name={`${this.props.frontId} - frontStages`}
                       checked={frontStages[key] === this.state.collectionSet}
                       onChange={() => this.handleCollectionSetSelect(key)}
                       label={toTitleCase(frontStages[key])}


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Each front live/front toggle should have unique name so we can toggle them independently...

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
