### PR TITLE
Add Favourite Fronts to Fronts Menu

### DIFF
--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -31,6 +31,7 @@ case class Defaults(
   clipboardArticles: Option[List[Trail]],
   frontIds: Option[List[String]],
   frontIdsByPriority: Option[Map[String, List[String]]],
+  faveFrontIdsByPriority: Option[Map[String, List[String]]],
   capiLiveUrl: String = "",
   capiPreviewUrl: String = ""
 )
@@ -65,6 +66,7 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
         Metadata.tags.map{
           case (_, meta) => meta
         },
+        None,
         None,
         None,
         None

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -31,7 +31,7 @@ case class Defaults(
   clipboardArticles: Option[List[Trail]],
   frontIds: Option[List[String]],
   frontIdsByPriority: Option[Map[String, List[String]]],
-  faveFrontIdsByPriority: Option[Map[String, List[String]]],
+  favouriteFrontIdsByPriority: Option[Map[String, List[String]]],
   capiLiveUrl: String = "",
   capiPreviewUrl: String = ""
 )

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -52,6 +52,17 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
     }
   }
 
+  def putFaveFrontIdsByPriority() = APIAuthAction { request =>
+    val maybeFaveFrontIdsByPriority: Option[Map[String, List[String]]] = request.body.asJson.flatMap(
+      _.asOpt[Map[String, List[String]]])
+    maybeFaveFrontIdsByPriority match {
+      case Some(faveFrontIdsByPriority) =>
+        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('faveFrontIdsByPriority -> faveFrontIdsByPriority)))
+        Ok
+      case _ => BadRequest
+    }
+  }
+
   def migrateUserData() = AccessAPIAuthAction.async {
     val result = frontsApi.amazonClient.config.flatMap { config =>
       val maybeUserData = Scanamo.exec(dynamo.client)(userDataTable.scan)

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -52,12 +52,12 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
     }
   }
 
-  def putFaveFrontIdsByPriority() = APIAuthAction { request =>
-    val maybeFaveFrontIdsByPriority: Option[Map[String, List[String]]] = request.body.asJson.flatMap(
+  def putFavouriteFrontIdsByPriority() = APIAuthAction { request =>
+    val maybeFavouriteFrontIdsByPriority: Option[Map[String, List[String]]] = request.body.asJson.flatMap(
       _.asOpt[Map[String, List[String]]])
-    maybeFaveFrontIdsByPriority match {
-      case Some(faveFrontIdsByPriority) =>
-        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('faveFrontIdsByPriority -> faveFrontIdsByPriority)))
+    maybeFavouriteFrontIdsByPriority match {
+      case Some(favouriteFrontIdsByPriority) =>
+        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('favouriteFrontIdsByPriority -> favouriteFrontIdsByPriority)))
         Ok
       case _ => BadRequest
     }

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -61,6 +61,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
       maybeUserData.map(_.clipboardArticles.getOrElse(List())),
       maybeUserData.map(_.frontIds.getOrElse(List())),
       maybeUserData.map(_.frontIdsByPriority.getOrElse(Map())),
+      maybeUserData.map(_.faveFrontIdsByPriority.getOrElse(Map())),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
     )

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -61,7 +61,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
       maybeUserData.map(_.clipboardArticles.getOrElse(List())),
       maybeUserData.map(_.frontIds.getOrElse(List())),
       maybeUserData.map(_.frontIdsByPriority.getOrElse(Map())),
-      maybeUserData.map(_.faveFrontIdsByPriority.getOrElse(Map())),
+      maybeUserData.map(_.favouriteFrontIdsByPriority.getOrElse(Map())),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
     )

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -17,10 +17,21 @@ object UserData {
     }
   )(Json.stringify(_))
 }
+
+/**
+  * Example of frontIdsByPriority data model:
+  * "favouriteFrontIdsByPriority": {
+  *   "editorial": [
+  *     "uk/news",
+  *     "au/news"
+  *   ]
+  * }
+  * @TODO make these strongly typed via com.gu.facia.client.models package
+  */
 case class UserData(
-                     email: String,
-                     clipboardArticles: Option[List[Trail]],
-                     frontIds: Option[List[String]],
-                     frontIdsByPriority: Option[Map[String, List[String]]],
-                     faveFrontIdsByPriority: Option[Map[String, List[String]]]
-                   )
+  email: String,
+  clipboardArticles: Option[List[Trail]],
+  frontIds: Option[List[String]],
+  frontIdsByPriority: Option[Map[String, List[String]]],
+  favouriteFrontIdsByPriority: Option[Map[String, List[String]]]
+)

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -21,4 +21,6 @@ case class UserData(
                      email: String,
                      clipboardArticles: Option[List[Trail]],
                      frontIds: Option[List[String]],
-                     frontIdsByPriority: Option[Map[String, List[String]]])
+                     frontIdsByPriority: Option[Map[String, List[String]]],
+                     faveFrontIdsByPriority: Option[Map[String, List[String]]]
+                   )

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -19,6 +19,7 @@ import {
   editorCloseAllOverviews,
   editorOpenAllOverviews,
   createSelectEditorFrontsByPriority,
+  createSelectFrontIdWithOpenAndStarredStatesByPriority,
   editorMoveFront,
   selectEditorFrontIds,
   selectEditorFrontIdsByPriority,
@@ -126,6 +127,68 @@ describe('frontsUIBundle', () => {
       });
     });
   });
+  describe('selectEditorFaveFrontIdsByPriority', () => {
+    it('should handle empty priorities', () => {
+      expect(
+        selectEditorFaveFrontIdsByPriority(initialState, 'editorial')
+      ).toEqual([]);
+    });
+    it('should select priorities', () => {
+      const stateWithFronts = {
+        editor: {
+          ...initialState.editor,
+          faveFrontIdsByPriority: { commercial: ['1', '2'] }
+        }
+      } as any;
+      expect(
+        selectEditorFaveFrontIdsByPriority(stateWithFronts, 'commercial')
+      ).toEqual(['1', '2']);
+    });
+  });
+  describe('createSelectFrontIdWithOpenAndStarredStatesByPriority', () => {
+    const selectFrontIdWithOpenAndStarredStatesByPriority = createSelectFrontIdWithOpenAndStarredStatesByPriority();
+    it('should select all fronts by priority', () => {
+      expect(
+        selectFrontIdWithOpenAndStarredStatesByPriority(
+          initialState,
+          'commercial'
+        )
+      ).toHaveLength(4);
+    });
+    it('should add correct Open State meta data', () => {
+      const stateWithEditorFronts = {
+        ...initialState,
+        editor: {
+          ...initialState.editor,
+          frontIdsByPriority: {
+            commercial: ['sc-johnson-partner-zone', 'a-shot-of-sustainability']
+          },
+          faveFrontIdsByPriority: {
+            commercial: [
+              'sc-johnson-partner-zone',
+              'un-global-compact-partner-zone'
+            ]
+          }
+        }
+      } as any;
+      expect(
+        selectFrontIdWithOpenAndStarredStatesByPriority(
+          stateWithEditorFronts,
+          'commercial'
+        )
+      ).toEqual([
+        { id: 'a-shot-of-sustainability', isOpen: true, isStarred: false },
+        { id: 'sc-johnson-partner-zone', isOpen: true, isStarred: true },
+        {
+          id: 'sustainable-business/fairtrade-partner-zone',
+          isOpen: false,
+          isStarred: false
+        },
+        { id: 'un-global-compact-partner-zone', isOpen: false, isStarred: true }
+      ]);
+    });
+  });
+
   describe('reducer', () => {
     it('should move a front within the open editor fronts by ID', () => {
       const state = {

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -2,9 +2,9 @@ import {
   default as innerReducer,
   editorOpenFront,
   editorCloseFront,
-  editorStarFront,
-  editorUnstarFront,
-  editorSetFaveFronts,
+  editorFavouriteFront,
+  editorUnfavouriteFront,
+  editorSetFavouriteFronts,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,
@@ -23,8 +23,8 @@ import {
   editorMoveFront,
   selectEditorFrontIds,
   selectEditorFrontIdsByPriority,
-  selectEditorFaveFrontIds,
-  selectEditorFaveFrontIdsByPriority
+  selectEditorFavouriteFrontIds,
+  selectEditorFavouriteFrontIdsByPriority
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import { Action } from 'types/Action';
@@ -108,40 +108,40 @@ describe('frontsUIBundle', () => {
         );
       });
     });
-    describe('selectEditorFaveFrontIdsByPriority', () => {
+    describe('selectEditorFavouriteFrontIdsByPriority', () => {
       it('should handle empty priorities', () => {
         expect(
-          selectEditorFaveFrontIdsByPriority(initialState, 'editorial')
+          selectEditorFavouriteFrontIdsByPriority(initialState, 'editorial')
         ).toEqual([]);
       });
       it('should select priorities', () => {
         const stateWithFronts = {
           editor: {
             ...initialState.editor,
-            faveFrontIdsByPriority: { commercial: ['1', '2'] }
+            favouriteFrontIdsByPriority: { commercial: ['1', '2'] }
           }
         } as any;
         expect(
-          selectEditorFaveFrontIdsByPriority(stateWithFronts, 'commercial')
+          selectEditorFavouriteFrontIdsByPriority(stateWithFronts, 'commercial')
         ).toEqual(['1', '2']);
       });
     });
   });
-  describe('selectEditorFaveFrontIdsByPriority', () => {
+  describe('selectEditorFavouriteFrontIdsByPriority', () => {
     it('should handle empty priorities', () => {
       expect(
-        selectEditorFaveFrontIdsByPriority(initialState, 'editorial')
+        selectEditorFavouriteFrontIdsByPriority(initialState, 'editorial')
       ).toEqual([]);
     });
     it('should select priorities', () => {
       const stateWithFronts = {
         editor: {
           ...initialState.editor,
-          faveFrontIdsByPriority: { commercial: ['1', '2'] }
+          favouriteFrontIdsByPriority: { commercial: ['1', '2'] }
         }
       } as any;
       expect(
-        selectEditorFaveFrontIdsByPriority(stateWithFronts, 'commercial')
+        selectEditorFavouriteFrontIdsByPriority(stateWithFronts, 'commercial')
       ).toEqual(['1', '2']);
     });
   });
@@ -163,7 +163,7 @@ describe('frontsUIBundle', () => {
           frontIdsByPriority: {
             commercial: ['sc-johnson-partner-zone', 'a-shot-of-sustainability']
           },
-          faveFrontIdsByPriority: {
+          favouriteFrontIdsByPriority: {
             commercial: [
               'sc-johnson-partner-zone',
               'un-global-compact-partner-zone'
@@ -250,11 +250,11 @@ describe('frontsUIBundle', () => {
     });
 
     it('should add a front to the favourite editor fronts', () => {
-      const state = reducer(undefined, editorStarFront(
+      const state = reducer(undefined, editorFavouriteFront(
         'exampleFront',
         'editorial'
       ) as any);
-      expect(selectEditorFaveFrontIds(state)).toEqual({
+      expect(selectEditorFavouriteFrontIds(state)).toEqual({
         editorial: ['exampleFront']
       });
     });
@@ -262,14 +262,14 @@ describe('frontsUIBundle', () => {
     it('should remove a front to the favourite editor fronts', () => {
       const state = reducer(
         {
-          faveFrontIdsByPriority: {
+          favouriteFrontIdsByPriority: {
             editorial: ['front1', 'front2'],
             training: ['front1', 'front2']
           }
         } as any,
-        editorUnstarFront('front1', 'editorial')
+        editorUnfavouriteFront('front1', 'editorial')
       );
-      expect(selectEditorFaveFrontIds(state)).toEqual({
+      expect(selectEditorFavouriteFrontIds(state)).toEqual({
         editorial: ['front2'],
         training: ['front1', 'front2']
       });
@@ -349,9 +349,9 @@ describe('frontsUIBundle', () => {
             editorial: ['front1', 'front2']
           }
         } as any,
-        editorSetFaveFronts({ editorial: ['front1', 'front3'] })
+        editorSetFavouriteFronts({ editorial: ['front1', 'front3'] })
       );
-      expect(selectEditorFaveFrontIds(state)).toEqual({
+      expect(selectEditorFavouriteFrontIds(state)).toEqual({
         editorial: ['front1', 'front3']
       });
     });

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -274,7 +274,6 @@ describe('frontsUIBundle', () => {
         training: ['front1', 'front2']
       });
     });
-
     it('should clear the article fragment selection when selected article fragments are removed from a front', () => {
       const state = reducer(
         {
@@ -336,14 +335,13 @@ describe('frontsUIBundle', () => {
     });
     it('should set the fronts to the open editor fronts', () => {
       const state = reducer(
-        { frontIds: ['front1', 'front2'] } as any, // TODO should test be updated to frontIDs by priority???
+        { frontIds: ['front1', 'front2'] } as any,
         editorSetOpenFronts({ editorial: ['front1', 'front3'] })
       );
       expect(selectEditorFrontIds(state)).toEqual({
         editorial: ['front1', 'front3']
       });
     });
-    // TODO What is this doing? Getting fave fronts from config and setting it to editor state
     it('should set the fave fronts from config to the fave fronts in editor', () => {
       const state = reducer(
         {
@@ -357,7 +355,6 @@ describe('frontsUIBundle', () => {
         editorial: ['front1', 'front3']
       });
     });
-
     it('should add a collection to the open editor collections', () => {
       const state = reducer(undefined, editorOpenCollections(
         'exampleCollection'

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -2,6 +2,8 @@ import {
   default as innerReducer,
   editorOpenFront,
   editorCloseFront,
+  // editorStarFront, // TODO add tests
+  // editorUnstarFront,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -9,6 +9,8 @@ import {
   EditorClearOpenFronts,
   EditorSetOpenFronts,
   EditorAddFront,
+  EditorStarFront,
+  EditorUnstarFront,
   EditorSelectArticleFragment,
   EditorClearArticleFragmentSelection,
   EditorOpenCollection,
@@ -36,6 +38,8 @@ export const EDITOR_CLOSE_CURRENT_FRONTS_MENU =
 export const EDITOR_OPEN_FRONT = 'EDITOR_OPEN_FRONT';
 export const EDITOR_MOVE_FRONT = 'EDITOR_MOVE_FRONT';
 export const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
+export const EDITOR_STAR_FRONT = 'EDITOR_STAR_FRONT';
+export const EDITOR_UNSTAR_FRONT = 'EDITOR_UNSTAR_FRONT';
 export const EDITOR_CLEAR_OPEN_FRONTS = 'EDITOR_CLEAR_OPEN_FRONTS';
 export const EDITOR_SET_OPEN_FRONTS = 'EDITOR_SET_OPEN_FRONTS';
 export const EDITOR_OPEN_COLLECTION = 'EDITOR_OPEN_COLLECTION';
@@ -112,6 +116,27 @@ const editorCloseFront = (frontId: string): EditorCloseFront => {
   };
 };
 
+// TODO: persistence
+const editorStarFront = (frontId: string): EditorStarFront => {
+  return {
+    type: EDITOR_STAR_FRONT,
+    payload: { frontId }
+    // meta: {
+    //   persistTo: 'openFrontIds'
+    // }
+  };
+};
+
+const editorUnstarFront = (frontId: string): EditorUnstarFront => {
+  return {
+    type: EDITOR_UNSTAR_FRONT,
+    payload: { frontId }
+    // meta: {
+    //   persistTo: 'openFrontIds'
+    // }
+  };
+};
+
 const editorClearOpenFronts = (): EditorClearOpenFronts => ({
   type: EDITOR_CLEAR_OPEN_FRONTS,
   meta: {
@@ -180,6 +205,7 @@ interface State {
   frontIdsByPriority: {
     [id: string]: string[];
   };
+  faveFrontIds: string[];
   collectionIds: string[];
   closedOverviews: string[];
   clipboardOpen: boolean;
@@ -262,6 +288,7 @@ const defaultState = {
   showOpenFrontsMenu: false,
   frontIds: [],
   frontIdsByPriority: {},
+  faveFrontIds: [],
   collectionIds: [],
   clipboardOpen: true,
   closedOverviews: [],
@@ -365,6 +392,18 @@ const reducer = (state: State = defaultState, action: Action): State => {
             action.payload.frontId
           )
         }
+      };
+    }
+    case EDITOR_STAR_FRONT: {
+      return {
+        ...state,
+        faveFrontIds: state.faveFrontIds.concat(action.payload.frontId)
+      };
+    }
+    case EDITOR_UNSTAR_FRONT: {
+      return {
+        ...state,
+        faveFrontIds: without(state.faveFrontIds, action.payload.frontId)
       };
     }
     case EDITOR_CLEAR_OPEN_FRONTS: {
@@ -479,6 +518,8 @@ export {
   editorOpenFront,
   editorMoveFront,
   editorCloseFront,
+  editorStarFront,
+  editorUnstarFront,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -9,9 +9,9 @@ import {
   EditorClearOpenFronts,
   EditorSetOpenFronts,
   EditorAddFront,
-  EditorStarFront,
-  EditorUnstarFront,
-  EditorSetFaveFronts,
+  EditorFavouriteFront,
+  EditorUnfavouriteFront,
+  EditorSetFavouriteFronts,
   EditorSelectArticleFragment,
   EditorClearArticleFragmentSelection,
   EditorOpenCollection,
@@ -39,8 +39,8 @@ export const EDITOR_CLOSE_CURRENT_FRONTS_MENU =
 export const EDITOR_OPEN_FRONT = 'EDITOR_OPEN_FRONT';
 export const EDITOR_MOVE_FRONT = 'EDITOR_MOVE_FRONT';
 export const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
-export const EDITOR_STAR_FRONT = 'EDITOR_STAR_FRONT';
-export const EDITOR_UNSTAR_FRONT = 'EDITOR_UNSTAR_FRONT';
+export const EDITOR_FAVOURITE_FRONT = 'EDITOR_FAVOURITE_FRONT';
+export const EDITOR_UNFAVOURITE_FRONT = 'EDITOR_UNFAVOURITE_FRONT';
 export const EDITOR_SET_FAVE_FRONTS = 'EDITOR_SET_FAVE_FRONTS';
 export const EDITOR_CLEAR_OPEN_FRONTS = 'EDITOR_CLEAR_OPEN_FRONTS';
 export const EDITOR_SET_OPEN_FRONTS = 'EDITOR_SET_OPEN_FRONTS';
@@ -118,28 +118,28 @@ const editorCloseFront = (frontId: string): EditorCloseFront => {
   };
 };
 
-const editorStarFront = (
+const editorFavouriteFront = (
   frontId: string,
   priority: string
-): EditorStarFront => {
+): EditorFavouriteFront => {
   return {
-    type: EDITOR_STAR_FRONT,
+    type: EDITOR_FAVOURITE_FRONT,
     payload: { frontId, priority },
     meta: {
-      persistTo: 'faveFrontIds'
+      persistTo: 'favouriteFrontIds'
     }
   };
 };
 
-const editorUnstarFront = (
+const editorUnfavouriteFront = (
   frontId: string,
   priority: string
-): EditorUnstarFront => {
+): EditorUnfavouriteFront => {
   return {
-    type: EDITOR_UNSTAR_FRONT,
+    type: EDITOR_UNFAVOURITE_FRONT,
     payload: { frontId, priority },
     meta: {
-      persistTo: 'faveFrontIds'
+      persistTo: 'favouriteFrontIds'
     }
   };
 };
@@ -160,12 +160,12 @@ const editorSetOpenFronts = (frontIdsByPriority: {
   }
 });
 
-const editorSetFaveFronts = (faveFrontIdsByPriority: {
+const editorSetFavouriteFronts = (favouriteFrontIdsByPriority: {
   [id: string]: string[];
-}): EditorSetFaveFronts => ({
+}): EditorSetFavouriteFronts => ({
   type: EDITOR_SET_FAVE_FRONTS,
   payload: {
-    faveFrontIdsByPriority
+    favouriteFrontIdsByPriority
   }
 });
 
@@ -221,7 +221,7 @@ interface State {
   frontIdsByPriority: {
     [id: string]: string[];
   };
-  faveFrontIdsByPriority: {
+  favouriteFrontIdsByPriority: {
     [id: string]: string[];
   };
   collectionIds: string[];
@@ -274,13 +274,13 @@ const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
     (state, priority: string) =>
       selectEditorFrontsByPriority(state, { priority }),
     (state, priority: string) =>
-      selectEditorFaveFrontIdsByPriority(state, priority),
+      selectEditorFavouriteFrontIdsByPriority(state, priority),
 
-    (frontsForPriority, openFronts, faveFronts) => {
+    (frontsForPriority, openFronts, favouriteFronts) => {
       return frontsForPriority.map(({ id }) => ({
         id,
         isOpen: !!openFronts.find(_ => _.id === id),
-        isStarred: !!faveFronts.includes(id)
+        isStarred: !!favouriteFronts.includes(id)
       }));
     }
   );
@@ -289,18 +289,18 @@ const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
 const selectEditorFrontIds = (state: GlobalState) =>
   state.editor.frontIdsByPriority;
 
-const selectEditorFaveFrontIds = (state: GlobalState) =>
-  state.editor.faveFrontIdsByPriority;
+const selectEditorFavouriteFrontIds = (state: GlobalState) =>
+  state.editor.favouriteFrontIdsByPriority;
 
 const selectEditorFrontIdsByPriority = (
   state: GlobalState,
   priority: string
 ): string[] => state.editor.frontIdsByPriority[priority] || [];
 
-const selectEditorFaveFrontIdsByPriority = (
+const selectEditorFavouriteFrontIdsByPriority = (
   state: GlobalState,
   priority: string
-): string[] => state.editor.faveFrontIdsByPriority[priority] || [];
+): string[] => state.editor.favouriteFrontIdsByPriority[priority] || [];
 
 const selectHasMultipleFrontsOpen = createSelector(
   selectEditorFrontIdsByPriority,
@@ -318,7 +318,7 @@ const defaultState = {
   showOpenFrontsMenu: false,
   frontIds: [],
   frontIdsByPriority: {},
-  faveFrontIdsByPriority: {},
+  favouriteFrontIdsByPriority: {},
   collectionIds: [],
   clipboardOpen: true,
   closedOverviews: [],
@@ -424,26 +424,26 @@ const reducer = (state: State = defaultState, action: Action): State => {
         }
       };
     }
-    case EDITOR_STAR_FRONT: {
+    case EDITOR_FAVOURITE_FRONT: {
       const priority = action.payload.priority;
       return {
         ...state,
-        faveFrontIdsByPriority: {
-          ...state.faveFrontIdsByPriority,
-          [priority]: (state.faveFrontIdsByPriority[priority] || []).concat(
-            action.payload.frontId
-          )
+        favouriteFrontIdsByPriority: {
+          ...state.favouriteFrontIdsByPriority,
+          [priority]: (
+            state.favouriteFrontIdsByPriority[priority] || []
+          ).concat(action.payload.frontId)
         }
       };
     }
-    case EDITOR_UNSTAR_FRONT: {
+    case EDITOR_UNFAVOURITE_FRONT: {
       const priority = action.payload.priority;
       return {
         ...state,
-        faveFrontIdsByPriority: {
-          ...state.faveFrontIdsByPriority,
+        favouriteFrontIdsByPriority: {
+          ...state.favouriteFrontIdsByPriority,
           [priority]: without(
-            state.faveFrontIdsByPriority[priority],
+            state.favouriteFrontIdsByPriority[priority],
             action.payload.frontId
           )
         }
@@ -452,7 +452,7 @@ const reducer = (state: State = defaultState, action: Action): State => {
     case EDITOR_SET_FAVE_FRONTS: {
       return {
         ...state,
-        faveFrontIdsByPriority: action.payload.faveFrontIdsByPriority
+        favouriteFrontIdsByPriority: action.payload.favouriteFrontIdsByPriority
       };
     }
     case EDITOR_CLEAR_OPEN_FRONTS: {
@@ -567,9 +567,9 @@ export {
   editorOpenFront,
   editorMoveFront,
   editorCloseFront,
-  editorStarFront,
-  editorUnstarFront,
-  editorSetFaveFronts,
+  editorFavouriteFront,
+  editorUnfavouriteFront,
+  editorSetFavouriteFronts,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,
@@ -580,9 +580,9 @@ export {
   createSelectEditorFrontsByPriority,
   createSelectFrontIdWithOpenAndStarredStatesByPriority,
   selectEditorFrontIds,
-  selectEditorFaveFrontIds,
+  selectEditorFavouriteFrontIds,
   selectEditorFrontIdsByPriority,
-  selectEditorFaveFrontIdsByPriority,
+  selectEditorFavouriteFrontIdsByPriority,
   selectEditorArticleFragment,
   selectIsCollectionOpen,
   editorOpenClipboard,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -267,16 +267,20 @@ const createSelectEditorFrontsByPriority = () =>
     }
   );
 
-const createSelectFrontIdAndOpenStateByPriority = () => {
+const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
   const selectEditorFrontsByPriority = createSelectEditorFrontsByPriority();
   return createSelector(
     getFrontsWithPriority,
     (state, priority: string) =>
       selectEditorFrontsByPriority(state, { priority }),
-    (frontsForPriority, openFronts) => {
+    (state, priority: string) =>
+      selectEditorFaveFrontIdsByPriority(state, priority),
+
+    (frontsForPriority, openFronts, faveFronts) => {
       return frontsForPriority.map(({ id }) => ({
         id,
-        isOpen: !!openFronts.find(_ => _.id === id)
+        isOpen: !!openFronts.find(_ => _.id === id),
+        isStarred: !!faveFronts.includes(id)
       }));
     }
   );
@@ -574,7 +578,7 @@ export {
   editorClearArticleFragmentSelection,
   selectIsCurrentFrontsMenuOpen,
   createSelectEditorFrontsByPriority,
-  createSelectFrontIdAndOpenStateByPriority,
+  createSelectFrontIdWithOpenAndStarredStatesByPriority,
   selectEditorFrontIds,
   selectEditorFaveFrontIds,
   selectEditorFrontIdsByPriority,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -131,17 +131,16 @@ const editorStarFront = (
   };
 };
 
-// TODO: persistence
 const editorUnstarFront = (
   frontId: string,
   priority: string
 ): EditorUnstarFront => {
   return {
     type: EDITOR_UNSTAR_FRONT,
-    payload: { frontId, priority }
-    // meta: {
-    //   persistTo: 'openFrontIds'
-    // }
+    payload: { frontId, priority },
+    meta: {
+      persistTo: 'faveFrontIds'
+    }
   };
 };
 

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -117,20 +117,26 @@ const editorCloseFront = (frontId: string): EditorCloseFront => {
 };
 
 // TODO: persistence
-const editorStarFront = (frontId: string): EditorStarFront => {
+const editorStarFront = (
+  frontId: string,
+  priority: string
+): EditorStarFront => {
   return {
     type: EDITOR_STAR_FRONT,
-    payload: { frontId }
+    payload: { frontId, priority }
     // meta: {
     //   persistTo: 'openFrontIds'
     // }
   };
 };
 
-const editorUnstarFront = (frontId: string): EditorUnstarFront => {
+const editorUnstarFront = (
+  frontId: string,
+  priority: string
+): EditorUnstarFront => {
   return {
     type: EDITOR_UNSTAR_FRONT,
-    payload: { frontId }
+    payload: { frontId, priority }
     // meta: {
     //   persistTo: 'openFrontIds'
     // }
@@ -205,7 +211,9 @@ interface State {
   frontIdsByPriority: {
     [id: string]: string[];
   };
-  faveFrontIds: string[];
+  faveFrontIdsByPriority: {
+    [id: string]: string[];
+  };
   collectionIds: string[];
   closedOverviews: string[];
   clipboardOpen: boolean;
@@ -288,7 +296,7 @@ const defaultState = {
   showOpenFrontsMenu: false,
   frontIds: [],
   frontIdsByPriority: {},
-  faveFrontIds: [],
+  faveFrontIdsByPriority: {},
   collectionIds: [],
   clipboardOpen: true,
   closedOverviews: [],
@@ -395,15 +403,28 @@ const reducer = (state: State = defaultState, action: Action): State => {
       };
     }
     case EDITOR_STAR_FRONT: {
+      const priority = action.payload.priority;
       return {
         ...state,
-        faveFrontIds: state.faveFrontIds.concat(action.payload.frontId)
+        faveFrontIdsByPriority: {
+          ...state.faveFrontIdsByPriority,
+          [priority]: (state.faveFrontIdsByPriority[priority] || []).concat(
+            action.payload.frontId
+          )
+        }
       };
     }
     case EDITOR_UNSTAR_FRONT: {
+      const priority = action.payload.priority;
       return {
         ...state,
-        faveFrontIds: without(state.faveFrontIds, action.payload.frontId)
+        frontIdsByPriority: {
+          ...state.faveFrontIdsByPriority,
+          [priority]: without(
+            state.faveFrontIdsByPriority[priority],
+            action.payload.frontId
+          )
+        }
       };
     }
     case EDITOR_CLEAR_OPEN_FRONTS: {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -11,6 +11,7 @@ import {
   EditorAddFront,
   EditorStarFront,
   EditorUnstarFront,
+  EditorSetFaveFronts,
   EditorSelectArticleFragment,
   EditorClearArticleFragmentSelection,
   EditorOpenCollection,
@@ -40,6 +41,7 @@ export const EDITOR_MOVE_FRONT = 'EDITOR_MOVE_FRONT';
 export const EDITOR_CLOSE_FRONT = 'EDITOR_CLOSE_FRONT';
 export const EDITOR_STAR_FRONT = 'EDITOR_STAR_FRONT';
 export const EDITOR_UNSTAR_FRONT = 'EDITOR_UNSTAR_FRONT';
+export const EDITOR_SET_FAVE_FRONTS = 'EDITOR_SET_FAVE_FRONTS';
 export const EDITOR_CLEAR_OPEN_FRONTS = 'EDITOR_CLEAR_OPEN_FRONTS';
 export const EDITOR_SET_OPEN_FRONTS = 'EDITOR_SET_OPEN_FRONTS';
 export const EDITOR_OPEN_COLLECTION = 'EDITOR_OPEN_COLLECTION';
@@ -116,20 +118,20 @@ const editorCloseFront = (frontId: string): EditorCloseFront => {
   };
 };
 
-// TODO: persistence
 const editorStarFront = (
   frontId: string,
   priority: string
 ): EditorStarFront => {
   return {
     type: EDITOR_STAR_FRONT,
-    payload: { frontId, priority }
-    // meta: {
-    //   persistTo: 'openFrontIds'
-    // }
+    payload: { frontId, priority },
+    meta: {
+      persistTo: 'faveFrontIds'
+    }
   };
 };
 
+// TODO: persistence
 const editorUnstarFront = (
   frontId: string,
   priority: string
@@ -156,6 +158,15 @@ const editorSetOpenFronts = (frontIdsByPriority: {
   type: EDITOR_SET_OPEN_FRONTS,
   payload: {
     frontIdsByPriority
+  }
+});
+
+const editorSetFaveFronts = (faveFrontIdsByPriority: {
+  [id: string]: string[];
+}): EditorSetFaveFronts => ({
+  type: EDITOR_SET_FAVE_FRONTS,
+  payload: {
+    faveFrontIdsByPriority
   }
 });
 
@@ -275,10 +286,18 @@ const createSelectFrontIdAndOpenStateByPriority = () => {
 const selectEditorFrontIds = (state: GlobalState) =>
   state.editor.frontIdsByPriority;
 
+const selectEditorFaveFrontIds = (state: GlobalState) =>
+  state.editor.faveFrontIdsByPriority;
+
 const selectEditorFrontIdsByPriority = (
   state: GlobalState,
   priority: string
 ): string[] => state.editor.frontIdsByPriority[priority] || [];
+
+const selectEditorFaveFrontIdsByPriority = (
+  state: GlobalState,
+  priority: string
+): string[] => state.editor.faveFrontIdsByPriority[priority] || [];
 
 const selectHasMultipleFrontsOpen = createSelector(
   selectEditorFrontIdsByPriority,
@@ -418,13 +437,19 @@ const reducer = (state: State = defaultState, action: Action): State => {
       const priority = action.payload.priority;
       return {
         ...state,
-        frontIdsByPriority: {
+        faveFrontIdsByPriority: {
           ...state.faveFrontIdsByPriority,
           [priority]: without(
             state.faveFrontIdsByPriority[priority],
             action.payload.frontId
           )
         }
+      };
+    }
+    case EDITOR_SET_FAVE_FRONTS: {
+      return {
+        ...state,
+        faveFrontIdsByPriority: action.payload.faveFrontIdsByPriority
       };
     }
     case EDITOR_CLEAR_OPEN_FRONTS: {
@@ -541,6 +566,7 @@ export {
   editorCloseFront,
   editorStarFront,
   editorUnstarFront,
+  editorSetFaveFronts,
   editorClearOpenFronts,
   editorSetOpenFronts,
   editorOpenCollections,
@@ -551,7 +577,9 @@ export {
   createSelectEditorFrontsByPriority,
   createSelectFrontIdAndOpenStateByPriority,
   selectEditorFrontIds,
+  selectEditorFaveFrontIds,
   selectEditorFrontIdsByPriority,
+  selectEditorFaveFrontIdsByPriority,
   selectEditorArticleFragment,
   selectIsCollectionOpen,
   editorOpenClipboard,

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -23,12 +23,6 @@ const ButtonAdd = styled(ButtonCircular)`
   padding: 3px;
 `;
 
-const ListContainer = styled('ul')`
-  list-style: none;
-  margin-top: 0;
-  padding-left: 0;
-`;
-
 const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
   position: absolute;
   top: 8px;
@@ -58,6 +52,12 @@ const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
         fill: ${({ theme }) => theme.shared.colors.greyMedium};
       }
     `}
+`;
+
+const ListContainer = styled('ul')`
+  list-style: none;
+  margin-top: 0;
+  padding-left: 0;
 `;
 
 const ListItem = styled('li')<{ isActive?: boolean; isStarred?: boolean }>`

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -8,9 +8,10 @@ import TextHighlighter from './util/TextHighlighter';
 
 interface Props {
   fronts: Array<{ id: string; isOpen: boolean }>;
-  // favouriteFronts: Array<{ id: string }>;
+  favouriteFronts: string[];
   onSelect: (frontId: string) => void;
   onStar: (frontId: string) => void;
+  onUnstar: (frontId: string) => void;
   searchString: string;
 }
 
@@ -73,7 +74,14 @@ const ListLabel = styled('span')<{ isActive?: boolean }>`
     `};
 `;
 
-const FrontList = ({ fronts, onSelect, onStar, searchString }: Props) => {
+const FrontList = ({
+  fronts,
+  favouriteFronts,
+  onSelect,
+  onStar,
+  onUnstar,
+  searchString
+}: Props) => {
   if (!fronts) {
     return null;
   }
@@ -97,7 +105,9 @@ const FrontList = ({ fronts, onSelect, onStar, searchString }: Props) => {
           <ButtonFavorite
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();
-              onStar(front.id);
+              return favouriteFronts.includes(front.id)
+                ? onUnstar(front.id)
+                : onStar(front.id);
             }}
           >
             <StarIcon

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -95,7 +95,12 @@ const FrontList = ({ fronts, onSelect, onFavorite, searchString }: Props) => {
             />
           </ListLabel>
           {/* // onUnFavorite */}
-          <ButtonFavorite onClick={() => onFavorite(front.id)}>
+          <ButtonFavorite
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.stopPropagation();
+              onFavorite(front.id);
+            }}
+          >
             <StarIcon
               size="l"
               fill={theme.shared.colors.blackLight}

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -11,7 +11,7 @@ interface Props {
   renderOnlyStarred?: boolean;
   onSelect: (frontId: string) => void;
   onStar: (frontId: string) => void;
-  onUnstar: (frontId: string) => void;
+  onUnfavourite: (frontId: string) => void;
   searchString?: string;
 }
 
@@ -103,7 +103,7 @@ const FrontList = ({
   renderOnlyStarred,
   onSelect,
   onStar,
-  onUnstar,
+  onUnfavourite,
   searchString
 }: Props) => {
   if (!fronts) {
@@ -133,7 +133,9 @@ const FrontList = ({
             isStarred={!!front.isStarred}
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();
-              return !!front.isStarred ? onUnstar(front.id) : onStar(front.id);
+              return !!front.isStarred
+                ? onUnfavourite(front.id)
+                : onStar(front.id);
             }}
           >
             <StarIcon

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -10,7 +10,7 @@ interface Props {
   fronts: Array<{ id: string; isOpen: boolean }>;
   // favouriteFronts: Array<{ id: string }>;
   onSelect: (frontId: string) => void;
-  onFavorite: (frontId: string) => void;
+  onStar: (frontId: string) => void;
   searchString: string;
 }
 
@@ -73,7 +73,7 @@ const ListLabel = styled('span')<{ isActive?: boolean }>`
     `};
 `;
 
-const FrontList = ({ fronts, onSelect, onFavorite, searchString }: Props) => {
+const FrontList = ({ fronts, onSelect, onStar, searchString }: Props) => {
   if (!fronts) {
     return null;
   }
@@ -98,7 +98,7 @@ const FrontList = ({ fronts, onSelect, onFavorite, searchString }: Props) => {
           <ButtonFavorite
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();
-              onFavorite(front.id);
+              onStar(front.id);
             }}
           >
             <StarIcon

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -35,8 +35,8 @@ const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
   svg .fill {
     fill: ${({ theme }) => theme.shared.colors.blackLight};
   }
-  &&:hover svg .fill,
-  &&:hover svg .outline {
+  &:hover svg .fill,
+  &:hover svg .outline {
     fill: ${({ theme }) => theme.shared.colors.greyMedium};
   }
 
@@ -47,8 +47,7 @@ const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
       svg .fill {
         fill: ${({ theme }) => `${theme.shared.colors.orangeLight}`};
       }
-      &&:hover svg .fill,
-      &&:hover svg .outline {
+      &:hover svg .outline {
         fill: ${({ theme }) => theme.shared.colors.greyMedium};
       }
     `}
@@ -77,6 +76,12 @@ const ListItem = styled('li')<{ isActive?: boolean; isStarred?: boolean }>`
       }
       :hover ${ButtonFavorite} {
         background-color: ${({ theme }) => theme.base.colors.frontListButton};
+      }
+      :hover svg .fill {
+        fill: ${({ theme, isStarred }) =>
+          isStarred
+            ? theme.base.colors.orangeLight
+            : theme.base.colors.frontListButton};
       }
     `};
 `;
@@ -113,6 +118,7 @@ const FrontList = ({
       {frontsToRender.map(front => (
         <ListItem
           isActive={!front.isOpen}
+          isStarred={!!front.isStarred}
           key={front.id}
           onClick={!front.isOpen ? () => onSelect(front.id) : undefined}
         >

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -1,16 +1,45 @@
 import React from 'react';
 import { css } from 'styled-components';
-import { styled } from 'constants/theme';
+import { styled, theme } from 'constants/theme';
 
 import ButtonCircular from 'shared/components/input/ButtonCircular';
-import { MoreIcon } from 'shared/components/icons/Icons';
+import { MoreIcon, StarIcon } from 'shared/components/icons/Icons';
 import TextHighlighter from './util/TextHighlighter';
 
 interface Props {
   fronts: Array<{ id: string; isOpen: boolean }>;
+  // favouriteFronts: Array<{ id: string }>;
   onSelect: (frontId: string) => void;
+  onFavorite: (frontId: string) => void;
   searchString: string;
 }
+
+const ButtonAdd = styled(ButtonCircular)`
+  background-color: ${({ theme }) => theme.base.colors.frontListButton};
+  position: absolute;
+  top: 8px;
+  right: 5px;
+  padding: 3px;
+`;
+
+const ButtonFavorite = styled(ButtonCircular)`
+  background-color: ${({ theme }) => theme.shared.colors.blackLight};
+  position: absolute;
+  top: 8px;
+  right: 35px;
+  :hover {
+    background-color: ${({ theme }) => theme.shared.colors.blackLight};
+  }
+  :hover > svg .fill {
+    fill: ${({ theme }) => theme.shared.colors.greyMedium};
+  }
+`;
+
+const ListContainer = styled('ul')`
+  list-style: none;
+  margin-top: 0;
+  padding-left: 0;
+`;
 
 const ListItem = styled('li')<{ isActive?: boolean }>`
   position: relative;
@@ -25,19 +54,18 @@ const ListItem = styled('li')<{ isActive?: boolean }>`
     css`
       cursor: pointer;
       &:hover {
-        background-color: rgba(255, 255, 255, 0.05);
+        background-color: ${({ theme }) => theme.base.colors.frontListButton};
+      }
+      &:hover ${ButtonFavorite} {
+        background-color: ${({ theme }) => theme.base.colors.frontListButton};
       }
     `};
 `;
 
-const ListContainer = styled('ul')`
-  list-style: none;
-  margin-top: 0;
-  padding-left: 0;
-`;
-
 const ListLabel = styled('span')<{ isActive?: boolean }>`
-  max-width: calc(100% - 30px);
+  max-width: calc(100% - 60px);
+  display: inline-block;
+  word-break: break-all;
   ${({ isActive }) =>
     !isActive &&
     css`
@@ -45,15 +73,7 @@ const ListLabel = styled('span')<{ isActive?: boolean }>`
     `};
 `;
 
-const ButtonAdd = styled(ButtonCircular)`
-  background-color: ${({ theme }) => theme.base.colors.frontListButton};
-  position: absolute;
-  top: 8px;
-  right: 5px;
-  padding: 3px;
-`;
-
-const FrontList = ({ fronts, onSelect, searchString }: Props) => {
+const FrontList = ({ fronts, onSelect, onFavorite, searchString }: Props) => {
   if (!fronts) {
     return null;
   }
@@ -74,6 +94,14 @@ const FrontList = ({ fronts, onSelect, searchString }: Props) => {
               searchString={searchString}
             />
           </ListLabel>
+          {/* // onUnFavorite */}
+          <ButtonFavorite onClick={() => onFavorite(front.id)}>
+            <StarIcon
+              size="l"
+              fill={theme.shared.colors.blackLight}
+              outline={theme.shared.colors.greyMedium}
+            />
+          </ButtonFavorite>
           {!front.isOpen && (
             <ButtonAdd>
               <MoreIcon />

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -7,12 +7,12 @@ import { MoreIcon, StarIcon } from 'shared/components/icons/Icons';
 import TextHighlighter from './util/TextHighlighter';
 
 interface Props {
-  fronts: Array<{ id: string; isOpen: boolean }>;
-  favouriteFronts: string[];
+  fronts: Array<{ id: string; isOpen: boolean; isStarred: boolean }>;
+  renderOnlyStarred?: boolean;
   onSelect: (frontId: string) => void;
   onStar: (frontId: string) => void;
   onUnstar: (frontId: string) => void;
-  searchString: string;
+  searchString?: string;
 }
 
 const ButtonAdd = styled(ButtonCircular)`
@@ -23,7 +23,7 @@ const ButtonAdd = styled(ButtonCircular)`
   padding: 3px;
 `;
 
-const ButtonFavorite = styled(ButtonCircular)`
+const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
   background-color: ${({ theme }) => theme.shared.colors.blackLight};
   position: absolute;
   top: 8px;
@@ -34,6 +34,16 @@ const ButtonFavorite = styled(ButtonCircular)`
   :hover > svg .fill {
     fill: ${({ theme }) => theme.shared.colors.greyMedium};
   }
+  ${({ isStarred }) =>
+    !!isStarred &&
+    css`
+      svg .fill {
+        fill: ${({ theme }) => theme.shared.colors.greyMedium};
+      }
+      :hover > svg .fill {
+        fill: ${({ theme }) => theme.shared.colors.blackLight};
+      }
+    `}
 `;
 
 const ListContainer = styled('ul')`
@@ -42,7 +52,7 @@ const ListContainer = styled('ul')`
   padding-left: 0;
 `;
 
-const ListItem = styled('li')<{ isActive?: boolean }>`
+const ListItem = styled('li')<{ isActive?: boolean; isStarred?: boolean }>`
   position: relative;
   padding: 10px 5px;
   font-family: TS3TextSans;
@@ -76,7 +86,7 @@ const ListLabel = styled('span')<{ isActive?: boolean }>`
 
 const FrontList = ({
   fronts,
-  favouriteFronts,
+  renderOnlyStarred,
   onSelect,
   onStar,
   onUnstar,
@@ -85,7 +95,9 @@ const FrontList = ({
   if (!fronts) {
     return null;
   }
-  const frontsToRender = searchString
+  const frontsToRender = renderOnlyStarred
+    ? fronts.filter(_ => _.isStarred)
+    : searchString
     ? fronts.filter(_ => _.id.includes(searchString))
     : fronts;
   return (
@@ -103,11 +115,10 @@ const FrontList = ({
             />
           </ListLabel>
           <ButtonFavorite
+            isStarred={!!front.isStarred}
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();
-              return favouriteFronts.includes(front.id)
-                ? onUnstar(front.id)
-                : onStar(front.id);
+              return !!front.isStarred ? onUnstar(front.id) : onStar(front.id);
             }}
           >
             <StarIcon

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -35,8 +35,9 @@ const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
   svg .fill {
     fill: ${({ theme }) => theme.shared.colors.blackLight};
   }
-  &:hover svg .fill,
-  &:hover svg .outline {
+  /* Double && needed to override css specificity of ListItem with isActive set */
+  &&:hover svg .fill,
+  &&:hover svg .outline {
     fill: ${({ theme }) => theme.shared.colors.greyMedium};
   }
 

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -94,7 +94,6 @@ const FrontList = ({ fronts, onSelect, onStar, searchString }: Props) => {
               searchString={searchString}
             />
           </ListLabel>
-          {/* // onUnFavorite */}
           <ButtonFavorite
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'styled-components';
-import { styled, theme } from 'constants/theme';
+import { styled, theme as styleTheme } from 'constants/theme';
 
 import ButtonCircular from 'shared/components/input/ButtonCircular';
 import { MoreIcon, StarIcon } from 'shared/components/icons/Icons';
@@ -123,8 +123,8 @@ const FrontList = ({
           >
             <StarIcon
               size="l"
-              fill={theme.shared.colors.blackLight}
-              outline={theme.shared.colors.greyMedium}
+              fill={styleTheme.shared.colors.blackLight}
+              outline={styleTheme.shared.colors.greyMedium}
             />
           </ButtonFavorite>
           {!front.isOpen && (

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -23,33 +23,41 @@ const ButtonAdd = styled(ButtonCircular)`
   padding: 3px;
 `;
 
-const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
-  background-color: ${({ theme }) => theme.shared.colors.blackLight};
-  position: absolute;
-  top: 8px;
-  right: 35px;
-  :hover {
-    background-color: ${({ theme }) => theme.shared.colors.blackLight};
-  }
-  :hover > svg .fill {
-    fill: ${({ theme }) => theme.shared.colors.greyMedium};
-  }
-  ${({ isStarred }) =>
-    !!isStarred &&
-    css`
-      svg .fill {
-        fill: ${({ theme }) => theme.shared.colors.greyMedium};
-      }
-      :hover > svg .fill {
-        fill: ${({ theme }) => theme.shared.colors.blackLight};
-      }
-    `}
-`;
-
 const ListContainer = styled('ul')`
   list-style: none;
   margin-top: 0;
   padding-left: 0;
+`;
+
+const ButtonFavorite = styled(ButtonCircular)<{ isStarred: boolean }>`
+  position: absolute;
+  top: 8px;
+  right: 35px;
+  cursor: pointer;
+  background-color: ${({ theme }) => theme.shared.colors.blackLight};
+  :hover {
+    background-color: ${({ theme }) => theme.shared.colors.blackLight};
+  }
+  svg .fill {
+    fill: ${({ theme }) => theme.shared.colors.blackLight};
+  }
+  &&:hover svg .fill,
+  &&:hover svg .outline {
+    fill: ${({ theme }) => theme.shared.colors.greyMedium};
+  }
+
+  ${({ isStarred }) =>
+    !!isStarred &&
+    css`
+      svg .outline,
+      svg .fill {
+        fill: ${({ theme }) => `${theme.shared.colors.orangeLight}`};
+      }
+      &&:hover svg .fill,
+      &&:hover svg .outline {
+        fill: ${({ theme }) => theme.shared.colors.greyMedium};
+      }
+    `}
 `;
 
 const ListItem = styled('li')<{ isActive?: boolean; isStarred?: boolean }>`
@@ -64,10 +72,10 @@ const ListItem = styled('li')<{ isActive?: boolean; isStarred?: boolean }>`
     isActive &&
     css`
       cursor: pointer;
-      &:hover {
+      :hover {
         background-color: ${({ theme }) => theme.base.colors.frontListButton};
       }
-      &:hover ${ButtonFavorite} {
+      :hover ${ButtonFavorite} {
         background-color: ${({ theme }) => theme.base.colors.frontListButton};
       }
     `};

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -90,7 +90,7 @@ class FrontsEdit extends React.Component<Props> {
           onSelectFront={id =>
             this.props.editorOpenFront(id, this.props.match.params.priority)
           }
-          onFavoriteFront={this.props.editorStarFront}
+          onStarFront={this.props.editorStarFront}
         />
       </FrontsEditContainer>
     );

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -7,6 +7,7 @@ import getFrontsConfig from 'actions/Fronts';
 import {
   editorOpenFront,
   editorStarFront,
+  editorUnstarFront,
   selectEditorFrontIdsByPriority,
   selectIsCurrentFrontsMenuOpen
 } from 'bundles/frontsUIBundle';
@@ -28,6 +29,7 @@ interface Props {
   staleFronts: { [id: string]: boolean };
   editorOpenFront: (frontId: string, priority: string) => void;
   editorStarFront: (frontId: string, priority: string) => void;
+  editorUnstarFront: (frontId: string, priority: string) => void;
   getFrontsConfig: () => void;
   isCurrentFrontsMenuOpen: boolean;
 }
@@ -93,6 +95,9 @@ class FrontsEdit extends React.Component<Props> {
           onStarFront={id =>
             this.props.editorStarFront(id, this.props.match.params.priority)
           }
+          onUnstarFront={id =>
+            this.props.editorUnstarFront(id, this.props.match.params.priority)
+          }
         />
       </FrontsEditContainer>
     );
@@ -115,6 +120,8 @@ const mapDispatchToProps = (dispatch: Dispatch, props: Props) => ({
   },
   editorStarFront: (id: string) =>
     dispatch(editorStarFront(id, props.match.params.priority)),
+  editorUnstarFront: (id: string) =>
+    dispatch(editorUnstarFront(id, props.match.params.priority)),
   getFrontsConfig: () => dispatch(getFrontsConfig())
 });
 

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -27,7 +27,7 @@ interface Props {
   frontIds: string[];
   staleFronts: { [id: string]: boolean };
   editorOpenFront: (frontId: string, priority: string) => void;
-  editorStarFront: (frontId: string) => void;
+  editorStarFront: (frontId: string, priority: string) => void;
   getFrontsConfig: () => void;
   isCurrentFrontsMenuOpen: boolean;
 }
@@ -90,7 +90,9 @@ class FrontsEdit extends React.Component<Props> {
           onSelectFront={id =>
             this.props.editorOpenFront(id, this.props.match.params.priority)
           }
-          onStarFront={this.props.editorStarFront}
+          onStarFront={id =>
+            this.props.editorStarFront(id, this.props.match.params.priority)
+          }
         />
       </FrontsEditContainer>
     );
@@ -111,7 +113,8 @@ const mapDispatchToProps = (dispatch: Dispatch, props: Props) => ({
   editorOpenFront: (id: string) => {
     dispatch(editorOpenFront(id, props.match.params.priority));
   },
-  editorStarFront: (id: string) => dispatch(editorStarFront(id)),
+  editorStarFront: (id: string) =>
+    dispatch(editorStarFront(id, props.match.params.priority)),
   getFrontsConfig: () => dispatch(getFrontsConfig())
 });
 

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -5,9 +5,10 @@ import { match } from 'react-router-dom';
 import { styled } from 'constants/theme';
 import getFrontsConfig from 'actions/Fronts';
 import {
-  selectIsCurrentFrontsMenuOpen,
   editorOpenFront,
-  selectEditorFrontIdsByPriority
+  editorStarFront,
+  selectEditorFrontIdsByPriority,
+  selectIsCurrentFrontsMenuOpen
 } from 'bundles/frontsUIBundle';
 import { State } from 'types/State';
 import { ActionError } from 'types/Action';
@@ -26,6 +27,7 @@ interface Props {
   frontIds: string[];
   staleFronts: { [id: string]: boolean };
   editorOpenFront: (frontId: string, priority: string) => void;
+  editorStarFront: (frontId: string) => void;
   getFrontsConfig: () => void;
   isCurrentFrontsMenuOpen: boolean;
 }
@@ -88,6 +90,7 @@ class FrontsEdit extends React.Component<Props> {
           onSelectFront={id =>
             this.props.editorOpenFront(id, this.props.match.params.priority)
           }
+          onFavoriteFront={this.props.editorStarFront}
         />
       </FrontsEditContainer>
     );
@@ -108,6 +111,7 @@ const mapDispatchToProps = (dispatch: Dispatch, props: Props) => ({
   editorOpenFront: (id: string) => {
     dispatch(editorOpenFront(id, props.match.params.priority));
   },
+  editorStarFront: (id: string) => dispatch(editorStarFront(id)),
   getFrontsConfig: () => dispatch(getFrontsConfig())
 });
 

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -6,8 +6,8 @@ import { styled } from 'constants/theme';
 import getFrontsConfig from 'actions/Fronts';
 import {
   editorOpenFront,
-  editorStarFront,
-  editorUnstarFront,
+  editorFavouriteFront,
+  editorUnfavouriteFront,
   selectEditorFrontIdsByPriority,
   selectIsCurrentFrontsMenuOpen
 } from 'bundles/frontsUIBundle';
@@ -28,8 +28,8 @@ interface Props {
   frontIds: string[];
   staleFronts: { [id: string]: boolean };
   editorOpenFront: (frontId: string, priority: string) => void;
-  editorStarFront: (frontId: string, priority: string) => void;
-  editorUnstarFront: (frontId: string, priority: string) => void;
+  editorFavouriteFront: (frontId: string, priority: string) => void;
+  editorUnfavouriteFront: (frontId: string, priority: string) => void;
   getFrontsConfig: () => void;
   isCurrentFrontsMenuOpen: boolean;
 }
@@ -92,11 +92,17 @@ class FrontsEdit extends React.Component<Props> {
           onSelectFront={id =>
             this.props.editorOpenFront(id, this.props.match.params.priority)
           }
-          onStarFront={id =>
-            this.props.editorStarFront(id, this.props.match.params.priority)
+          onFavouriteFront={id =>
+            this.props.editorFavouriteFront(
+              id,
+              this.props.match.params.priority
+            )
           }
-          onUnstarFront={id =>
-            this.props.editorUnstarFront(id, this.props.match.params.priority)
+          onUnfavouriteFront={id =>
+            this.props.editorUnfavouriteFront(
+              id,
+              this.props.match.params.priority
+            )
           }
         />
       </FrontsEditContainer>
@@ -118,10 +124,10 @@ const mapDispatchToProps = (dispatch: Dispatch, props: Props) => ({
   editorOpenFront: (id: string) => {
     dispatch(editorOpenFront(id, props.match.params.priority));
   },
-  editorStarFront: (id: string) =>
-    dispatch(editorStarFront(id, props.match.params.priority)),
-  editorUnstarFront: (id: string) =>
-    dispatch(editorUnstarFront(id, props.match.params.priority)),
+  editorFavouriteFront: (id: string) =>
+    dispatch(editorFavouriteFront(id, props.match.params.priority)),
+  editorUnfavouriteFront: (id: string) =>
+    dispatch(editorUnfavouriteFront(id, props.match.params.priority)),
   getFrontsConfig: () => dispatch(getFrontsConfig())
 });
 

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -86,6 +86,7 @@ const FrontsMenuSearchImage = styled('div')`
 interface Props {
   onSelectFront: (frontId: string) => void;
   onStarFront: (frontId: string) => void;
+  onUnstarFront: (frontId: string) => void;
 }
 
 interface State {
@@ -106,8 +107,11 @@ class FrontsMenu extends React.Component<Props, State> {
   };
 
   public onStarFront = (frontId: string) => {
-    alert('favoriting' + frontId);
     this.props.onStarFront(frontId);
+  };
+
+  public onUnstarFront = (frontId: string) => {
+    this.props.onUnstarFront(frontId);
   };
 
   public onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -167,6 +171,7 @@ class FrontsMenu extends React.Component<Props, State> {
               <FrontsList
                 onSelect={this.onSelectFront}
                 onStar={this.onStarFront}
+                onUnstar={this.onUnstarFront}
                 searchString={this.state.searchString}
               />
             </FrontsMenuContent>

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -85,7 +85,7 @@ const FrontsMenuSearchImage = styled('div')`
 
 interface Props {
   onSelectFront: (frontId: string) => void;
-  onFavoriteFront: (frontId: string) => void;
+  onStarFront: (frontId: string) => void;
 }
 
 interface State {
@@ -105,9 +105,9 @@ class FrontsMenu extends React.Component<Props, State> {
     this.props.onSelectFront(frontId);
   };
 
-  public onFavoriteFront = (frontId: string) => {
+  public onStarFront = (frontId: string) => {
     alert('favoriting' + frontId);
-    this.props.onFavoriteFront(frontId);
+    this.props.onStarFront(frontId);
   };
 
   public onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -166,7 +166,7 @@ class FrontsMenu extends React.Component<Props, State> {
               </FrontsMenuSubHeading>
               <FrontsList
                 onSelect={this.onSelectFront}
-                onFavorite={this.onFavoriteFront}
+                onStar={this.onStarFront}
                 searchString={this.state.searchString}
               />
             </FrontsMenuContent>

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -10,7 +10,7 @@ import LargeSectionHeader from '../layout/LargeSectionHeader';
 import ButtonOverlay from '../inputs/ButtonOverlay';
 import ScrollContainer from '../ScrollContainer';
 import Overlay from '../layout/Overlay';
-import FrontsList from '../../containers/FrontsList';
+import FrontsList from '../FrontsListContainer';
 import Row from 'components/Row';
 import Col from 'components/Col';
 
@@ -85,6 +85,7 @@ const FrontsMenuSearchImage = styled('div')`
 
 interface Props {
   onSelectFront: (frontId: string) => void;
+  onFavoriteFront: (frontId: string) => void;
 }
 
 interface State {
@@ -102,6 +103,11 @@ class FrontsMenu extends React.Component<Props, State> {
   public onSelectFront = (frontId: string) => {
     this.toggleFrontsMenu();
     this.props.onSelectFront(frontId);
+  };
+
+  public onFavoriteFront = (frontId: string) => {
+    alert('favoriting' + frontId);
+    this.props.onFavoriteFront(frontId);
   };
 
   public onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -160,6 +166,7 @@ class FrontsMenu extends React.Component<Props, State> {
               </FrontsMenuSubHeading>
               <FrontsList
                 onSelect={this.onSelectFront}
+                onFavorite={this.onFavoriteFront}
                 searchString={this.state.searchString}
               />
             </FrontsMenuContent>

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -86,8 +86,8 @@ const FrontsMenuSearchImage = styled('div')`
 
 interface Props {
   onSelectFront: (frontId: string) => void;
-  onStarFront: (frontId: string) => void;
-  onUnstarFront: (frontId: string) => void;
+  onFavouriteFront: (frontId: string) => void;
+  onUnfavouriteFront: (frontId: string) => void;
 }
 
 interface State {
@@ -107,12 +107,12 @@ class FrontsMenu extends React.Component<Props, State> {
     this.props.onSelectFront(frontId);
   };
 
-  public onStarFront = (frontId: string) => {
-    this.props.onStarFront(frontId);
+  public onFavouriteFront = (frontId: string) => {
+    this.props.onFavouriteFront(frontId);
   };
 
-  public onUnstarFront = (frontId: string) => {
-    this.props.onUnstarFront(frontId);
+  public onUnfavouriteFront = (frontId: string) => {
+    this.props.onUnfavouriteFront(frontId);
   };
 
   public onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -162,8 +162,8 @@ class FrontsMenu extends React.Component<Props, State> {
               <FrontsList
                 renderOnlyStarred
                 onSelect={this.onSelectFront}
-                onStar={this.onStarFront}
-                onUnstar={this.onUnstarFront}
+                onStar={this.onFavouriteFront}
+                onUnfavourite={this.onUnfavouriteFront}
               />
 
               <FrontsMenuSubHeading>
@@ -183,8 +183,8 @@ class FrontsMenu extends React.Component<Props, State> {
               </FrontsMenuSubHeading>
               <FrontsList
                 onSelect={this.onSelectFront}
-                onStar={this.onStarFront}
-                onUnstar={this.onUnstarFront}
+                onStar={this.onFavouriteFront}
+                onUnfavourite={this.onUnfavouriteFront}
                 searchString={this.state.searchString}
               />
             </FrontsMenuContent>

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -32,6 +32,7 @@ const FrontsMenuSubHeading = styled('div')`
   font-size: 16px;
   line-height: 30px;
   font-weight: bold;
+  color: ${({ theme }) => theme.shared.colors.orangeLight};
   border-bottom: ${({ theme }) =>
     `solid 1px ${theme.base.colors.frontListBorder}`};
   max-height: 100%;
@@ -153,6 +154,18 @@ class FrontsMenu extends React.Component<Props, State> {
             fixed={<FrontsMenuHeading>Add Front</FrontsMenuHeading>}
           >
             <FrontsMenuContent>
+              <FrontsMenuSubHeading>
+                <Row>
+                  <Col>Favourites</Col>
+                </Row>
+              </FrontsMenuSubHeading>
+              <FrontsList
+                renderOnlyStarred
+                onSelect={this.onSelectFront}
+                onStar={this.onStarFront}
+                onUnstar={this.onUnstarFront}
+              />
+
               <FrontsMenuSubHeading>
                 <Row>
                   <Col>All</Col>

--- a/client-v2/src/components/FrontsListContainer.ts
+++ b/client-v2/src/components/FrontsListContainer.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { match, withRouter, RouteComponentProps } from 'react-router';
 import { createSelectFrontIdAndOpenStateByPriority } from 'bundles/frontsUIBundle';
 import { State } from '../types/State';
-import FrontList from '../components/FrontList';
+import FrontList from './FrontList';
 
 type Props = {
   match: match<{ priority: string }>;
@@ -16,6 +16,7 @@ const mapStateToProps = () => {
         state,
         props.match.params.priority || ''
       )
+      // favouriteFronts: // write selector getFaveFrontsWithPriority
     };
   };
 };

--- a/client-v2/src/components/FrontsListContainer.ts
+++ b/client-v2/src/components/FrontsListContainer.ts
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 import { match, withRouter, RouteComponentProps } from 'react-router';
-import { createSelectFrontIdAndOpenStateByPriority } from 'bundles/frontsUIBundle';
+import {
+  createSelectFrontIdAndOpenStateByPriority,
+  selectEditorFaveFrontIdsByPriority
+} from 'bundles/frontsUIBundle';
 import { State } from '../types/State';
 import FrontList from './FrontList';
 
@@ -15,8 +18,11 @@ const mapStateToProps = () => {
       fronts: selectFrontIdAndOpenState(
         state,
         props.match.params.priority || ''
+      ),
+      favouriteFronts: selectEditorFaveFrontIdsByPriority(
+        state,
+        props.match.params.priority || ''
       )
-      // favouriteFronts: // write selector getFaveFrontsWithPriority
     };
   };
 };

--- a/client-v2/src/components/FrontsListContainer.ts
+++ b/client-v2/src/components/FrontsListContainer.ts
@@ -1,9 +1,6 @@
 import { connect } from 'react-redux';
 import { match, withRouter, RouteComponentProps } from 'react-router';
-import {
-  createSelectFrontIdAndOpenStateByPriority,
-  selectEditorFaveFrontIdsByPriority
-} from 'bundles/frontsUIBundle';
+import { createSelectFrontIdWithOpenAndStarredStatesByPriority } from 'bundles/frontsUIBundle';
 import { State } from '../types/State';
 import FrontList from './FrontList';
 
@@ -12,14 +9,10 @@ type Props = {
 } & RouteComponentProps<any>;
 
 const mapStateToProps = () => {
-  const selectFrontIdAndOpenState = createSelectFrontIdAndOpenStateByPriority();
+  const selectFrontIdWithOpenAndStarredStates = createSelectFrontIdWithOpenAndStarredStatesByPriority();
   return (state: State, props: Props) => {
     return {
-      fronts: selectFrontIdAndOpenState(
-        state,
-        props.match.params.priority || ''
-      ),
-      favouriteFronts: selectEditorFaveFrontIdsByPriority(
+      fronts: selectFrontIdWithOpenAndStarredStates(
         state,
         props.match.params.priority || ''
       )

--- a/client-v2/src/components/util/TextHighlighter.tsx
+++ b/client-v2/src/components/util/TextHighlighter.tsx
@@ -7,7 +7,7 @@ const Muted = styled('span')`
 
 interface IProps {
   originalString: string;
-  searchString: string;
+  searchString?: string;
 }
 
 /**

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -655,9 +655,9 @@ const state = {
   clipboard: ['56a3b407-741c-439f-a678-175abea44a9f'],
   editor: {
     showOpenFrontsMenu: false,
-    frontIds: ['sc-johnson-partner-zone'],
+    frontIds: [],
     frontIdsByPriority: {},
-    faveFrontIds: [],
+    faveFrontIdsByPriority: {},
     collectionIds: [],
     selectedArticleFragments: {},
     closedOverviews: [],

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -249,6 +249,7 @@ const state = {
     ],
     frontIds: [],
     frontIdsByPriority: {},
+    faveFrontIdsByPriority: {},
     capiLiveUrl: 'https://fronts.local.dev-gutools.co.uk/api/live/',
     capiPreviewUrl: 'https://fronts.local.dev-gutools.co.uk/api/preview/'
   },

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -657,6 +657,7 @@ const state = {
     showOpenFrontsMenu: false,
     frontIds: ['sc-johnson-partner-zone'],
     frontIdsByPriority: {},
+    faveFrontIds: [],
     collectionIds: [],
     selectedArticleFragments: {},
     closedOverviews: [],

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -249,7 +249,7 @@ const state = {
     ],
     frontIds: [],
     frontIdsByPriority: {},
-    faveFrontIdsByPriority: {},
+    favouriteFrontIdsByPriority: {},
     capiLiveUrl: 'https://fronts.local.dev-gutools.co.uk/api/live/',
     capiPreviewUrl: 'https://fronts.local.dev-gutools.co.uk/api/preview/'
   },
@@ -658,7 +658,7 @@ const state = {
     showOpenFrontsMenu: false,
     frontIds: [],
     frontIdsByPriority: {},
-    faveFrontIdsByPriority: {},
+    favouriteFrontIdsByPriority: {},
     collectionIds: [],
     selectedArticleFragments: {},
     closedOverviews: [],

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -8,7 +8,10 @@ import configureStore from 'util/configureStore';
 import pageConfig from 'util/extractConfigFromPage';
 import App from 'components/App';
 import { configReceived } from 'actions/Config';
-import { editorSetOpenFronts } from 'bundles/frontsUIBundle';
+import {
+  editorSetOpenFronts,
+  editorSetFaveFronts
+} from 'bundles/frontsUIBundle';
 import { storeClipboardContent } from 'actions/Clipboard';
 import { Dispatch } from 'types/Store';
 import Modal from 'react-modal';
@@ -37,6 +40,9 @@ if (pageConfig.env.toUpperCase() !== 'DEV' && pageConfig.sentryPublicDSN) {
 store.dispatch(configReceived(pageConfig));
 if (pageConfig.frontIdsByPriority) {
   store.dispatch(editorSetOpenFronts(pageConfig.frontIdsByPriority));
+}
+if (pageConfig.faveFrontIdsByPriority) {
+  store.dispatch(editorSetFaveFronts(pageConfig.faveFrontIdsByPriority));
 }
 
 (store.dispatch as Dispatch)(

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -10,7 +10,7 @@ import App from 'components/App';
 import { configReceived } from 'actions/Config';
 import {
   editorSetOpenFronts,
-  editorSetFaveFronts
+  editorSetFavouriteFronts
 } from 'bundles/frontsUIBundle';
 import { storeClipboardContent } from 'actions/Clipboard';
 import { Dispatch } from 'types/Store';
@@ -41,8 +41,10 @@ store.dispatch(configReceived(pageConfig));
 if (pageConfig.frontIdsByPriority) {
   store.dispatch(editorSetOpenFronts(pageConfig.frontIdsByPriority));
 }
-if (pageConfig.faveFrontIdsByPriority) {
-  store.dispatch(editorSetFaveFronts(pageConfig.faveFrontIdsByPriority));
+if (pageConfig.favouriteFrontIdsByPriority) {
+  store.dispatch(
+    editorSetFavouriteFronts(pageConfig.favouriteFrontIdsByPriority)
+  );
 }
 
 (store.dispatch as Dispatch)(

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -209,6 +209,27 @@ async function saveOpenFrontIds(frontsByPriority?: {
   }
 }
 
+async function saveFaveFrontIds(faveFrontsByPriority?: {
+  [priority: string]: string[];
+}): Promise<void> {
+  try {
+    await pandaFetch(`/userdata/faveFrontIdsByPriority`, {
+      method: 'put',
+      credentials: 'same-origin',
+      body: JSON.stringify(faveFrontsByPriority),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (response) {
+    throw new Error(
+      `Tried to store the favourite fronts configuration but the server responded with ${
+        response.status
+      }: ${response.body}`
+    );
+  }
+}
+
 async function getCollection(collectionId: {
   id: string;
   lastUpdated?: number;
@@ -341,6 +362,7 @@ export {
   updateCollection,
   saveClipboard,
   saveOpenFrontIds,
+  saveFaveFrontIds,
   getCapiUriForContentIds,
   fetchVisibleArticles,
   discardDraftChangesToCollection

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -209,14 +209,14 @@ async function saveOpenFrontIds(frontsByPriority?: {
   }
 }
 
-async function saveFaveFrontIds(faveFrontsByPriority?: {
+async function saveFavouriteFrontIds(favouriteFrontsByPriority?: {
   [priority: string]: string[];
 }): Promise<void> {
   try {
-    await pandaFetch(`/userdata/faveFrontIdsByPriority`, {
+    await pandaFetch(`/userdata/favouriteFrontIdsByPriority`, {
       method: 'put',
       credentials: 'same-origin',
-      body: JSON.stringify(faveFrontsByPriority),
+      body: JSON.stringify(favouriteFrontsByPriority),
       headers: {
         'Content-Type': 'application/json'
       }
@@ -362,7 +362,7 @@ export {
   updateCollection,
   saveClipboard,
   saveOpenFrontIds,
-  saveFaveFrontIds,
+  saveFavouriteFrontIds,
   getCapiUriForContentIds,
   fetchVisibleArticles,
   discardDraftChangesToCollection

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -36,6 +36,34 @@ const DownCaretIcon = ({ fill, size = 'm', title = null }: IconProps) => (
   </svg>
 );
 
+const StarIcon = ({
+  fill = theme.colors.white,
+  outline = theme.colors.white,
+  size = 'm',
+  title = null
+}: IconProps & { outline?: string }) => (
+  <svg
+    className="star-icon"
+    width={mapSize(size)}
+    height={mapSize(size)}
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    <title>{title}</title>
+    <path
+      className="fill"
+      fill={fill}
+      d="M12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28z"
+    />
+    <path
+      className="outline"
+      fill={outline}
+      d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"
+    />
+  </svg>
+);
+
 const RubbishBinIcon = ({
   fill = theme.colors.white,
   size = 'm',
@@ -180,5 +208,6 @@ export {
   ClearIcon, // tapered x
   LockedPadlockIcon,
   MagnifyingGlassIcon,
-  AddImageIcon
+  AddImageIcon,
+  StarIcon
 };

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -71,11 +71,10 @@ interface EditorStarFront {
   meta: PersistMeta;
 }
 
-// TODO persistence
 interface EditorUnstarFront {
   type: typeof EDITOR_UNSTAR_FRONT;
   payload: { frontId: string; priority: string };
-  // meta: PersistMeta;
+  meta: PersistMeta;
 }
 
 interface EditorSetFaveFronts {

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -22,6 +22,8 @@ import {
   EDITOR_OPEN_FRONT,
   EDITOR_MOVE_FRONT,
   EDITOR_CLOSE_FRONT,
+  EDITOR_STAR_FRONT,
+  EDITOR_UNSTAR_FRONT,
   EDITOR_OPEN_COLLECTION,
   EDITOR_CLOSE_COLLECTION,
   EDITOR_CLEAR_OPEN_FRONTS,
@@ -61,6 +63,20 @@ interface EditorCloseFront {
   payload: { frontId: string };
   meta: PersistMeta;
 }
+
+//TODO persistence
+interface EditorStarFront {
+  type: typeof EDITOR_STAR_FRONT;
+  payload: { frontId: string };
+  // meta: PersistMeta;
+}
+
+interface EditorUnstarFront {
+  type: typeof EDITOR_UNSTAR_FRONT;
+  payload: { frontId: string };
+  // meta: PersistMeta;
+}
+
 interface EditorOpenCollection {
   type: typeof EDITOR_OPEN_COLLECTION;
   payload: { collectionIds: string | string[] };
@@ -269,6 +285,8 @@ type Action =
   | EditorClearOpenFronts
   | EditorSetOpenFronts
   | EditorCloseFront
+  | EditorStarFront
+  | EditorUnstarFront
   | EditorSelectArticleFragment
   | EditorClearArticleFragmentSelection
   | EditorOpenClipboard
@@ -314,6 +332,8 @@ export {
   EditorClearOpenFronts,
   EditorSetOpenFronts,
   EditorCloseFront,
+  EditorStarFront,
+  EditorUnstarFront,
   EditorOpenCollection,
   EditorCloseCollection,
   EditorSelectArticleFragment,

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -22,8 +22,8 @@ import {
   EDITOR_OPEN_FRONT,
   EDITOR_MOVE_FRONT,
   EDITOR_CLOSE_FRONT,
-  EDITOR_STAR_FRONT,
-  EDITOR_UNSTAR_FRONT,
+  EDITOR_FAVOURITE_FRONT,
+  EDITOR_UNFAVOURITE_FRONT,
   EDITOR_SET_OPEN_FRONTS,
   EDITOR_SET_FAVE_FRONTS,
   EDITOR_OPEN_COLLECTION,
@@ -65,21 +65,21 @@ interface EditorCloseFront {
   meta: PersistMeta;
 }
 
-interface EditorStarFront {
-  type: typeof EDITOR_STAR_FRONT;
+interface EditorFavouriteFront {
+  type: typeof EDITOR_FAVOURITE_FRONT;
   payload: { frontId: string; priority: string };
   meta: PersistMeta;
 }
 
-interface EditorUnstarFront {
-  type: typeof EDITOR_UNSTAR_FRONT;
+interface EditorUnfavouriteFront {
+  type: typeof EDITOR_UNFAVOURITE_FRONT;
   payload: { frontId: string; priority: string };
   meta: PersistMeta;
 }
 
-interface EditorSetFaveFronts {
+interface EditorSetFavouriteFronts {
   type: typeof EDITOR_SET_FAVE_FRONTS;
-  payload: { faveFrontIdsByPriority: { [id: string]: string[] } };
+  payload: { favouriteFrontIdsByPriority: { [id: string]: string[] } };
 }
 
 interface EditorOpenCollection {
@@ -290,9 +290,9 @@ type Action =
   | EditorClearOpenFronts
   | EditorSetOpenFronts
   | EditorCloseFront
-  | EditorStarFront
-  | EditorUnstarFront
-  | EditorSetFaveFronts
+  | EditorFavouriteFront
+  | EditorUnfavouriteFront
+  | EditorSetFavouriteFronts
   | EditorSelectArticleFragment
   | EditorClearArticleFragmentSelection
   | EditorOpenClipboard
@@ -338,9 +338,9 @@ export {
   EditorClearOpenFronts,
   EditorSetOpenFronts,
   EditorCloseFront,
-  EditorStarFront,
-  EditorUnstarFront,
-  EditorSetFaveFronts,
+  EditorFavouriteFront,
+  EditorUnfavouriteFront,
+  EditorSetFavouriteFronts,
   EditorOpenCollection,
   EditorCloseCollection,
   EditorSelectArticleFragment,

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -67,13 +67,13 @@ interface EditorCloseFront {
 //TODO persistence
 interface EditorStarFront {
   type: typeof EDITOR_STAR_FRONT;
-  payload: { frontId: string };
+  payload: { frontId: string; priority: string };
   // meta: PersistMeta;
 }
 
 interface EditorUnstarFront {
   type: typeof EDITOR_UNSTAR_FRONT;
-  payload: { frontId: string };
+  payload: { frontId: string; priority: string };
   // meta: PersistMeta;
 }
 

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -24,10 +24,11 @@ import {
   EDITOR_CLOSE_FRONT,
   EDITOR_STAR_FRONT,
   EDITOR_UNSTAR_FRONT,
+  EDITOR_SET_OPEN_FRONTS,
+  EDITOR_SET_FAVE_FRONTS,
   EDITOR_OPEN_COLLECTION,
   EDITOR_CLOSE_COLLECTION,
   EDITOR_CLEAR_OPEN_FRONTS,
-  EDITOR_SET_OPEN_FRONTS,
   EDITOR_SELECT_ARTICLE_FRAGMENT,
   EDITOR_CLEAR_ARTICLE_FRAGMENT_SELECTION,
   EDITOR_OPEN_CLIPBOARD,
@@ -64,17 +65,22 @@ interface EditorCloseFront {
   meta: PersistMeta;
 }
 
-//TODO persistence
 interface EditorStarFront {
   type: typeof EDITOR_STAR_FRONT;
   payload: { frontId: string; priority: string };
-  // meta: PersistMeta;
+  meta: PersistMeta;
 }
 
+// TODO persistence
 interface EditorUnstarFront {
   type: typeof EDITOR_UNSTAR_FRONT;
   payload: { frontId: string; priority: string };
   // meta: PersistMeta;
+}
+
+interface EditorSetFaveFronts {
+  type: typeof EDITOR_SET_FAVE_FRONTS;
+  payload: { faveFrontIdsByPriority: { [id: string]: string[] } };
 }
 
 interface EditorOpenCollection {
@@ -287,6 +293,7 @@ type Action =
   | EditorCloseFront
   | EditorStarFront
   | EditorUnstarFront
+  | EditorSetFaveFronts
   | EditorSelectArticleFragment
   | EditorClearArticleFragmentSelection
   | EditorOpenClipboard
@@ -334,6 +341,7 @@ export {
   EditorCloseFront,
   EditorStarFront,
   EditorUnstarFront,
+  EditorSetFaveFronts,
   EditorOpenCollection,
   EditorCloseCollection,
   EditorSelectArticleFragment,

--- a/client-v2/src/types/Config.ts
+++ b/client-v2/src/types/Config.ts
@@ -38,7 +38,7 @@ interface Config {
   frontIdsByPriority: {
     [id: string]: string[];
   };
-  faveFrontIdsByPriority: {
+  favouriteFrontIdsByPriority: {
     [id: string]: string[];
   };
   clipboardArticles: NestedArticleFragment[];

--- a/client-v2/src/types/Config.ts
+++ b/client-v2/src/types/Config.ts
@@ -38,6 +38,9 @@ interface Config {
   frontIdsByPriority: {
     [id: string]: string[];
   };
+  faveFrontIdsByPriority: {
+    [id: string]: string[];
+  };
   clipboardArticles: NestedArticleFragment[];
 }
 

--- a/client-v2/src/util/__tests__/storeMiddleware.spec.ts
+++ b/client-v2/src/util/__tests__/storeMiddleware.spec.ts
@@ -5,7 +5,7 @@ import config from 'fixtures/config';
 import {
   persistCollectionOnEdit,
   persistOpenFrontsOnEdit,
-  persistFaveFrontsOnEdit
+  persistFavouriteFrontsOnEdit
 } from '../storeMiddleware';
 import { Collection } from 'shared/types/Collection';
 
@@ -133,13 +133,13 @@ describe('Store middleware', () => {
     });
   });
 
-  describe('persistFaveFrontsOnEdit', () => {
-    let persistFaveFrontIdsSpy: any;
+  describe('persistFavouriteFrontsOnEdit', () => {
+    let persistFavouriteFrontIdsSpy: any;
     beforeEach(() => {
-      persistFaveFrontIdsSpy = jest.fn();
+      persistFavouriteFrontIdsSpy = jest.fn();
       mockStore = configureStore([
         thunk,
-        persistFaveFrontsOnEdit(persistFaveFrontIdsSpy)
+        persistFavouriteFrontsOnEdit(persistFavouriteFrontIdsSpy)
       ]);
     });
     it('should do nothing for actions without the correct persistTo property in the action meta', () => {
@@ -147,20 +147,22 @@ describe('Store middleware', () => {
       store.dispatch({
         type: 'ARBITRARY_ACTION'
       });
-      expect(persistFaveFrontIdsSpy.mock.calls.length).toBe(0);
+      expect(persistFavouriteFrontIdsSpy.mock.calls.length).toBe(0);
     });
     it("should call the persist function with the state's fave front ids if it receives an action with the correct persistTo property", () => {
       const store = mockStore({
-        editor: { faveFrontIdsByPriority: { editorial: ['front1', 'front2'] } }
+        editor: {
+          favouriteFrontIdsByPriority: { editorial: ['front1', 'front2'] }
+        }
       });
       store.dispatch({
         type: 'ARBITRARY_ACTION',
         meta: {
-          persistTo: 'faveFrontIds'
+          persistTo: 'favouriteFrontIds'
         }
       });
-      expect(persistFaveFrontIdsSpy.mock.calls.length).toBe(1);
-      expect(persistFaveFrontIdsSpy.mock.calls[0][0]).toEqual({
+      expect(persistFavouriteFrontIdsSpy.mock.calls.length).toBe(1);
+      expect(persistFavouriteFrontIdsSpy.mock.calls[0][0]).toEqual({
         editorial: ['front1', 'front2']
       });
     });

--- a/client-v2/src/util/__tests__/storeMiddleware.spec.ts
+++ b/client-v2/src/util/__tests__/storeMiddleware.spec.ts
@@ -149,7 +149,7 @@ describe('Store middleware', () => {
       });
       expect(persistFaveFrontIdsSpy.mock.calls.length).toBe(0);
     });
-    it("should call the persist function with the state's fave front ids if it receives an action the correct persistTo property", () => {
+    it("should call the persist function with the state's fave front ids if it receives an action with the correct persistTo property", () => {
       const store = mockStore({
         editor: { faveFrontIdsByPriority: { editorial: ['front1', 'front2'] } }
       });

--- a/client-v2/src/util/__tests__/storeMiddleware.spec.ts
+++ b/client-v2/src/util/__tests__/storeMiddleware.spec.ts
@@ -4,7 +4,8 @@ import { stateWithCollection } from 'shared/fixtures/shared';
 import config from 'fixtures/config';
 import {
   persistCollectionOnEdit,
-  persistOpenFrontsOnEdit
+  persistOpenFrontsOnEdit,
+  persistFaveFrontsOnEdit
 } from '../storeMiddleware';
 import { Collection } from 'shared/types/Collection';
 
@@ -61,6 +62,7 @@ describe('Store middleware', () => {
       );
     });
   });
+
   describe('persistOpenFrontsOnEdit', () => {
     let persistFrontIdsSpy: any;
     beforeEach(() => {
@@ -126,6 +128,39 @@ describe('Store middleware', () => {
       });
       expect(persistFrontIdsSpy.mock.calls.length).toBe(1);
       expect(persistFrontIdsSpy.mock.calls[0][0]).toEqual({
+        editorial: ['front1', 'front2']
+      });
+    });
+  });
+
+  describe('persistFaveFrontsOnEdit', () => {
+    let persistFaveFrontIdsSpy: any;
+    beforeEach(() => {
+      persistFaveFrontIdsSpy = jest.fn();
+      mockStore = configureStore([
+        thunk,
+        persistFaveFrontsOnEdit(persistFaveFrontIdsSpy)
+      ]);
+    });
+    it('should do nothing for actions without the correct persistTo property in the action meta', () => {
+      const store = mockStore();
+      store.dispatch({
+        type: 'ARBITRARY_ACTION'
+      });
+      expect(persistFaveFrontIdsSpy.mock.calls.length).toBe(0);
+    });
+    it("should call the persist function with the state's fave front ids if it receives an action the correct persistTo property", () => {
+      const store = mockStore({
+        editor: { faveFrontIdsByPriority: { editorial: ['front1', 'front2'] } }
+      });
+      store.dispatch({
+        type: 'ARBITRARY_ACTION',
+        meta: {
+          persistTo: 'faveFrontIds'
+        }
+      });
+      expect(persistFaveFrontIdsSpy.mock.calls.length).toBe(1);
+      expect(persistFaveFrontIdsSpy.mock.calls[0][0]).toEqual({
         editorial: ['front1', 'front2']
       });
     });

--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -9,7 +9,8 @@ import {
   updateStateFromUrlChange,
   persistCollectionOnEdit,
   persistClipboardOnEdit,
-  persistOpenFrontsOnEdit
+  persistOpenFrontsOnEdit,
+  persistFaveFrontsOnEdit
 } from './storeMiddleware';
 import { State } from 'types/State';
 
@@ -24,7 +25,8 @@ export default function configureStore(initialState?: State) {
       router,
       persistCollectionOnEdit(),
       persistClipboardOnEdit(),
-      persistOpenFrontsOnEdit()
+      persistOpenFrontsOnEdit(),
+      persistFaveFrontsOnEdit()
     ),
     window.devToolsExtension ? window.devToolsExtension() : (f: unknown) => f
   );

--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -10,7 +10,7 @@ import {
   persistCollectionOnEdit,
   persistClipboardOnEdit,
   persistOpenFrontsOnEdit,
-  persistFaveFrontsOnEdit
+  persistFavouriteFrontsOnEdit
 } from './storeMiddleware';
 import { State } from 'types/State';
 
@@ -26,7 +26,7 @@ export default function configureStore(initialState?: State) {
       persistCollectionOnEdit(),
       persistClipboardOnEdit(),
       persistOpenFrontsOnEdit(),
-      persistFaveFrontsOnEdit()
+      persistFavouriteFrontsOnEdit()
     ),
     window.devToolsExtension ? window.devToolsExtension() : (f: unknown) => f
   );

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -9,13 +9,13 @@ import { selectors } from 'shared/bundles/collectionsBundle';
 import { updateCollection } from 'actions/Collections';
 import { updateClipboard } from 'actions/Clipboard';
 import { selectSharedState } from 'shared/selectors/shared';
-import { saveOpenFrontIds, saveFaveFrontIds } from 'services/faciaApi';
+import { saveOpenFrontIds, saveFavouriteFrontIds } from 'services/faciaApi';
 import { NestedArticleFragment } from 'shared/types/Collection';
 import { denormaliseClipboard } from 'util/clipboardUtils';
 import { getFront } from 'selectors/frontsSelectors';
 import {
   selectEditorFrontIds,
-  selectEditorFaveFrontIds
+  selectEditorFavouriteFrontIds
 } from 'bundles/frontsUIBundle';
 
 const updateStateFromUrlChange: Middleware<{}, State, Dispatch> = ({
@@ -46,7 +46,7 @@ const updateStateFromUrlChange: Middleware<{}, State, Dispatch> = ({
 
 interface PersistMeta {
   // The resource to persist the data to
-  persistTo: 'collection' | 'clipboard' | 'openFrontIds' | 'faveFrontIds';
+  persistTo: 'collection' | 'clipboard' | 'openFrontIds' | 'favouriteFrontIds';
   // The id to to search for in this resource
   id?: string;
   // The key to take from the action payload if it is not specified. Defaults to
@@ -221,12 +221,12 @@ const persistOpenFrontsOnEdit: (
   return result;
 };
 
-const persistFaveFrontsOnEdit: (
+const persistFavouriteFrontsOnEdit: (
   persistFn?: (
     persistFrontIds?: { [priority: string]: string[] }
   ) => Promise<void>
 ) => Middleware<{}, State, Dispatch> = (
-  persistFrontIds = saveFaveFrontIds
+  persistFrontIds = saveFavouriteFrontIds
 ) => store => next => (action: Action) => {
   const actions = unwrapBatchedActions(action);
 
@@ -234,16 +234,17 @@ const persistFaveFrontsOnEdit: (
     !actions.some(
       act =>
         (act as Action & ActionPersistMeta).meta &&
-        (act as Action & ActionPersistMeta).meta.persistTo === 'faveFrontIds'
+        (act as Action & ActionPersistMeta).meta.persistTo ===
+          'favouriteFrontIds'
     )
   ) {
     return next(action);
   }
   const result = next(action);
   const state = store.getState();
-  const faveFrontIdsByPriority = selectEditorFaveFrontIds(state);
+  const favouriteFrontIdsByPriority = selectEditorFavouriteFrontIds(state);
 
-  persistFrontIds(faveFrontIdsByPriority);
+  persistFrontIds(favouriteFrontIdsByPriority);
   return result;
 };
 
@@ -252,7 +253,7 @@ export {
   persistCollectionOnEdit,
   persistClipboardOnEdit,
   persistOpenFrontsOnEdit,
-  persistFaveFrontsOnEdit,
+  persistFavouriteFrontsOnEdit,
   updateStateFromUrlChange,
   addPersistMetaToAction
 };

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -221,11 +221,6 @@ const persistOpenFrontsOnEdit: (
   return result;
 };
 
-// Dispatch payload
-// const noOpMiddleware = persistFrontIds/faciaApiCall => store => next => action => {
-//   return next(action)
-// }
-
 const persistFaveFrontsOnEdit: (
   persistFn?: (
     persistFrontIds?: { [priority: string]: string[] }

--- a/conf/routes
+++ b/conf/routes
@@ -57,7 +57,7 @@ POST        /treats/*collectionId                    controllers.FaciaToolContro
 PUT        /userdata/clipboard                       controllers.UserDataController.putClipboardContent()
 PUT        /userdata/frontIds                        controllers.UserDataController.putFrontIds()
 PUT        /userdata/frontIdsByPriority              controllers.UserDataController.putFrontIdsByPriority()
-PUT        /userdata/faveFrontIdsByPriority          controllers.UserDataController.putFaveFrontIdsByPriority()
+PUT        /userdata/favouriteFrontIdsByPriority     controllers.UserDataController.putFavouriteFrontIdsByPriority()
 # For temporary internal use -- migrates user data to a new format
 PUT        /userdata/migrate                         controllers.UserDataController.migrateUserData()
 

--- a/conf/routes
+++ b/conf/routes
@@ -57,6 +57,7 @@ POST        /treats/*collectionId                    controllers.FaciaToolContro
 PUT        /userdata/clipboard                       controllers.UserDataController.putClipboardContent()
 PUT        /userdata/frontIds                        controllers.UserDataController.putFrontIds()
 PUT        /userdata/frontIdsByPriority              controllers.UserDataController.putFrontIdsByPriority()
+PUT        /userdata/faveFrontIdsByPriority          controllers.UserDataController.putFaveFrontIdsByPriority()
 # For temporary internal use -- migrates user data to a new format
 PUT        /userdata/migrate                         controllers.UserDataController.migrateUserData()
 


### PR DESCRIPTION
## What's changed?

Gives power users the option to star favourite fronts in the Fronts Menu for easy access. Their list of favourite fronts is persisted across sessions.

## Implementation notes

I've copied the implementation for persisting a user's open front and so added a new route to the backend to handle this update.


![Kapture 2019-03-25 at 14 44 01](https://user-images.githubusercontent.com/32312712/54928958-b1a39380-4f0c-11e9-8b04-9ed4ef8d7f9f.gif)


## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
