### PR TITLE
Reorder form fields as requested by newsdesk

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -205,55 +205,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           <InputGroup>
             <ConditionalField
               permittedFields={editableFields}
-              name="headline"
-              label="Headline"
-              placeholder={articleCapiFieldValues.headline}
-              component={InputTextArea}
-              useHeadlineFont
-              rows="2"
-            />
-            <ConditionalField
-              permittedFields={editableFields}
-              name="isBoosted"
-              component={InputCheckboxToggle}
-              label="Boost"
-              id={getInputId(articleFragmentId, 'boost')}
-              type="checkbox"
-            />
-            <ConditionalField
-              permittedFields={editableFields}
-              name="showQuotedHeadline"
-              component={InputCheckboxToggle}
-              label="Quote headline"
-              id={getInputId(articleFragmentId, 'quote-headline')}
-              type="checkbox"
-            />
-            <ConditionalField
-              permittedFields={editableFields}
-              name="showBoostedHeadline"
-              component={InputCheckboxToggle}
-              label="Large headline"
-              id={getInputId(articleFragmentId, 'large-headline')}
-              type="checkbox"
-            />
-            <ConditionalField
-              permittedFields={editableFields}
-              name="showLivePlayable"
-              component={InputCheckboxToggle}
-              label="Show updates"
-              id={getInputId(articleFragmentId, 'show-updates')}
-              type="checkbox"
-            />
-            <ConditionalField
-              permittedFields={editableFields}
-              name="showMainVideo"
-              component={InputCheckboxToggle}
-              label="Show video"
-              id={getInputId(articleFragmentId, 'show-video')}
-              type="checkbox"
-            />
-            <ConditionalField
-              permittedFields={editableFields}
               name="customKicker"
               label="Kicker"
               component={InputText}
@@ -320,6 +271,46 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             </ConditionalComponent>
             <ConditionalField
               permittedFields={editableFields}
+              name="headline"
+              label="Headline"
+              placeholder={articleCapiFieldValues.headline}
+              component={InputTextArea}
+              useHeadlineFont
+              rows="2"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="trailText"
+              label="Trail text"
+              component={InputTextArea}
+              placeholder={articleCapiFieldValues.trailText}
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="isBoosted"
+              component={InputCheckboxToggle}
+              label="Boost"
+              id={getInputId(articleFragmentId, 'boost')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showQuotedHeadline"
+              component={InputCheckboxToggle}
+              label="Quote headline"
+              id={getInputId(articleFragmentId, 'quote-headline')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showBoostedHeadline"
+              component={InputCheckboxToggle}
+              label="Large headline"
+              id={getInputId(articleFragmentId, 'large-headline')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
               name="isBreaking"
               component={InputCheckboxToggle}
               label="Breaking News"
@@ -346,10 +337,19 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             )}
             <ConditionalField
               permittedFields={editableFields}
-              name="trailText"
-              label="Trail text"
-              component={InputTextArea}
-              placeholder={articleCapiFieldValues.trailText}
+              name="showLivePlayable"
+              component={InputCheckboxToggle}
+              label="Show updates"
+              id={getInputId(articleFragmentId, 'show-updates')}
+              type="checkbox"
+            />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="showMainVideo"
+              component={InputCheckboxToggle}
+              label="Show video"
+              id={getInputId(articleFragmentId, 'show-video')}
+              type="checkbox"
             />
           </InputGroup>
           <RowContainer>


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Network front editors asked the fields on the edit form to be reorderd: https://trello.com/c/t5ZxKaRt/481-change-order-of-the-edit-panel-to-kicker-headline-trail-boost-quote-large-headline-breaking-news-show-byline
![Screenshot 2019-03-26 at 08 37 33](https://user-images.githubusercontent.com/3066534/54982403-ad29ba00-4fa2-11e9-846b-fea46be1fd5e.png)

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
