### PR TITLE
Display front publication time on sublinks

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -186,7 +186,7 @@ const articleBodyDefault = ({
           </CollectionItemDraftMetaContent>
         )}
 
-        {size === 'default' && frontPublicationTime && (
+        {frontPublicationTime && (
           <CollectionItemMetaContent>
             {distanceInWordsStrict(Date.now(), new Date(frontPublicationTime))}
           </CollectionItemMetaContent>


### PR DESCRIPTION

## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Display same dates on sublinks as we display on main articles as requested by Mariana. 

![Screenshot 2019-03-27 at 09 49 02](https://user-images.githubusercontent.com/3066534/55066495-d23b2d00-5075-11e9-8187-699f58e3248d.png)

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
