### PR TITLE
Style search input field with Text Sans

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -69,6 +69,7 @@ const FrontsMenuSearchInput = styled('input')`
   padding-right: 20px;
   border: 0;
   color: white;
+  font-family: TS3TextSans;
   font-size: 16px;
   :active,
   :focus {


### PR DESCRIPTION
No idea if that’s a correct way/place to do this. I would rather style all sans-serif to be Text Sans (there shouldn’t be any system fonts as they are unpredictable), but don’t know how/where. Feel free to nuke this momentous contribution of mine!

![search input](https://user-images.githubusercontent.com/6032869/55071239-f4d24380-507f-11e9-8e29-da4454d6a4ca.gif)
