### PR TITLE
Add first publication date

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -79,6 +79,10 @@ const SlideshowIcon = styled('div')`
   height: 14px;
 `;
 
+const FirstPublicationDate = styled(CollectionItemMetaContent)`
+  color: ${({ theme }) => theme.shared.colors.green};
+`;
+
 interface ArticleBodyProps {
   frontPublicationTime?: string;
   firstPublicationDate?: string;
@@ -145,12 +149,11 @@ const articleBodyDefault = ({
 }: ArticleBodyProps) => {
   const ArticleHeadingContainer =
     size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
-
   const displayByline = size === 'default' && showByline && byline;
   const displayTrail =
     size === 'default' && trailText && !(showByline && byline);
-
   const kickerToDisplay = isBreaking ? 'Breaking news' : kicker;
+  const now = Date.now();
 
   return (
     <>
@@ -178,18 +181,25 @@ const articleBodyDefault = ({
         )}
 
         {scheduledPublicationDate && (
-          <CollectionItemDraftMetaContent>
+          <CollectionItemDraftMetaContent title="The time until this article is scheduled to be published.">
             {distanceInWordsStrict(
               new Date(scheduledPublicationDate),
-              Date.now()
+              now
             )}
           </CollectionItemDraftMetaContent>
         )}
-
         {frontPublicationTime && (
-          <CollectionItemMetaContent>
-            {distanceInWordsStrict(Date.now(), new Date(frontPublicationTime))}
+          <CollectionItemMetaContent title="The time elapsed since this article was added to this front.">
+            {distanceInWordsStrict(now, new Date(frontPublicationTime))}
           </CollectionItemMetaContent>
+        )}
+        {firstPublicationDate && (
+          <FirstPublicationDate title="The time elapsed since this article was first published.">
+            {distanceInWordsStrict(
+              new Date(firstPublicationDate),
+              now
+            )}
+          </FirstPublicationDate>
         )}
       </CollectionItemMetaContainer>
       <CollectionItemContent displaySize={size}>
@@ -282,7 +292,6 @@ const articleBodyDefault = ({
           toolTipPosition={'top'}
           toolTipAlign={'right'}
         />
-        <HideMetaDataOnToolTipDisplay size={size} />
       </HoverActionsAreaOverlay>
     </>
   );

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -20,10 +20,7 @@ import {
   HoverDeleteButton,
   HoverAddToClipboardButton
 } from '../input/HoverActionButtons';
-import {
-  HoverActionsAreaOverlay,
-  HideMetaDataOnToolTipDisplay
-} from '../CollectionHoverItems';
+import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import { CollectionItemSizes } from 'shared/types/Collection';
 import CollectionItemTrail from '../collectionItem/CollectionItemTrail';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
@@ -182,10 +179,7 @@ const articleBodyDefault = ({
 
         {scheduledPublicationDate && (
           <CollectionItemDraftMetaContent title="The time until this article is scheduled to be published.">
-            {distanceInWordsStrict(
-              new Date(scheduledPublicationDate),
-              now
-            )}
+            {distanceInWordsStrict(new Date(scheduledPublicationDate), now)}
           </CollectionItemDraftMetaContent>
         )}
         {frontPublicationTime && (
@@ -193,12 +187,9 @@ const articleBodyDefault = ({
             {distanceInWordsStrict(now, new Date(frontPublicationTime))}
           </CollectionItemMetaContent>
         )}
-        {firstPublicationDate && (
+        {size === 'default' && firstPublicationDate && (
           <FirstPublicationDate title="The time elapsed since this article was first published.">
-            {distanceInWordsStrict(
-              new Date(firstPublicationDate),
-              now
-            )}
+            {distanceInWordsStrict(new Date(firstPublicationDate), now)}
           </FirstPublicationDate>
         )}
       </CollectionItemMetaContainer>

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -10,9 +10,9 @@ import baseStyled, { ThemedStyledInterface } from 'styled-components';
 const colors = {
   blackDark: '#121212', // darkest
   blackLight: '#333',
-  greyDark: '#444444', //
+  greyDark: '#444444',
   greyMediumDark: '#515151',
-  greyMedium: '#767676', //
+  greyMedium: '#767676',
   greyMediumLight: '#999999',
   greyLight: '#A9A9A9',
   greyVeryLight: '#c9c9c9',
@@ -23,7 +23,8 @@ const colors = {
   white: '#FFF', // lightest
   orange: '#FF7F0F',
   orangeLight: '#FD8A2E',
-  orangeDark: '#E05E00'
+  orangeDark: '#E05E00',
+  green: '#4F9245'
 };
 
 const base = {


### PR DESCRIPTION
## What's changed?

The first publication date is now visible on articles, beneath the front publication date.

<img width="585" alt="Screenshot 2019-03-28 at 12 22 45" src="https://user-images.githubusercontent.com/7767575/55157466-582da580-5154-11e9-8e3d-81cfe0301cc1.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
