### PR TITLE
Disable launch/discard when edit form is open

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -121,7 +121,7 @@
     "redux-batched-actions": "^0.4.1",
     "redux-form": "^7.4.2",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1",
+    "reselect": "^4.0.0",
     "sanitize-html": "^1.20.0",
     "styled-components": "^3.2.5",
     "ts-optchain": "^0.1.2",

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -94,6 +94,11 @@ const Collection = ({
               priority="default"
               onClick={() => discardDraftChanges(id)}
               disabled={isEditFormOpen}
+              title={
+                isEditFormOpen
+                  ? 'You cannot discard changes to this collection whilst the edit form is open.'
+                  : undefined
+              }
             >
               Discard
             </Button>
@@ -102,6 +107,11 @@ const Collection = ({
               priority="primary"
               onClick={() => publish(id, frontId)}
               disabled={isEditFormOpen}
+              title={
+                isEditFormOpen
+                  ? 'You cannot launch this collection whilst the edit form is open.'
+                  : undefined
+              }
             >
               Launch
             </Button>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -22,10 +22,12 @@ import {
   selectIsCollectionOpen,
   editorOpenCollections,
   editorCloseCollections,
-  selectHasMultipleFrontsOpen
+  selectHasMultipleFrontsOpen,
+  selectEditorArticleFragment
 } from 'bundles/frontsUIBundle';
 import { getArticlesForCollections } from 'actions/Collections';
 import { collectionItemSets } from 'constants/fronts';
+import { createSelectIsArticleInCollection } from 'shared/selectors/collection';
 
 interface CollectionPropsBeforeState {
   id: string;
@@ -46,6 +48,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   groups: Group[];
   displayEditWarning: boolean;
   isCollectionLocked: boolean;
+  isEditFormOpen: boolean;
   isOpen: boolean;
   hasMultipleFrontsOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
@@ -64,6 +67,7 @@ const Collection = ({
   displayEditWarning,
   isCollectionLocked,
   isOpen,
+  isEditFormOpen,
   onChangeOpenState,
   hasMultipleFrontsOpen,
   discardDraftChangesToCollection: discardDraftChanges
@@ -89,6 +93,7 @@ const Collection = ({
               size="l"
               priority="default"
               onClick={() => discardDraftChanges(id)}
+              disabled={isEditFormOpen}
             >
               Discard
             </Button>
@@ -96,6 +101,7 @@ const Collection = ({
               size="l"
               priority="primary"
               onClick={() => publish(id, frontId)}
+              disabled={isEditFormOpen}
             >
               Launch
             </Button>
@@ -119,24 +125,38 @@ const Collection = ({
 const createMapStateToProps = () => {
   const collectionStageGroupsSelector = createCollectionStageGroupsSelector();
   const editWarningSelector = createCollectionEditWarningSelector();
+  const selectIsArticleInCollection = createSelectIsArticleInCollection();
   return (
     state: State,
-    { browsingStage, id, priority }: CollectionPropsBeforeState
-  ) => ({
-    hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
-      collectionId: id
-    }),
-    isCollectionLocked: isCollectionLockedSelector(state, id),
-    groups: collectionStageGroupsSelector(selectSharedState(state), {
-      collectionSet: browsingStage,
-      collectionId: id
-    }),
-    displayEditWarning: editWarningSelector(selectSharedState(state), {
-      collectionId: id
-    }),
-    isOpen: selectIsCollectionOpen(state, id),
-    hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority)
-  });
+    { browsingStage, id, priority, frontId }: CollectionPropsBeforeState
+  ) => {
+    const selectedArticleFragmentData = selectEditorArticleFragment(
+      state,
+      frontId
+    );
+    return {
+      hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
+        collectionId: id
+      }),
+      isCollectionLocked: isCollectionLockedSelector(state, id),
+      groups: collectionStageGroupsSelector(selectSharedState(state), {
+        collectionSet: browsingStage,
+        collectionId: id
+      }),
+      displayEditWarning: editWarningSelector(selectSharedState(state), {
+        collectionId: id
+      }),
+      isOpen: selectIsCollectionOpen(state, id),
+      isEditFormOpen:
+        !!selectedArticleFragmentData &&
+        selectIsArticleInCollection(state.shared, {
+          collectionId: id,
+          collectionSet: browsingStage,
+          articleFragmentId: selectedArticleFragmentData.id
+        }),
+      hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority)
+    };
+  };
 };
 
 const mapDispatchToProps = (

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -62,7 +62,7 @@ const colorMap = {
 const backgroundMap = {
   disabled: {
     default: theme.colors.greyMediumLight,
-    primary: theme.colors.orangeDark,
+    primary: theme.colors.orangeFaded,
     muted: theme.colors.greyLight
   },
   selected: {

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -24,6 +24,7 @@ const colors = {
   orange: '#FF7F0F',
   orangeLight: '#FD8A2E',
   orangeDark: '#E05E00',
+  orangeFaded: '#D08B5A',
   green: '#4F9245'
 };
 

--- a/client-v2/src/shared/selectors/__tests__/collection.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/collection.spec.ts
@@ -1,4 +1,7 @@
-import { selectArticlesInCollections } from '../collection';
+import {
+  selectArticlesInCollections,
+  createSelectIsArticleInCollection
+} from '../collection';
 import { stateWithCollection } from '../../fixtures/shared';
 
 describe('Collection selectors', () => {
@@ -30,6 +33,27 @@ describe('Collection selectors', () => {
           itemSet: 'draft'
         })
       ).toEqual([]);
+    });
+  });
+  describe('createSelectIsArticleInCollection', () => {
+    const selectIsArticleInCollection = createSelectIsArticleInCollection();
+    it('should return true if the article is within a given collection', () => {
+      expect(
+        selectIsArticleInCollection(stateWithCollection.shared, {
+          collectionId: 'exampleCollection',
+          collectionSet: 'live',
+          articleFragmentId: '95e2bfc0-8999-4e6e-a359-19960967c1e0'
+        })
+      ).toEqual(true);
+    });
+    it("should return false if it's not", () => {
+      expect(
+        selectIsArticleInCollection(stateWithCollection.shared, {
+          collectionId: 'exampleCollection',
+          collectionSet: 'live',
+          articleFragmentId: 'not-a-thing'
+        })
+      ).toEqual(false);
     });
   });
 });

--- a/client-v2/src/shared/selectors/collection.ts
+++ b/client-v2/src/shared/selectors/collection.ts
@@ -27,3 +27,15 @@ export const selectArticlesInCollections = createSelector(
     ),
   articleIds => uniq(flatten(articleIds))
 );
+
+export const createSelectIsArticleInCollection = () => {
+  const articlesInCollectionSelector = createArticlesInCollectionSelector();
+  return createSelector(
+    articlesInCollectionSelector,
+    (
+      _: State,
+      { articleFragmentId: articleId }: { articleFragmentId: string }
+    ) => articleId,
+    (articleIds, articleId) => articleIds.indexOf(articleId) !== -1
+  );
+};

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -669,6 +669,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
+"@babel/runtime-corejs2@^7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz#a0cec2c41717fa415e9c204f32b603d88b1796c2"
+  integrity sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
@@ -806,6 +814,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
   integrity sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==
 
+"@types/react-beautiful-dnd@^10.1.0":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-10.1.1.tgz#7afae39a4247f30c13b8bbb726ccd1b8cda9d4a5"
+  integrity sha512-75XELhEIWKTkyd1GdVZFvS1MtJwDs9tM37BbIat8mevcw+uH5dcJzZiwESHIWAzySHawS48nkKCQk/bEDp13Mw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dates@^17.1.5":
   version "17.1.5"
   resolved "https://registry.yarnpkg.com/@types/react-dates/-/react-dates-17.1.5.tgz#3b293c7334372f15f04beaac02df0041316be2fc"
@@ -868,6 +883,13 @@
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.0.3.tgz#cce5c983d66cc5c3582e7c2f44b274ab635a8acc"
   integrity sha512-NWOAxVQeJxpXuNKgw83Hah0nquiw1nUexM9qY/Hk3a+XhZwgMtaa6GLA9E1TKMT75Odb3/KE/jiBO4enTuEJjQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^2.0.16":
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.16.tgz#2dcb9e396ab385ee19c4af1c9caa469a14cd042f"
+  integrity sha512-FUJEx2BGJPU1qVQoWd9v7wpOwnCPTWhcE4iTaU5prry9SvwiI11lCXOci8Nz9cM/Fuf650l7Skg6nlVeCYjPFA==
   dependencies:
     "@types/react" "*"
 
@@ -3059,6 +3081,11 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
+core-js@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -3149,6 +3176,13 @@ crypto-md5@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-md5/-/crypto-md5-1.0.0.tgz#ccc8da750c753c7edcbabc542967472a384e86bb"
   integrity sha1-zMjadQx1PH7curxUKWdHKjhOhrs=
+
+css-box-model@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.1.1.tgz#c9fd8e7a8b1d59d41d6812fd1765433f671b2ee0"
+  integrity sha512-ZxbuLFeAPEDb0wPbGfT7783Vb00MVAkvOlMKwr0kA2PD5EGxk6P3MAhedvVuyVJCWb54bb+6HQ7pdPYENf8AZw==
+  dependencies:
+    tiny-invariant "^1.0.3"
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -3537,6 +3571,13 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -6613,6 +6654,11 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.2.tgz#6aba5276856d72fb44ead3efab86432f94ba203d"
+  integrity sha512-o7lldN4fs/axqctc03NF+PMhd2veRrWeJ2n2GjEzUPBD4F9rmNg4A+bQCACIzwjHJEXuYv4aFFMaH35KZfHUrw==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -7926,6 +7972,11 @@ querystringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
   integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
 
+raf-schd@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.0.tgz#9855756c5045ff4ed4516e14a47719387c3c907b"
+  integrity sha512-m7zq0JkIrECzw9mO5Zcq6jN4KayE34yoIS9hJoiZNXyOAT06PPA8PrR+WtJIeFW09YjUfNkMMN9lrmAt6BURCA==
+
 raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
@@ -8018,6 +8069,20 @@ react-addons-shallow-compare@^15.6.2:
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
+
+react-beautiful-dnd@^10.1.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-10.1.1.tgz#d753088d77d7632e77cf8a8935fafcffa38f574b"
+  integrity sha512-TdE06Shfp56wm28EzjgC56EEMgGI5PDHejJ2bxuAZvZr8CVsbksklsJC06Hxf0MSL7FHbflL/RpkJck9isuxHg==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.2"
+    css-box-model "^1.1.1"
+    memoize-one "^5.0.1"
+    prop-types "^15.6.1"
+    raf-schd "^4.0.0"
+    react-redux "^5.0.7"
+    redux "^4.0.1"
+    tiny-invariant "^1.0.4"
 
 react-dates@^18.3.1:
   version "18.3.1"
@@ -8157,6 +8222,16 @@ react-testing-library@^5.2.1:
   integrity sha512-Bw52++7uORuIQnL55lK/WQfppqAc9+8yFG4lWUp/kmSOvYDnt8J9oI5fNCfAGSQi9iIhAv9aNsI2G5rtid0nrA==
   dependencies:
     dom-testing-library "^3.12.0"
+
+react-transition-group@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.7.1.tgz#1fe6d54e811e8f9dfd329aa836b39d9cd16587cb"
+  integrity sha512-b0VJTzNRnXxRpCuxng6QJbAzmmrhBn1BZJfPPnHbH2PIo8msdkajqwtfdyGm/OypPXZNfAHKEqeN15wjMXrRJQ==
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react-with-direction@^1.3.0:
   version "1.3.0"
@@ -8340,6 +8415,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -8530,10 +8610,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
-  integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-cwd@^1.0.0:
   version "1.0.0"
@@ -9615,6 +9695,11 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-invariant@^1.0.3, tiny-invariant@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.4.tgz#346b5415fd93cb696b0c4e8a96697ff590f92463"
+  integrity sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==
 
 tmp@0.0.28:
   version "0.0.28"


### PR DESCRIPTION
## What's changed?

Disable launch/discard buttons if the edit form is open. This prevents people from mistakenly launching changes that haven't been saved, or discarding changes and re-saving previous edits over the article meta.

![discard](https://user-images.githubusercontent.com/7767575/55172961-d0a35f00-5172-11e9-871e-7bc54f1221c7.gif)

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
