### PR TITLE
More consistent buttons for kicker options

### DIFF
--- a/client-v2/src/components/ConfirmModal.tsx
+++ b/client-v2/src/components/ConfirmModal.tsx
@@ -66,10 +66,10 @@ const ConfirmModal = ({
     <h1>{title}</h1>
     {description && <p>{description}</p>}
     <Actions>
-      <ButtonDefault size="l" inline pill onClick={onReject}>
+      <ButtonDefault size="l" inline onClick={onReject}>
         Cancel
       </ButtonDefault>
-      <ButtonDefault size="l" inline pill priority="primary" onClick={onAccept}>
+      <ButtonDefault size="l" inline priority="primary" onClick={onAccept}>
         Proceed
       </ButtonDefault>
     </Actions>

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -239,6 +239,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   component={InputButton}
                   buttonText={kickerOptions.webTitle}
                   selected={showKickerTag}
+                  size="s"
                   onClick={() => {
                     if (!showKickerTag) {
                       change('showKickerTag', true);
@@ -249,13 +250,14 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     }
                   }}
                 />
-              )}
+              )}{' '}
               {kickerOptions.sectionName && (
                 <Field
                   permittedFields={editableFields}
                   name="showKickerSection"
                   component={InputButton}
                   selected={showKickerSection}
+                  size="s"
                   buttonText={kickerOptions.sectionName}
                   onClick={() => {
                     if (!showKickerSection) {

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -17,7 +17,6 @@ interface ButtonProps {
   selected?: boolean;
   priority?: ButtonPriorities;
   size?: ButtonSizes;
-  pill?: boolean;
   dark?: boolean;
   inline?: boolean;
   disabled?: boolean;
@@ -125,7 +124,6 @@ export default styled(`button`)`
   display: inline-block;
   appearance: none;
   background: ${mapAction(backgroundMap)};
-  border-radius: ${({ pill }) => (pill ? '0.5em' : '0')};
   color: ${mapAction(colorMap)};
   font-family: TS3TextSans;
   font-size: ${mapSize(fontSizeMap)};

--- a/client-v2/src/shared/components/input/InputButton.tsx
+++ b/client-v2/src/shared/components/input/InputButton.tsx
@@ -7,7 +7,7 @@ type Props = {
 } & WrappedFieldProps;
 
 export default ({ buttonText, ...rest }: Props) => (
-  <Button type="button" priority="muted" pill {...rest}>
+  <Button type="button" {...rest}>
     {buttonText}
   </Button>
 );


### PR DESCRIPTION
## What's changed?

Makes the buttons in the kicker options and the modal more consistent with the rest of the tool.

Before:
<img width="342" alt="Screenshot 2019-03-28 at 16 45 52" src="https://user-images.githubusercontent.com/7767575/55176413-fdf30b80-5178-11e9-95da-20e8402a079c.png">

After:
<img width="375" alt="Screenshot 2019-03-28 at 16 45 29" src="https://user-images.githubusercontent.com/7767575/55176415-ffbccf00-5178-11e9-9dd8-b47ea08f2c6c.png">


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
