### PR TITLE
Remove kicker information if the kicker is empty

### DIFF
--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -217,6 +217,23 @@ describe('ArticleFragmentForm transform functions', () => {
         imageSrcWidth: '100'
       });
     });
+    it('should remove customKicker and showKickerCustom if the kicker is empty', () => {
+      const values = {
+        customKicker: '',
+        showKickerCustom: true
+      };
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        values
+      );
+      expect(
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', {
+          ...formValues,
+          ...values
+        })
+      ).toEqual({});
+    });
     it('should handle conversion of string values for images', () => {
       const values = {
         primaryImage: {

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -164,7 +164,7 @@ export const getArticleFragmentMetaFromFormValues = (
     return field;
   };
 
-  const completeMeta = omit(
+  let completeMeta = omit(
     {
       ...values,
       headline: getStringField(values.headline),
@@ -180,6 +180,10 @@ export const getArticleFragmentMetaFromFormValues = (
     'primaryImage',
     'cutoutImage'
   );
+
+  if (!values.customKicker) {
+    completeMeta = omit(completeMeta, 'customKicker', 'showKickerCustom');
+  }
 
   // We only return dirtied values.
   const isDirtySelector = isDirty(formName);


### PR DESCRIPTION
## What's changed?

Remove kicker information if the kicker is empty. Leaving it there as an empty string produces odd behaviour on dotcom -- e.g. for liveblogs, it removes the fancy flashing 'live' indicator.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
