### PR TITLE
Stop event propagation for ophan/view links

### DIFF
--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -83,7 +83,12 @@ const HoverViewButton = ({
   showToolTip,
   hideToolTip
 }: ButtonProps) => (
-  <Link href={isLive ? getPaths(urlPath).live : getPaths(urlPath).preview}>
+  <Link
+    onClick={e => {
+      e.stopPropagation();
+    }}
+    href={isLive ? getPaths(urlPath).live : getPaths(urlPath).preview}
+  >
     <ActionButton onMouseEnter={showToolTip} onMouseLeave={hideToolTip}>
       <ViewHoverIcon />
     </ActionButton>
@@ -98,6 +103,9 @@ const HoverOphanButton = ({
 }: ButtonProps) =>
   isLive ? (
     <Link
+      onClick={e => {
+        e.stopPropagation();
+      }}
       href={getPaths(`https://www.theguardian.com/${urlPath}`).ophan}
       data-testid={'ophan-hover-button'}
     >


### PR DESCRIPTION
## What's changed?

Stop event propagation for ophan/view links. This stops clicks on those links simultaneously  selecting the underlying article for editing.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
