### PR TITLE
Only show scheduled publication date if first published date is already present

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -177,7 +177,7 @@ const articleBodyDefault = ({
           </NotLiveContainer>
         )}
 
-        {scheduledPublicationDate && (
+        {scheduledPublicationDate && !firstPublicationDate && (
           <CollectionItemDraftMetaContent title="The time until this article is scheduled to be published.">
             {distanceInWordsStrict(new Date(scheduledPublicationDate), now)}
           </CollectionItemDraftMetaContent>


### PR DESCRIPTION
## What's changed?

Sometimes an article has both a scheduled publication date and a first published date. We shouldn't show the former if the latter exists.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
