### PR TITLE
Better spacing for full front meta containers

### DIFF
--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -85,21 +85,24 @@ const LockedCollectionFlag = styled('span')`
 
 const CollectionMetaContainer = styled('div')`
   display: flex;
+  flex-basis: 30%;
   position: relative;
   font-family: TS3TextSans;
   font-size: 12px;
   font-weight: normal;
   justify-content: space-between;
+  cursor: pointer;
 `;
 
 const CollectionMetaBase = styled('span')`
   position: relative;
   padding-top: 3px;
-  padding-right: 40px;
+  padding-right: 20px;
 `;
 
 const CollectionMeta = styled(CollectionMetaBase)`
   padding-left: 10px;
+  min-width: 150px;
 `;
 
 const ItemCountMeta = styled(CollectionMetaBase)`
@@ -127,12 +130,10 @@ const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
 
 const CollectionToggleContainer = styled('div')`
   padding-top: 5px;
-  width: 100%;
   max-width: 130px;
   display: flex;
   justify-content: flex-end;
   z-index: 2;
-  cursor: pointer;
   :hover {
     ${ButtonCircularWithTransition} {
       background-color: ${({ theme }) =>


### PR DESCRIPTION
## What's changed?

From this --

![Screenshot 2019-04-02 at 10 42 38](https://user-images.githubusercontent.com/7767575/55400899-010a4500-5547-11e9-806d-4b97dea27e55.png)

To this -- 

<img width="603" alt="Screenshot 2019-04-02 at 12 59 47" src="https://user-images.githubusercontent.com/7767575/55400966-3747c480-5547-11e9-9c3d-69d4547826fc.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
