### PR TITLE
Make many things smaller

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -72,7 +72,7 @@ const VisitedWrapper = styled.a`
   text-decoration: none;
   display: flex;
   color: inherit;
-  cursor: auto;
+  cursor: pointer;
   width: 100%;
   :visited ${Title} {
     color: ${({ theme }) => theme.capiInterface.textVisited};

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -64,7 +64,7 @@ const Title = styled(`h2`)`
   margin: 2px 0 0;
   vertical-align: top;
   font-family: GHGuardianHeadline;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 500;
 `;
 
@@ -73,6 +73,7 @@ const VisitedWrapper = styled.a`
   display: flex;
   color: inherit;
   cursor: auto;
+  width: 100%;
   :visited ${Title} {
     color: ${({ theme }) => theme.capiInterface.textVisited};
   }
@@ -80,12 +81,12 @@ const VisitedWrapper = styled.a`
 
 const MetaContainer = styled('div')`
   position: relative;
-  width: 80px;
+  min-width: 80px;
   padding: 0px 2px;
 `;
 
 const FirstPublished = styled('div')`
-  font-size: 12px;
+  font-size: 11px;
   margin: 2px 0;
 `;
 
@@ -101,7 +102,6 @@ const Tone = styled('div')`
 `;
 
 const Body = styled('div')`
-  width: 213px;
   padding-left: 8px;
 `;
 

--- a/client-v2/src/shared/components/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/CollectionItemBody.tsx
@@ -16,7 +16,7 @@ export default styled('div')<{
   min-height: 35px;
   cursor: pointer;
   position: relative;
-  min-height: ${({ size }) => (size === 'small' ? '35px' : '83px')};
+  min-height: ${({ size }) => (size === 'small' ? '25px' : '67px')};
   opacity: ${({ fade }) => (fade ? 0.5 : 1)};
   background-color: ${({ theme }) =>
     theme.shared.base.colors.backgroundColorLight};

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -8,13 +8,14 @@ const ThumbnailBase = styled('div')`
 
 const ThumbnailSmall = styled(ThumbnailBase)`
   width: 83px;
+  min-width: 83px;
   height: 50px;
-  margin: 3px 5px 3px 5px;
 `;
 
 export { ThumbnailSmall };
 
 export default styled(ThumbnailBase)`
   width: 130px;
+  min-width: 130px;
   height: 83px;
 `;

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -17,5 +17,5 @@ export { ThumbnailSmall };
 export default styled(ThumbnailBase)`
   width: 130px;
   min-width: 130px;
-  height: 83px;
+  height: 67px;
 `;

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -176,7 +176,6 @@ const articleBodyDefault = ({
               : notLiveLabels.draft}
           </NotLiveContainer>
         )}
-
         {scheduledPublicationDate && !firstPublicationDate && (
           <CollectionItemDraftMetaContent title="The time until this article is scheduled to be published.">
             {distanceInWordsStrict(new Date(scheduledPublicationDate), now)}

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -108,12 +108,17 @@ interface ArticleBodyProps {
   type?: string;
 }
 
-const renderColouredQuotes = (pillarId?: string, isLive?: boolean) => {
+const renderColouredQuotes = (
+  size?: 'small' | 'default',
+  pillarId?: string,
+  isLive?: boolean
+) => {
   const pillarColour = getPillarColor(pillarId, isLive || true);
+  const height = size === 'small' ? '12px' : '18px';
   return (
     <React.Fragment>
-      <ColouredQuote colour={pillarColour} />
-      <ColouredQuote colour={pillarColour} />
+      <ColouredQuote colour={pillarColour} height={height} />
+      <ColouredQuote colour={pillarColour} height={height} />
     </React.Fragment>
   );
 };
@@ -207,18 +212,12 @@ const articleBodyDefault = ({
           )}
           {showQuotedHeadline && (
             <ArticleBodyQuoteContainer>
-              {renderColouredQuotes(pillarId, isLive)}
+              {renderColouredQuotes(size, pillarId, isLive)}
             </ArticleBodyQuoteContainer>
           )}
-          {size === 'default' ? (
-            <CollectionItemHeading html data-testid="headline">
-              {headline}
-            </CollectionItemHeading>
-          ) : (
-            <CollectionItemHeading html data-testid="headline">
-              {headline}
-            </CollectionItemHeading>
-          )}
+          <CollectionItemHeading html data-testid="headline" displaySize={size}>
+            {headline}
+          </CollectionItemHeading>
         </ArticleHeadingContainer>
         {displayTrail && (
           <CollectionItemTrail html>{trailText}</CollectionItemTrail>

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -186,7 +186,7 @@ const articleBodyDefault = ({
             {distanceInWordsStrict(now, new Date(frontPublicationTime))}
           </CollectionItemMetaContent>
         )}
-        {firstPublicationDate && (
+        {size === 'default' && firstPublicationDate && (
           <FirstPublicationDate title="The time elapsed since this article was first published.">
             {distanceInWordsStrict(new Date(firstPublicationDate), now)}
           </FirstPublicationDate>

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -30,7 +30,7 @@ import ColouredQuote from '../collectionItem/CollectionItemQuote';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   width: 130px;
-  height: 83px;
+  height: 67px;
 `;
 
 const NotLiveContainer = styled(CollectionItemMetaHeading)`
@@ -181,17 +181,17 @@ const articleBodyDefault = ({
               : notLiveLabels.draft}
           </NotLiveContainer>
         )}
-        {scheduledPublicationDate && !firstPublicationDate && (
+        {!!scheduledPublicationDate && !firstPublicationDate && (
           <CollectionItemDraftMetaContent title="The time until this article is scheduled to be published.">
             {distanceInWordsStrict(new Date(scheduledPublicationDate), now)}
           </CollectionItemDraftMetaContent>
         )}
-        {frontPublicationTime && (
+        {!!frontPublicationTime && (
           <CollectionItemMetaContent title="The time elapsed since this article was added to this front.">
             {distanceInWordsStrict(now, new Date(frontPublicationTime))}
           </CollectionItemMetaContent>
         )}
-        {size === 'default' && firstPublicationDate && (
+        {!!firstPublicationDate && (
           <FirstPublicationDate title="The time elapsed since this article was first published.">
             {distanceInWordsStrict(new Date(firstPublicationDate), now)}
           </FirstPublicationDate>

--- a/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
@@ -28,7 +28,7 @@ export default styled('div')<{
     css`
       font-size: 14px;
     `}
-  min-height: ${({ size }) => (size === 'small' ? '35px' : '83px')};
+  min-height: ${({ size }) => (size === 'small' ? '25px' : '67px')};
   cursor: pointer;
   background-color: ${({ displayType, theme }) =>
     displayType === 'default'

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 import { styled } from 'shared/constants/theme';
 import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 
-const Wrapper = styled('span')`
+const Wrapper = styled('span')<{ displaySize?: 'small' | 'default' }>`
   font-family: GHGuardianHeadline;
   font-weight: 500;
   padding-top: 2px;
-  font-size: 16px;
+  font-size: ${({ displaySize }) =>
+    displaySize === 'small' ? '13px' : '15px'};
 `;
 
 type CollectionItemHeading = {
   children?: string;
   html?: boolean;
+  displaySize?: 'small' | 'default';
 } & React.HTMLProps<HTMLSpanElement>;
 
 const CollectionItemHeading = ({
   children = '',
+  size,
   html = false,
   ref, // remove this for TS reasons
   ...props

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
@@ -6,7 +6,7 @@ import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline'
 const MetaContainer = styled('div')`
   position: relative;
   width: 80px;
-  padding: 0px 8px;
+  padding: 0 4px;
 `;
 
 export default ({ children }: { children: React.ReactNode }) => (

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContent.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContent.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'shared/constants/theme';
 
 export default styled('div')`
-  font-size: 12px;
+  font-size: 11px;
   margin: 2px 0;
 `;

--- a/client-v2/src/shared/components/collectionItem/CollectionItemQuote.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemQuote.tsx
@@ -2,12 +2,18 @@ import React from 'react';
 
 interface ColouredQuoteProps {
   colour: string;
+  width?: string;
+  height?: string;
 }
 
-const ColouredQuote = ({ colour }: ColouredQuoteProps) => (
+const ColouredQuote = ({
+  colour,
+  width = '8px',
+  height = '19px'
+}: ColouredQuoteProps) => (
   <svg
-    width="8px"
-    height="19px"
+    width={width}
+    height={height}
     fill={colour}
     viewBox="0 0 35 25"
     xmlns="http://www.w3.org/2000/svg"

--- a/client-v2/src/shared/components/collectionItem/CollectionItemTrail.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemTrail.tsx
@@ -5,7 +5,8 @@ import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 const Wrapper = styled('div')`
   width: 100%;
   margin-top: 3px;
-  font-size: 14px;
+  font-size: 13px;
+  line-height: 17px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## What's changed?

Things have been ensmallened. Many things. As specified by @akemitakagi -- let us know if anything's not right here!

Before (slightly bigger than it should be because of a bug with subarticle dates, but close enough) -- 

<img width="609" alt="Screenshot 2019-04-02 at 11 24 12" src="https://user-images.githubusercontent.com/7767575/55404418-c0fb9000-554f-11e9-8303-c48ef7bf257d.png">

After (note the extra articles visible as a result of the changes!) -- 

<img width="608" alt="Screenshot 2019-04-02 at 13 54 56" src="https://user-images.githubusercontent.com/7767575/55404411-bd680900-554f-11e9-811b-31b1f9da5dfc.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
