### PR TITLE
Add front publication date to sublinks if missing

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -5,7 +5,8 @@ import {
   removeSupportingArticleFragment,
   updateArticleFragmentMeta,
   createArticleFragment,
-  articleFragmentsReceived
+  articleFragmentsReceived,
+  maybeAddFrontPublicationDate
 } from 'shared/actions/ArticleFragments';
 import { ArticleFragment } from 'shared/types/Collection';
 import {
@@ -94,6 +95,7 @@ const maybeInsertGroupArticleFragment = (
     // group may not result in that group getting any bigger, and hence won't
     // require a modal!
     dispatch(insertGroupArticleFragment(id, index, articleFragmentId));
+    dispatch(maybeAddFrontPublicationDate(articleFragmentId));
 
     const state = getState();
 

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -10,7 +10,8 @@ import {
   RemoveGroupArticleFragment,
   RemoveSupportingArticleFragment,
   UpdateArticleFragmentMeta,
-  ClearArticleFragments
+  ClearArticleFragments,
+  MaybeAddFrontPublicationDate
 } from 'shared/types/Action';
 import { createFragment } from 'shared/util/articleFragment';
 import { createLinkSnap, createLatestSnap } from 'shared/util/snap';
@@ -193,6 +194,16 @@ function createArticleFragment(
   };
 }
 
+const maybeAddFrontPublicationDate = (
+  fragmentId: string
+): MaybeAddFrontPublicationDate => ({
+  type: 'SHARED/MAYBE_ADD_FRONT_PUBLICATION',
+  payload: {
+    id: fragmentId,
+    date: Date.now()
+  }
+});
+
 export {
   updateArticleFragmentMeta,
   articleFragmentsReceived,
@@ -201,5 +212,6 @@ export {
   removeGroupArticleFragment,
   removeSupportingArticleFragment,
   createArticleFragment,
-  clearArticleFragments
+  clearArticleFragments,
+  maybeAddFrontPublicationDate
 };

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -95,6 +95,23 @@ const articleFragments = (
         }
       };
     }
+    // We add frontPublicationDates here  because sublinks coming from the old tool do not have front publication
+    // dates. The new fronts tool adds these to sublinks always.
+    case 'SHARED/MAYBE_ADD_FRONT_PUBLICATION': {
+      const { id, date } = action.payload;
+      const fragment = state[id];
+
+      if (fragment.frontPublicationDate) {
+        return state;
+      }
+
+      const newFragment = { ...fragment, frontPublicationDate: date };
+      return {
+        ...state,
+        [id]: newFragment
+      };
+    }
+
     default: {
       return state;
     }

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -65,6 +65,14 @@ interface CapGroupSiblings {
   };
 }
 
+interface MaybeAddFrontPublicationDate {
+  type: 'SHARED/MAYBE_ADD_FRONT_PUBLICATION';
+  payload: {
+    id: string;
+    date: number;
+  };
+}
+
 type Action =
   | GroupsReceived
   | InsertGroupArticleFragment
@@ -76,6 +84,7 @@ type Action =
   | ArticleFragmentsReceived
   | ClearArticleFragments
   | UpdateArticleFragmentMeta
+  | MaybeAddFrontPublicationDate
   | CapGroupSiblings;
 
 export {
@@ -89,5 +98,6 @@ export {
   UpdateArticleFragmentMeta,
   InsertArticleFragmentPayload,
   RemoveArticleFragmentPayload,
-  CapGroupSiblings
+  CapGroupSiblings,
+  MaybeAddFrontPublicationDate
 };


### PR DESCRIPTION
## What's changed?

The old tool doesn't add frontPublicationDates to sublinks so collection save fails when sublinks get dragged to main position because they are missing a frontPublicationDate. This PR fixes the bug.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
