### PR TITLE
Image display

### DIFF
--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -320,7 +320,6 @@ describe('ArticleFragments actions', () => {
       );
 
       expect(s2.shared.articleFragments.a.meta).toMatchObject({
-        imageReplace: true,
         imageSrc: src,
         imageSrcThumb: thumb,
         imageSrcOrigin: origin,

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -10,6 +10,7 @@ import {
 } from 'redux-form';
 import { styled } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
+import Thumbnail from 'shared/components/Thumbnail';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import {
@@ -38,9 +39,9 @@ import {
   ArticleFragmentFormData,
   getArticleFragmentMetaFromFormValues,
   getInitialValuesForArticleFragmentForm,
-  getCapiValuesForArticleTextFields
+  getCapiValuesForArticleFields
 } from 'util/form';
-import { CapiTextFields } from 'util/form';
+import { CapiFields } from 'util/form';
 import { Dispatch } from 'types/Store';
 import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
 import { selectors as collectionSelectors } from 'shared/bundles/collectionsBundle';
@@ -168,7 +169,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       showKickerTag,
       showKickerSection,
       frontId,
-      articleExists
+      articleExists,
+      imageReplace
     } = this.props;
 
     return (
@@ -357,16 +359,28 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           <RowContainer>
             <Row>
               <Col>
-                <ImageWrapper faded={imageHide}>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name="primaryImage"
-                    component={InputImage}
-                    disabled={imageHide}
-                    criteria={imageCriteria}
-                    frontId={frontId}
+                {imageReplace && (
+                  <ImageWrapper faded={imageHide}>
+                    <ConditionalField
+                      permittedFields={editableFields}
+                      name="primaryImage"
+                      component={InputImage}
+                      disabled={imageHide}
+                      criteria={imageCriteria}
+                      frontId={frontId}
+                    />
+                  </ImageWrapper>
+                )}
+                {!imageReplace && (
+                  <Thumbnail
+                    style={{
+                      backgroundImage: `url('${
+                        articleCapiFieldValues.thumbnail
+                      }')`,
+                      opacity: imageHide ? 0.5 : 1
+                    }}
                   />
-                </ImageWrapper>
+                )}
               </Col>
               <Col>
                 <InputGroup>
@@ -376,6 +390,17 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     component={InputCheckboxToggle}
                     label="Hide media"
                     id={getInputId(articleFragmentId, 'hide-media')}
+                    type="checkbox"
+                    default={false}
+                  />
+                </InputGroup>
+                <InputGroup>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="imageReplace"
+                    component={InputCheckboxToggle}
+                    label="Replace media"
+                    id={getInputId(articleFragmentId, 'image-replace')}
                     type="checkbox"
                     default={false}
                   />
@@ -487,7 +512,8 @@ interface ContainerProps {
   editableFields?: string[];
   showKickerTag: boolean;
   showKickerSection: boolean;
-  articleCapiFieldValues: CapiTextFields;
+  articleCapiFieldValues: CapiFields;
+  imageReplace: boolean;
 }
 
 interface InterfaceProps {
@@ -544,9 +570,7 @@ const createMapStateToProps = () => {
       collectionId: (parentCollection && parentCollection.id) || null,
       getLastUpdatedBy,
       initialValues: getInitialValuesForArticleFragmentForm(article),
-      articleCapiFieldValues: getCapiValuesForArticleTextFields(
-        externalArticle
-      ),
+      articleCapiFieldValues: getCapiValuesForArticleFields(externalArticle),
       editableFields:
         article && selectFormFields(state, article.uuid, isSupporting),
       kickerOptions: article
@@ -554,6 +578,7 @@ const createMapStateToProps = () => {
         : {},
       imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
       imageHide: valueSelector(state, 'imageHide'),
+      imageReplace: valueSelector(state, 'imageReplace'),
       imageCutoutReplace: valueSelector(state, 'imageCutoutReplace'),
       showByline: valueSelector(state, 'showByline'),
       showKickerTag: valueSelector(state, 'showKickerTag'),

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -10,7 +10,7 @@ import {
 } from 'redux-form';
 import { styled } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
-import Thumbnail from 'shared/components/Thumbnail';
+import { ThumbnailEditForm } from 'shared/components/Thumbnail';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import {
@@ -372,7 +372,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   </ImageWrapper>
                 )}
                 {!imageReplace && (
-                  <Thumbnail
+                  <ThumbnailEditForm
                     style={{
                       backgroundImage: `url('${
                         articleCapiFieldValues.thumbnail

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -386,23 +386,31 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 <InputGroup>
                   <ConditionalField
                     permittedFields={editableFields}
-                    name="imageHide"
-                    component={InputCheckboxToggle}
-                    label="Hide media"
-                    id={getInputId(articleFragmentId, 'hide-media')}
-                    type="checkbox"
-                    default={false}
-                  />
-                </InputGroup>
-                <InputGroup>
-                  <ConditionalField
-                    permittedFields={editableFields}
                     name="imageReplace"
                     component={InputCheckboxToggle}
                     label="Replace media"
                     id={getInputId(articleFragmentId, 'image-replace')}
                     type="checkbox"
                     default={false}
+                    onChange={e => {
+                      change('imageHide', false);
+                      change('imageReplace', true);
+                    }}
+                  />
+                </InputGroup>
+                <InputGroup>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="imageHide"
+                    component={InputCheckboxToggle}
+                    label="Hide media"
+                    id={getInputId(articleFragmentId, 'hide-media')}
+                    type="checkbox"
+                    default={false}
+                    onChange={e => {
+                      change('imageReplace', false);
+                      change('imageHide', true);
+                    }}
                   />
                 </InputGroup>
               </Col>

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -373,12 +373,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 )}
                 {!imageReplace && (
                   <ThumbnailEditForm
-                    style={{
-                      backgroundImage: `url('${
-                        articleCapiFieldValues.thumbnail
-                      }')`,
-                      opacity: imageHide ? 0.5 : 1
-                    }}
+                    imageHide={imageHide}
+                    url={articleCapiFieldValues.thumbnail}
                   />
                 )}
               </Col>

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -19,6 +19,7 @@ const formValues = {
   headline: "Sister of academic's killer warned police he was mentally ill",
   imageCutoutReplace: false,
   imageHide: false,
+  imageReplace: false,
   imageSlideshowReplace: false,
   isBoosted: false,
   isBreaking: false,
@@ -209,7 +210,6 @@ describe('ArticleFragmentForm transform functions', () => {
           ...values
         })
       ).toEqual({
-        imageReplace: true,
         imageSrc: 'exampleSrc',
         imageSrcHeight: '100',
         imageSrcOrigin: 'exampleOrigin',
@@ -271,7 +271,6 @@ describe('ArticleFragmentForm transform functions', () => {
           ...values
         })
       ).toEqual({
-        imageReplace: true,
         imageSrc: 'exampleSrc',
         imageSrcHeight: '100',
         imageSrcOrigin: 'exampleOrigin',

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -20,6 +20,7 @@ export const defaultFields = [
   'trailText',
   'imageCutoutReplace',
   'imageHide',
+  'imageReplace',
   'imageSlideshowReplace',
   'primaryImage',
   'cutoutImage',

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -12,7 +12,13 @@ const ThumbnailSmall = styled(ThumbnailBase)`
   height: 50px;
 `;
 
-export { ThumbnailSmall };
+const ThumbnailEditForm = styled(ThumbnailBase)`
+  width: 100%;
+  height: 115px;
+  margin-bottom: 10px;
+`;
+
+export { ThumbnailSmall, ThumbnailEditForm };
 
 export default styled(ThumbnailBase)`
   width: 130px;

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -12,10 +12,15 @@ const ThumbnailSmall = styled(ThumbnailBase)`
   height: 50px;
 `;
 
-const ThumbnailEditForm = styled(ThumbnailBase)`
+const ThumbnailEditForm = styled(ThumbnailBase)<{
+  imageHide: boolean;
+  url: string | undefined | void;
+}>`
   width: 100%;
   height: 115px;
   margin-bottom: 10px;
+  opacity: ${({ imageHide }) => (imageHide ? 0.5 : 1)};
+  background-image: ${({ url }) => `url('${url}')`};
 `;
 
 export { ThumbnailSmall, ThumbnailEditForm };

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -134,11 +134,7 @@ const formToMetaFieldMap: { [fieldName: string]: string } = {
   imageCutoutSrcOrigin: 'cutoutImage'
 };
 
-export const getImageMetaFromValidationResponse = (
-  image: ImageData,
-  hideImage?: boolean,
-  imageReplace?: boolean
-) => ({
+export const getImageMetaFromValidationResponse = (image: ImageData) => ({
   imageSrc: image.src,
   imageSrcThumb: image.thumb,
   imageSrcWidth: intToStr(image.width),
@@ -174,11 +170,7 @@ export const getArticleFragmentMetaFromFormValues = (
       headline: getStringField(values.headline),
       trailText: getStringField(values.trailText),
       byline: getStringField(values.byline),
-      ...getImageMetaFromValidationResponse(
-        primaryImage,
-        values.imageHide,
-        values.imageReplace
-      ),
+      ...getImageMetaFromValidationResponse(primaryImage),
       imageCutoutSrc: cutoutImage.src,
       imageCutoutSrcWidth: intToStr(cutoutImage.width),
       imageCutoutSrcHeight: intToStr(cutoutImage.height),

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -26,6 +26,7 @@ export interface ArticleFragmentFormData {
   slideshow: Array<ImageData | void> | void;
   showKickerTag: boolean;
   showKickerSection: boolean;
+  imageReplace: boolean;
 }
 
 export interface ImageData {
@@ -96,6 +97,7 @@ export const getInitialValuesForArticleFragmentForm = (
         trailText: article.trailText || '',
         imageCutoutReplace: article.imageCutoutReplace || false,
         imageHide: article.imageHide || false,
+        imageReplace: article.imageReplace || false,
         imageSlideshowReplace: article.imageSlideshowReplace || false,
         primaryImage: {
           src: article.imageSrc,
@@ -121,7 +123,6 @@ export const getInitialValuesForArticleFragmentForm = (
 // the two models to figure out which meta fields should be
 // added to the form output when a form field is dirtied.
 const formToMetaFieldMap: { [fieldName: string]: string } = {
-  imageReplace: 'primaryImage',
   imageSrc: 'primaryImage',
   imageSrcThumb: 'primaryImage',
   imageSrcWidth: 'primaryImage',
@@ -135,9 +136,9 @@ const formToMetaFieldMap: { [fieldName: string]: string } = {
 
 export const getImageMetaFromValidationResponse = (
   image: ImageData,
-  hideImage?: boolean
+  hideImage?: boolean,
+  imageReplace?: boolean
 ) => ({
-  imageReplace: !!image.src && !hideImage,
   imageSrc: image.src,
   imageSrcThumb: image.thumb,
   imageSrcWidth: intToStr(image.width),
@@ -173,7 +174,11 @@ export const getArticleFragmentMetaFromFormValues = (
       headline: getStringField(values.headline),
       trailText: getStringField(values.trailText),
       byline: getStringField(values.byline),
-      ...getImageMetaFromValidationResponse(primaryImage, values.imageHide),
+      ...getImageMetaFromValidationResponse(
+        primaryImage,
+        values.imageHide,
+        values.imageReplace
+      ),
       imageCutoutSrc: cutoutImage.src,
       imageCutoutSrcWidth: intToStr(cutoutImage.width),
       imageCutoutSrcHeight: intToStr(cutoutImage.height),
@@ -190,7 +195,9 @@ export const getArticleFragmentMetaFromFormValues = (
 
   // We only return dirtied values.
   const isDirtySelector = isDirty(formName);
-  return pickBy(completeMeta, (_, key) => {
+  const returnValue = pickBy(completeMeta, (_, key) => {
     return isDirtySelector(state, formToMetaFieldMap[key] || key);
   });
+
+  return returnValue;
 };

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -195,9 +195,7 @@ export const getArticleFragmentMetaFromFormValues = (
 
   // We only return dirtied values.
   const isDirtySelector = isDirty(formName);
-  const returnValue = pickBy(completeMeta, (_, key) => {
+  return pickBy(completeMeta, (_, key) => {
     return isDirtySelector(state, formToMetaFieldMap[key] || key);
   });
-
-  return returnValue;
 };

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -36,29 +36,32 @@ export interface ImageData {
   thumb?: string;
 }
 
-export interface CapiTextFields {
+export interface CapiFields {
   headline: string;
   trailText: string;
   byline: string;
+  thumbnail?: string | void;
 }
 
 const strToInt = (str: string | void) => (str ? parseInt(str, 10) : undefined);
 const intToStr = (int: number | void) => (int ? int.toString() : undefined);
 
-export const getCapiValuesForArticleTextFields = (
+export const getCapiValuesForArticleFields = (
   article: CapiArticle | void
-): CapiTextFields => {
+): CapiFields => {
   if (!article) {
     return {
       headline: '',
       trailText: '',
-      byline: ''
+      byline: '',
+      thumbnail: ''
     };
   }
   return {
     headline: article.fields.headline || '',
     trailText: article.fields.trailText || '',
-    byline: article.fields.byline || ''
+    byline: article.fields.byline || '',
+    thumbnail: article.fields.thumbnail
   };
 };
 


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Network front editors wanted to see the capi trail image on the edit form when nothing had been overridden. To accommodate the request I replicated the imageReplace behaviour from the old tool where you have to explicitly select imageReplace and add an image from the grid to replace an image. Without this toggle it would have been unclear in the form if the image had been replaced.  

<img width="460" alt="Screenshot 2019-04-04 at 07 25 57" src="https://user-images.githubusercontent.com/3066534/55534020-04b6dc80-56ab-11e9-9b98-bc07875064a0.png">

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
