### PR TITLE
Pass capi id to insert article action

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -4,7 +4,10 @@ import { connect } from 'react-redux';
 import Article from 'shared/components/article/Article';
 import { State } from 'types/State';
 import { createCollectionItemTypeSelector } from 'shared/selectors/collectionItem';
-import { selectSharedState } from 'shared/selectors/shared';
+import {
+  selectSharedState,
+  externalArticleIdFromArticleFragmentSelector
+} from 'shared/selectors/shared';
 import collectionItemTypes from 'shared/constants/collectionItemTypes';
 import {
   CollectionItemTypes,
@@ -39,9 +42,10 @@ interface ContainerProps {
 }
 
 type ArticleContainerProps = ContainerProps & {
-  onAddToClipboard: (uuid: string) => void;
+  onAddToClipboard: (externalArticleId: string | undefined) => void;
   type: CollectionItemTypes;
   isSelected: boolean;
+  externalArticleId: string | undefined;
 };
 
 class CollectionItem extends React.Component<ArticleContainerProps> {
@@ -75,7 +79,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       type,
       size,
       articleNotifications,
-      isUneditable
+      isUneditable,
+      externalArticleId
     } = this.props;
 
     const notifications =
@@ -91,7 +96,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             isUneditable={isUneditable}
             {...getNodeProps()}
             onDelete={onDelete}
-            onAddToClipboard={() => onAddToClipboard(uuid)}
+            onAddToClipboard={() => onAddToClipboard(externalArticleId)}
             onClick={() => onSelect(uuid)}
             fade={!isSelected}
             size={size}
@@ -140,21 +145,28 @@ const createMapStateToProps = () => {
       type: selectType(selectSharedState(state), props.uuid),
       isSelected:
         !selectedArticleFragmentData ||
-        selectedArticleFragmentData.id === props.uuid
+        selectedArticleFragmentData.id === props.uuid,
+      externalArticleId: externalArticleIdFromArticleFragmentSelector(
+        selectSharedState(state),
+        props.uuid
+      )
     };
   };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    onAddToClipboard: (id: string) =>
-      dispatch(
-        insertArticleFragment(
-          { id: 'clipboard', type: 'clipboard', index: 0 },
-          id,
-          'clipboard'
-        )
-      )
+    onAddToClipboard: (id: string | undefined) => {
+      if (id) {
+        dispatch(
+          insertArticleFragment(
+            { id: 'clipboard', type: 'clipboard', index: 0 },
+            id,
+            'clipboard'
+          )
+        );
+      }
+    }
   };
 };
 

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -418,6 +418,19 @@ const groupSiblingsArticleCountSelector = (state: State, groupId: string) =>
     0
   );
 
+const externalArticleIdFromArticleFragmentSelector = (
+  state: State,
+  id: string
+): string | undefined => {
+  const externalArticle = externalArticleFromArticleFragmentSelector(state, id);
+
+  if (!externalArticle) {
+    return undefined;
+  }
+
+  return externalArticle.id;
+};
+
 export {
   externalArticleFromArticleFragmentSelector,
   createArticleFromArticleFragmentSelector,
@@ -437,5 +450,6 @@ export {
   groupCollectionSelector,
   groupSiblingsSelector,
   groupSiblingsArticleCountSelector,
-  articleTagSelector
+  articleTagSelector,
+  externalArticleIdFromArticleFragmentSelector
 };


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_
We were passing the article uuid instead of the capi id to the insert action when clicking to copy an article to the clipboard so the whole action was failing. This PR fixes that issue.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
