### PR TITLE
Ignore nonexistence collections instead of throwing an error

### DIFF
--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -153,6 +153,23 @@ describe('Collection actions', () => {
         { id: 'testCollection2', lastUpdated: 1547479667115 }
       ]);
     });
+    it('should ignore automated collections without content', async () => {
+      const collectionIds = [
+        'testCollection1',
+        'testCollection2',
+        'automatedCollection'
+      ];
+      const request = fetchMock.post(
+        '/collections',
+        getCollectionsThunkFaciaApiResponse
+      );
+      await store.dispatch(getCollections(collectionIds, true) as any);
+      const result = request.lastOptions().body;
+      expect(JSON.parse(result as string)).toEqual([
+        { id: 'testCollection1', lastUpdated: 1547479667115 },
+        { id: 'testCollection2', lastUpdated: 1547479667115 }
+      ]);
+    });
   });
 
   describe('fetchArticles thunk', () => {

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -538,6 +538,10 @@ const stateWithCollection: any = {
           testCollection2: {
             displayName: 'testCollection',
             type: 'type'
+          },
+          automatedCollection: {
+            displayName: 'automated',
+            type: 'type'
           }
         }
       },


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_
Polling was broken for all fronts which contained an automated collection because we were throwing an error for fetching polling params if we could not find the collection in the state. 

Going to fix part two next week: https://trello.com/c/pQVF9GLy/527-we-can-fetch-collectionjson-for-automated-containers-because-theyve-never-had-any-content-in-them-we-dont-handle-this-case-in-an

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
