### PR TITLE
Move collection articles with keyboard

### DIFF
--- a/client-v2/src/actions/KeyboardNavigation.ts
+++ b/client-v2/src/actions/KeyboardNavigation.ts
@@ -36,8 +36,8 @@ const keyboardArticleFragmentMove = (
 
       const nextPosition = nextIndexAndGroupSelector(
         state,
-        id,
         groupId || '',
+        id,
         action
       );
 
@@ -45,7 +45,6 @@ const keyboardArticleFragmentMove = (
         const { toIndex, nextGroupId } = nextPosition;
 
         const to: PosSpec = { type, index: toIndex, id: nextGroupId };
-
         dispatch(moveArticleFragment(to, fragment, from, persistTo));
       }
     } else if (persistTo === 'clipboard') {

--- a/client-v2/src/actions/KeyboardNavigation.ts
+++ b/client-v2/src/actions/KeyboardNavigation.ts
@@ -11,6 +11,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import { PosSpec } from 'lib/dnd';
 import { ThunkResult, Dispatch } from 'types/Store';
 import { setFocusState } from 'bundles/focusBundle';
+import { editorOpenCollections } from 'bundles/frontsUIBundle';
 
 const keyboardArticleFragmentMove = (
   action: 'up' | 'down',
@@ -45,7 +46,12 @@ const keyboardArticleFragmentMove = (
       );
 
       if (nextPosition && nextPosition.nextGroupId) {
-        const { toIndex, nextGroupId } = nextPosition;
+        const { toIndex, nextGroupId, collectionId } = nextPosition;
+
+        // If we are moving between collections we should open the collection first
+        if (collectionId) {
+          dispatch(editorOpenCollections(collectionId));
+        }
 
         const to: PosSpec = { type, index: toIndex, id: nextGroupId };
         dispatch(moveArticleFragment(to, fragment, from, persistTo));

--- a/client-v2/src/actions/KeyboardNavigation.ts
+++ b/client-v2/src/actions/KeyboardNavigation.ts
@@ -10,6 +10,7 @@ import {
 import { ArticleFragment } from 'shared/types/Collection';
 import { PosSpec } from 'lib/dnd';
 import { ThunkResult, Dispatch } from 'types/Store';
+import { setFocusState } from 'bundles/focusBundle';
 
 const keyboardArticleFragmentMove = (
   action: 'up' | 'down',
@@ -46,6 +47,13 @@ const keyboardArticleFragmentMove = (
 
         const to: PosSpec = { type, index: toIndex, id: nextGroupId };
         dispatch(moveArticleFragment(to, fragment, from, persistTo));
+        dispatch(
+          setFocusState({
+            type: 'collectionArticle',
+            groupId: nextGroupId,
+            articleFragment: fragment
+          })
+        );
       }
     } else if (persistTo === 'clipboard') {
       const clipboardIndeces = nextClipboardIndexSelector(state, id, action);

--- a/client-v2/src/actions/KeyboardNavigation.ts
+++ b/client-v2/src/actions/KeyboardNavigation.ts
@@ -16,7 +16,8 @@ const keyboardArticleFragmentMove = (
   action: 'up' | 'down',
   persistTo: 'collection' | 'clipboard',
   fragment?: ArticleFragment,
-  groupId?: string
+  groupId?: string,
+  frontId?: string
 ): ThunkResult<void> => {
   return (dispatch: Dispatch, getState) => {
     if (!fragment) {
@@ -39,7 +40,8 @@ const keyboardArticleFragmentMove = (
         state,
         groupId || '',
         id,
-        action
+        action,
+        frontId || ''
       );
 
       if (nextPosition && nextPosition.nextGroupId) {
@@ -51,7 +53,8 @@ const keyboardArticleFragmentMove = (
           setFocusState({
             type: 'collectionArticle',
             groupId: nextGroupId,
-            articleFragment: fragment
+            articleFragment: fragment,
+            frontId
           })
         );
       }

--- a/client-v2/src/bundles/focusBundle.ts
+++ b/client-v2/src/bundles/focusBundle.ts
@@ -24,9 +24,9 @@ export const selectIsClipboardFocused = (state: GlobalState) => {
   return false;
 };
 
-export const selectFocusedClipboardArticle = (state: GlobalState) => {
+export const selectFocusedArticle = (state: GlobalState, focusType: string) => {
   const focusState = selectFocusState(state);
-  if (focusState && focusState.type === 'clipboardArticle') {
+  if (focusState && focusState.type === focusType) {
     return focusState.articleFragment && focusState.articleFragment.uuid;
   }
 };

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -30,7 +30,7 @@ import DragIntentContainer from 'shared/components/DragIntentContainer';
 import {
   setFocusState,
   resetFocusState,
-  selectFocusedClipboardArticle,
+  selectFocusedArticle,
   selectIsClipboardFocused
 } from 'bundles/focusBundle';
 
@@ -258,7 +258,7 @@ class Clipboard extends React.Component<ClipboardProps> {
 
 const mapStateToProps = (state: State) => ({
   isClipboardOpen: selectIsClipboardOpen(state),
-  focusedArticle: selectFocusedClipboardArticle(state),
+  focusedArticle: selectFocusedArticle(state, 'clipboardArticle'),
   isClipboardFocused: selectIsClipboardFocused(state)
 });
 

--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -70,6 +70,7 @@ class CollectionNotification extends React.Component<
           {!alsoOn.meritsWarning && <span>Also on other fronts.</span>}
           &nbsp;
           <ToggleDetailsButton
+            tabIndex={-1}
             size="s"
             onClick={e => {
               e.stopPropagation();

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -90,6 +90,7 @@ const Collection = ({
         canPublish && (
           <React.Fragment>
             <Button
+              tabIndex={-1}
               size="l"
               priority="default"
               onClick={() => discardDraftChanges(id)}
@@ -103,6 +104,7 @@ const Collection = ({
               Discard
             </Button>
             <Button
+              tabIndex={-1}
               size="l"
               priority="primary"
               onClick={() => publish(id, frontId)}

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -33,7 +33,11 @@ import FrontDetailView from './FrontDetailView';
 import CollectionItem from './CollectionComponents/CollectionItem';
 import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { initialiseCollectionsForFront } from 'actions/Collections';
-import { resetFocusState, setFocusState } from 'bundles/focusBundle';
+import {
+  resetFocusState,
+  setFocusState,
+  selectFocusedArticle
+} from 'bundles/focusBundle';
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
@@ -58,7 +62,11 @@ const CollectionWrapper = styled('div')`
   }
 `;
 
-const CollectionItemWrapper = styled('div')`
+const CollectionItemWrapper = styled('div')<{ articleSelected?: boolean }>`
+  border: ${({ articleSelected, theme }) =>
+    articleSelected
+      ? `1px solid ${theme.shared.base.colors.focusColor}`
+      : `none`};
   &:focus {
     border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
     outline: none;
@@ -89,6 +97,7 @@ type FrontProps = FrontPropsBeforeState & {
     groupId: string,
     articleFragment: TArticleFragment
   ) => void;
+  focusedArticle?: string;
 };
 
 interface FrontState {
@@ -213,6 +222,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                       articleFragment
                                     )
                                   }
+                                  articleSelected={
+                                    this.props.focusedArticle ===
+                                    articleFragment.uuid
+                                  }
                                 >
                                   <CollectionItem
                                     frontId={this.props.id}
@@ -312,7 +325,8 @@ const mapStateToProps = (state: State, props: FrontPropsBeforeState) => ({
   front: getFront(state, props.id),
   articlesVisible: visibleFrontArticlesSelector(state, {
     collectionSet: props.browsingStage
-  })
+  }),
+  focusedArticle: selectFocusedArticle(state, 'collectionArticle')
 });
 
 const mapDispatchToProps = (

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { styled } from 'constants/theme';
-import { theme } from 'constants/theme';
+import { styled, theme } from 'constants/theme';
 import { connect } from 'react-redux';
 import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';
@@ -34,6 +33,7 @@ import FrontDetailView from './FrontDetailView';
 import CollectionItem from './CollectionComponents/CollectionItem';
 import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { initialiseCollectionsForFront } from 'actions/Collections';
+import { resetFocusState } from 'bundles/focusBundle';
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
@@ -49,16 +49,17 @@ const FrontContentContainer = styled('div')`
 `;
 
 const CollectionWrapper = styled('div')`
- &:focus {
-    border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+  &:focus {
+    border: 1px solid ${({ themeColours }) => themeColours.shared.base.colors.focusColor};
     border-top: 2px solid ${({ theme }) => theme.shared.base.colors.focusColor};
-    border-bottom: 2px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    border-bottom: 2px solid
+      ${({ theme }) => theme.shared.base.colors.focusColor};
     outline: none;
   }
 `;
 
 const CollectionItemWrapper = styled('div')`
- &:focus {
+  &:focus {
     border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
     outline: none;
   }
@@ -82,6 +83,7 @@ type FrontProps = FrontPropsBeforeState & {
   addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   front: FrontConfig;
   articlesVisible: { [id: string]: VisibleArticlesResponse };
+  handleBlur: () => void;
 };
 
 interface FrontState {
@@ -107,10 +109,6 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
     if (this.props.browsingStage !== newProps.browsingStage) {
       this.props.initialiseFront();
     }
-  }
-
-  public componentDidUpdate() {
-    console.log('rerendering');
   }
 
   public handleError = (error: string) => {
@@ -159,7 +157,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                   articlesVisible && articlesVisible[collectionId];
                 let collectionItemCount: number = 0;
                 return (
-                  <CollectionWrapper tabIndex={0}>
+                  <CollectionWrapper tabIndex={0} onBlur={this.handleBlur}>
                     <Collection
                       key={collectionId}
                       id={collectionId}
@@ -197,6 +195,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                               return (
                                 <CollectionItemWrapper
                                   tabIndex={0}
+                                  onBlur={this.handleBlur}
                                 >
                                   <CollectionItem
                                     frontId={this.props.id}
@@ -240,7 +239,9 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                           }
                                           isUneditable={isUneditable}
                                           getNodeProps={() =>
-                                            !isUneditable ? supportingDragProps : {}
+                                            !isUneditable
+                                              ? supportingDragProps
+                                              : {}
                                           }
                                           onDelete={() =>
                                             this.props.removeSupportingCollectionItem(
@@ -275,6 +276,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
       </React.Fragment>
     );
   }
+
+  private handleBlur = () => this.props.handleBlur();
 }
 
 const mapStateToProps = (state: State, props: FrontPropsBeforeState) => ({
@@ -314,7 +317,8 @@ const mapDispatchToProps = (
     editorOpenCollections: (ids: string[]) =>
       dispatch(editorOpenCollections(ids)),
     addImageToArticleFragment: (id: string, response: ValidationResponse) =>
-      dispatch(addImageToArticleFragment(id, response))
+      dispatch(addImageToArticleFragment(id, response)),
+    handleBlur: () => dispatch(resetFocusState())
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -86,7 +86,7 @@ type FrontProps = FrontPropsBeforeState & {
   handleBlur: () => void;
   handleFocus: (collectionId: string) => void;
   handleArticleFocus: (
-    collectionId: string,
+    groupId: string,
     articleFragment: TArticleFragment
   ) => void;
 };
@@ -166,6 +166,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                     tabIndex={0}
                     onBlur={this.handleBlur}
                     onFocus={() => this.handleFocus(collectionId)}
+                    key={collectionId}
                   >
                     <Collection
                       key={collectionId}
@@ -208,7 +209,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                   onFocus={event =>
                                     this.handleArticleFocus(
                                       event,
-                                      collectionId,
+                                      group.uuid,
                                       articleFragment
                                     )
                                   }
@@ -298,10 +299,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
     this.props.handleFocus(collectionId);
   private handleArticleFocus = (
     e: React.FocusEvent<HTMLDivElement>,
-    collectionId: string,
+    groupId: string,
     articleFragment: TArticleFragment
   ) => {
-    this.props.handleArticleFocus(collectionId, articleFragment);
+    this.props.handleArticleFocus(groupId, articleFragment);
     e.stopPropagation();
   };
 }
@@ -347,14 +348,11 @@ const mapDispatchToProps = (
     handleBlur: () => dispatch(resetFocusState()),
     handleFocus: (collectionId: string) =>
       dispatch(setFocusState({ type: 'collection', collectionId })),
-    handleArticleFocus: (
-      collectionId: string,
-      articleFragment: TArticleFragment
-    ) =>
+    handleArticleFocus: (groupId: string, articleFragment: TArticleFragment) =>
       dispatch(
         setFocusState({
           type: 'collectionArticle',
-          collectionId,
+          groupId,
           articleFragment
         })
       )

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -98,7 +98,8 @@ type FrontProps = FrontPropsBeforeState & {
   handleFocus: (collectionId: string) => void;
   handleArticleFocus: (
     groupId: string,
-    articleFragment: TArticleFragment
+    articleFragment: TArticleFragment,
+    frontId: string
   ) => void;
   focusedArticle?: string;
 };
@@ -222,7 +223,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                                     this.handleArticleFocus(
                                       event,
                                       group.uuid,
-                                      articleFragment
+                                      articleFragment,
+                                      front.id
                                     )
                                   }
                                   articleSelected={
@@ -316,9 +318,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   private handleArticleFocus = (
     e: React.FocusEvent<HTMLDivElement>,
     groupId: string,
-    articleFragment: TArticleFragment
+    articleFragment: TArticleFragment,
+    frontId: string
   ) => {
-    this.props.handleArticleFocus(groupId, articleFragment);
+    this.props.handleArticleFocus(groupId, articleFragment, frontId);
     e.stopPropagation();
   };
 }
@@ -365,12 +368,17 @@ const mapDispatchToProps = (
     handleBlur: () => dispatch(resetFocusState()),
     handleFocus: (collectionId: string) =>
       dispatch(setFocusState({ type: 'collection', collectionId })),
-    handleArticleFocus: (groupId: string, articleFragment: TArticleFragment) =>
+    handleArticleFocus: (
+      groupId: string,
+      articleFragment: TArticleFragment,
+      frontId: string
+    ) =>
       dispatch(
         setFocusState({
           type: 'collectionArticle',
           groupId,
-          articleFragment
+          articleFragment,
+          frontId
         })
       )
   };

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -53,6 +53,9 @@ const FrontContentContainer = styled('div')`
 `;
 
 const CollectionWrapper = styled('div')`
+  & + & {
+    margin-top: 10px;
+  }
   &:focus {
     border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
     border-top: 2px solid ${props => props.theme.shared.base.colors.focusColor};

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -48,6 +48,22 @@ const FrontContentContainer = styled('div')`
   padding-top: 1px;
 `;
 
+const CollectionWrapper = styled('div')`
+ &:focus {
+    border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    border-top: 2px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    border-bottom: 2px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    outline: none;
+  }
+`;
+
+const CollectionItemWrapper = styled('div')`
+ &:focus {
+    border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    outline: none;
+  }
+`;
+
 interface FrontPropsBeforeState {
   id: string;
   browsingStage: CollectionItemSets;
@@ -91,6 +107,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
     if (this.props.browsingStage !== newProps.browsingStage) {
       this.props.initialiseFront();
     }
+  }
+
+  public componentDidUpdate() {
+    console.log('rerendering');
   }
 
   public handleError = (error: string) => {
@@ -139,102 +159,108 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                   articlesVisible && articlesVisible[collectionId];
                 let collectionItemCount: number = 0;
                 return (
-                  <Collection
-                    key={collectionId}
-                    id={collectionId}
-                    priority={front.priority}
-                    frontId={this.props.id}
-                    alsoOn={this.props.alsoOn}
-                    canPublish={this.props.browsingStage !== 'live'}
-                    browsingStage={this.props.browsingStage}
-                  >
-                    {(group, isUneditable) => (
-                      <GroupDisplay key={group.uuid} groupName={group.name}>
-                        <GroupLevel
-                          isUneditable={isUneditable}
-                          groupId={group.uuid}
-                          onMove={this.handleMove}
-                          onDrop={this.handleInsert}
-                        >
-                          {(articleFragment, afDragProps) => {
-                            collectionItemCount += 1;
-                            const articleNotifications: string[] = [];
-                            if (
-                              collectionArticlesVisible &&
-                              collectionItemCount ===
-                                collectionArticlesVisible.mobile
-                            ) {
-                              articleNotifications.push('mobile');
-                            }
-                            if (
-                              collectionArticlesVisible &&
-                              collectionItemCount ===
-                                collectionArticlesVisible.desktop
-                            ) {
-                              articleNotifications.push('desktop');
-                            }
-                            return (
-                              <CollectionItem
-                                frontId={this.props.id}
-                                onImageDrop={imageData => {
-                                  this.props.addImageToArticleFragment(
-                                    articleFragment.uuid,
-                                    imageData
-                                  );
-                                }}
-                                uuid={articleFragment.uuid}
-                                parentId={group.uuid}
-                                isUneditable={isUneditable}
-                                getNodeProps={() =>
-                                  !isUneditable ? afDragProps : {}
-                                }
-                                onSelect={this.props.selectArticleFragment}
-                                onDelete={() =>
-                                  this.props.removeCollectionItem(
-                                    group.uuid,
-                                    articleFragment.uuid
-                                  )
-                                }
-                                articleNotifications={articleNotifications}
-                              >
-                                <ArticleFragmentLevel
-                                  isUneditable={isUneditable}
-                                  articleFragmentId={articleFragment.uuid}
-                                  onMove={this.handleMove}
-                                  onDrop={this.handleInsert}
+                  <CollectionWrapper tabIndex={0}>
+                    <Collection
+                      key={collectionId}
+                      id={collectionId}
+                      priority={front.priority}
+                      frontId={this.props.id}
+                      alsoOn={this.props.alsoOn}
+                      canPublish={this.props.browsingStage !== 'live'}
+                      browsingStage={this.props.browsingStage}
+                    >
+                      {(group, isUneditable) => (
+                        <GroupDisplay key={group.uuid} groupName={group.name}>
+                          <GroupLevel
+                            isUneditable={isUneditable}
+                            groupId={group.uuid}
+                            onMove={this.handleMove}
+                            onDrop={this.handleInsert}
+                          >
+                            {(articleFragment, afDragProps) => {
+                              collectionItemCount += 1;
+                              const articleNotifications: string[] = [];
+                              if (
+                                collectionArticlesVisible &&
+                                collectionItemCount ===
+                                  collectionArticlesVisible.mobile
+                              ) {
+                                articleNotifications.push('mobile');
+                              }
+                              if (
+                                collectionArticlesVisible &&
+                                collectionItemCount ===
+                                  collectionArticlesVisible.desktop
+                              ) {
+                                articleNotifications.push('desktop');
+                              }
+                              return (
+                                <CollectionItemWrapper
+                                  tabIndex={0}
                                 >
-                                  {(supporting, supportingDragProps) => (
-                                    <CollectionItem
-                                      frontId={this.props.id}
-                                      uuid={supporting.uuid}
-                                      parentId={articleFragment.uuid}
-                                      onSelect={id =>
-                                        this.props.selectArticleFragment(
-                                          id,
-                                          true
-                                        )
-                                      }
+                                  <CollectionItem
+                                    frontId={this.props.id}
+                                    onImageDrop={imageData => {
+                                      this.props.addImageToArticleFragment(
+                                        articleFragment.uuid,
+                                        imageData
+                                      );
+                                    }}
+                                    uuid={articleFragment.uuid}
+                                    parentId={group.uuid}
+                                    isUneditable={isUneditable}
+                                    getNodeProps={() =>
+                                      !isUneditable ? afDragProps : {}
+                                    }
+                                    onSelect={this.props.selectArticleFragment}
+                                    onDelete={() =>
+                                      this.props.removeCollectionItem(
+                                        group.uuid,
+                                        articleFragment.uuid
+                                      )
+                                    }
+                                    articleNotifications={articleNotifications}
+                                  >
+                                    <ArticleFragmentLevel
                                       isUneditable={isUneditable}
-                                      getNodeProps={() =>
-                                        !isUneditable ? supportingDragProps : {}
-                                      }
-                                      onDelete={() =>
-                                        this.props.removeSupportingCollectionItem(
-                                          articleFragment.uuid,
-                                          supporting.uuid
-                                        )
-                                      }
-                                      size="small"
-                                    />
-                                  )}
-                                </ArticleFragmentLevel>
-                              </CollectionItem>
-                            );
-                          }}
-                        </GroupLevel>
-                      </GroupDisplay>
-                    )}
-                  </Collection>
+                                      articleFragmentId={articleFragment.uuid}
+                                      onMove={this.handleMove}
+                                      onDrop={this.handleInsert}
+                                    >
+                                      {(supporting, supportingDragProps) => (
+                                        <CollectionItem
+                                          frontId={this.props.id}
+                                          uuid={supporting.uuid}
+                                          parentId={articleFragment.uuid}
+                                          onSelect={id =>
+                                            this.props.selectArticleFragment(
+                                              id,
+                                              true
+                                            )
+                                          }
+                                          isUneditable={isUneditable}
+                                          getNodeProps={() =>
+                                            !isUneditable ? supportingDragProps : {}
+                                          }
+                                          onDelete={() =>
+                                            this.props.removeSupportingCollectionItem(
+                                              articleFragment.uuid,
+                                              supporting.uuid
+                                            )
+                                          }
+                                          size="small"
+                                        />
+                                      )}
+                                    </ArticleFragmentLevel>
+                                  </CollectionItem>
+                                </CollectionItemWrapper>
+                              );
+                            }}
+                          </GroupLevel>
+                        </GroupDisplay>
+                      )}
+                    </Collection>
+                  </CollectionWrapper>
                 );
               })}
             </Root>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -54,21 +54,21 @@ const FrontContentContainer = styled('div')`
 
 const CollectionWrapper = styled('div')`
   &:focus {
-    border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
-    border-top: 2px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
+    border-top: 2px solid ${props => props.theme.shared.base.colors.focusColor};
     border-bottom: 2px solid
-      ${({ theme }) => theme.shared.base.colors.focusColor};
+      ${props => props.theme.shared.base.colors.focusColor};
     outline: none;
   }
 `;
 
 const CollectionItemWrapper = styled('div')<{ articleSelected?: boolean }>`
-  border: ${({ articleSelected, theme }) =>
-    articleSelected
-      ? `1px solid ${theme.shared.base.colors.focusColor}`
+  border: ${props =>
+    props.articleSelected
+      ? `1px solid ${props.theme.shared.base.colors.focusColor}`
       : `none`};
   &:focus {
-    border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
+    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
     outline: none;
   }
 `;

--- a/client-v2/src/keyboard/index.ts
+++ b/client-v2/src/keyboard/index.ts
@@ -24,6 +24,7 @@ interface BaseFocusState {
   articleFragment?: ArticleFragment;
   groupId?: string;
   collectionId?: string;
+  frontId?: string;
 }
 
 export type ApplicationFocusStates = BaseFocusState;

--- a/client-v2/src/keyboard/index.ts
+++ b/client-v2/src/keyboard/index.ts
@@ -22,6 +22,7 @@ type FocusableTypes =
 interface BaseFocusState {
   type: FocusableTypes;
   articleFragment?: ArticleFragment;
+  groupId?: string;
   collectionId?: string;
 }
 

--- a/client-v2/src/keyboard/index.ts
+++ b/client-v2/src/keyboard/index.ts
@@ -13,11 +13,16 @@ import paste from './keyboardActionMaps/paste';
 import { moveUp, moveDown } from './keyboardActionMaps/move';
 import { ArticleFragment } from '../shared/types/Collection';
 
-type FocusableTypes = 'clipboard' | 'clipboardArticle';
+type FocusableTypes =
+  | 'clipboard'
+  | 'clipboardArticle'
+  | 'collection'
+  | 'collectionArticle';
 
 interface BaseFocusState {
   type: FocusableTypes;
   articleFragment?: ArticleFragment;
+  collectionId?: string;
 }
 
 export type ApplicationFocusStates = BaseFocusState;

--- a/client-v2/src/keyboard/keyboardActionMaps/move.ts
+++ b/client-v2/src/keyboard/keyboardActionMaps/move.ts
@@ -28,7 +28,8 @@ const moveUp: KeyboardActionMap = {
           'up',
           'collection',
           focusData.articleFragment,
-          focusData.groupId
+          focusData.groupId,
+          focusData.frontId
         )
       );
     } catch (e) {
@@ -62,7 +63,8 @@ const moveDown: KeyboardActionMap = {
           'down',
           'collection',
           focusData.articleFragment,
-          focusData.groupId
+          focusData.groupId,
+          focusData.frontId
         )
       );
     } catch (e) {

--- a/client-v2/src/keyboard/keyboardActionMaps/move.ts
+++ b/client-v2/src/keyboard/keyboardActionMaps/move.ts
@@ -18,6 +18,22 @@ const moveUp: KeyboardActionMap = {
     } catch (e) {
       Raven.captureMessage(`Moving item up in clipboard failed: ${e.message}`);
     }
+  },
+  collectionArticle: (focusData: ApplicationFocusStates) => async (
+    dispatch: Dispatch
+  ) => {
+    try {
+      dispatch(
+        keyboardArticleFragmentMove(
+          'up',
+          'collection',
+          focusData.articleFragment,
+          focusData.groupId
+        )
+      );
+    } catch (e) {
+      Raven.captureMessage(`Moving item up in clipboard failed: ${e.message}`);
+    }
   }
 };
 
@@ -31,6 +47,22 @@ const moveDown: KeyboardActionMap = {
           'down',
           'clipboard',
           focusData.articleFragment
+        )
+      );
+    } catch (e) {
+      Raven.captureMessage(`Moving item up in clipboard failed: ${e.message}`);
+    }
+  },
+  collectionArticle: (focusData: ApplicationFocusStates) => async (
+    dispatch: Dispatch
+  ) => {
+    try {
+      dispatch(
+        keyboardArticleFragmentMove(
+          'down',
+          'collection',
+          focusData.articleFragment,
+          focusData.groupId
         )
       );
     } catch (e) {

--- a/client-v2/src/keyboard/keyboardActionMaps/move.ts
+++ b/client-v2/src/keyboard/keyboardActionMaps/move.ts
@@ -51,7 +51,9 @@ const moveDown: KeyboardActionMap = {
         )
       );
     } catch (e) {
-      Raven.captureMessage(`Moving item up in clipboard failed: ${e.message}`);
+      Raven.captureMessage(
+        `Moving item down in clipboard failed: ${e.message}`
+      );
     }
   },
   collectionArticle: (focusData: ApplicationFocusStates) => async (
@@ -68,7 +70,9 @@ const moveDown: KeyboardActionMap = {
         )
       );
     } catch (e) {
-      Raven.captureMessage(`Moving item up in clipboard failed: ${e.message}`);
+      Raven.captureMessage(
+        `Moving item down in clipboard failed: ${e.message}`
+      );
     }
   }
 };

--- a/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -124,6 +124,9 @@ describe('nextIndexAndGroupSelector', () => {
         id: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
         type: 'fixed/small/slow-IV'
       },
+      'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99': {
+        uneditable: true
+      },
       '4ab657ff-c105-4292-af23-cda00457b6b7': {
         draft: ['group3'],
         lastUpdated: 1547202598354,
@@ -263,7 +266,7 @@ describe('nextIndexAndGroupSelector', () => {
     ).toEqual({ toIndex: 3, nextGroupId: 'group2' });
   });
 
-  it('return next group id when moving down between collections', () => {
+  it('return next editable group id when moving down between collections', () => {
     expect(
       nextIndexAndGroupSelector(
         stateWithGroups,

--- a/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -263,7 +263,11 @@ describe('nextIndexAndGroupSelector', () => {
         'up',
         'sc-johnson-partner-zone'
       )
-    ).toEqual({ toIndex: 3, nextGroupId: 'group2' });
+    ).toEqual({
+      toIndex: 3,
+      nextGroupId: 'group2',
+      collectionId: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808'
+    });
   });
 
   it('return next editable group id when moving down between collections', () => {
@@ -275,6 +279,10 @@ describe('nextIndexAndGroupSelector', () => {
         'down',
         'sc-johnson-partner-zone'
       )
-    ).toEqual({ toIndex: 0, nextGroupId: 'group3' });
+    ).toEqual({
+      toIndex: 0,
+      nextGroupId: 'group3',
+      collectionId: '4ab657ff-c105-4292-af23-cda00457b6b7'
+    });
   });
 });

--- a/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -146,44 +146,81 @@ describe('nextIndexAndGroupSelector', () => {
         stateWithEmptyGroup,
         'gobbleygook',
         'some-id',
-        'up'
+        'up',
+        'sc-johnson-partner-zone'
       )
     ).toEqual(null);
   });
 
   it('return null when moving top article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(stateWithGroups, 'group1', 'fragment-1', 'up')
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group1',
+        'fragment-1',
+        'up',
+        'sc-johnson-partner-zone'
+      )
     ).toEqual(null);
   });
 
   it('return next group id and index when moving up article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(stateWithGroups, 'group1', 'fragment-2', 'up')
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group1',
+        'fragment-2',
+        'up',
+        'sc-johnson-partner-zone'
+      )
     ).toEqual({ toIndex: 0, nextGroupId: 'group1' });
   });
 
   it('return null when moving bottom article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(stateWithGroups, 'group2', 'fragment-6', 'down')
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group2',
+        'fragment-6',
+        'down',
+        'sc-johnson-partner-zone'
+      )
     ).toEqual(null);
   });
 
   it('return next group id and index when moving down article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(stateWithGroups, 'group1', 'fragment-2', 'down')
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group1',
+        'fragment-2',
+        'down',
+        'sc-johnson-partner-zone'
+      )
     ).toEqual({ toIndex: 2, nextGroupId: 'group1' });
   });
 
   it('return next group id when moving down between groups', () => {
     expect(
-      nextIndexAndGroupSelector(stateWithGroups, 'group1', 'fragment-3', 'down')
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group1',
+        'fragment-3',
+        'down',
+        'sc-johnson-partner-zone'
+      )
     ).toEqual({ toIndex: 0, nextGroupId: 'group2' });
   });
 
   it('return next group id when moving up between groups', () => {
     expect(
-      nextIndexAndGroupSelector(stateWithGroups, 'group2', 'fragment-4', 'up')
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group2',
+        'fragment-4',
+        'up',
+        'sc-johnson-partner-zone'
+      )
     ).toEqual({ toIndex: 3, nextGroupId: 'group1' });
   });
 });

--- a/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -55,6 +55,12 @@ describe('nextIndexAndGroupSelector', () => {
       name: 'groupname',
       uuid: 'group2',
       articleFragments: ['fragment-4', 'fragment-5', 'fragment-6']
+    },
+    group3: {
+      id: 'group3',
+      name: 'groupname',
+      uuid: 'group3',
+      articleFragments: ['fragment-7', 'fragment-8']
     }
   };
   const artFragments = {
@@ -93,17 +99,38 @@ describe('nextIndexAndGroupSelector', () => {
       frontPublicationDate: 1547204861924,
       meta: { supporting: [] },
       uuid: 'id-6'
+    },
+    'fragment-7': {
+      id: 'internal-code/page/123',
+      frontPublicationDate: 1547204861924,
+      meta: { supporting: [] },
+      uuid: 'id-7'
+    },
+    'fragment-8': {
+      id: 'internal-code/page/123',
+      frontPublicationDate: 1547204861924,
+      meta: { supporting: [] },
+      uuid: 'id-8'
     }
   };
   const collections = {
     data: {
-      '5a32abdf-2d1c-4f9e-a116-617e4d055ab9': {
-        live: ['group1', 'group2'],
+      'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
+        draft: ['group1', 'group2'],
         lastUpdated: 1547202598354,
         updatedBy: 'Name Surname',
         updatedEmail: 'email@email.co.uk',
         displayName: 'headlines',
-        id: '5a32abdf-2d1c-4f9e-a116-617e4d055ab9',
+        id: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
+        type: 'fixed/small/slow-IV'
+      },
+      '4ab657ff-c105-4292-af23-cda00457b6b7': {
+        draft: ['group3'],
+        lastUpdated: 1547202598354,
+        updatedBy: 'Name Surname',
+        updatedEmail: 'email@email.co.uk',
+        displayName: 'headlines',
+        id: '4ab657ff-c105-4292-af23-cda00457b6b7',
         type: 'fixed/small/slow-IV'
       }
     },
@@ -180,8 +207,8 @@ describe('nextIndexAndGroupSelector', () => {
     expect(
       nextIndexAndGroupSelector(
         stateWithGroups,
-        'group2',
-        'fragment-6',
+        'group3',
+        'fragment-8',
         'down',
         'sc-johnson-partner-zone'
       )
@@ -222,5 +249,29 @@ describe('nextIndexAndGroupSelector', () => {
         'sc-johnson-partner-zone'
       )
     ).toEqual({ toIndex: 3, nextGroupId: 'group1' });
+  });
+
+  it('return next group id when moving up between collections', () => {
+    expect(
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group3',
+        'fragment-7',
+        'up',
+        'sc-johnson-partner-zone'
+      )
+    ).toEqual({ toIndex: 3, nextGroupId: 'group2' });
+  });
+
+  it('return next group id when moving down between collections', () => {
+    expect(
+      nextIndexAndGroupSelector(
+        stateWithGroups,
+        'group2',
+        'fragment-6',
+        'down',
+        'sc-johnson-partner-zone'
+      )
+    ).toEqual({ toIndex: 0, nextGroupId: 'group3' });
   });
 });

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -25,13 +25,17 @@ const getFronts = (state: State): FrontConfigMap =>
 
 const getFront = (state: State, id: string) => getFronts(state)[id];
 
-const getUnlockedFrontCollections = (state: State, frontId: string): string[] => getFront(state, frontId).collections.reduce((unlockedCollections: string[], collectionId) => {
-  const collection = getCollectionConfig(state, collectionId);
-  if (!collection.uneditable) {
-    unlockedCollections.push(collectionId);
-  }
-  return unlockedCollections;
-}, []);
+const getUnlockedFrontCollections = (state: State, frontId: string): string[] =>
+  getFront(state, frontId).collections.reduce(
+    (unlockedCollections: string[], collectionId) => {
+      const collection = getCollectionConfig(state, collectionId);
+      if (!collection.uneditable) {
+        unlockedCollections.push(collectionId);
+      }
+      return unlockedCollections;
+    },
+    []
+  );
 
 const getFrontsByPriority = createSelector(
   [getFronts],

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -25,8 +25,13 @@ const getFronts = (state: State): FrontConfigMap =>
 
 const getFront = (state: State, id: string) => getFronts(state)[id];
 
-const getFrontCollections = (state: State, frontId: string) =>
-  getFront(state, frontId).collections;
+const getUnlockedFrontCollections = (state: State, frontId: string): string[] => getFront(state, frontId).collections.reduce((unlockedCollections: string[], collectionId) => {
+  const collection = getCollectionConfig(state, collectionId);
+  if (!collection.uneditable) {
+    unlockedCollections.push(collectionId);
+  }
+  return unlockedCollections;
+}, []);
 
 const getFrontsByPriority = createSelector(
   [getFronts],
@@ -282,7 +287,6 @@ const visibleFrontArticlesSelector = createSelector(
 export {
   getFront,
   getFronts,
-  getFrontCollections,
   getFrontsConfig,
   getCollectionConfig,
   frontsConfigSelector,
@@ -294,5 +298,6 @@ export {
   hasUnpublishedChangesSelector,
   clipboardSelector,
   visibleArticlesSelector,
-  visibleFrontArticlesSelector
+  visibleFrontArticlesSelector,
+  getUnlockedFrontCollections
 };

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -25,6 +25,9 @@ const getFronts = (state: State): FrontConfigMap =>
 
 const getFront = (state: State, id: string) => getFronts(state)[id];
 
+const getFrontCollections = (state: State, frontId: string) =>
+  getFront(state, frontId).collections;
+
 const getFrontsByPriority = createSelector(
   [getFronts],
   (fronts: FrontConfigMap): FrontsByPriority =>
@@ -279,6 +282,7 @@ const visibleFrontArticlesSelector = createSelector(
 export {
   getFront,
   getFronts,
+  getFrontCollections,
   getFrontsConfig,
   getCollectionConfig,
   frontsConfigSelector,

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -51,6 +51,8 @@ const nextIndexAndGroupSelector = (
     groupId,
     articleId
   );
+
+  // Checking if moving inside the group
   if (action === 'down') {
     // If the article fragment is not the last in the group, the article stays in the group
     if (currentArticleIndex < groupArticleFragments.length - 1) {
@@ -65,7 +67,7 @@ const nextIndexAndGroupSelector = (
     }
   }
 
-  // If the article can't stay in the same group we check if there is another group it can move to
+  // Checking if moving between groups but inside the collection
   const { collection, collectionItemSet } = groupCollectionSelector(
     sharedState,
     groupId
@@ -92,48 +94,46 @@ const nextIndexAndGroupSelector = (
       }
     }
 
-    if (frontId) {
-      const frontCollections = getFrontCollections(state, frontId);
-      const collectionIndex = frontCollections.indexOf(collection.id);
-      if (action === 'down') {
-        if (collectionIndex < frontCollections.length - 1) {
-          const collectionSelector = createCollectionSelector();
-          const coll = collectionSelector(sharedState, {
-            collectionId: frontCollections[collectionIndex + 1]
-          });
-          if (!coll || !coll.draft) {
-            return null;
-          }
-
-          const nextGroupId = coll.draft[0];
-          return { toIndex: 0, nextGroupId };
+    // Checking if moving between collections
+    const frontCollections = getFrontCollections(state, frontId);
+    const collectionIndex = frontCollections.indexOf(collection.id);
+    if (action === 'down') {
+      if (collectionIndex < frontCollections.length - 1) {
+        const collectionSelector = createCollectionSelector();
+        const coll = collectionSelector(sharedState, {
+          collectionId: frontCollections[collectionIndex + 1]
+        });
+        if (!coll || !coll.draft) {
+          return null;
         }
+
+        const nextGroupId = coll.draft[0];
+        return { toIndex: 0, nextGroupId };
       }
-      if (action === 'up') {
-        if (collectionIndex !== 0) {
-          const collectionSelector = createCollectionSelector();
-          const coll = collectionSelector(sharedState, {
-            collectionId: frontCollections[collectionIndex - 1]
-          });
+    }
+    if (action === 'up') {
+      if (collectionIndex !== 0) {
+        const collectionSelector = createCollectionSelector();
+        const coll = collectionSelector(sharedState, {
+          collectionId: frontCollections[collectionIndex - 1]
+        });
 
-          if (!coll || !coll.draft) {
-            return null;
-          }
-
-          const nextIndex = coll.draft.length;
-          const nextGroupId = coll.draft[nextIndex - 1];
-
-          const nextGroupArticles = groupsSelector(sharedState)[nextGroupId]
-            .articleFragments;
-
-          return { toIndex: nextGroupArticles.length, nextGroupId };
+        if (!coll || !coll.draft) {
+          return null;
         }
+
+        const nextIndex = coll.draft.length;
+        const nextGroupId = coll.draft[nextIndex - 1];
+
+        const nextGroupArticles = groupsSelector(sharedState)[nextGroupId]
+          .articleFragments;
+
+        return { toIndex: nextGroupArticles.length, nextGroupId };
       }
     }
   }
 
-  // Move to the next collection: TODO
-  // Else there is nowhere we can move
+  // If there is nowhere we can move we return null
 
   return null;
 };

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -7,7 +7,7 @@ import {
 } from '../shared/selectors/shared';
 import { clipboardContentSelector } from 'selectors/clipboardSelectors';
 import { State } from 'types/State';
-import { getFrontCollections } from './frontsSelectors';
+import { getUnlockedFrontCollections } from './frontsSelectors';
 
 const nextClipboardIndexSelector = (
   state: State,
@@ -95,7 +95,7 @@ const nextIndexAndGroupSelector = (
     }
 
     // Checking if moving between collections
-    const frontCollections = getFrontCollections(state, frontId);
+    const frontCollections = getUnlockedFrontCollections(state, frontId);
     const collectionIndex = frontCollections.indexOf(collection.id);
     if (action === 'down') {
       if (collectionIndex < frontCollections.length - 1) {

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -108,7 +108,7 @@ const nextIndexAndGroupSelector = (
         }
 
         const nextGroupId = coll.draft[0];
-        return { toIndex: 0, nextGroupId };
+        return { toIndex: 0, nextGroupId, collectionId: coll.id };
       }
     }
     if (action === 'up') {
@@ -128,7 +128,11 @@ const nextIndexAndGroupSelector = (
         const nextGroupArticles = groupsSelector(sharedState)[nextGroupId]
           .articleFragments;
 
-        return { toIndex: nextGroupArticles.length, nextGroupId };
+        return {
+          toIndex: nextGroupArticles.length,
+          nextGroupId,
+          collectionId: coll.id
+        };
       }
     }
   }

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -95,15 +95,15 @@ const nextIndexAndGroupSelector = (
     if (frontId) {
       const frontCollections = getFrontCollections(state, frontId);
       const collectionIndex = frontCollections.indexOf(collection.id);
-
       if (action === 'down') {
         if (collectionIndex < frontCollections.length - 1) {
           const collectionSelector = createCollectionSelector();
           const coll = collectionSelector(sharedState, {
             collectionId: frontCollections[collectionIndex + 1]
           });
-
-          if (!coll || !coll.draft) { return null; }
+          if (!coll || !coll.draft) {
+            return null;
+          }
 
           const nextGroupId = coll.draft[0];
           return { toIndex: 0, nextGroupId };
@@ -116,12 +116,17 @@ const nextIndexAndGroupSelector = (
             collectionId: frontCollections[collectionIndex - 1]
           });
 
-          if (!coll || !coll.draft) { return null; }
+          if (!coll || !coll.draft) {
+            return null;
+          }
 
-          const nextIndex = coll.draft.length - 1;
-          const nextGroupId = coll.draft[nextIndex];
+          const nextIndex = coll.draft.length;
+          const nextGroupId = coll.draft[nextIndex - 1];
 
-          return { toIndex: nextIndex, nextGroupId };
+          const nextGroupArticles = groupsSelector(sharedState)[nextGroupId]
+            .articleFragments;
+
+          return { toIndex: nextGroupArticles.length, nextGroupId };
         }
       }
     }

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -203,7 +203,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
         id={collection && createCollectionId(collection)}
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
       >
-        <ContainerHeadingPinline>
+        <ContainerHeadingPinline tabIndex={-1}>
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText isLoading={!collection} title={displayName}>
               {displayName}
@@ -277,6 +277,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               <ButtonCircularCaret
                 active={this.props.isOpen!}
                 preActive={this.state.hasDragOpenIntent}
+                tabIndex={-1}
               />
             </CollectionToggleContainer>
           </CollectionMetaContainer>


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Move articles inside collections and between collections using up and down arrows. 

Annoyingly we don't have a good solution for keyboard shortcuts for selecting specific fronts/collections yet as mousetrap does not understand regexes in keyboard commands.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
