### PR TITLE
Fetch missing collections as well

### DIFF
--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -127,6 +127,67 @@ describe('Collection actions', () => {
         }
       });
     });
+    it('should add fetched automated collections to the store', async () => {
+      const collectionIds = ['automatedCollection'];
+      fetchMock.post('/collections', []);
+      await store.dispatch(getCollections(collectionIds) as any);
+      expect(store.getState().shared.collections.data).toEqual({
+        exampleCollection: {
+          displayName: 'Example Collection',
+          draft: [],
+          id: 'exampleCollection',
+          live: ['abc', 'def'],
+          previously: undefined,
+          type: 'type'
+        },
+        exampleCollectionTwo: {
+          displayName: 'Example Collection',
+          draft: ['def'],
+          id: 'exampleCollection',
+          live: ['abc'],
+          previously: undefined,
+          type: 'type'
+        },
+        automatedCollection: {
+          id: 'automatedCollection',
+          displayName: 'automated',
+          type: 'type',
+          draft: ['uuid'],
+          live: ['uuid'],
+          metadata: undefined,
+          platform: undefined,
+          previously: ['uuid'],
+          groups: undefined,
+          frontsToolSettings: undefined
+        },
+        testCollection1: {
+          displayName: 'testCollection',
+          draft: ['uuid'],
+          frontsToolSettings: undefined,
+          groups: undefined,
+          id: 'testCollection1',
+          lastUpdated: 1547479667115,
+          live: ['uuid'],
+          metadata: undefined,
+          platform: undefined,
+          previously: ['uuid'],
+          type: 'type'
+        },
+        testCollection2: {
+          displayName: 'testCollection',
+          draft: ['uuid'],
+          frontsToolSettings: undefined,
+          groups: undefined,
+          id: 'testCollection2',
+          lastUpdated: 1547479667115,
+          live: ['uuid'],
+          metadata: undefined,
+          platform: undefined,
+          previously: ['uuid'],
+          type: 'type'
+        }
+      });
+    });
     it('should send only collection id and type in request body when returnOnlyUpdatedCollection is false or default', async () => {
       const collectionIds = ['testCollection1', 'testCollection2'];
       const request = fetchMock.post(
@@ -153,7 +214,7 @@ describe('Collection actions', () => {
         { id: 'testCollection2', lastUpdated: 1547479667115 }
       ]);
     });
-    it('should ignore automated collections without content', async () => {
+    it('should correctly poll for changes in automated collections', async () => {
       const collectionIds = [
         'testCollection1',
         'testCollection2',
@@ -167,7 +228,8 @@ describe('Collection actions', () => {
       const result = request.lastOptions().body;
       expect(JSON.parse(result as string)).toEqual([
         { id: 'testCollection1', lastUpdated: 1547479667115 },
-        { id: 'testCollection2', lastUpdated: 1547479667115 }
+        { id: 'testCollection2', lastUpdated: 1547479667115 },
+        { id: 'automatedCollection' }
       ]);
     });
   });

--- a/client-v2/src/shared/actions/Groups.ts
+++ b/client-v2/src/shared/actions/Groups.ts
@@ -3,7 +3,7 @@ import { CapGroupSiblings } from 'shared/types/Action';
 
 function groupsReceived(groups: { [id: string]: Group }) {
   return {
-    type: 'SHARED/GROUPS_RECEIVED',
+    type: 'SHARED/GROUPS_RECEIVED' as 'SHARED/GROUPS_RECEIVED',
     payload: groups
   };
 }


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_
Fixes a bug where new/automated collections were always displaying as loading and we were not able to add content in them. This is because we weren't correctly handling the case of the collection.json file not existing for these collections. This PR fixes this by constructing an empty collection from the collectionConfig if a separate collection json file does not exist.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
