### PR TITLE
Rv delete kickers

### DIFF
--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -149,7 +149,7 @@ describe('ArticleFragmentForm transform functions', () => {
     });
   });
   describe('Derive articleFragment meta from form values', () => {
-    it('should return nothing if no form values were dirtied', () => {
+    it('should return existing meta if no form values were dirtied', () => {
       const state = createStateWithChangedFormFields(
         initialState,
         'exampleId',
@@ -157,7 +157,7 @@ describe('ArticleFragmentForm transform functions', () => {
       );
       expect(
         getArticleFragmentMetaFromFormValues(state, 'exampleId', formValues)
-      ).toEqual({});
+      ).toEqual({ headline: 'Bill Shorten', supporting: [] });
     });
     it('should derive values, removing the slideshow array if empty', () => {
       const byline = 'Caroline Davies edited';
@@ -186,7 +186,8 @@ describe('ArticleFragmentForm transform functions', () => {
         headline:
           "Sister of academic's killer warned police he was mentally ill edited",
         trailText:
-          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him edited'
+          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him edited',
+        supporting: []
       });
     });
     it('should derive values, setting the imageReplace value if necessary', () => {
@@ -214,7 +215,9 @@ describe('ArticleFragmentForm transform functions', () => {
         imageSrcHeight: '100',
         imageSrcOrigin: 'exampleOrigin',
         imageSrcThumb: 'exampleThumb',
-        imageSrcWidth: '100'
+        imageSrcWidth: '100',
+        supporting: [],
+        headline: 'Bill Shorten'
       });
     });
     it('should remove customKicker and showKickerCustom if the kicker is empty', () => {
@@ -232,7 +235,7 @@ describe('ArticleFragmentForm transform functions', () => {
           ...formValues,
           ...values
         })
-      ).toEqual({});
+      ).toEqual({ supporting: [], headline: 'Bill Shorten' });
     });
     it('should handle conversion of string values for images', () => {
       const values = {
@@ -271,6 +274,7 @@ describe('ArticleFragmentForm transform functions', () => {
           ...values
         })
       ).toEqual({
+        headline: 'Bill Shorten',
         imageSrc: 'exampleSrc',
         imageSrcHeight: '100',
         imageSrcOrigin: 'exampleOrigin',
@@ -291,7 +295,8 @@ describe('ArticleFragmentForm transform functions', () => {
             origin: 'exampleOrigin',
             thumb: 'exampleThumb'
           }
-        ]
+        ],
+        supporting: []
       });
     });
   });

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -157,7 +157,7 @@ describe('ArticleFragmentForm transform functions', () => {
       );
       expect(
         getArticleFragmentMetaFromFormValues(state, 'exampleId', formValues)
-      ).toEqual({ headline: 'Bill Shorten', supporting: [] });
+      ).toEqual({ headline: 'Bill Shorten' });
     });
     it('should derive values, removing the slideshow array if empty', () => {
       const byline = 'Caroline Davies edited';
@@ -186,8 +186,7 @@ describe('ArticleFragmentForm transform functions', () => {
         headline:
           "Sister of academic's killer warned police he was mentally ill edited",
         trailText:
-          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him edited',
-        supporting: []
+          'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him edited'
       });
     });
     it('should derive values, setting the imageReplace value if necessary', () => {
@@ -216,7 +215,6 @@ describe('ArticleFragmentForm transform functions', () => {
         imageSrcOrigin: 'exampleOrigin',
         imageSrcThumb: 'exampleThumb',
         imageSrcWidth: '100',
-        supporting: [],
         headline: 'Bill Shorten'
       });
     });
@@ -235,7 +233,7 @@ describe('ArticleFragmentForm transform functions', () => {
           ...formValues,
           ...values
         })
-      ).toEqual({ supporting: [], headline: 'Bill Shorten' });
+      ).toEqual({ headline: 'Bill Shorten' });
     });
     it('should handle conversion of string values for images', () => {
       const values = {
@@ -295,8 +293,7 @@ describe('ArticleFragmentForm transform functions', () => {
             origin: 'exampleOrigin',
             thumb: 'exampleThumb'
           }
-        ],
-        supporting: []
+        ]
       });
     });
   });

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -262,6 +262,12 @@ const state = {
         frontPublicationDate: 1547204861924,
         meta: { supporting: [] },
         uuid: '56a3b407-741c-439f-a678-175abea44a9f'
+      },
+      exampleId: {
+        id: 'internal-code/page/5592826',
+        frontPublicationDate: 1547204861924,
+        meta: { headline: 'Bill Shorten', supporting: [] },
+        uuid: 'exampleId'
       }
     },
     groups: {

--- a/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
+++ b/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
@@ -16,7 +16,7 @@ describe('articleFragmentsReducer', () => {
       headline: 'headline'
     });
   });
-  it("shouldn't overwrite properties", () => {
+  it('should overwrite properties', () => {
     expect(
       reducer(
         stateWithClipboard.shared.articleFragments as any,
@@ -26,8 +26,7 @@ describe('articleFragmentsReducer', () => {
         stateWithClipboard.shared
       ).article2.meta
     ).toEqual({
-      headline: 'headline',
-      supporting: ['article3']
+      headline: 'headline'
     });
   });
 });

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -22,10 +22,7 @@ const articleFragments = (
         ...state,
         [id]: {
           ...state[id],
-          meta: {
-            ...(state[id].meta || {}),
-            ...action.payload.meta
-          }
+          meta: action.payload.meta
         }
       };
     }

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -1,4 +1,5 @@
 import omit from 'lodash/omit';
+import omitBy from 'lodash/omitBy';
 import compact from 'lodash/compact';
 import clamp from 'lodash/clamp';
 import pickBy from 'lodash/pickBy';
@@ -206,12 +207,13 @@ export const getArticleFragmentMetaFromFormValues = (
   };
 
   if (!values.customKicker) {
-    newArticleFragmentMeta = omit(
-      newArticleFragmentMeta,
-      'customKicker',
-      'showKickerCustom'
-    );
+    newArticleFragmentMeta = omit(newArticleFragmentMeta, 'showKickerCustom');
   }
 
-  return newArticleFragmentMeta;
+  return omitBy(newArticleFragmentMeta, (value: string | boolean | any[]) => {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
+    return !value;
+  });
 };


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

This PR makes sure we can omit empty values from the articleFragment meta object. It fixes a bug where we couldn't remove kickers from articles because omitted values were not being recognised as updated on the form. This pr also cleans all falsy values and empty arrays from the meta object to correspond with what is saved in the meta by v1 and avoid any obscure future bugs.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
