### PR TITLE
Display less info on collection overview panel and shrink it

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -43,7 +43,7 @@ const Container = styled(ContentContainer)<ContainerProps>`
 `;
 
 const ContainerBody = styled.div`
-  width: 360px;
+  width: 130px;
 `;
 
 const FrontCollectionsOverview = ({

--- a/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
@@ -1,48 +1,8 @@
 import {
-  isCollectionBackfilledSelector,
   isCollectionLockedSelector,
-  createCollectionHasUnsavedArticleEditsWarningSelector,
   createCollectionsInOpenFrontsSelector
 } from 'selectors/collectionSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
-
-import state from 'fixtures/initialState';
-import { reducer, initialize, change } from 'redux-form';
-
-const createCleanFormState = () =>
-  reducer(
-    undefined,
-    initialize('56a3b407-741c-439f-a678-175abea44a9f', { field: true })
-  );
-
-describe('Checking if Collection Articles on Fronts have dirty form data', () => {
-  it('return false if any article in collection is clean', () => {
-    const hasUnsavedArticleEditsSelector = createCollectionHasUnsavedArticleEditsWarningSelector();
-    const cleanState = { ...state, form: createCleanFormState() };
-    expect(
-      hasUnsavedArticleEditsSelector(cleanState, {
-        collectionSet: 'live',
-        collectionId: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808'
-      })
-    ).toEqual(false);
-  });
-
-  it('return true if any article in collection is dirty ', () => {
-    const hasUnsavedArticleEditsSelector = createCollectionHasUnsavedArticleEditsWarningSelector();
-    const dirtyFormState = reducer(
-      createCleanFormState(),
-      change('56a3b407-741c-439f-a678-175abea44a9f', 'field', false)
-    );
-    const dirtyState = { ...state, form: dirtyFormState };
-
-    expect(
-      hasUnsavedArticleEditsSelector(dirtyState, {
-        collectionSet: 'live',
-        collectionId: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808'
-      })
-    ).toEqual(true);
-  });
-});
 
 describe('Validating Front Collection configuration metadata', () => {
   it('validates correctly if Collection is uneditable ', () => {
@@ -58,28 +18,6 @@ describe('Validating Front Collection configuration metadata', () => {
     ).toEqual(true);
     expect(
       isCollectionLockedSelector(
-        {
-          fronts: {
-            frontsConfig
-          }
-        } as any,
-        'collection2'
-      )
-    ).toEqual(false);
-  });
-  it('validates correctly if Collection is backfilled', () => {
-    expect(
-      isCollectionBackfilledSelector(
-        {
-          fronts: {
-            frontsConfig
-          }
-        } as any,
-        'collection1'
-      )
-    ).toEqual(true);
-    expect(
-      isCollectionBackfilledSelector(
         {
           fronts: {
             frontsConfig

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -2,11 +2,8 @@ import { State } from 'types/State';
 import { getCollectionConfig } from './frontsSelectors';
 import {
   selectSharedState,
-  createArticlesInCollectionSelector,
   createCollectionSelector
 } from 'shared/selectors/shared';
-import { isDirty } from 'redux-form';
-import { CollectionItemSets } from 'shared/types/Collection';
 import flatten from 'lodash/flatten';
 import { createSelectEditorFrontsByPriority } from 'bundles/frontsUIBundle';
 
@@ -57,30 +54,8 @@ function createCollectionsInOpenFrontsSelector() {
 const isCollectionLockedSelector = (state: State, id: string): boolean =>
   !!getCollectionConfig(state, id).uneditable;
 
-const isCollectionBackfilledSelector = (state: State, id: string): boolean =>
-  !!getCollectionConfig(state, id).backfill;
-
-const createCollectionHasUnsavedArticleEditsWarningSelector = () => {
-  const articlesInCollectionSelector = createArticlesInCollectionSelector();
-
-  return (
-    state: State,
-    props: {
-      collectionSet: CollectionItemSets;
-      collectionId: string;
-    }
-  ) =>
-    articlesInCollectionSelector(selectSharedState(state), props).reduce(
-      (hasEdits: boolean, article: string) =>
-        hasEdits || isDirty(article)(state),
-      false
-    );
-};
-
 export {
   collectionParamsSelector,
   isCollectionLockedSelector,
-  isCollectionBackfilledSelector,
-  createCollectionsInOpenFrontsSelector,
-  createCollectionHasUnsavedArticleEditsWarningSelector
+  createCollectionsInOpenFrontsSelector
 };


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Make the overview panel smaller. 

- Don't display last modified dates
- Don't display data on backfills, locked articles
- Keep title, number of articles and unlaunched changes indicator

![Screenshot 2019-04-16 at 13 59 37](https://user-images.githubusercontent.com/3066534/56211514-f6c06e80-604f-11e9-9487-90359600463b.png)


## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
