### PR TITLE
Prevent drop zones from blocking cursor events when a drag is not occurring

### DIFF
--- a/client-v2/src/components/DropZone.tsx
+++ b/client-v2/src/components/DropZone.tsx
@@ -4,10 +4,11 @@ import { theme } from 'constants/theme';
 
 const DropContainer = styled('div')`
   position: relative;
-  height: 15px;
+  height: 10px;
 `;
 
 const DropIndicator = styled('div')`
+  position: relative;
   height: 100%;
   pointer-events: none;
 `;

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -50,12 +50,14 @@ const ArticleFragmentLevel = ({
         override={isTarget}
         dropColor="hsl(0, 0%, 64%)"
         style={{
-          marginTop: '-15px',
-          padding: '3px'
+          marginTop: '-30px',
+          height: '30px'
         }}
         indicatorStyle={{
-          marginLeft: '20px',
-          marginRight: `${displayType === 'default' ? '130px' : 0}`
+          marginLeft: '80px',
+          marginRight: `${displayType === 'default' ? '130px' : 0}`,
+          top: '66%',
+          height: '33%'
         }}
       />
     )}

--- a/client-v2/src/lib/dnd/DropZone.tsx
+++ b/client-v2/src/lib/dnd/DropZone.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StoreConsumer } from './Root';
 import { Store, Sub } from './store';
 import { NO_STORE_ERROR } from './constants';
+import { styled } from 'constants/theme';
 
 interface OuterProps {
   parentKey: string;
@@ -17,10 +18,15 @@ type Props = OuterProps & ContextProps;
 
 interface State {
   isTarget: boolean;
+  isActive: boolean;
 }
 
+const DropZoneContainer = styled.div<{ isActive: boolean }>`
+  ${({ isActive }) => !isActive && 'pointer-events: none'}
+`;
+
 class DropZone extends React.Component<Props, State> {
-  public state = { isTarget: false };
+  public state = { isTarget: false, isActive: false };
 
   public componentDidMount() {
     if (!this.props.store) {
@@ -37,10 +43,19 @@ class DropZone extends React.Component<Props, State> {
   }
 
   public render() {
-    return this.props.children(this.state.isTarget);
+    return (
+      <DropZoneContainer isActive={this.state.isActive}>
+        {this.props.children(this.state.isTarget)}
+      </DropZoneContainer>
+    );
   }
 
   private handleStoreUpdate: Sub = (id, hoverIndex) => {
+    const state = this.props.store && this.props.store.getState();
+    const isActive = state ? state.isDraggedOver : false;
+    if (isActive !== this.state.isActive) {
+      this.setState({ isActive });
+    }
     if (
       id === this.props.parentKey &&
       hoverIndex === this.props.index &&

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -78,7 +78,11 @@ interface ContextProps {
 
 type Props<T> = OuterProps<T> & ContextProps;
 
-class Level<T> extends React.Component<Props<T>, { isDraggedOver: boolean }> {
+interface State {
+  isDraggedOver: boolean;
+}
+
+class Level<T> extends React.Component<Props<T>, State> {
   get key() {
     return `${this.props.parentId}:${this.props.parentType}`;
   }

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -151,12 +151,6 @@ class Level<T> extends React.Component<Props<T>, State> {
 
     e.preventDefault();
 
-    // Reset the dragging state on drop
-    if (this.props.store) {
-      const { key, index: storeIndex } = this.props.store.getState();
-      this.props.store.update(key, storeIndex, false);
-    }
-
     const { onMove = () => null, onDrop = () => null } = this.props;
     const af = e.dataTransfer.getData(TRANSFER_TYPE);
 

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -78,7 +78,7 @@ interface ContextProps {
 
 type Props<T> = OuterProps<T> & ContextProps;
 
-class Level<T> extends React.Component<Props<T>> {
+class Level<T> extends React.Component<Props<T>, { isDraggedOver: boolean }> {
   get key() {
     return `${this.props.parentId}:${this.props.parentType}`;
   }
@@ -137,7 +137,7 @@ class Level<T> extends React.Component<Props<T>> {
       return;
     }
     e.preventDefault();
-    this.props.store.update(this.key, this.getDropIndex(e, i, isNode));
+    this.props.store.update(this.key, this.getDropIndex(e, i, isNode), true);
   };
 
   private onDrop = (i: number, isNode: boolean) => (e: React.DragEvent) => {
@@ -146,6 +146,13 @@ class Level<T> extends React.Component<Props<T>> {
     }
 
     e.preventDefault();
+
+    // Reset the dragging state on drop
+    if (this.props.store) {
+      const { key, index: storeIndex } = this.props.store.getState();
+      this.props.store.update(key, storeIndex, false);
+    }
+
     const { onMove = () => null, onDrop = () => null } = this.props;
     const af = e.dataTransfer.getData(TRANSFER_TYPE);
 

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -43,6 +43,8 @@ export default class Root extends React.Component<Props, State> {
     if (!e.defaultPrevented) {
       this.reset();
     }
+    const { key, index } = this.state.store.getState();
+    this.state.store.update(key, index, true);
   };
 
   private onDragLeave = ({
@@ -57,7 +59,7 @@ export default class Root extends React.Component<Props, State> {
     }
   };
 
-  private reset = () => this.state.store.update(null, null);
+  private reset = () => this.state.store.update(null, null, false);
 }
 
 export { StoreConsumer, isMove, isInside };

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -25,6 +25,7 @@ export default class Root extends React.Component<Props, State> {
     return (
       <div
         {...divProps}
+        onDragEnter={this.onDragEnter}
         onDragOver={this.onDragOver}
         onDragLeave={this.onDragLeave}
         onDragEnd={this.reset}
@@ -39,12 +40,15 @@ export default class Root extends React.Component<Props, State> {
     );
   }
 
+  private onDragEnter = () => {
+    const { key, index } = this.state.store.getState();
+    this.state.store.update(key, index, true);
+  };
+
   private onDragOver = (e: React.DragEvent) => {
     if (!e.defaultPrevented) {
       this.reset();
     }
-    const { key, index } = this.state.store.getState();
-    this.state.store.update(key, index, true);
   };
 
   private onDragLeave = ({

--- a/client-v2/src/lib/dnd/__tests__/store.spec.ts
+++ b/client-v2/src/lib/dnd/__tests__/store.spec.ts
@@ -3,13 +3,21 @@ import createStore from '../store';
 describe('store', () => {
   it('has an initial state of null', () => {
     const store = createStore();
-    expect(store.getState()).toEqual({ key: null, index: null });
+    expect(store.getState()).toEqual({
+      key: null,
+      index: null,
+      isDraggedOver: false
+    });
   });
 
   it('updates the state with `update`', () => {
     const store = createStore();
-    store.update('a', 1);
-    expect(store.getState()).toEqual({ key: 'a', index: 1 });
+    store.update('a', 1, false);
+    expect(store.getState()).toEqual({
+      key: 'a',
+      index: 1,
+      isDraggedOver: false
+    });
   });
 
   it('sends updates to listeners', () => {
@@ -24,7 +32,7 @@ describe('store', () => {
     };
 
     store.subscribe(fn);
-    store.update('a', 1);
+    store.update('a', 1, false);
     expect([key, index]).toEqual(['a', 1]);
   });
 
@@ -41,7 +49,7 @@ describe('store', () => {
 
     store.subscribe(fn);
     store.unsubscribe(fn);
-    store.update('a', 1);
+    store.update('a', 1, false);
     expect([key, index]).toEqual(['b', 2]);
   });
 });

--- a/client-v2/src/lib/dnd/store.ts
+++ b/client-v2/src/lib/dnd/store.ts
@@ -6,17 +6,20 @@ type Sub = (key: Key, index: Index) => void;
 interface State {
   key: Key;
   index: Index;
+  isDraggedOver: boolean;
 }
 
-const createStore = (initState: State = { key: null, index: null }) => {
+const createStore = (
+  initState: State = { key: null, index: null, isDraggedOver: false }
+) => {
   let subs: Sub[] = [];
   let state = initState;
 
   return {
     subscribe: (fn: Sub) => (subs = [...subs, fn]),
     unsubscribe: (fn: Sub) => (subs = subs.filter(c => c !== fn)),
-    update: (key: Key, index: Index) => {
-      state = { key, index };
+    update: (key: Key, index: Index, isDraggedOver: boolean) => {
+      state = { key, index, isDraggedOver };
       subs.forEach(sub => sub(key, index));
     },
     getState: () => state


### PR DESCRIPTION
## What's changed?

Prevent drop zones from blocking cursor events when a drag is not occurring. Drop zones obscure the bottom part of articles, which affects hover and drag operations.

This change gives us a little more freedom to style our drop zones without worrying that they get in the way of other cursor operations, so dropzones for supporting articles have been expanded to be less fiddly, and the space between articles has been reduced by 5px, giving us about an extra article's worth of space on the 900 or so px you get on a MacBook screen 👍 

## Implementation notes

It'd be great to have @RichieAHB's input here to check that my changes are consistent with his lib code!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
