### PR TITLE
Debounce save requests and add tests

### DIFF
--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -1,0 +1,207 @@
+import { createStore, compose, applyMiddleware } from 'redux';
+import { persistCollectionOnEdit } from 'util/storeMiddleware';
+import thunk from 'redux-thunk';
+import { enableBatching } from 'redux-batched-actions';
+import { moveArticleFragment } from 'actions/ArticleFragments';
+import { Dispatch } from 'types/Store';
+import fetchMock from 'fetch-mock';
+import rootReducer from 'reducers/rootReducer';
+import { NestedArticleFragment } from 'shared/types/Collection';
+import { updateCollection } from 'actions/Collections';
+
+const A1 = {
+  uuid: 'a1',
+  id: 'a',
+  frontPublicationDate: 1000,
+  meta: {}
+};
+
+const A2 = {
+  uuid: 'a2',
+  id: 'b',
+  frontPublicationDate: 2000,
+  meta: {}
+};
+
+const A3 = {
+  uuid: 'a3',
+  id: 'c',
+  frontPublicationDate: 2000,
+  meta: {}
+};
+
+const init = () => {
+  const initState = {
+    shared: {
+      collections: {
+        loadingIds: [],
+        updatingIds: [],
+        data: {
+          c1: {
+            id: 'c1',
+            live: ['g1'],
+            draft: [],
+            previously: []
+          },
+          c2: {
+            id: 'c2',
+            live: ['g2'],
+            draft: [],
+            previously: []
+          }
+        }
+      },
+      groups: {
+        g1: {
+          uuid: 'g1',
+          id: 'g1',
+          articleFragments: ['a1', 'a2']
+        },
+        g2: {
+          uuid: 'g2',
+          id: 'g2',
+          articleFragments: ['a3']
+        }
+      },
+      articleFragments: {
+        a1: A1,
+        a2: A2,
+        a3: A3
+      }
+    }
+  };
+  const reducer = enableBatching(rootReducer);
+  const middleware = compose(
+    applyMiddleware(
+      thunk,
+      // the second param here is debounce time, we have to set this
+      // as longer debounce times with lodash/debounce don't play well
+      // with jest fake timers
+      persistCollectionOnEdit(updateCollection, 1)
+    )
+  );
+  return createStore(reducer, initState as any, middleware);
+};
+
+const groupedArticleFragmentIds = (afs: NestedArticleFragment[]) =>
+  afs.reduce(
+    (acc, af) => ({
+      ...acc,
+      [af.meta.group || 0]: (acc[af.meta.group || 0] || []).concat(af.id)
+    }),
+    {} as { [groupId: string]: string[] }
+  );
+
+jest.useFakeTimers();
+
+describe('Collection persistence', () => {
+  describe('moves', () => {
+    beforeEach(fetchMock.restore);
+    it('makes one persistence request for moves in same collection', () => {
+      const { dispatch }: { dispatch: Dispatch } = init();
+      fetchMock.mock(/stories-visible/, {});
+      fetchMock.mock(
+        /v2Edits/,
+        {},
+        {
+          name: 'edits'
+        }
+      );
+      dispatch(
+        moveArticleFragment(
+          { id: 'g1', type: 'group', index: 1 },
+          A1,
+          { id: 'g1', type: 'group', index: 0 },
+          'collection'
+        )
+      );
+
+      jest.runAllTimers();
+
+      // fetch mock typings error
+      const calls: any = fetchMock.calls('edits');
+      expect(calls).toHaveLength(1);
+      const articleFragments = groupedArticleFragmentIds(
+        JSON.parse(calls[0][1].body).collection.live
+      );
+      expect(articleFragments).toEqual({ g1: ['b', 'a'] });
+    });
+
+    it('moves between two collections DOWNWARDS make two persistence requests', () => {
+      const { dispatch }: { dispatch: Dispatch } = init();
+      fetchMock.mock(/stories-visible/, {});
+      fetchMock.mock(
+        /v2Edits/,
+        {},
+        {
+          name: 'edits'
+        }
+      );
+      dispatch(
+        moveArticleFragment(
+          { id: 'g2', type: 'group', index: 0 },
+          A1,
+          { id: 'g1', type: 'group', index: 0 },
+          'collection'
+        )
+      );
+
+      jest.runAllTimers();
+
+      // fetch mock typings error
+      const calls: any = fetchMock.calls('edits');
+      expect(calls).toHaveLength(2);
+      const c1afs = groupedArticleFragmentIds(
+        JSON.parse(calls[0][1].body).collection.live
+      );
+      expect(c1afs).toEqual({
+        g1: ['b']
+      });
+      const c2afs = groupedArticleFragmentIds(
+        JSON.parse(calls[1][1].body).collection.live
+      );
+      expect(c2afs).toEqual({
+        g2: ['a', 'c']
+      });
+    });
+
+    // @TODO - fix this issue in another PR
+    // it('moves between collections UPWARDS make two persistence requests', () => {
+    //   const { dispatch }: { dispatch: Dispatch } = init();
+    //   fetchMock.mock(/stories-visible/, {});
+    //   fetchMock.mock(
+    //     /v2Edits/,
+    //     {},
+    //     {
+    //       name: 'edits'
+    //     }
+    //   );
+    //   dispatch(
+    //     moveArticleFragment(
+    //       { id: 'g1', type: 'group', index: 0 },
+    //       A3,
+    //       { id: 'g2', type: 'group', index: 0 },
+    //       'collection'
+    //     )
+    //   );
+
+    //   jest.runAllTimers();
+
+    //   // fetch mock typings error
+    //   const calls: any = fetchMock.calls('edits');
+    //   expect(calls).toHaveLength(2);
+    //   const c1afs = groupedArticleFragmentIds(
+    //     JSON.parse(calls[0][1].body).collection.live
+    //   );
+    //   expect(c1afs).toEqual({
+    //     g1: ['c', 'a', 'b']
+    //   });
+    //   const c2afs = groupedArticleFragmentIds(
+    //     JSON.parse(calls[1][1].body).collection.live
+    //   );
+    //   expect(c2afs).toEqual({
+    //     g2: []
+    //   });
+    // });
+  });
+});

--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -77,6 +77,7 @@ const init = () => {
       // the second param here is debounce time, we have to set this
       // as longer debounce times with lodash/debounce don't play well
       // with jest fake timers
+      // https://github.com/facebook/jest/issues/3465
       persistCollectionOnEdit(updateCollection, 1)
     )
   );

--- a/client-v2/src/util/__tests__/storeMiddleware.spec.ts
+++ b/client-v2/src/util/__tests__/storeMiddleware.spec.ts
@@ -21,12 +21,14 @@ const state = {
   config
 };
 
+jest.useFakeTimers();
+
 describe('Store middleware', () => {
   describe('persistCollectionOnEdit', () => {
     beforeEach(() => {
       mockStore = configureStore([
         thunk,
-        persistCollectionOnEdit(mockCollectionUpdateAction)
+        persistCollectionOnEdit(mockCollectionUpdateAction, 1)
       ]);
     });
     it('should do nothing for actions without the correct persistTo property in the action meta', () => {
@@ -34,6 +36,7 @@ describe('Store middleware', () => {
       store.dispatch({
         type: 'ARBITRARY_ACTION'
       });
+      jest.runAllTimers();
       expect(store.getActions().length).toBe(1);
     });
     it('should issue updates for the relevant collection', () => {
@@ -50,6 +53,7 @@ describe('Store middleware', () => {
           key: 'articleFragmentId'
         }
       });
+      jest.runAllTimers();
       expect(store.getActions()[1]).toEqual(
         mockCollectionUpdateAction({
           id: 'exampleCollection',

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -103,7 +103,7 @@ const persistCollectionOnEdit = (
       });
       pendingCollectionIds = [];
     },
-    debounceTime, // @TODO make this configurable
+    debounceTime,
     { trailing: true }
   );
 


### PR DESCRIPTION
## What's changed?

This change introduces debouncing to saves. This means that collections will only fire one save request for example: a thunk with multiple actions that might have previously triggered multiple save requests. This was happening in `moveArticleFragment` before this change.

These tests have highlighted another issue that wasn't being spotted before now. Namely that when moving "upwards" between collections. The fetch requests to save the collection that had just had the article removed was not being fired.

This is being caused at the crossover of the persistence collection-finding logic and the way the collection cap logic has been handled. We have inserted the moved article fragment into its new position before firing the remove action. When we fire the remove action, the persistence middleware finds the articleFragment in its new collection first (this collection appears first when searching for it) and misses the actual collection we want to save - the place where it previously was, which is in a collection further along in the collections map.

I've not fixed this as it was existing before this change but there is a commented out test that tests this issue, so will pick this up in another PR. 

## Implementation notes

Relatively simple debouncing logic, although it's worth noting (as mentioned in a comment) that we have to change the debounce time in the tests, despite using Jest's fake timers. See https://github.com/facebook/jest/issues/3465

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
