### PR TITLE
Revert "Prevent drop zones from blocking cursor events when a drag is not occurring"

### DIFF
--- a/client-v2/src/components/DropZone.tsx
+++ b/client-v2/src/components/DropZone.tsx
@@ -4,11 +4,10 @@ import { theme } from 'constants/theme';
 
 const DropContainer = styled('div')`
   position: relative;
-  height: 10px;
+  height: 15px;
 `;
 
 const DropIndicator = styled('div')`
-  position: relative;
   height: 100%;
   pointer-events: none;
 `;

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -50,14 +50,12 @@ const ArticleFragmentLevel = ({
         override={isTarget}
         dropColor="hsl(0, 0%, 64%)"
         style={{
-          marginTop: '-30px',
-          height: '30px'
+          marginTop: '-15px',
+          padding: '3px'
         }}
         indicatorStyle={{
-          marginLeft: '80px',
-          marginRight: `${displayType === 'default' ? '130px' : 0}`,
-          top: '66%',
-          height: '33%'
+          marginLeft: '20px',
+          marginRight: `${displayType === 'default' ? '130px' : 0}`
         }}
       />
     )}

--- a/client-v2/src/lib/dnd/DropZone.tsx
+++ b/client-v2/src/lib/dnd/DropZone.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { StoreConsumer } from './Root';
 import { Store, Sub } from './store';
 import { NO_STORE_ERROR } from './constants';
-import { styled } from 'constants/theme';
 
 interface OuterProps {
   parentKey: string;
@@ -18,15 +17,10 @@ type Props = OuterProps & ContextProps;
 
 interface State {
   isTarget: boolean;
-  isActive: boolean;
 }
 
-const DropZoneContainer = styled.div<{ isActive: boolean }>`
-  ${({ isActive }) => !isActive && 'pointer-events: none'}
-`;
-
 class DropZone extends React.Component<Props, State> {
-  public state = { isTarget: false, isActive: false };
+  public state = { isTarget: false };
 
   public componentDidMount() {
     if (!this.props.store) {
@@ -43,19 +37,10 @@ class DropZone extends React.Component<Props, State> {
   }
 
   public render() {
-    return (
-      <DropZoneContainer isActive={this.state.isActive}>
-        {this.props.children(this.state.isTarget)}
-      </DropZoneContainer>
-    );
+    return this.props.children(this.state.isTarget);
   }
 
   private handleStoreUpdate: Sub = (id, hoverIndex) => {
-    const state = this.props.store && this.props.store.getState();
-    const isActive = state ? state.isDraggedOver : false;
-    if (isActive !== this.state.isActive) {
-      this.setState({ isActive });
-    }
     if (
       id === this.props.parentKey &&
       hoverIndex === this.props.index &&

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -78,11 +78,7 @@ interface ContextProps {
 
 type Props<T> = OuterProps<T> & ContextProps;
 
-interface State {
-  isDraggedOver: boolean;
-}
-
-class Level<T> extends React.Component<Props<T>, State> {
+class Level<T> extends React.Component<Props<T>> {
   get key() {
     return `${this.props.parentId}:${this.props.parentType}`;
   }
@@ -141,7 +137,7 @@ class Level<T> extends React.Component<Props<T>, State> {
       return;
     }
     e.preventDefault();
-    this.props.store.update(this.key, this.getDropIndex(e, i, isNode), true);
+    this.props.store.update(this.key, this.getDropIndex(e, i, isNode));
   };
 
   private onDrop = (i: number, isNode: boolean) => (e: React.DragEvent) => {
@@ -150,7 +146,6 @@ class Level<T> extends React.Component<Props<T>, State> {
     }
 
     e.preventDefault();
-
     const { onMove = () => null, onDrop = () => null } = this.props;
     const af = e.dataTransfer.getData(TRANSFER_TYPE);
 

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -25,7 +25,6 @@ export default class Root extends React.Component<Props, State> {
     return (
       <div
         {...divProps}
-        onDragEnter={this.onDragEnter}
         onDragOver={this.onDragOver}
         onDragLeave={this.onDragLeave}
         onDragEnd={this.reset}
@@ -39,11 +38,6 @@ export default class Root extends React.Component<Props, State> {
       </div>
     );
   }
-
-  private onDragEnter = () => {
-    const { key, index } = this.state.store.getState();
-    this.state.store.update(key, index, true);
-  };
 
   private onDragOver = (e: React.DragEvent) => {
     if (!e.defaultPrevented) {
@@ -63,7 +57,7 @@ export default class Root extends React.Component<Props, State> {
     }
   };
 
-  private reset = () => this.state.store.update(null, null, false);
+  private reset = () => this.state.store.update(null, null);
 }
 
 export { StoreConsumer, isMove, isInside };

--- a/client-v2/src/lib/dnd/__tests__/store.spec.ts
+++ b/client-v2/src/lib/dnd/__tests__/store.spec.ts
@@ -3,21 +3,13 @@ import createStore from '../store';
 describe('store', () => {
   it('has an initial state of null', () => {
     const store = createStore();
-    expect(store.getState()).toEqual({
-      key: null,
-      index: null,
-      isDraggedOver: false
-    });
+    expect(store.getState()).toEqual({ key: null, index: null });
   });
 
   it('updates the state with `update`', () => {
     const store = createStore();
-    store.update('a', 1, false);
-    expect(store.getState()).toEqual({
-      key: 'a',
-      index: 1,
-      isDraggedOver: false
-    });
+    store.update('a', 1);
+    expect(store.getState()).toEqual({ key: 'a', index: 1 });
   });
 
   it('sends updates to listeners', () => {
@@ -32,7 +24,7 @@ describe('store', () => {
     };
 
     store.subscribe(fn);
-    store.update('a', 1, false);
+    store.update('a', 1);
     expect([key, index]).toEqual(['a', 1]);
   });
 
@@ -49,7 +41,7 @@ describe('store', () => {
 
     store.subscribe(fn);
     store.unsubscribe(fn);
-    store.update('a', 1, false);
+    store.update('a', 1);
     expect([key, index]).toEqual(['b', 2]);
   });
 });

--- a/client-v2/src/lib/dnd/store.ts
+++ b/client-v2/src/lib/dnd/store.ts
@@ -6,20 +6,17 @@ type Sub = (key: Key, index: Index) => void;
 interface State {
   key: Key;
   index: Index;
-  isDraggedOver: boolean;
 }
 
-const createStore = (
-  initState: State = { key: null, index: null, isDraggedOver: false }
-) => {
+const createStore = (initState: State = { key: null, index: null }) => {
   let subs: Sub[] = [];
   let state = initState;
 
   return {
     subscribe: (fn: Sub) => (subs = [...subs, fn]),
     unsubscribe: (fn: Sub) => (subs = subs.filter(c => c !== fn)),
-    update: (key: Key, index: Index, isDraggedOver: boolean) => {
-      state = { key, index, isDraggedOver };
+    update: (key: Key, index: Index) => {
+      state = { key, index };
       subs.forEach(sub => sub(key, index));
     },
     getState: () => state


### PR DESCRIPTION
Reverts guardian/facia-tool#686 -- it blocks dropping in empty groups or collections, which like a chump I'd failed to test!