### PR TITLE
Dry run the deduping before applying any changes

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -120,9 +120,8 @@ const maybeInsertGroupArticleFragment = (
               applyBeforeReducer: true
             })(id, collectionCap)
           ]),
-          // otherwise just undo the insertion and don't persist as nothing
-          // has actually changed
-          [removeGroupArticleFragment(id, articleFragmentId)]
+          // otherwise do nothing
+          []
         )
       );
     } else {

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -27,6 +27,9 @@ import {
 import confirmModal from 'reducers/confirmModalReducer';
 import { endConfirmModal } from 'actions/ConfirmModal';
 import config from 'reducers/configReducer';
+import { enableBatching } from 'redux-batched-actions';
+import { Dispatch } from 'types/Store';
+import { State } from 'types/State';
 
 const root = (state: any = {}, action: any) => ({
   confirmModal: confirmModal(state.confirmModal, action),
@@ -43,7 +46,10 @@ const root = (state: any = {}, action: any) => ({
   config: config(state.config, action)
 });
 
-const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
+const buildStore = (
+  added: ArticleFragmentSpec,
+  collectionCap = Infinity
+): { dispatch: Dispatch; getState: () => State } => {
   const groupA: ArticleFragmentSpec[] = [
     ['a', '1', [['g', '7']]],
     ['b', '2', undefined],
@@ -83,7 +89,11 @@ const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
     },
     clipboard: clipboard.map(([uuid]) => uuid)
   };
-  return createStore(root, state as any, applyMiddleware(thunk));
+  return createStore(
+    enableBatching(root),
+    state as any,
+    applyMiddleware(thunk)
+  );
 };
 
 const insert = async (
@@ -288,10 +298,10 @@ describe('ArticleFragments actions', () => {
 
     it('collection caps allow moves within collections without a modal', () => {
       const s1 = move(['a', '1'], 2, 'group', 'a', 'group', 'a', {
-        cap: 3,
+        cap: 6,
         accept: null
       });
-      expect(groupArticlesSelector(s1, 'a')).toEqual(['b', 'a', 'c']);
+      expect(groupArticlesSelector(s1, 'a')).toEqual(['b', 'c', 'a']);
     });
   });
 

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -29,7 +29,6 @@ import { endConfirmModal } from 'actions/ConfirmModal';
 import config from 'reducers/configReducer';
 import { enableBatching } from 'redux-batched-actions';
 import { Dispatch } from 'types/Store';
-import { State } from 'types/State';
 
 const root = (state: any = {}, action: any) => ({
   confirmModal: confirmModal(state.confirmModal, action),
@@ -46,10 +45,7 @@ const root = (state: any = {}, action: any) => ({
   config: config(state.config, action)
 });
 
-const buildStore = (
-  added: ArticleFragmentSpec,
-  collectionCap = Infinity
-): { dispatch: Dispatch; getState: () => State } => {
+const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
   const groupA: ArticleFragmentSpec[] = [
     ['a', '1', [['g', '7']]],
     ['b', '2', undefined],
@@ -89,11 +85,15 @@ const buildStore = (
     },
     clipboard: clipboard.map(([uuid]) => uuid)
   };
-  return createStore(
+  const { getState, dispatch } = createStore(
     enableBatching(root),
     state as any,
     applyMiddleware(thunk)
   );
+  return {
+    getState,
+    dispatch: dispatch as Dispatch
+  };
 };
 
 const insert = async (

--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -30,6 +30,13 @@ const A3 = {
   meta: {}
 };
 
+const A4 = {
+  uuid: 'a4',
+  id: 'd',
+  frontPublicationDate: 2000,
+  meta: {}
+};
+
 const init = () => {
   const initState = {
     shared: {
@@ -60,13 +67,14 @@ const init = () => {
         g2: {
           uuid: 'g2',
           id: 'g2',
-          articleFragments: ['a3']
+          articleFragments: ['a3', 'a4']
         }
       },
       articleFragments: {
         a1: A1,
         a2: A2,
-        a3: A3
+        a3: A3,
+        a4: A4
       }
     }
   };
@@ -162,47 +170,47 @@ describe('Collection persistence', () => {
         JSON.parse(calls[1][1].body).collection.live
       );
       expect(c2afs).toEqual({
-        g2: ['a', 'c']
+        g2: ['a', 'c', 'd']
       });
     });
 
     // @TODO - fix this issue in another PR
-    // it('moves between collections UPWARDS make two persistence requests', () => {
-    //   const { dispatch }: { dispatch: Dispatch } = init();
-    //   fetchMock.mock(/stories-visible/, {});
-    //   fetchMock.mock(
-    //     /v2Edits/,
-    //     {},
-    //     {
-    //       name: 'edits'
-    //     }
-    //   );
-    //   dispatch(
-    //     moveArticleFragment(
-    //       { id: 'g1', type: 'group', index: 0 },
-    //       A3,
-    //       { id: 'g2', type: 'group', index: 0 },
-    //       'collection'
-    //     )
-    //   );
+    it('moves between collections UPWARDS make two persistence requests', () => {
+      const { dispatch }: { dispatch: Dispatch } = init();
+      fetchMock.mock(/stories-visible/, {});
+      fetchMock.mock(
+        /v2Edits/,
+        {},
+        {
+          name: 'edits'
+        }
+      );
+      dispatch(
+        moveArticleFragment(
+          { id: 'g1', type: 'group', index: 0 },
+          A3,
+          { id: 'g2', type: 'group', index: 0 },
+          'collection'
+        )
+      );
 
-    //   jest.runAllTimers();
+      jest.runAllTimers();
 
-    //   // fetch mock typings error
-    //   const calls: any = fetchMock.calls('edits');
-    //   expect(calls).toHaveLength(2);
-    //   const c1afs = groupedArticleFragmentIds(
-    //     JSON.parse(calls[0][1].body).collection.live
-    //   );
-    //   expect(c1afs).toEqual({
-    //     g1: ['c', 'a', 'b']
-    //   });
-    //   const c2afs = groupedArticleFragmentIds(
-    //     JSON.parse(calls[1][1].body).collection.live
-    //   );
-    //   expect(c2afs).toEqual({
-    //     g2: []
-    //   });
-    // });
+      // fetch mock typings error
+      const calls: any = fetchMock.calls('edits');
+      expect(calls).toHaveLength(2);
+      const c1afs = groupedArticleFragmentIds(
+        JSON.parse(calls[0][1].body).collection.live
+      );
+      expect(c1afs).toEqual({
+        g2: ['d']
+      });
+      const c2afs = groupedArticleFragmentIds(
+        JSON.parse(calls[1][1].body).collection.live
+      );
+      expect(c2afs).toEqual({
+        g1: ['c', 'a', 'b']
+      });
+    });
   });
 });

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -2,10 +2,12 @@ import { State } from 'types/State';
 import { getCollectionConfig } from './frontsSelectors';
 import {
   selectSharedState,
-  createCollectionSelector
+  createCollectionSelector,
+  groupsArticleCount
 } from 'shared/selectors/shared';
 import flatten from 'lodash/flatten';
 import { createSelectEditorFrontsByPriority } from 'bundles/frontsUIBundle';
+import { getUpdatedSiblingGroupsForInsertion } from 'shared/reducers/groupsReducer';
 
 const selectCollection = createCollectionSelector();
 
@@ -54,7 +56,27 @@ function createCollectionsInOpenFrontsSelector() {
 const isCollectionLockedSelector = (state: State, id: string): boolean =>
   !!getCollectionConfig(state, id).uneditable;
 
+const willCollectionHitCollectionCapSelector = (
+  state: State,
+  groupId: string,
+  index: number,
+  articleFragmentId: string,
+  collectionCap: number
+) => {
+  const shared = selectSharedState(state);
+  const patch = getUpdatedSiblingGroupsForInsertion(
+    shared,
+    shared.groups,
+    groupId,
+    index,
+    articleFragmentId
+  );
+  const articleCount = groupsArticleCount(Object.values(patch));
+  return collectionCap && articleCount > collectionCap;
+};
+
 export {
+  willCollectionHitCollectionCapSelector,
   collectionParamsSelector,
   isCollectionLockedSelector,
   createCollectionsInOpenFrontsSelector

--- a/client-v2/src/shared/reducers/groupsReducer.ts
+++ b/client-v2/src/shared/reducers/groupsReducer.ts
@@ -9,18 +9,18 @@ import { capGroupArticleFragments } from 'shared/util/capGroupArticleFragments';
 import keyBy from 'lodash/keyBy';
 
 const getUpdatedSiblingGroupsForInsertion = (
-  state: State,
-  groups: State['groups'],
+  sharedState: State,
+  groupsState: State['groups'],
   insertionGroupId: string,
   insertionIndex: number,
   articleFragmentId: string
 ) => {
-  const articleFragmentsMap = articleFragmentsSelector(state);
-  const groupSiblings = groupSiblingsSelector(state, insertionGroupId);
+  const articleFragmentsMap = articleFragmentsSelector(sharedState);
+  const groupSiblings = groupSiblingsSelector(sharedState, insertionGroupId);
 
   if (!articleFragmentsMap[articleFragmentId]) {
     // this may have happened if we've purged after a poll
-    return groups;
+    return groupsState;
   }
 
   return groupSiblings.reduce(

--- a/client-v2/src/shared/reducers/groupsReducer.ts
+++ b/client-v2/src/shared/reducers/groupsReducer.ts
@@ -8,6 +8,39 @@ import {
 import { capGroupArticleFragments } from 'shared/util/capGroupArticleFragments';
 import keyBy from 'lodash/keyBy';
 
+const getUpdatedSiblingGroupsForInsertion = (
+  state: State,
+  groups: State['groups'],
+  insertionGroupId: string,
+  insertionIndex: number,
+  articleFragmentId: string
+) => {
+  const articleFragmentsMap = articleFragmentsSelector(state);
+  const groupSiblings = groupSiblingsSelector(state, insertionGroupId);
+
+  if (!articleFragmentsMap[articleFragmentId]) {
+    // this may have happened if we've purged after a poll
+    return groups;
+  }
+
+  return groupSiblings.reduce(
+    (acc, sibling) => ({
+      ...acc,
+      [sibling.uuid]: {
+        ...sibling,
+        articleFragments: insertAndDedupeSiblings(
+          sibling.articleFragments || [],
+          [articleFragmentId],
+          insertionIndex,
+          articleFragmentsMap,
+          sibling.uuid === insertionGroupId // this means no insertions happen here if it's not this group
+        )
+      }
+    }),
+    {} as State['groups']
+  );
+};
+
 const groups = (
   state: State['groups'] = {},
   action: Action,
@@ -36,34 +69,15 @@ const groups = (
     }
     case 'SHARED/INSERT_GROUP_ARTICLE_FRAGMENT': {
       const { id, index, articleFragmentId } = action.payload;
-      const articleFragmentsMap = articleFragmentsSelector(prevSharedState);
-      const groupSiblings = groupSiblingsSelector(prevSharedState, id);
-
-      if (!articleFragmentsMap[articleFragmentId]) {
-        // this may have happened if we've purged after a poll
-        return state;
-      }
-
-      const dedupedSiblings = groupSiblings.reduce(
-        (acc, sibling) => ({
-          ...acc,
-          [sibling.uuid]: {
-            ...sibling,
-            articleFragments: insertAndDedupeSiblings(
-              sibling.articleFragments || [],
-              [articleFragmentId],
-              index,
-              articleFragmentsMap,
-              sibling.uuid === id // this means no insertions happen here if it's not this group
-            )
-          }
-        }),
-        {} as State['groups']
-      );
-
       return {
         ...state,
-        ...dedupedSiblings
+        ...getUpdatedSiblingGroupsForInsertion(
+          prevSharedState,
+          state,
+          id,
+          index,
+          articleFragmentId
+        )
       };
     }
     case 'SHARED/CAP_GROUP_SIBLINGS': {
@@ -84,5 +98,7 @@ const groups = (
     }
   }
 };
+
+export { getUpdatedSiblingGroupsForInsertion };
 
 export default groups;

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -407,11 +407,11 @@ const groupSiblingsSelector = (state: State, groupId: string) => {
   );
 };
 
+const groupsArticleCount = (groups: Group[]) =>
+  groups.reduce((acc, group) => acc + group.articleFragments.length, 0);
+
 const groupSiblingsArticleCountSelector = (state: State, groupId: string) =>
-  groupSiblingsSelector(state, groupId).reduce(
-    (acc, group) => acc + group.articleFragments.length,
-    0
-  );
+  groupsArticleCount(groupSiblingsSelector(state, groupId));
 
 const indexInGroupSelector = (
   state: State,
@@ -454,5 +454,6 @@ export {
   articleTagSelector,
   indexInGroupSelector,
   groupsSelector,
+  groupsArticleCount,
   externalArticleIdFromArticleFragmentSelector
 };

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -9973,10 +9973,10 @@ typescript@^2.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
+typescript@^3.2:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
+  integrity sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
## What's changed?

Our deduplication logic lead to inconsistent states when persisting. It ran inserts on the state, which caused the same article fragment to be in two places at once. Sometimes this inconsistency was very brief - only within the same stack - sometimes it was while a collection config modal was open. Either way it was long enough to break some invariants for our persistence layer, and it could also behave oddly when a modal was opened and collection polling overwrote a collection.

This now allows an external caller to run the reducer behaviour outside the reducer in order to reflect on the changes that will be made before they are committed. This means we don't have to commit any changes to the state until we're ready, ensuring that we're not in an inconsistent state for any period of time.

This is still up for discussion, hence the DO NOT MERGE. Also, there is [a test here](https://github.com/guardian/facia-tool/compare/rahb/jsh/upwards-collection-move?expand=1#diff-bce28573bf43e4679e120998f0484767R299) that was working before this change and now isn't and - on reflection - _looks_ like it shouldn't have been working before. So that needs some more investigation to make sure this is testing the right thing, and why it wasn't working before.

## Implementation notes

There is a minor coupling between how we figure out whether a group belongs to a collection that has exceeded its collection cap here but I think it's fine. Because we don't actually update the redux state object we can only count the article fragments in the group we get back in the `patch` rather than have the `groupSiblingsArticleCountSelector` work this our for us. Under the hood the selector calls the same function (it is exported for this reason) to derive the same number, but perhaps there is a nicer way to do this.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
