### PR TITLE
Align article thumbnail right

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -87,6 +87,10 @@ const MetaContainer = styled('div')`
   padding: 0px 2px;
 `;
 
+const ArticleThumbnail = styled(ThumbnailSmall)`
+  margin-left: auto;
+`;
+
 const FirstPublished = styled('div')`
   font-size: 11px;
   margin: 2px 0;
@@ -187,7 +191,7 @@ const FeedItem = ({ article, onAddToClipboard = noop }: FeedItemProps) => (
       <Body>
         <Title data-testid="headline">{article.webTitle}</Title>
       </Body>
-      <ThumbnailSmall
+      <ArticleThumbnail
         style={{
           backgroundImage: `url('${getThumbnail(
             article,


### PR DESCRIPTION
## What's changed?

In the feed, align the article thumbnail right, keeping its place if the article text does not fill its container.

Before:

<img width="409" alt="Screenshot 2019-04-23 at 09 06 55" src="https://user-images.githubusercontent.com/7767575/56565289-f112dd80-65a7-11e9-83fb-066c38f2296a.png">
After:

<img width="409" alt="Screenshot 2019-04-23 at 09 10 22" src="https://user-images.githubusercontent.com/7767575/56565297-f4a66480-65a7-11e9-9c83-c5c860dafe7d.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
