### PR TITLE
Fix article visibility details

### DIFF
--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -20,7 +20,7 @@ import {
 import { resetFocusState, setFocusState } from 'bundles/focusBundle';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
-import { createArticleVisiblityDetailsSelector } from 'selectors/frontsSelectors';
+import { createArticleVisibilityDetailsSelector } from 'selectors/frontsSelectors';
 
 const getArticleNotifications = (
   id: string,
@@ -211,15 +211,15 @@ class CollectionContext extends React.Component<
 }
 
 const createMapStateToProps = () => {
-  const articleVisiblityDetailsSelector = createArticleVisiblityDetailsSelector();
+  const articleVisibilityDetailsSelector = createArticleVisibilityDetailsSelector();
   return (state: State, props: CollectionContextProps) => {
-    const articleVisiblityDetails = articleVisiblityDetailsSelector(state, {
+    const articleVisibilityDetails = articleVisibilityDetailsSelector(state, {
       collectionId: props.id,
       collectionSet: props.browsingStage
     });
     return {
-      lastDesktopArticle: articleVisiblityDetails.desktop,
-      lastMobileArticle: articleVisiblityDetails.mobile
+      lastDesktopArticle: articleVisibilityDetails.desktop,
+      lastMobileArticle: articleVisibilityDetails.mobile
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { styled } from 'constants/theme';
+import Collection from './CollectionComponents/Collection';
+import { AlsoOnDetail } from 'types/Collection';
+import {
+  CollectionItemSets,
+  ArticleFragment as TArticleFragment
+} from 'shared/types/Collection';
+import GroupDisplayComponent from 'shared/components/GroupDisplay';
+import GroupLevel from 'components/clipboard/GroupLevel';
+import CollectionItem from './CollectionComponents/CollectionItem';
+import ArticleFragmentLevel from 'components/clipboard/ArticleFragmentLevel';
+import { PosSpec, Move } from 'lib/dnd';
+import { ValidationResponse } from 'shared/util/validateImageSrc';
+import { Dispatch } from 'types/Store';
+import {
+  removeArticleFragment,
+  addImageToArticleFragment
+} from 'actions/ArticleFragments';
+import { resetFocusState, setFocusState } from 'bundles/focusBundle';
+import { connect } from 'react-redux';
+import { State } from 'types/State';
+import { createArticleVisiblityDetailsSelector } from 'selectors/frontsSelectors';
+
+const getArticleNotifications = (
+  id: string,
+  lastDesktopArticle?: string,
+  lastMobileArticle?: string
+) => {
+  const notifications = [];
+  if (lastDesktopArticle === id) {
+    notifications.push('desktop');
+  }
+  if (lastMobileArticle === id) {
+    notifications.push('mobile');
+  }
+  return notifications;
+};
+
+const CollectionWrapper = styled('div')`
+  & + & {
+    margin-top: 10px;
+  }
+  &:focus {
+    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
+    border-top: 2px solid ${props => props.theme.shared.base.colors.focusColor};
+    border-bottom: 2px solid
+      ${props => props.theme.shared.base.colors.focusColor};
+    outline: none;
+  }
+`;
+
+const CollectionItemWrapper = styled('div')<{ articleSelected?: boolean }>`
+  border: ${props =>
+    props.articleSelected
+      ? `1px solid ${props.theme.shared.base.colors.focusColor}`
+      : `none`};
+  &:focus {
+    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
+    outline: none;
+  }
+`;
+
+interface CollectionContextProps {
+  id: string;
+  frontId: string;
+  priority: string;
+  alsoOn: {
+    [id: string]: AlsoOnDetail;
+  };
+  browsingStage: CollectionItemSets;
+  handleMove: (move: Move<TArticleFragment>) => void;
+  handleInsert: (e: React.DragEvent, to: PosSpec) => void;
+  focusedArticle?: string;
+  selectArticleFragment: (isSupporting?: boolean) => (id: string) => void;
+}
+
+type ConnectedCollectionContextProps = CollectionContextProps & {
+  handleArticleFocus: (
+    e: React.FocusEvent<HTMLDivElement>,
+    groupId: string,
+    articleFragment: TArticleFragment,
+    frontId: string
+  ) => void;
+  addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
+  removeCollectionItem: (parentId: string, id: string) => void;
+  removeSupportingCollectionItem: (parentId: string, id: string) => void;
+  handleFocus: (id: string) => void;
+  handleBlur: () => void;
+  lastDesktopArticle?: string;
+  lastMobileArticle?: string;
+};
+
+class CollectionContext extends React.Component<
+  ConnectedCollectionContextProps
+> {
+  public render() {
+    const {
+      id,
+      frontId,
+      handleBlur,
+      handleFocus,
+      priority,
+      alsoOn,
+      browsingStage,
+      handleMove,
+      handleInsert,
+      handleArticleFocus,
+      selectArticleFragment,
+      removeCollectionItem,
+      removeSupportingCollectionItem,
+      focusedArticle,
+      lastDesktopArticle,
+      lastMobileArticle
+    } = this.props;
+    return (
+      <CollectionWrapper
+        tabIndex={0}
+        onBlur={() => handleBlur()}
+        onFocus={() => handleFocus(id)}
+      >
+        <Collection
+          key={id}
+          id={id}
+          priority={priority}
+          frontId={frontId}
+          alsoOn={alsoOn}
+          canPublish={browsingStage !== 'live'}
+          browsingStage={browsingStage}
+        >
+          {(group, isUneditable) => (
+            <GroupDisplayComponent key={group.uuid} groupName={group.name}>
+              <GroupLevel
+                isUneditable={isUneditable}
+                groupId={group.uuid}
+                onMove={handleMove}
+                onDrop={handleInsert}
+              >
+                {(articleFragment, afDragProps) => (
+                  <CollectionItemWrapper
+                    tabIndex={0}
+                    onBlur={() => handleBlur()}
+                    onFocus={e =>
+                      handleArticleFocus(
+                        e,
+                        group.uuid,
+                        articleFragment,
+                        frontId
+                      )
+                    }
+                    articleSelected={focusedArticle === articleFragment.uuid}
+                  >
+                    <CollectionItem
+                      frontId={this.props.id}
+                      onImageDrop={imageData => {
+                        this.props.addImageToArticleFragment(
+                          articleFragment.uuid,
+                          imageData
+                        );
+                      }}
+                      uuid={articleFragment.uuid}
+                      parentId={group.uuid}
+                      isUneditable={isUneditable}
+                      getNodeProps={() => (!isUneditable ? afDragProps : {})}
+                      onSelect={selectArticleFragment()}
+                      onDelete={() =>
+                        removeCollectionItem(group.uuid, articleFragment.uuid)
+                      }
+                      articleNotifications={getArticleNotifications(
+                        articleFragment.uuid,
+                        lastDesktopArticle,
+                        lastMobileArticle
+                      )}
+                    >
+                      <ArticleFragmentLevel
+                        isUneditable={isUneditable}
+                        articleFragmentId={articleFragment.uuid}
+                        onMove={handleMove}
+                        onDrop={handleInsert}
+                      >
+                        {(supporting, supportingDragProps) => (
+                          <CollectionItem
+                            frontId={this.props.id}
+                            uuid={supporting.uuid}
+                            parentId={articleFragment.uuid}
+                            onSelect={selectArticleFragment(true)}
+                            isUneditable={isUneditable}
+                            getNodeProps={() =>
+                              !isUneditable ? supportingDragProps : {}
+                            }
+                            onDelete={() =>
+                              removeSupportingCollectionItem(
+                                articleFragment.uuid,
+                                supporting.uuid
+                              )
+                            }
+                            size="small"
+                          />
+                        )}
+                      </ArticleFragmentLevel>
+                    </CollectionItem>
+                  </CollectionItemWrapper>
+                )}
+              </GroupLevel>
+            </GroupDisplayComponent>
+          )}
+        </Collection>
+      </CollectionWrapper>
+    );
+  }
+}
+
+const createMapStateToProps = () => {
+  const articleVisiblityDetailsSelector = createArticleVisiblityDetailsSelector();
+  return (state: State, props: CollectionContextProps) => {
+    const articleVisiblityDetails = articleVisiblityDetailsSelector(state, {
+      collectionId: props.id,
+      collectionSet: props.browsingStage
+    });
+    return {
+      lastDesktopArticle: articleVisiblityDetails.desktop,
+      lastMobileArticle: articleVisiblityDetails.mobile
+    };
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  removeCollectionItem: (parentId: string, uuid: string) => {
+    dispatch(removeArticleFragment('group', parentId, uuid, 'collection'));
+  },
+  removeSupportingCollectionItem: (parentId: string, uuid: string) => {
+    dispatch(
+      removeArticleFragment('articleFragment', parentId, uuid, 'collection')
+    );
+  },
+  addImageToArticleFragment: (id: string, response: ValidationResponse) =>
+    dispatch(addImageToArticleFragment(id, response)),
+  handleBlur: () => dispatch(resetFocusState()),
+  handleFocus: (collectionId: string) =>
+    dispatch(setFocusState({ type: 'collection', collectionId }))
+});
+
+export default connect(
+  createMapStateToProps,
+  mapDispatchToProps
+)(CollectionContext);

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -164,12 +164,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 }
 
-const createMapStateToProps = () => {
-  return (state: State, props: FrontPropsBeforeState) => {
-    return {
-      front: getFront(state, { frontId: props.id }),
-      focusedArticle: selectFocusedArticle(state, 'collectionArticle')
-    };
+const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
+  return {
+    front: getFront(state, { frontId: props.id }),
+    focusedArticle: selectFocusedArticle(state, 'collectionArticle')
   };
 };
 
@@ -206,6 +204,6 @@ const mapDispatchToProps = (
 };
 
 export default connect(
-  createMapStateToProps,
+  mapStateToProps,
   mapDispatchToProps
 )(FrontComponent);

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -4,11 +4,7 @@ import { connect } from 'react-redux';
 import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
-import {
-  removeArticleFragment,
-  moveArticleFragment,
-  addImageToArticleFragment
-} from 'actions/ArticleFragments';
+import { moveArticleFragment } from 'actions/ArticleFragments';
 import { insertArticleFragmentFromDropEvent } from 'util/collectionUtils';
 import { AlsoOnDetail } from 'types/Collection';
 import {
@@ -19,24 +15,13 @@ import {
   CollectionItemSets,
   ArticleFragment as TArticleFragment
 } from 'shared/types/Collection';
-import Collection from './CollectionComponents/Collection';
-import GroupDisplay from 'shared/components/GroupDisplay';
-import ArticleFragmentLevel from 'components/clipboard/ArticleFragmentLevel';
-import GroupLevel from 'components/clipboard/GroupLevel';
 import { getFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
-import { visibleFrontArticlesSelector } from 'selectors/frontsSelectors';
-import { VisibleArticlesResponse } from 'types/FaciaApi';
 import { events } from 'services/GA';
 import FrontDetailView from './FrontDetailView';
-import CollectionItem from './CollectionComponents/CollectionItem';
-import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { initialiseCollectionsForFront } from 'actions/Collections';
-import {
-  resetFocusState,
-  setFocusState,
-  selectFocusedArticle
-} from 'bundles/focusBundle';
+import { setFocusState, selectFocusedArticle } from 'bundles/focusBundle';
+import Collection from './Collection';
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
@@ -51,30 +36,6 @@ const FrontContentContainer = styled('div')`
   padding-top: 1px;
 `;
 
-const CollectionWrapper = styled('div')`
-  & + & {
-    margin-top: 10px;
-  }
-  &:focus {
-    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
-    border-top: 2px solid ${props => props.theme.shared.base.colors.focusColor};
-    border-bottom: 2px solid
-      ${props => props.theme.shared.base.colors.focusColor};
-    outline: none;
-  }
-`;
-
-const CollectionItemWrapper = styled('div')<{ articleSelected?: boolean }>`
-  border: ${props =>
-    props.articleSelected
-      ? `1px solid ${props.theme.shared.base.colors.focusColor}`
-      : `none`};
-  &:focus {
-    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
-    outline: none;
-  }
-`;
-
 interface FrontPropsBeforeState {
   id: string;
   browsingStage: CollectionItemSets;
@@ -86,23 +47,16 @@ type FrontProps = FrontPropsBeforeState & {
   dispatch: Dispatch;
   initialiseFront: () => void;
   selectArticleFragment: (
-    frontId: string,
-    isSupporting?: boolean
-  ) => (id: string) => void;
-  removeCollectionItem: (parentId: string, id: string) => void;
-  removeSupportingCollectionItem: (parentId: string, id: string) => void;
+    frontId: string
+  ) => (isSupporting?: boolean) => (id: string) => void;
   editorOpenCollections: (ids: string[]) => void;
-  addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   front: FrontConfig;
-  articlesVisible: { [id: string]: VisibleArticlesResponse };
-  handleBlur: () => void;
-  handleFocus: (collectionId: string) => void;
+  focusedArticle?: string;
   handleArticleFocus: (
     groupId: string,
     articleFragment: TArticleFragment,
     frontId: string
   ) => void;
-  focusedArticle?: string;
 };
 
 interface FrontState {
@@ -154,7 +108,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 
   public render() {
-    const { front, articlesVisible } = this.props;
+    const { front } = this.props;
     return (
       <React.Fragment>
         <div
@@ -171,135 +125,22 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         <FrontContainer>
           <FrontContentContainer>
             <Root id={this.props.id} data-testid={this.props.id}>
-              {front.collections.map(collectionId => {
-                const collectionArticlesVisible =
-                  articlesVisible && articlesVisible[collectionId];
-                let collectionItemCount: number = 0;
-                return (
-                  <CollectionWrapper
-                    tabIndex={0}
-                    onBlur={this.handleBlur}
-                    onFocus={() => this.handleFocus(collectionId)}
-                    key={collectionId}
-                  >
-                    <Collection
-                      key={collectionId}
-                      id={collectionId}
-                      priority={front.priority}
-                      frontId={this.props.id}
-                      alsoOn={this.props.alsoOn}
-                      canPublish={this.props.browsingStage !== 'live'}
-                      browsingStage={this.props.browsingStage}
-                    >
-                      {(group, isUneditable) => (
-                        <GroupDisplay key={group.uuid} groupName={group.name}>
-                          <GroupLevel
-                            isUneditable={isUneditable}
-                            groupId={group.uuid}
-                            onMove={this.handleMove}
-                            onDrop={this.handleInsert}
-                          >
-                            {(articleFragment, afDragProps) => {
-                              collectionItemCount += 1;
-                              const articleNotifications: string[] = [];
-                              if (
-                                collectionArticlesVisible &&
-                                collectionItemCount ===
-                                  collectionArticlesVisible.mobile
-                              ) {
-                                articleNotifications.push('mobile');
-                              }
-                              if (
-                                collectionArticlesVisible &&
-                                collectionItemCount ===
-                                  collectionArticlesVisible.desktop
-                              ) {
-                                articleNotifications.push('desktop');
-                              }
-                              return (
-                                <CollectionItemWrapper
-                                  tabIndex={0}
-                                  onBlur={this.handleBlur}
-                                  onFocus={event =>
-                                    this.handleArticleFocus(
-                                      event,
-                                      group.uuid,
-                                      articleFragment,
-                                      front.id
-                                    )
-                                  }
-                                  articleSelected={
-                                    this.props.focusedArticle ===
-                                    articleFragment.uuid
-                                  }
-                                >
-                                  <CollectionItem
-                                    frontId={this.props.id}
-                                    onImageDrop={imageData => {
-                                      this.props.addImageToArticleFragment(
-                                        articleFragment.uuid,
-                                        imageData
-                                      );
-                                    }}
-                                    uuid={articleFragment.uuid}
-                                    parentId={group.uuid}
-                                    isUneditable={isUneditable}
-                                    getNodeProps={() =>
-                                      !isUneditable ? afDragProps : {}
-                                    }
-                                    onSelect={this.props.selectArticleFragment(
-                                      this.props.id
-                                    )}
-                                    onDelete={() =>
-                                      this.props.removeCollectionItem(
-                                        group.uuid,
-                                        articleFragment.uuid
-                                      )
-                                    }
-                                    articleNotifications={articleNotifications}
-                                  >
-                                    <ArticleFragmentLevel
-                                      isUneditable={isUneditable}
-                                      articleFragmentId={articleFragment.uuid}
-                                      onMove={this.handleMove}
-                                      onDrop={this.handleInsert}
-                                    >
-                                      {(supporting, supportingDragProps) => (
-                                        <CollectionItem
-                                          frontId={this.props.id}
-                                          uuid={supporting.uuid}
-                                          parentId={articleFragment.uuid}
-                                          onSelect={this.props.selectArticleFragment(
-                                            this.props.id,
-                                            true
-                                          )}
-                                          isUneditable={isUneditable}
-                                          getNodeProps={() =>
-                                            !isUneditable
-                                              ? supportingDragProps
-                                              : {}
-                                          }
-                                          onDelete={() =>
-                                            this.props.removeSupportingCollectionItem(
-                                              articleFragment.uuid,
-                                              supporting.uuid
-                                            )
-                                          }
-                                          size="small"
-                                        />
-                                      )}
-                                    </ArticleFragmentLevel>
-                                  </CollectionItem>
-                                </CollectionItemWrapper>
-                              );
-                            }}
-                          </GroupLevel>
-                        </GroupDisplay>
-                      )}
-                    </Collection>
-                  </CollectionWrapper>
-                );
-              })}
+              {front.collections.map(collectionId => (
+                <Collection
+                  key={collectionId}
+                  id={collectionId}
+                  frontId={this.props.id}
+                  priority={front.priority}
+                  browsingStage={this.props.browsingStage}
+                  alsoOn={this.props.alsoOn}
+                  handleInsert={this.handleInsert}
+                  handleMove={this.handleMove}
+                  selectArticleFragment={this.props.selectArticleFragment(
+                    this.props.id
+                  )}
+                  handleArticleFocus={this.handleArticleFocus}
+                />
+              ))}
             </Root>
           </FrontContentContainer>
           <FrontContentContainer>
@@ -312,10 +153,6 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
       </React.Fragment>
     );
   }
-
-  private handleBlur = () => this.props.handleBlur();
-  private handleFocus = (collectionId: string) =>
-    this.props.handleFocus(collectionId);
   private handleArticleFocus = (
     e: React.FocusEvent<HTMLDivElement>,
     groupId: string,
@@ -327,13 +164,12 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 }
 
-const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
-  return {
-    front: getFront(state, { frontId: props.id }),
-    articlesVisible: visibleFrontArticlesSelector(state, {
-      collectionSet: props.browsingStage
-    }),
-    focusedArticle: selectFocusedArticle(state, 'collectionArticle')
+const createMapStateToProps = () => {
+  return (state: State, props: FrontPropsBeforeState) => {
+    return {
+      front: getFront(state, { frontId: props.id }),
+      focusedArticle: selectFocusedArticle(state, 'collectionArticle')
+    };
   };
 };
 
@@ -345,27 +181,14 @@ const mapDispatchToProps = (
     dispatch,
     initialiseFront: () =>
       dispatch(initialiseCollectionsForFront(props.id, props.browsingStage)),
-    selectArticleFragment: (frontId: string, isSupporting?: boolean) => (
+    selectArticleFragment: (frontId: string) => (isSupporting?: boolean) => (
       articleFragmentId: string
     ) =>
       dispatch(
         editorSelectArticleFragment(frontId, articleFragmentId, isSupporting)
       ),
-    removeCollectionItem: (parentId: string, uuid: string) => {
-      dispatch(removeArticleFragment('group', parentId, uuid, 'collection'));
-    },
-    removeSupportingCollectionItem: (parentId: string, uuid: string) => {
-      dispatch(
-        removeArticleFragment('articleFragment', parentId, uuid, 'collection')
-      );
-    },
     editorOpenCollections: (ids: string[]) =>
       dispatch(editorOpenCollections(ids)),
-    addImageToArticleFragment: (id: string, response: ValidationResponse) =>
-      dispatch(addImageToArticleFragment(id, response)),
-    handleBlur: () => dispatch(resetFocusState()),
-    handleFocus: (collectionId: string) =>
-      dispatch(setFocusState({ type: 'collection', collectionId })),
     handleArticleFocus: (
       groupId: string,
       articleFragment: TArticleFragment,
@@ -383,6 +206,6 @@ const mapDispatchToProps = (
 };
 
 export default connect(
-  mapStateToProps,
+  createMapStateToProps,
   mapDispatchToProps
 )(FrontComponent);

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -1,6 +1,7 @@
 import {
   getFrontsWithPriority,
-  alsoOnFrontSelector
+  alsoOnFrontSelector,
+  createArticleVisiblityDetailsSelector
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';
@@ -160,6 +161,75 @@ describe('Selecting which front collection is also on correctly', () => {
         meritsWarning: true,
         fronts: [{ id: 'commercialFront', priority: 'commercial' }]
       }
+    });
+  });
+});
+
+const visibilityState = {
+  fronts: {
+    collectionVisibility: {
+      draft: {
+        a: {
+          desktop: 4,
+          mobile: 3
+        }
+      }
+    }
+  },
+  shared: {
+    collections: {
+      data: {
+        a: {
+          draft: ['g1', 'g2']
+        }
+      }
+    },
+    groups: {
+      g1: {
+        articleFragments: ['a1', 'a2', 'a3']
+      },
+      g2: {
+        articleFragments: ['a4', 'a5']
+      }
+    },
+    articleFragments: {
+      a1: {
+        uuid: 'a1',
+        meta: {
+          // this tests that we ignore supporting articles
+          supporting: ['a6']
+        }
+      },
+      a2: {
+        uuid: 'a2'
+      },
+      a3: {
+        uuid: 'a3'
+      },
+      a4: {
+        uuid: 'a4'
+      },
+      a5: {
+        uuid: 'a5'
+      },
+      a6: {
+        uuid: 'a5'
+      }
+    }
+  }
+};
+
+describe('Article visibility selector', () => {
+  it('returns the id of the articleFragment at the last visible position for mobile and desktop, ignoring supporting articleFragments', () => {
+    const articleVisiblityDetailsSelector = createArticleVisiblityDetailsSelector();
+    expect(
+      articleVisiblityDetailsSelector(visibilityState as any, {
+        collectionSet: 'draft',
+        collectionId: 'a'
+      })
+    ).toEqual({
+      desktop: 'a4',
+      mobile: 'a3'
     });
   });
 });

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -1,7 +1,7 @@
 import {
   getFrontsWithPriority,
   alsoOnFrontSelector,
-  createArticleVisiblityDetailsSelector
+  createArticleVisibilityDetailsSelector
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';
@@ -221,9 +221,9 @@ const visibilityState = {
 
 describe('Article visibility selector', () => {
   it('returns the id of the articleFragment at the last visible position for mobile and desktop, ignoring supporting articleFragments', () => {
-    const articleVisiblityDetailsSelector = createArticleVisiblityDetailsSelector();
+    const articleVisibilityDetailsSelector = createArticleVisibilityDetailsSelector();
     expect(
-      articleVisiblityDetailsSelector(visibilityState as any, {
+      articleVisibilityDetailsSelector(visibilityState as any, {
         collectionSet: 'draft',
         collectionId: 'a'
       })

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -7,6 +7,11 @@ import { breakingNewsFrontId } from 'constants/fronts';
 import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
+import {
+  createArticlesInCollectionSelector,
+  selectSharedState
+} from 'shared/selectors/shared';
+import { createShallowEqualResultSelector } from 'shared/util/selectorUtils';
 
 interface FrontConfigMap {
   [id: string]: FrontConfig;
@@ -282,17 +287,49 @@ const visibleArticlesSelector = createSelector(
   }
 );
 
-const defaultVisibleFrontArticles = {};
+const defaultVisibleFrontArticles = {
+  desktop: undefined,
+  mobile: undefined
+};
 
-const visibleFrontArticlesSelector = createSelector(
-  [collectionVisibilitiesSelector, collectionSetSelector],
-  (collectionVisibilities, collectionSet) => {
-    if (collectionSet === 'previously') {
-      return defaultVisibleFrontArticles;
+const createArticleVisiblityDetailsSelector = () => {
+  const articlesInCollectionSelector = createArticlesInCollectionSelector();
+
+  // Have to adapt this to work on root state
+  const rootArticlesInCollectionSelector = (
+    state: State,
+    extra: {
+      collectionId: string;
+      collectionSet: CollectionItemSets;
     }
-    return collectionVisibilities[collectionSet];
-  }
-);
+  ) =>
+    articlesInCollectionSelector(selectSharedState(state), {
+      ...extra,
+      includeSupportingArticles: false
+    });
+
+  return createShallowEqualResultSelector(
+    collectionVisibilitiesSelector,
+    collectionSetSelector,
+    collectionIdSelector,
+    rootArticlesInCollectionSelector,
+    (collectionVisibilities, collectionSet, collectionId, articles) => {
+      if (collectionSet === 'previously') {
+        return defaultVisibleFrontArticles;
+      }
+      const visibilities = collectionVisibilities[collectionSet][collectionId];
+
+      if (!visibilities) {
+        return defaultVisibleFrontArticles;
+      }
+
+      return {
+        desktop: articles[visibilities.desktop - 1],
+        mobile: articles[visibilities.mobile - 1]
+      };
+    }
+  );
+};
 
 export {
   getFront,
@@ -308,6 +345,6 @@ export {
   hasUnpublishedChangesSelector,
   clipboardSelector,
   visibleArticlesSelector,
-  visibleFrontArticlesSelector,
-  getUnlockedFrontCollections
+  getUnlockedFrontCollections,
+  createArticleVisiblityDetailsSelector
 };

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -292,7 +292,7 @@ const defaultVisibleFrontArticles = {
   mobile: undefined
 };
 
-const createArticleVisiblityDetailsSelector = () => {
+const createArticleVisibilityDetailsSelector = () => {
   const articlesInCollectionSelector = createArticlesInCollectionSelector();
 
   // Have to adapt this to work on root state
@@ -346,5 +346,5 @@ export {
   clipboardSelector,
   visibleArticlesSelector,
   getUnlockedFrontCollections,
-  createArticleVisiblityDetailsSelector
+  createArticleVisibilityDetailsSelector
 };


### PR DESCRIPTION
## What's changed?

This fixes an issue where our `Front` render function was impure and as a result, would not render the visibility icons in all cases. Specifically this was happening when components below a `Front` were re-rendering but the front was not -  due to optimisations we'd made around drag and drop. I've refactored the selector and also moved a bit of logic to a _different_ `Collection` component, to make selecting this easier.

Fixes: https://trello.com/c/1j5jwQsE/543-adding-new-articles-to-collections-should-update-mobile-desktop-indicators

## Implementation notes

I've assumed the visibility numbers are not zero-indexed so I'm subtracting 1 here in order to get the index of the ordered article fragments to pick from, which I think follows what was being done before. I've also added a test for this.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
