### PR TITLE
Be kind, rewind! (Revert article meta to CAPI value)

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -281,6 +281,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               component={InputTextArea}
               useHeadlineFont
               rows="2"
+              originalValue={articleCapiFieldValues.headline}
             />
             <ConditionalField
               permittedFields={editableFields}
@@ -288,6 +289,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               label="Trail text"
               component={InputTextArea}
               placeholder={articleCapiFieldValues.trailText}
+              originalValue={articleCapiFieldValues.trailText}
             />
             <ConditionalField
               permittedFields={editableFields}
@@ -337,6 +339,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 component={InputText}
                 placeholder={articleCapiFieldValues.byline}
                 useHeadlineFont
+                originalValue={articleCapiFieldValues.byline}
               />
             )}
             <ConditionalField

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -36,6 +36,26 @@ const DownCaretIcon = ({ fill, size = 'm', title = null }: IconProps) => (
   </svg>
 );
 
+const RewindIcon = ({ fill = '#333', size = 'xxs' }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    width={mapSize(size)}
+    height={mapSize(size)}
+    fill={fill}
+    viewBox="0 0 330.002 330.002"
+    xmlSpace="preserve"
+  >
+    <path
+      d="M320.741,1.143c-5.602-2.322-12.057-1.039-16.347,3.251L180.001,128.787V15.001
+	c0-6.067-3.654-11.537-9.26-13.858c-5.605-2.324-12.059-1.039-16.347,3.251l-150,149.999c-2.813,2.813-4.394,6.628-4.394,10.606
+	c0,3.978,1.58,7.794,4.394,10.607l150,150.001c2.87,2.87,6.706,4.394,10.61,4.394c1.932,0,3.881-0.374,5.736-1.142
+	c5.605-2.322,9.26-7.792,9.26-13.858V201.213l124.394,124.394c2.869,2.87,6.706,4.394,10.609,4.394c1.933,0,3.882-0.374,5.737-1.142
+	c5.605-2.322,9.26-7.792,9.26-13.858v-300C330.001,8.934,326.347,3.465,320.741,1.143z"
+    />
+  </svg>
+);
+
 const StarIcon = ({
   fill = theme.colors.white,
   outline = theme.colors.white,
@@ -203,6 +223,7 @@ const AddImageIcon = ({
 export {
   DownCaretIcon,
   RubbishBinIcon,
+  RewindIcon,
   CloseIcon, // block x
   MoreIcon, // tapered +
   ClearIcon, // tapered x

--- a/client-v2/src/shared/components/input/CreateInput.tsx
+++ b/client-v2/src/shared/components/input/CreateInput.tsx
@@ -16,6 +16,7 @@ type Props = {
 const RewindButton = styled.button.attrs({
   type: 'button'
 })`
+  background: transparent;
   display: inline-block;
   border: none;
   opacity: 0.5;
@@ -43,7 +44,7 @@ export default (
     React.HTMLAttributes<HTMLInputElement> & StyledProps<any>
   >,
   type?: string
-) => ({ label, input, originalValue, meta, ...rest }: Props) => (
+) => ({ label, input, originalValue, ...rest }: Props) => (
   <InputContainer>
     {label && (
       <InputLabel htmlFor={label}>

--- a/client-v2/src/shared/components/input/CreateInput.tsx
+++ b/client-v2/src/shared/components/input/CreateInput.tsx
@@ -4,19 +4,59 @@ import { StyledProps } from 'styled-components';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
+import { RewindIcon } from '../icons/Icons';
+import { styled } from 'constants/theme';
 
 type Props = {
   label?: string;
+  // If provided, the user can revert to this value by clicking the 'rewind' button.
+  originalValue?: string;
 } & WrappedFieldProps;
+
+const RewindButton = styled.button.attrs({
+  type: 'button'
+})`
+  display: inline-block;
+  border: none;
+  opacity: 0.5;
+  cursor: pointer;
+  &:hover {
+    opacity: 1;
+  }
+  &:active,
+  &:focus {
+    outline: none;
+  }
+`;
+
+const InputComponentContainer = styled.div`
+  position: relative;
+  &:hover {
+    ${RewindButton} {
+      display: block;
+    }
+  }
+`;
 
 export default (
   Component: new (props: any) => React.Component<
     React.HTMLAttributes<HTMLInputElement> & StyledProps<any>
   >,
   type?: string
-) => ({ label, input, ...rest }: Props) => (
+) => ({ label, input, originalValue, meta, ...rest }: Props) => (
   <InputContainer>
-    {label && <InputLabel htmlFor={label}>{label}</InputLabel>}
-    <Component id={label} {...input} {...rest} type={type} />
+    {label && (
+      <InputLabel htmlFor={label}>
+        {label}
+        {originalValue && input.value !== originalValue && (
+          <RewindButton onClick={() => input.onChange(originalValue)}>
+            <RewindIcon />
+          </RewindButton>
+        )}
+      </InputLabel>
+    )}
+    <InputComponentContainer>
+      <Component id={label} {...input} {...rest} type={type} />
+    </InputComponentContainer>
   </InputContainer>
 );


### PR DESCRIPTION
## What's changed?

Adds a 'rewind' indicator that reverts the given value to its CAPI value. This indicator applies to three properties, as it did in the old tool -- headline, trailText and byline.

![revert](https://user-images.githubusercontent.com/7767575/56593505-e2e2b280-65e3-11e9-9da2-713f73ed9fde.gif)

@akemitakagi -- does this look OK?

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
