### PR TITLE
Enlargen checkbox click target size

### DIFF
--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -12,6 +12,8 @@ const CheckboxContainer = styled('div')`
 
 const Label = InputLabel.extend`
   color: ${props => props.theme.shared.base.colors.textMuted};
+  flex: 1;
+  cursor: pointer;
 `;
 
 const Switch = styled('div')`
@@ -75,7 +77,9 @@ export default ({
   <>
     <InputContainer>
       <CheckboxContainer>
-        <Label size="sm">{label}</Label>
+        <Label htmlFor={id} size="sm">
+          {label}
+        </Label>
         <Switch>
           <Checkbox
             type="checkbox"


### PR DESCRIPTION
## What's changed?

The label part of the checkbox component now correctly references its input, and has been expanded to cover the entire container, giving the user a larger click target.

![checkbox](https://user-images.githubusercontent.com/7767575/56643282-3bac5c80-6671-11e9-9877-827575a4f58b.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
