### PR TITLE
Collection article counts without supporting

### DIFF
--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -301,7 +301,8 @@ const createMapStateToProps = () => {
       collection: collectionSelectors.selectById(sharedState, props.id),
       articleIds: selectArticlesInCollection(sharedState, {
         collectionId: props.id,
-        collectionSet: props.browsingStage
+        collectionSet: props.browsingStage,
+        includeSupportingArticles: false
       })
     };
   };


### PR DESCRIPTION
## What's changed?

This excludes supporting articles from the collection article count:

<img width="603" alt="Screenshot 2019-04-24 at 16 20 26" src="https://user-images.githubusercontent.com/1652187/56671632-e68e3c00-66ac-11e9-9cf7-f9c1b5f10055.png">

Can be seen in v1 here:

<img width="819" alt="Screenshot 2019-04-24 at 16 19 49" src="https://user-images.githubusercontent.com/1652187/56671650-ef7f0d80-66ac-11e9-802c-e019fa87a0e9.png">

## Implementation notes

Very complicated 🙄 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
