### PR TITLE
Fix dnd state issue

### DIFF
--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -99,7 +99,7 @@ const VisibilityDivider = ({ notifications }: { notifications: string[] }) =>
   notifications.length ? (
     <VisibilityDividerEl>
       {notifications.map(notification => (
-        <Notification>{notification}</Notification>
+        <Notification key={notification}>{notification}</Notification>
       ))}
     </VisibilityDividerEl>
   ) : null;

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -27,8 +27,8 @@ export default class Root extends React.Component<Props, State> {
         {...divProps}
         onDragOver={this.onDragOver}
         onDragLeave={this.onDragLeave}
-        onDragEnd={this.reset}
-        onDrop={this.reset}
+        onDragEnd={() => this.reset(false)}
+        onDrop={() => this.reset(false)}
       >
         <StoreProvider value={this.state.store}>
           <AddParentInfo id={this.props.id} type="root">
@@ -41,14 +41,12 @@ export default class Root extends React.Component<Props, State> {
 
   private onDragOver = (e: React.DragEvent) => {
     if (!e.defaultPrevented) {
-      this.reset();
+      this.reset(true);
       return;
     }
     const state = this.state.store.getState();
-    if (state.isDraggedOver === false) {
-      const { key, index } = state;
-      this.state.store.update(key, index, true);
-    }
+    const { key, index } = state;
+    this.state.store.update(key, index, true);
   };
 
   private onDragLeave = ({
@@ -59,11 +57,13 @@ export default class Root extends React.Component<Props, State> {
     // is there a better way to do this?
     const { top, right, bottom, left } = currentTarget.getBoundingClientRect();
     if (cx <= left || cx >= right || cy <= top || cy >= bottom) {
-      this.reset();
+      this.reset(false);
     }
   };
 
-  private reset = () => this.state.store.update(null, null, false);
+  private reset = (over: boolean) => {
+    this.state.store.update(null, null, over);
+  };
 }
 
 export { StoreConsumer, isMove, isInside };


### PR DESCRIPTION
## What's changed?

This fixes an issue where in certain cases drop zones would be disabled even when over them.

## Implementation notes

Previously I added an early return after `reset` but this wasn't accounting for the `isDraggedOver`. I've now ensure this gets included in the state update. I've also removed the conditional updating below this and left it to the store to decide whether to dispatch.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
