### PR TITLE
SUBLINKS: hide sublinks by default and toggle showing them 

### DIFF
--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -58,9 +58,9 @@ test('Snap Links - Guardian', async t => {
   await t
     .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => false)
-    .dragToElement(tagSnap, frontDropZone(1))
+    .dragToElement(tagSnap, frontDropZone(1)) //drag tag into parent position (not a sublink)
     .expect(frontDropZone().count)
-    .eql(frontDropsCount + 1)
+    .eql(frontDropsCount + 2) // adding a sublink adds 1 dropzone, adding a normal article adds 2
     .expect(frontSnapLink(0).textContent)
     .contains('Recipes | The Guardian')
     .expect(frontSnapLink(0).textContent)
@@ -75,7 +75,7 @@ test('Snap Links - Guardian Latest', async t => {
     .setNativeDialogHandler(() => true)
     .dragToElement(tagSnap, frontDropZone(1))
     .expect(frontDropZone().count)
-    .eql(frontDropsCount + 1)
+    .eql(frontDropsCount + 2)
     .expect(frontSnapLink(0).textContent)
     .contains('{ Recipes }')
     .expect(frontSnapLink(0).textContent)
@@ -90,7 +90,7 @@ test('Snap Links - External', async t => {
     .setNativeDialogHandler(() => false)
     .dragToElement(externalSnap, frontDropZone(1))
     .expect(frontDropZone().count)
-    .eql(frontDropsCount + 1)
+    .eql(frontDropsCount + 2)
     .expect(frontSnapLink(0).textContent)
     .contains('Business - BBC News');
 });

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -83,6 +83,13 @@ const SupportingDivider = styled.hr`
   width: 50%;
 `;
 
+const FullDivider = styled('hr')`
+  border: 0;
+  border-top: 1px solid #ccc;
+  margin: 8px -10px 4px;
+  width: 115%;
+`;
+
 interface ClipboardProps {
   selectArticleFragment: (id: string, isSupporting?: boolean) => void;
   clearArticleFragmentSelection: () => void;
@@ -184,58 +191,65 @@ class Clipboard extends React.Component<ClipboardProps> {
                   onDrop={this.handleInsert}
                 >
                   {(articleFragment, getAfProps) => (
-                    <FocusWrapper
-                      tabIndex={0}
-                      onFocus={e => this.handleArticleFocus(e, articleFragment)}
-                      onBlur={this.handleBlur}
-                      uuid={articleFragment.uuid}
-                    >
-                      <CollectionItem
-                        uuid={articleFragment.uuid}
-                        parentId={clipboardId}
-                        frontId={clipboardId}
-                        getNodeProps={getAfProps}
-                        displayType="polaroid"
-                        onSelect={this.props.selectArticleFragment}
-                        onDelete={() =>
-                          this.props.removeCollectionItem(articleFragment.uuid)
+                    <>
+                      <FocusWrapper
+                        tabIndex={0}
+                        onFocus={e =>
+                          this.handleArticleFocus(e, articleFragment)
                         }
+                        onBlur={this.handleBlur}
+                        uuid={articleFragment.uuid}
                       >
-                        {hasSupporting(articleFragment) && (
-                          <SupportingDivider />
-                        )}
-                        <ArticleFragmentLevel
-                          articleFragmentId={articleFragment.uuid}
-                          onMove={this.handleMove}
-                          onDrop={this.handleInsert}
+                        <CollectionItem
+                          uuid={articleFragment.uuid}
+                          parentId={clipboardId}
+                          frontId={clipboardId}
+                          getNodeProps={getAfProps}
                           displayType="polaroid"
+                          onSelect={this.props.selectArticleFragment}
+                          onDelete={() =>
+                            this.props.removeCollectionItem(
+                              articleFragment.uuid
+                            )
+                          }
                         >
-                          {(supporting, getSProps, i, arr) => (
-                            <CollectionItem
-                              uuid={supporting.uuid}
-                              frontId={clipboardId}
-                              parentId={articleFragment.uuid}
-                              getNodeProps={getSProps}
-                              size="small"
-                              displayType="polaroid"
-                              onSelect={id =>
-                                this.props.selectArticleFragment(id, true)
-                              }
-                              onDelete={() =>
-                                this.props.removeSupportingCollectionItem(
-                                  articleFragment.uuid,
-                                  supporting.uuid
-                                )
-                              }
-                            >
-                              {i < arr.length - 1 ? (
-                                <SupportingDivider />
-                              ) : null}
-                            </CollectionItem>
+                          {hasSupporting(articleFragment) && (
+                            <SupportingDivider />
                           )}
-                        </ArticleFragmentLevel>
-                      </CollectionItem>
-                    </FocusWrapper>
+                          <ArticleFragmentLevel
+                            articleFragmentId={articleFragment.uuid}
+                            onMove={this.handleMove}
+                            onDrop={this.handleInsert}
+                            displayType="polaroid"
+                          >
+                            {(supporting, getSProps, i, arr) => (
+                              <CollectionItem
+                                uuid={supporting.uuid}
+                                frontId={clipboardId}
+                                parentId={articleFragment.uuid}
+                                getNodeProps={getSProps}
+                                size="small"
+                                displayType="polaroid"
+                                onSelect={id =>
+                                  this.props.selectArticleFragment(id, true)
+                                }
+                                onDelete={() =>
+                                  this.props.removeSupportingCollectionItem(
+                                    articleFragment.uuid,
+                                    supporting.uuid
+                                  )
+                                }
+                              >
+                                {i < arr.length - 1 ? (
+                                  <SupportingDivider />
+                                ) : null}
+                              </CollectionItem>
+                            )}
+                          </ArticleFragmentLevel>
+                        </CollectionItem>
+                      </FocusWrapper>
+                      <FullDivider />
+                    </>
                   )}
                 </ClipboardLevel>
               </Root>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Article from 'shared/components/article/Article';
 import { State } from 'types/State';
-import { styled } from 'shared/constants/theme';
 import { createCollectionItemTypeSelector } from 'shared/selectors/collectionItem';
 import {
   selectSharedState,
@@ -27,21 +26,7 @@ import {
   articleFragmentImageCriteria as imageCriteria,
   gridDataTransferTypes
 } from 'constants/image';
-import CollectionItemBody from 'shared/components/collectionItem/CollectionItemBody';
-import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
-import CollectionItemContainer from 'shared/components/collectionItem/CollectionItemContainer';
-import CollectionItemContent from 'shared/components/collectionItem/CollectionItemContent';
-import CollectionItemMetaContainer from 'shared/components/collectionItem/CollectionItemMetaContainer';
-
-const SublinkCollectionItemBody = styled(CollectionItemBody)`
-  display: flex;
-  border-top: 1px solid #c9c9c9;
-  min-height: 30px;
-  span {
-    font-size: 12px;
-    font-weight: bold;
-  }
-`;
+import Sublinks from './Sublinks';
 
 interface ContainerProps {
   uuid: string;
@@ -70,9 +55,12 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     showArticleSublinks: false
   };
 
-  public toggleShowArticleSublinks = () => {
+  public toggleShowArticleSublinks = (e?: React.MouseEvent) => {
     const togPos = this.state.showArticleSublinks ? false : true;
     this.setState({ showArticleSublinks: togPos });
+    if (e) {
+      e.stopPropagation();
+    }
   };
 
   public getDropHandler(onDrop?: (data: ValidationResponse) => void) {
@@ -106,7 +94,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       size,
       isUneditable,
       externalArticleId,
-      numSupportingArticles
+      numSupportingArticles,
+      parentId
     } = this.props;
 
     switch (type) {
@@ -125,46 +114,41 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             imageDropTypes={Object.values(gridDataTransferTypes)}
             onImageDrop={this.getDropHandler(this.props.onImageDrop)}
           >
-            {numSupportingArticles > 0 && (
-              <CollectionItemContainer
-                draggable={false}
-                onClick={this.toggleShowArticleSublinks}
-              >
-                <SublinkCollectionItemBody>
-                  <CollectionItemMetaContainer />
-                  <CollectionItemContent
-                    displaySize="small"
-                    displayType="default"
-                  >
-                    <span>
-                      {numSupportingArticles} sublink
-                      {numSupportingArticles > 1 && 's'}
-                      <ButtonCircularCaret
-                        openDir={this.state.showArticleSublinks ? 'down' : 'up'}
-                        clear={true}
-                      />
-                    </span>
-                  </CollectionItemContent>
-                </SublinkCollectionItemBody>
-              </CollectionItemContainer>
-            )}
-            {this.state.showArticleSublinks && children}
+            <Sublinks
+              numSupportingArticles={numSupportingArticles}
+              toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+              showArticleSublinks={this.state.showArticleSublinks}
+              parentId={parentId}
+            />
+            {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
+            {numSupportingArticles === 0
+              ? children
+              : this.state.showArticleSublinks && children}
           </Article>
         );
       case collectionItemTypes.SNAP_LINK:
         return (
-          <SnapLink
-            id={uuid}
-            isUneditable={isUneditable}
-            {...getNodeProps()}
-            onDelete={onDelete}
-            onClick={isUneditable ? undefined : () => onSelect(uuid)}
-            fade={!isSelected}
-            size={size}
-            displayType={displayType}
-          >
-            {children}
-          </SnapLink>
+          <>
+            <SnapLink
+              id={uuid}
+              isUneditable={isUneditable}
+              {...getNodeProps()}
+              onDelete={onDelete}
+              onClick={isUneditable ? undefined : () => onSelect(uuid)}
+              fade={!isSelected}
+              size={size}
+              displayType={displayType}
+            />
+            <Sublinks
+              numSupportingArticles={numSupportingArticles}
+              toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+              showArticleSublinks={this.state.showArticleSublinks}
+              parentId={parentId}
+            />
+            {numSupportingArticles === 0
+              ? children
+              : this.state.showArticleSublinks && children}
+          </>
         );
       default:
         return (

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { styled } from 'shared/constants/theme';
+
+import CollectionItemBody from 'shared/components/collectionItem/CollectionItemBody';
+import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
+import CollectionItemContainer from 'shared/components/collectionItem/CollectionItemContainer';
+import CollectionItemContent from 'shared/components/collectionItem/CollectionItemContent';
+import CollectionItemMetaContainer from 'shared/components/collectionItem/CollectionItemMetaContainer';
+import DragIntentContainer from 'shared/components/DragIntentContainer';
+
+const SublinkCollectionItemBody = styled(CollectionItemBody)<{
+  dragHoverActive: boolean;
+  isClipboard: boolean;
+}>`
+  display: flex;
+  min-height: 30px;
+  border-width: ${({ isClipboard }) =>
+    isClipboard ? 'none' : '1px solid #c9c9c9'};
+  background-color: ${({ isClipboard, dragHoverActive }) =>
+    dragHoverActive ? `#ededed` : isClipboard ? '#f6f6f6' : '#fff'};
+  flex-direction: ${({ isClipboard }) => (isClipboard ? 'column' : 'row')};
+  span {
+    font-size: 12px;
+    font-weight: bold;
+  }
+  :hover {
+    background-color: #ededed;
+  }
+`;
+
+const SublinkCollectionItemContent = styled(CollectionItemContent)<{
+  isClipboard: boolean;
+}>`
+  width: ${({ isClipboard }) => (isClipboard ? `auto` : `calc(100% - 100px)`)};
+  padding-left: ${({ isClipboard }) => (isClipboard ? `2px` : `8px`)};
+`;
+
+const SupportingDivider = styled('hr')`
+  border: 0;
+  border-top: 1px solid #ccc;
+  margin: 0.5em 0 0.25em;
+  width: 50%;
+`;
+
+interface SublinkProps {
+  numSupportingArticles: number;
+  toggleShowArticleSublinks: (e?: React.MouseEvent) => void;
+  showArticleSublinks: boolean;
+  parentId: string;
+}
+
+class Sublinks extends React.Component<SublinkProps> {
+  public state = {
+    dragHoverActive: false
+  };
+
+  public render() {
+    const {
+      numSupportingArticles,
+      toggleShowArticleSublinks,
+      showArticleSublinks,
+      parentId
+    } = this.props;
+
+    const isClipboard = parentId === 'clipboard';
+    return (
+      <>
+        {numSupportingArticles > 0 && (
+          <DragIntentContainer
+            active={!showArticleSublinks}
+            onDragIntentStart={() => {
+              this.setState({ dragHoverActive: true });
+            }}
+            onDragIntentEnd={() => {
+              this.setState({ dragHoverActive: false });
+            }}
+            delay={750}
+            onIntentConfirm={() => {
+              toggleShowArticleSublinks();
+            }}
+          >
+            <CollectionItemContainer
+              draggable={false}
+              onClick={toggleShowArticleSublinks}
+            >
+              <SublinkCollectionItemBody
+                dragHoverActive={this.state.dragHoverActive}
+                isClipboard={isClipboard}
+              >
+                {!isClipboard && <CollectionItemMetaContainer />}
+                {isClipboard && <SupportingDivider />}
+                <SublinkCollectionItemContent
+                  displaySize="small"
+                  displayType="default"
+                  isClipboard={isClipboard}
+                >
+                  <span>
+                    {numSupportingArticles} sublink
+                    {numSupportingArticles > 1 && 's'}
+                    <ButtonCircularCaret
+                      openDir={showArticleSublinks ? 'up' : 'down'}
+                      clear={true}
+                    />
+                  </span>
+                </SublinkCollectionItemContent>
+              </SublinkCollectionItemBody>
+            </CollectionItemContainer>
+          </DragIntentContainer>
+        )}
+      </>
+    );
+  }
+}
+
+export default Sublinks;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -74,7 +74,7 @@ class Sublinks extends React.Component<SublinkProps> {
             onDragIntentEnd={() => {
               this.setState({ dragHoverActive: false });
             }}
-            delay={750}
+            delay={300}
             onIntentConfirm={() => {
               toggleShowArticleSublinks();
             }}

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -28,7 +28,6 @@ class DragIntentContainer extends React.Component<Props> {
       this.tryRegisterDragIntent(e);
     }
     this.dragHoverDepth += 1;
-    e.stopPropagation();
   };
 
   public handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {

--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -28,6 +28,11 @@ class DragIntentContainer extends React.Component<Props> {
       this.tryRegisterDragIntent(e);
     }
     this.dragHoverDepth += 1;
+    e.stopPropagation();
+  };
+
+  public handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.stopPropagation();
   };
 
   public handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
@@ -98,6 +103,7 @@ class DragIntentContainer extends React.Component<Props> {
         onDragEnter={this.handleDragEnter}
         onDragLeave={this.handleDragLeave}
         onDrop={this.handleDrop}
+        onDragOver={this.handleDragOver}
       >
         {children}
       </div>

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
@@ -9,7 +9,7 @@ const MetaContainer = styled('div')`
   padding: 0 4px;
 `;
 
-export default ({ children }: { children: React.ReactNode }) => (
+export default ({ children }: { children?: React.ReactNode }) => (
   <MetaContainer>
     {children}
     <ShortVerticalPinline />


### PR DESCRIPTION
## What's changed?
Previously all sublinks on a story were shown. This change hides them unless the user wants to see them. 

If the user drags in a story over a closed set of sublinks: they should highlight a darker grey then open after a 0.75 second pause and then allow for the story to be drop in there

**New view**
(closed)
<img width="592" alt="Screenshot 2019-04-26 at 10 25 28" src="https://user-images.githubusercontent.com/10324129/56797928-ba3e0100-680d-11e9-98e8-ce12dca09a5f.png">


(open)
<img width="592" alt="Screenshot 2019-04-26 at 10 25 51" src="https://user-images.githubusercontent.com/10324129/56797947-c5912c80-680d-11e9-87bc-c04756fbffae.png">

**On Clipboard**
<img width="164" alt="Screenshot 2019-04-26 at 16 27 08" src="https://user-images.githubusercontent.com/10324129/56818802-4e28c080-6840-11e9-8572-bb13ed5929f6.png">

<img width="164" alt="Screenshot 2019-04-26 at 16 27 16" src="https://user-images.githubusercontent.com/10324129/56818816-5aad1900-6840-11e9-9c3c-11da493f3b99.png">



Trello ticket: https://trello.com/c/UGcKTkyE/516-collapse-sublinks-in-the-stories


## Implementation notes
Needed to change integration test!
Comment explains - depending on whether the article dragged in is a sublink or a full article, the number of new dropzones created is different. 
- Only one new dropzone is add when a sublink is pulled in
- Two are created when a full article is pulled in.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
