### PR TITLE
Fix dropping at bottom of full clipboard

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -80,7 +80,7 @@ const ClipboardBody = styled.div`
 const StyledDragIntentContainer = styled(DragIntentContainer)`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100%;
 `;
 
 const SupportingDivider = styled.hr`


### PR DESCRIPTION
## What's changed?

The clipboard parent was not expanding with its children, and as a result you couldn't drop to a full clipboard. This PR fixes that issue.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
