### PR TITLE
Remove redundant build step

### DIFF
--- a/client-v2/config/webpack.config.common.js
+++ b/client-v2/config/webpack.config.common.js
@@ -13,10 +13,7 @@ module.exports = {
     path: path.resolve(__dirname, '../../public/client-v2/dist'),
     filename: 'app.bundle.js'
   },
-  plugins: [
-    new webpack.EnvironmentPlugin(['BUILD_ENV']),
-    new ForkTsCheckerWebpackPlugin()
-  ],
+  plugins: [new ForkTsCheckerWebpackPlugin()],
   module: {
     rules: [
       {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -12,6 +12,7 @@ import {
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
   .before(setup)
+  .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
   .after(teardown);
 
 // quick and dirty check to see if there are any console errors on page load

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -14,7 +14,8 @@
     "dev-server": "yarn compileWithBabel $(yarn bin)/webpack-dev-server --config config/webpack.config.dev.js",
     "dev": "yarn install && yarn dev-server --open",
     "test": "yarn jest",
-    "test-integration": "BUILD_ENV=integration echo 'RUNNING ON EXISTING PROD BUILD - run yarn build before this to catch changes since last build' && node ./integration/run.js",
+    "test-integration": "BUILD_ENV=integration yarn build && node ./integration/run.js",
+    "test-integration-ci": "BUILD_ENV=integration node ./integration/run.js",
     "run-checks": "yarn test && yarn lint"
   },
   "devDependencies": {

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -14,8 +14,8 @@
     "dev-server": "yarn compileWithBabel $(yarn bin)/webpack-dev-server --config config/webpack.config.dev.js",
     "dev": "yarn install && yarn dev-server --open",
     "test": "yarn jest",
-    "test-integration": "BUILD_ENV=integration yarn build && node ./integration/run.js",
-    "test-integration-ci": "BUILD_ENV=integration node ./integration/run.js",
+    "test-integration": "yarn build && node ./integration/run.js",
+    "test-integration-ci": "node ./integration/run.js",
     "run-checks": "yarn test && yarn lint"
   },
   "devDependencies": {

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -14,8 +14,7 @@
     "dev-server": "yarn compileWithBabel $(yarn bin)/webpack-dev-server --config config/webpack.config.dev.js",
     "dev": "yarn install && yarn dev-server --open",
     "test": "yarn jest",
-    "test-integration": "BUILD_ENV=integration yarn build && node ./integration/run.js",
-    "retest-integration": "BUILD_ENV=integration && node ./integration/run.js",
+    "test-integration": "BUILD_ENV=integration echo 'RUNNING ON EXISTING PROD BUILD - run yarn build before this to catch changes since last build' && node ./integration/run.js",
     "run-checks": "yarn test && yarn lint"
   },
   "devDependencies": {

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -56,9 +56,7 @@ if (pageConfig.favouriteFrontIdsByPriority) {
   storeClipboardContent(pageConfig.clipboardArticles)
 );
 
-if (process.env.BUILD_ENV !== 'integration') {
-  pollingConfig(store);
-}
+pollingConfig(store);
 
 const reactMount = document.getElementById('react-mount');
 

--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -11,6 +11,9 @@ import { frontsEdit, base } from 'constants/routes';
  */
 export default (store: Store) =>
   setInterval(() => {
+    if ((window as any).IS_INTEGRATION) {
+      return;
+    }
     const path = `${base}${frontsEdit}`;
     const match = matchPath<{ priority: string }>(store.getState().path, {
       path

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -31,7 +31,7 @@ javascriptV2() {
     yarn lint
     yarn test
     yarn run build
-    yarn test-integration
+    yarn test-integration-ci
 
     popd
 }

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -30,8 +30,8 @@ javascriptV2() {
     yarn install
     yarn lint
     yarn test
-    yarn test-integration
     yarn run build
+    yarn test-integration
 
     popd
 }


### PR DESCRIPTION
## What's changed?

The integration test runs the build again, why not save time and do our actual build first, then test with that? 🚧 

## Implementation notes
N/A

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
