### PR TITLE
Use shallow equal results and connect focus lower

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -30,9 +30,9 @@ import DragIntentContainer from 'shared/components/DragIntentContainer';
 import {
   setFocusState,
   resetFocusState,
-  selectFocusedArticle,
   selectIsClipboardFocused
 } from 'bundles/focusBundle';
+import FocusWrapper from './FocusWrapper';
 
 const ClipboardWrapper = styled('div')`
   border: 1px solid #c9c9c9;
@@ -41,17 +41,6 @@ const ClipboardWrapper = styled('div')`
   &:focus {
     border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
     border-top: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
-    outline: none;
-  }
-`;
-
-const ArticleWrapper = styled('div')<{ articleSelected?: boolean }>`
-  border: ${({ articleSelected, theme }) =>
-    articleSelected
-      ? `1px solid ${theme.shared.base.colors.focusColor}`
-      : `none`};
-  &:focus {
-    border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
     outline: none;
   }
 `;
@@ -101,7 +90,6 @@ interface ClipboardProps {
   handleArticleFocus: (articleFragment: TArticleFragment) => void;
   handleBlur: () => void;
   dispatch: Dispatch;
-  focusedArticle?: string;
   isClipboardFocused: boolean;
 }
 
@@ -192,13 +180,11 @@ class Clipboard extends React.Component<ClipboardProps> {
                   onDrop={this.handleInsert}
                 >
                   {(articleFragment, afProps) => (
-                    <ArticleWrapper
+                    <FocusWrapper
                       tabIndex={0}
                       onFocus={e => this.handleArticleFocus(e, articleFragment)}
                       onBlur={this.handleBlur}
-                      articleSelected={
-                        this.props.focusedArticle === articleFragment.uuid
-                      }
+                      uuid={articleFragment.uuid}
                     >
                       <CollectionItem
                         uuid={articleFragment.uuid}
@@ -242,7 +228,7 @@ class Clipboard extends React.Component<ClipboardProps> {
                           )}
                         </ArticleFragmentLevel>
                       </CollectionItem>
-                    </ArticleWrapper>
+                    </FocusWrapper>
                   )}
                 </ClipboardLevel>
               </Root>
@@ -268,7 +254,6 @@ class Clipboard extends React.Component<ClipboardProps> {
 
 const mapStateToProps = (state: State) => ({
   isClipboardOpen: selectIsClipboardOpen(state),
-  focusedArticle: selectFocusedArticle(state, 'clipboardArticle'),
   isClipboardFocused: selectIsClipboardFocused(state)
 });
 

--- a/client-v2/src/components/FocusWrapper.tsx
+++ b/client-v2/src/components/FocusWrapper.tsx
@@ -1,0 +1,21 @@
+import { styled } from 'constants/theme';
+import { selectFocusedArticle } from 'bundles/focusBundle';
+import { connect } from 'react-redux';
+import { State } from 'types/State';
+
+const Wrapper = styled('div')<{ isSelected: boolean }>`
+  border: ${props =>
+    props.isSelected
+      ? `1px solid ${props.theme.shared.base.colors.focusColor}`
+      : `none`};
+  &:focus {
+    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
+    outline: none;
+  }
+`;
+
+const mapStateToProps = (state: State, { uuid }: { uuid: string }) => ({
+  isSelected: selectFocusedArticle(state, 'clipboardArticle') === uuid
+});
+
+export default connect(mapStateToProps)(Wrapper);

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -21,6 +21,7 @@ import { resetFocusState, setFocusState } from 'bundles/focusBundle';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
 import { createArticleVisibilityDetailsSelector } from 'selectors/frontsSelectors';
+import FocusWrapper from 'components/FocusWrapper';
 
 const getArticleNotifications = (
   id: string,
@@ -46,17 +47,6 @@ const CollectionWrapper = styled('div')`
     border-top: 2px solid ${props => props.theme.shared.base.colors.focusColor};
     border-bottom: 2px solid
       ${props => props.theme.shared.base.colors.focusColor};
-    outline: none;
-  }
-`;
-
-const CollectionItemWrapper = styled('div')<{ articleSelected?: boolean }>`
-  border: ${props =>
-    props.articleSelected
-      ? `1px solid ${props.theme.shared.base.colors.focusColor}`
-      : `none`};
-  &:focus {
-    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
     outline: none;
   }
 `;
@@ -114,7 +104,6 @@ interface CollectionContextProps {
   browsingStage: CollectionItemSets;
   handleMove: (move: Move<TArticleFragment>) => void;
   handleInsert: (e: React.DragEvent, to: PosSpec) => void;
-  focusedArticle?: string;
   selectArticleFragment: (isSupporting?: boolean) => (id: string) => void;
 }
 
@@ -152,7 +141,6 @@ class CollectionContext extends React.Component<
       selectArticleFragment,
       removeCollectionItem,
       removeSupportingCollectionItem,
-      focusedArticle,
       lastDesktopArticle,
       lastMobileArticle
     } = this.props;
@@ -181,7 +169,7 @@ class CollectionContext extends React.Component<
               >
                 {(articleFragment, afDragProps) => (
                   <>
-                    <CollectionItemWrapper
+                    <FocusWrapper
                       tabIndex={0}
                       onBlur={() => handleBlur()}
                       onFocus={e =>
@@ -192,7 +180,7 @@ class CollectionContext extends React.Component<
                           frontId
                         )
                       }
-                      articleSelected={focusedArticle === articleFragment.uuid}
+                      uuid={articleFragment.uuid}
                     >
                       <CollectionItem
                         frontId={this.props.id}
@@ -238,7 +226,7 @@ class CollectionContext extends React.Component<
                           )}
                         </ArticleFragmentLevel>
                       </CollectionItem>
-                    </CollectionItemWrapper>
+                    </FocusWrapper>
                     <VisibilityDivider
                       notifications={getArticleNotifications(
                         articleFragment.uuid,

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -20,7 +20,7 @@ import { FrontConfig } from 'types/FaciaApi';
 import { events } from 'services/GA';
 import FrontDetailView from './FrontDetailView';
 import { initialiseCollectionsForFront } from 'actions/Collections';
-import { setFocusState, selectFocusedArticle } from 'bundles/focusBundle';
+import { setFocusState } from 'bundles/focusBundle';
 import Collection from './Collection';
 
 // min-height required here to display scrollbar in Firefox:
@@ -51,7 +51,6 @@ type FrontProps = FrontPropsBeforeState & {
   ) => (isSupporting?: boolean) => (id: string) => void;
   editorOpenCollections: (ids: string[]) => void;
   front: FrontConfig;
-  focusedArticle?: string;
   handleArticleFocus: (
     groupId: string,
     articleFragment: TArticleFragment,
@@ -166,8 +165,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
 
 const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
   return {
-    front: getFront(state, { frontId: props.id }),
-    focusedArticle: selectFocusedArticle(state, 'collectionArticle')
+    front: getFront(state, { frontId: props.id })
   };
 };
 

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -216,7 +216,7 @@ const includeSupportingArticlesSelector = (
 
 const createArticlesInCollectionGroupSelector = () => {
   const collectionStageGroupsSelector = createCollectionStageGroupsSelector();
-  return createSelector(
+  return createShallowEqualResultSelector(
     articleFragmentsSelector,
     collectionStageGroupsSelector,
     groupNameSelector,
@@ -309,7 +309,7 @@ const articleFragmentIdSelector = (
 ) => articleFragmentId;
 
 const createSupportingArticlesSelector = () =>
-  createSelector(
+  createShallowEqualResultSelector(
     articleFragmentsFromRootStateSelector,
     articleFragmentIdSelector,
     (articleFragments, id) =>


### PR DESCRIPTION
## What's changed?

This change attempts to improve drag and drop speed to a reasonable level for people with many fronts open.

## Implementation notes

While investigating this I found three pieces of low-hanging fruit 🍒 to test with Mariana. Any time new article fragments got created every collection would re-render. This happened when dragging from the feed, or when dragging between fronts.

We can optimise this further (albeit with a fair bit more work) by factoring out the `createShallowEqualResultSelector` but it gets us a good deal of the way there, and I'm not sure how much of a performance improvement the refactor would give us.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
