### PR TITLE
Embiggen clipboard dropzone, for the nth time

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -73,14 +73,14 @@ const ClipboardTitle = styled.h2`
 
 const ClipboardBody = styled.div`
   padding: 10px;
-  flex-basis: 100%;
+  flex: 1;
   display: flex;
 `;
 
 const StyledDragIntentContainer = styled(DragIntentContainer)`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100%;
 `;
 
 const SupportingDivider = styled.hr`
@@ -183,7 +183,7 @@ class Clipboard extends React.Component<ClipboardProps> {
                 style={{
                   display: 'flex',
                   flexDirection: 'column',
-                  height: '100%',
+                  flex: '1',
                   width: '140px'
                 }}
               >


### PR DESCRIPTION
## What's changed?

The clipboard dropzone was nuked again by a clipboard layout change. This PR restores it to normalcy. Tested from empty to full to overflowing and back again.

_nobody touch anything_

In all seriousness, I've been wondering how to test this in a non-fragile way -- suggestions welcome.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
