### PR TITLE
Fix missing group names and change previously label

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -172,14 +172,14 @@ class Collection extends React.Component<CollectionProps> {
           ) : null
         }
       >
-        {groups.map(group => children(group, isUneditable))}
+        {groups.map(group => children(group, isUneditable, true))}
 
         <PreviouslyCollectionContainer data-testid="previously">
           <PreviouslyCollectionToggle
             onClick={this.togglePreviouslyOpen}
             data-testid="previously-toggle"
           >
-            Previously
+            Recently removed
             <ButtonCircularCaret active={isPreviouslyOpen} />
           </PreviouslyCollectionToggle>
           {isPreviouslyOpen && (


### PR DESCRIPTION
## What's changed?

Changes "Previously" to "Recently removed", also fixes a bug where group names weren't displaying.

### Group names
![Screenshot 2019-04-29 at 11 38 51](https://user-images.githubusercontent.com/1652187/56891150-6df3fa80-6a73-11e9-9770-0f9e6d2ddc94.png)

### Recently removed
![Screenshot 2019-04-29 at 11 38 29](https://user-images.githubusercontent.com/1652187/56891141-67658300-6a73-11e9-9154-c5d8f133bc61.png)

## Implementation notes

N/A

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included

