### PR TITLE
FIX: remove stopPropagation on DragOver events

### DIFF
--- a/client-v2/src/shared/components/DragIntentContainer.tsx
+++ b/client-v2/src/shared/components/DragIntentContainer.tsx
@@ -30,10 +30,6 @@ class DragIntentContainer extends React.Component<Props> {
     this.dragHoverDepth += 1;
   };
 
-  public handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-  };
-
   public handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
     this.dragHoverDepth -= 1;
     if (this.props.onDragLeave) {
@@ -102,7 +98,6 @@ class DragIntentContainer extends React.Component<Props> {
         onDragEnter={this.handleDragEnter}
         onDragLeave={this.handleDragLeave}
         onDrop={this.handleDrop}
-        onDragOver={this.handleDragOver}
       >
         {children}
       </div>


### PR DESCRIPTION
## What's changed?
Small fix to drag bug introduced in https://github.com/guardian/facia-tool/pull/703/files

Stopping propagation of DragOver events meant a lot of drag and drop events were not getting registered

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
