### PR TITLE
Reduce gap between empty groups

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -156,6 +156,7 @@ class Clipboard extends React.Component<ClipboardProps> {
       >
         <StyledDragIntentContainer
           active={!this.props.isClipboardOpen}
+          delay={300}
           onDragIntentStart={() => this.setState({ preActive: true })}
           onDragIntentEnd={() => this.setState({ preActive: false })}
           onIntentConfirm={() => this.props.toggleClipboard(true)}

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -193,6 +193,7 @@ class Clipboard extends React.Component<ClipboardProps> {
                         onFocus={e =>
                           this.handleArticleFocus(e, articleFragment)
                         }
+                        area="clipboard"
                         onBlur={this.handleBlur}
                         uuid={articleFragment.uuid}
                       >

--- a/client-v2/src/components/DropZone.tsx
+++ b/client-v2/src/components/DropZone.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { styled } from 'constants/theme';
 import { theme } from 'constants/theme';
 
-const DropContainer = styled('div')<{ disabled: boolean }>`
+const DropContainer = styled('div')<{
+  disabled: boolean;
+  doubleHeight?: boolean;
+}>`
   position: relative;
-  height: 10px;
+  height: ${({ doubleHeight }) => (doubleHeight ? '20px' : '10px')};
   ${({ disabled }) => disabled && 'pointer-events: none'}
 `;
 
@@ -18,6 +21,7 @@ class DropZone extends React.Component<
     onDrop: (e: React.DragEvent) => void;
     onDragOver: (e: React.DragEvent) => void;
     disabled?: boolean;
+    doubleHeight?: boolean;
     style: React.CSSProperties;
     indicatorStyle: React.CSSProperties;
     override?: boolean;
@@ -68,10 +72,11 @@ class DropZone extends React.Component<
         };
 
   public render() {
-    const { style } = this.props;
+    const { style, doubleHeight } = this.props;
     return (
       <DropContainer
         {...this.getEventProps()}
+        doubleHeight={doubleHeight}
         data-testid="drop-zone"
         style={style}
         disabled={!!this.props.disabled}

--- a/client-v2/src/components/FocusWrapper.tsx
+++ b/client-v2/src/components/FocusWrapper.tsx
@@ -4,13 +4,12 @@ import { connect } from 'react-redux';
 import { State } from 'types/State';
 
 const Wrapper = styled('div')<{ isSelected: boolean }>`
-  border: ${props =>
+  outline: ${props =>
     props.isSelected
       ? `1px solid ${props.theme.shared.base.colors.focusColor}`
       : `none`};
   &:focus {
-    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
-    outline: none;
+    outline: 1px solid ${props => props.theme.shared.base.colors.focusColor};
   }
 `;
 

--- a/client-v2/src/components/FocusWrapper.tsx
+++ b/client-v2/src/components/FocusWrapper.tsx
@@ -13,8 +13,11 @@ const Wrapper = styled('div')<{ isSelected: boolean }>`
   }
 `;
 
-const mapStateToProps = (state: State, { uuid }: { uuid: string }) => ({
-  isSelected: selectFocusedArticle(state, 'clipboardArticle') === uuid
+const mapStateToProps = (
+  state: State,
+  { uuid, area }: { uuid: string; area: 'clipboard' | 'collection' }
+) => ({
+  isSelected: selectFocusedArticle(state, `${area}Article`) === uuid
 });
 
 export default connect(mapStateToProps)(Wrapper);

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -42,13 +42,6 @@ const CollectionWrapper = styled('div')`
   & + & {
     margin-top: 10px;
   }
-  &:focus {
-    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
-    border-top: 2px solid ${props => props.theme.shared.base.colors.focusColor};
-    border-bottom: 2px solid
-      ${props => props.theme.shared.base.colors.focusColor};
-    outline: none;
-  }
 `;
 
 const Notification = styled.span`
@@ -117,7 +110,6 @@ type ConnectedCollectionContextProps = CollectionContextProps & {
   addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   removeCollectionItem: (parentId: string, id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
-  handleFocus: (id: string) => void;
   handleBlur: () => void;
   lastDesktopArticle?: string;
   lastMobileArticle?: string;
@@ -131,7 +123,6 @@ class CollectionContext extends React.Component<
       id,
       frontId,
       handleBlur,
-      handleFocus,
       priority,
       alsoOn,
       browsingStage,
@@ -145,11 +136,7 @@ class CollectionContext extends React.Component<
       lastMobileArticle
     } = this.props;
     return (
-      <CollectionWrapper
-        tabIndex={0}
-        onBlur={() => handleBlur()}
-        onFocus={() => handleFocus(id)}
-      >
+      <CollectionWrapper>
         <Collection
           key={id}
           id={id}
@@ -275,9 +262,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
   addImageToArticleFragment: (id: string, response: ValidationResponse) =>
     dispatch(addImageToArticleFragment(id, response)),
-  handleBlur: () => dispatch(resetFocusState()),
-  handleFocus: (collectionId: string) =>
-    dispatch(setFocusState({ type: 'collection', collectionId }))
+  handleBlur: () => dispatch(resetFocusState())
 });
 
 export default connect(

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -17,7 +17,7 @@ import {
   removeArticleFragment,
   addImageToArticleFragment
 } from 'actions/ArticleFragments';
-import { resetFocusState, setFocusState } from 'bundles/focusBundle';
+import { resetFocusState } from 'bundles/focusBundle';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
 import { createArticleVisibilityDetailsSelector } from 'selectors/frontsSelectors';

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -163,6 +163,7 @@ class CollectionContext extends React.Component<
                   <>
                     <FocusWrapper
                       tabIndex={0}
+                      area="collection"
                       onBlur={() => handleBlur()}
                       onFocus={e =>
                         handleArticleFocus(

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -62,15 +62,15 @@ const selectGrey = ({ theme }: { theme: Theme }) =>
 const VisibilityDividerEl = styled.div`
   display: flex;
   font-weight: bold;
-  font-size: 14px;
-  line-height: 1.25;
+  font-size: 12px;
+  line-height: 1;
   margin: 0.5em 0;
   text-transform: capitalize;
 
   :before {
-    background-image: linear-gradient(transparent 75%, ${selectGrey} 75%, ${selectGrey} 100%);
-    background-position: 0px 3px;
-    background-size: 4px 4px;
+    background-image: linear-gradient(transparent 66.66666%, ${selectGrey} 66.66666%, ${selectGrey} 100%);
+    background-position: 0px 2px;
+    background-size: 3px 3px;
     content: '';
     display: block;
     flex: 1;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -75,7 +75,7 @@ class Sublinks extends React.Component<SublinkProps> {
             onDragIntentEnd={() => {
               this.setState({ dragHoverActive: false });
             }}
-            delay={300}
+            delay={600}
             filterRegisterEvent={this.dragEventNotBlacklisted}
             onIntentConfirm={() => {
               toggleShowArticleSublinks();

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -16,7 +16,8 @@ const SublinkCollectionItemBody = styled(CollectionItemBody)<{
 }>`
   display: flex;
   min-height: 30px;
-  border: ${({ isClipboard }) => (isClipboard ? 'none' : '1px solid #c9c9c9')};
+  border-top: ${({ isClipboard }) =>
+    isClipboard ? 'none' : '1px solid #c9c9c9'};
   background-color: ${({ isClipboard, dragHoverActive }) =>
     dragHoverActive ? `#ededed` : isClipboard ? '#f6f6f6' : '#fff'};
   flex-direction: ${({ isClipboard }) => (isClipboard ? 'column' : 'row')};

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -45,6 +45,7 @@ const ArticleFragmentLevel = ({
     getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}
+    canDrop={!isUneditable}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
     dragImageOffsetX={dragOffsetX}
     dragImageOffsetY={dragOffsetY}

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -10,6 +10,7 @@ import ArticleDrag, {
 import DropZone from 'components/DropZone';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
 import { createArticlesFromIdsSelector } from 'shared/selectors/shared';
+import { styled } from 'constants/theme';
 
 interface OuterProps {
   groupId: string;
@@ -25,6 +26,10 @@ interface InnerProps {
 }
 
 type Props = OuterProps & InnerProps;
+
+const Spacer = styled.div`
+  margin-top: 10px;
+`;
 
 const GroupLevel = ({
   children,
@@ -45,16 +50,26 @@ const GroupLevel = ({
     getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}
+    canDrop={!isUneditable}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
     renderDrop={
       isUneditable
-        ? null
-        : (props, isTarget, isActive) => (
+        ? () => <Spacer />
+        : (props, isTarget, isActive, i) => (
             <DropZone
               {...props}
               disabled={!isActive}
               override={isTarget}
-              doubleHeight={!articleFragments.length}
+              doubleHeight={!articleFragments.length || i === 0}
+              style={
+                i === 0
+                  ? {
+                      height: '32px',
+                      marginTop: '-22px',
+                      paddingTop: '22px'
+                    }
+                  : {}
+              }
             />
           )
     }

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -54,16 +54,7 @@ const GroupLevel = ({
               {...props}
               disabled={!isActive}
               override={isTarget}
-              style={
-                // Pad the drop zone for ease of dropping if there's
-                // nothing in the group.
-                articleFragments.length
-                  ? undefined
-                  : {
-                      height: '30px',
-                      paddingBottom: '20px'
-                    }
-              }
+              doubleHeight={!articleFragments.length}
             />
           )
     }

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -71,6 +71,7 @@ interface OuterProps<T> {
   type: string;
   dragImageOffsetX?: number;
   dragImageOffsetY?: number;
+  canDrop?: boolean;
   getId: (t: T) => string;
   onMove: (move: Move<T>) => void;
   onDrop: (e: React.DragEvent, to: PosSpec) => void;
@@ -244,9 +245,10 @@ class Level<T> extends React.Component<Props<T>, State> {
     i: number,
     getNodeDragProps: (forceClone: boolean) => NodeChildrenProps
   ) {
+    const { canDrop = true } = this.props;
     return (forceClone = false) => ({
       ...getNodeDragProps(forceClone),
-      ...(this.props.renderDrop
+      ...(canDrop
         ? { onDragOver: this.onDragOver(i, true), onDrop: this.onDrop(i, true) }
         : {})
     });

--- a/client-v2/src/lib/dnd/__tests__/dnd.spec.tsx
+++ b/client-v2/src/lib/dnd/__tests__/dnd.spec.tsx
@@ -177,7 +177,7 @@ describe('Guration', () => {
     });
   });
 
-  it('does not allow dropping on to nodes when renderDrop is not defined', () => {
+  it('does not allow dropping on to nodes when canDrop is false', () => {
     let nodeProps;
     let dropProps;
     let edit: any;
@@ -193,6 +193,7 @@ describe('Guration', () => {
           onMove={() => null}
           onDrop={() => null}
           renderDrop={() => null}
+          canDrop={false}
         >
           {(child, getDragProps, i) => {
             if (i === 0) {
@@ -210,6 +211,7 @@ describe('Guration', () => {
                   edit = e;
                 }}
                 onDrop={() => null}
+                canDrop={false}
               >
                 {(_, getNodeProps, j) =>
                   j === 0 ? ((dropProps = getNodeProps()), null) : null

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -25,6 +25,8 @@ import ContentContainer from './layout/ContentContainer';
 import { css } from 'styled-components';
 import { events } from 'services/GA';
 import CollectionMetaContainer from './collection/CollectionMetaContainer';
+import { resetFocusState, setFocusState } from 'bundles/focusBundle';
+import { Dispatch } from 'types/Store';
 
 export const createCollectionId = ({ id }: Collection) => `collection-${id}`;
 
@@ -46,6 +48,8 @@ type Props = ContainerProps & {
   isOpen?: boolean;
   hasMultipleFrontsOpen?: boolean;
   onChangeOpenState?: (isOpen: boolean) => void;
+  handleFocus: (id: string) => void;
+  handleBlur: () => void;
 };
 
 interface CollectionState {
@@ -58,6 +62,12 @@ const CollectionContainer = ContentContainer.extend<{
   flex: 1;
   width: ${({ hasMultipleFrontsOpen }) =>
     hasMultipleFrontsOpen ? '510px' : '590px'};
+
+  &:focus {
+    border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
+    border-top: none;
+    outline: none;
+  }
 `;
 
 const HeadlineContentContainer = styled('span')`
@@ -177,6 +187,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 
   public render() {
     const {
+      id,
       collection,
       articleIds,
       headlineContent,
@@ -184,13 +195,18 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       isUneditable,
       isLocked,
       hasMultipleFrontsOpen,
-      children
+      children,
+      handleFocus,
+      handleBlur
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
     const displayName = collection ? collection.displayName : 'Loading';
     return (
       <CollectionContainer
         id={collection && createCollectionId(collection)}
+        tabIndex={0}
+        onFocus={() => handleFocus(id)}
+        onBlur={handleBlur}
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
       >
         <ContainerHeadingPinline tabIndex={-1}>
@@ -298,4 +314,13 @@ const createMapStateToProps = () => {
   };
 };
 
-export default connect(createMapStateToProps)(CollectionDisplay);
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  handleBlur: () => dispatch(resetFocusState()),
+  handleFocus: (collectionId: string) =>
+    dispatch(setFocusState({ type: 'collection', collectionId }))
+});
+
+export default connect(
+  createMapStateToProps,
+  mapDispatchToProps
+)(CollectionDisplay);

--- a/client-v2/src/shared/components/GroupDisplay.tsx
+++ b/client-v2/src/shared/components/GroupDisplay.tsx
@@ -11,16 +11,12 @@ const GroupHeading = styled('div')`
   font-weight: bold;
 `;
 
-const GroupContainer = styled('div')`
-  margin-top: 20px;
-`;
-
 const GroupDisplayComponent = ({ groupName }: GroupDisplayComponentProps) =>
   groupName ? (
-    <GroupContainer data-testid={groupName}>
+    <div data-testid={groupName}>
       <GroupHeading style={{ margin: 0 }}>{groupName}</GroupHeading>
       <HorizontalRule />
-    </GroupContainer>
+    </div>
   ) : null;
 
 export default GroupDisplayComponent;

--- a/client-v2/src/shared/components/GroupDisplay.tsx
+++ b/client-v2/src/shared/components/GroupDisplay.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import HorizontalRule from 'shared/components/layout/HorizontalRule';
 import { styled } from 'shared/constants/theme';
 
 interface GroupDisplayComponentProps {
@@ -7,15 +6,18 @@ interface GroupDisplayComponentProps {
 }
 
 const GroupHeading = styled('div')`
+  border-left: 1px solid #ccc;
+  border-top: 1px solid #ccc;
   font-size: 14px;
   font-weight: bold;
+  padding: 0.25em 0.25em 0;
+  text-transform: capitalize;
 `;
 
 const GroupDisplayComponent = ({ groupName }: GroupDisplayComponentProps) =>
   groupName ? (
     <div data-testid={groupName}>
       <GroupHeading style={{ margin: 0 }}>{groupName}</GroupHeading>
-      <HorizontalRule />
     </div>
   ) : null;
 

--- a/client-v2/src/shared/components/Link.tsx
+++ b/client-v2/src/shared/components/Link.tsx
@@ -5,4 +5,8 @@ export default styled(`a`).attrs({
   rel: 'noopener noreferrer'
 })`
   text-decoration: none;
+
+  &:focus {
+    outline: 1px solid ${props => props.theme.shared.base.colors.focusColor};
+  }
 `;

--- a/client-v2/src/shared/components/collection/CollectionMetaContainer.tsx
+++ b/client-v2/src/shared/components/collection/CollectionMetaContainer.tsx
@@ -7,6 +7,7 @@ export default styled('div')`
   font-size: 12px;
   font-weight: normal;
   justify-content: space-between;
+  margin-bottom: 0.5em;
   border-top: ${({ theme }) =>
     `1px solid ${theme.shared.base.colors.borderColor}`};
   cursor: pointer;

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -143,7 +143,7 @@ export default styled(`button`)`
     cursor: pointer;
   }
   &:focus {
-    outline: transparent;
+    outline: 1px solid ${props => props.theme.shared.base.colors.focusColor};
   }
 
   :not(:first-child) {

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -88,7 +88,11 @@ const HoverViewButton = ({
     }}
     href={isLive ? getPaths(urlPath).live : getPaths(urlPath).preview}
   >
-    <ActionButton onMouseEnter={showToolTip} onMouseLeave={hideToolTip}>
+    <ActionButton
+      tabIndex={-1}
+      onMouseEnter={showToolTip}
+      onMouseLeave={hideToolTip}
+    >
       <ViewHoverIcon />
     </ActionButton>
   </Link>
@@ -108,7 +112,11 @@ const HoverOphanButton = ({
       href={getPaths(`https://www.theguardian.com/${urlPath}`).ophan}
       data-testid={'ophan-hover-button'}
     >
-      <ActionButton onMouseEnter={showToolTip} onMouseLeave={hideToolTip}>
+      <ActionButton
+        tabIndex={-1}
+        onMouseEnter={showToolTip}
+        onMouseLeave={hideToolTip}
+      >
         <OphanHoverIcon />
       </ActionButton>
     </Link>


### PR DESCRIPTION
## What's changed?

This shrinks the gap for empty groups to use slightly less vertical space.

![Screenshot 2019-04-30 at 11 49 15 (2)](https://user-images.githubusercontent.com/1652187/56957135-0c4c9280-6b3e-11e9-8f6c-37ec8ea70eb6.png)

## Implementation notes

N/A

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
