### PR TITLE
Remove proactive sorting

### DIFF
--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -105,6 +105,6 @@ object CollectionService {
         group,
         article.meta.flatMap(_.isBoosted).getOrElse(false)
       )
-    }.sortBy(_.group).reverse
+    }
   }
 }


### PR DESCRIPTION
It doesn't seem that this is required and was producing slight bugs when certain fronts used boosted articles.

## What's changed?

Mobile desktop should appear in the right place.

## Implementation notes

The other thing worth noting here is that sorting here only solves a problem that could lead to many more bugs: groups that have interleaved article fragments in a collection. It _feels_ like an invariant in more places than this.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
