### PR TITLE
CLIPBOARD: Stop metadata loss when "add to clipboard" button is used 

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -11,7 +11,8 @@ import {
 import { ArticleFragment } from 'shared/types/Collection';
 import {
   selectSharedState,
-  articleFragmentsSelector
+  articleFragmentsSelector,
+  articleFragmentSelector
 } from 'shared/selectors/shared';
 import { ThunkResult, Dispatch } from 'types/Store';
 import { addPersistMetaToAction } from 'util/storeMiddleware';
@@ -289,6 +290,21 @@ const moveArticleFragment = (
   };
 };
 
+const cloneArticleFragmentToTarget = (
+  uuid: string,
+  toType: 'clipboard' | 'collection'
+): ThunkResult<void> => {
+  return (dispatch, getState) => {
+    const to = { id: toType, type: toType, index: 0 };
+    const fragment = articleFragmentSelector(
+      selectSharedState(getState()),
+      uuid
+    );
+    const from = null;
+    dispatch(moveArticleFragment(to, fragment, from, toType));
+  };
+};
+
 const addImageToArticleFragment = (
   uuid: string,
   imageData: ValidationResponse
@@ -304,5 +320,6 @@ export {
   updateArticleFragmentMetaWithPersist as updateArticleFragmentMeta,
   updateClipboardArticleFragmentMetaWithPersist as updateClipboardArticleFragmentMeta,
   removeArticleFragment,
-  addImageToArticleFragment
+  addImageToArticleFragment,
+  cloneArticleFragmentToTarget
 };

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -49,19 +49,19 @@ const root = (state: any = {}, action: any) => ({
 
 const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
   const groupA: ArticleFragmentSpec[] = [
-    ['a', '1', [['g', '7']], {}],
-    ['b', '2', undefined, {}],
-    ['c', '3', undefined, {}]
+    ['a', '1', [['g', '7']]],
+    ['b', '2', undefined],
+    ['c', '3', undefined]
   ];
   const groupB: ArticleFragmentSpec[] = [
-    ['i', '9', [['g', '7']], {}],
-    ['j', '10', undefined, {}],
-    ['k', '11', undefined, {}]
+    ['i', '9', [['g', '7']]],
+    ['j', '10', undefined],
+    ['k', '11', undefined]
   ];
   const clipboard: ArticleFragmentSpec[] = [
-    ['d', '4', undefined, {}],
-    ['e', '5', undefined, {}],
-    ['f', '6', undefined, {}]
+    ['d', '4', undefined],
+    ['e', '5', undefined],
+    ['f', '6', undefined]
   ];
   const all = [...groupA, ...groupB, ...clipboard, added];
   const state = {
@@ -112,7 +112,7 @@ const insert = async (
 ) => {
   const [uuid, id] = insertedArticleFragmentSpec;
   const { dispatch, getState } = buildStore(
-    [uuid, id, undefined, {}],
+    [uuid, id, undefined],
     collectionCapInfo ? collectionCapInfo.cap : Infinity
   );
   await dispatch(insertArticleFragment(
@@ -148,7 +148,7 @@ const move = (
 ) => {
   const [uuid, id] = movedArticleFragmentSpec;
   const { dispatch, getState } = buildStore(
-    [uuid, id, undefined, {}],
+    [uuid, id, undefined],
     collectionCapInfo ? collectionCapInfo.cap : Infinity
   );
   dispatch(moveArticleFragment(
@@ -157,7 +157,7 @@ const move = (
       id: toId,
       index
     },
-    specToFragment([uuid, id, undefined, {}]),
+    specToFragment([uuid, id, undefined]),
     {
       id: fromId,
       type: fromType,

--- a/client-v2/src/actions/__tests__/utils.ts
+++ b/client-v2/src/actions/__tests__/utils.ts
@@ -1,3 +1,5 @@
+import { ArticleFragmentMeta } from 'shared/types/Collection';
+
 export interface ArticleFragmentMap {
   [uuid: string]: {
     uuid: string;
@@ -10,7 +12,7 @@ export type ArticleFragmentSpec = [
   string, // uuid
   string, // id
   Array<[string, string]> | undefined, // all of supporting articles,
-  object // metadata changes
+  ArticleFragmentMeta? // metadata changes
 ];
 
 export const specToFragment = ([

--- a/client-v2/src/actions/__tests__/utils.ts
+++ b/client-v2/src/actions/__tests__/utils.ts
@@ -7,20 +7,23 @@ export interface ArticleFragmentMap {
 }
 
 export type ArticleFragmentSpec = [
-  string,
-  string,
-  Array<[string, string]> | undefined
+  string, // uuid
+  string, // id
+  Array<[string, string]> | undefined, // all of supporting articles,
+  object // metadata changes
 ];
 
 export const specToFragment = ([
   uuid,
   id,
-  supporting
+  supporting,
+  meta
 ]: ArticleFragmentSpec) => ({
   uuid,
   id,
   frontPublicationDate: 0,
   meta: {
+    ...meta,
     supporting: supporting && supporting.map(([suuid]) => suuid)
   }
 });
@@ -29,9 +32,9 @@ export const createArticleFragmentStateFromSpec = (
   specs: ArticleFragmentSpec[]
 ) =>
   specs.reduce(
-    (acc, [uuid, id, supporting]) => ({
+    (acc, [uuid, id, supporting, meta]) => ({
       ...acc,
-      [uuid]: specToFragment([uuid, id, supporting]),
+      [uuid]: specToFragment([uuid, id, supporting, meta]),
       ...(supporting
         ? supporting.reduce(
             (sacc, [suuid, sid]) => ({
@@ -39,7 +42,7 @@ export const createArticleFragmentStateFromSpec = (
               [suuid]: {
                 uuid: suuid,
                 id: sid,
-                meta: {}
+                meta: { ...meta }
               }
             }),
             {} as ArticleFragmentMap

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -15,7 +15,7 @@ import {
   CollectionItemDisplayTypes
 } from 'shared/types/Collection';
 import SnapLink from 'shared/components/snapLink/SnapLink';
-import { insertArticleFragment } from 'actions/ArticleFragments';
+import { cloneArticleFragmentToTarget } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import { selectEditorArticleFragment } from 'bundles/frontsUIBundle';
 import {
@@ -43,7 +43,10 @@ interface ContainerProps {
 }
 
 type ArticleContainerProps = ContainerProps & {
-  onAddToClipboard: (externalArticleId: string | undefined) => void;
+  onAddToClipboard: (
+    externalArticleId: string | undefined,
+    uuid: string
+  ) => void;
   type: CollectionItemTypes;
   isSelected: boolean;
   externalArticleId: string | undefined;
@@ -106,7 +109,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             isUneditable={isUneditable}
             {...getNodeProps()}
             onDelete={onDelete}
-            onAddToClipboard={() => onAddToClipboard(externalArticleId)}
+            onAddToClipboard={() => onAddToClipboard(externalArticleId, uuid)}
             onClick={isUneditable ? undefined : () => onSelect(uuid)}
             fade={!isSelected}
             size={size}
@@ -191,18 +194,11 @@ const createMapStateToProps = () => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    onAddToClipboard: (id: string | undefined) => {
-      if (id) {
-        dispatch(
-          insertArticleFragment(
-            { id: 'clipboard', type: 'clipboard', index: 0 },
-            // @TODO - if this is proving too slow we can pass the whole external article into
-            // this components and insert that data rather than fetching it from CAPI
-            { type: 'REF', data: id },
-            'clipboard'
-          )
-        );
+    onAddToClipboard: (id: string | undefined, uuid: string) => {
+      if (!id) {
+        return;
       }
+      dispatch(cloneArticleFragmentToTarget(uuid, 'clipboard'));
     }
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -14,8 +14,7 @@ const SublinkCollectionItemBody = styled(CollectionItemBody)<{
 }>`
   display: flex;
   min-height: 30px;
-  border-width: ${({ isClipboard }) =>
-    isClipboard ? 'none' : '1px solid #c9c9c9'};
+  border: ${({ isClipboard }) => (isClipboard ? 'none' : '1px solid #c9c9c9')};
   background-color: ${({ isClipboard, dragHoverActive }) =>
     dragHoverActive ? `#ededed` : isClipboard ? '#f6f6f6' : '#fff'};
   flex-direction: ${({ isClipboard }) => (isClipboard ? 'column' : 'row')};


### PR DESCRIPTION
## What's changed?

When articles were taken OUT of a collection and added to the clipboard, any meta changes that had been made to the story were lost. (eg. any edits to the headline or supporting articles added).

Because drag and drop between the collection and the clipboard worked fine, I have reused this logic for the button. This required a new thunk to be created. 

So this now uses: `moveArticleFragment`
Instead of:  `insertArticleFragment` 

A test has also been added. 

A styling change to sublinks has also been added to this PR 

https://trello.com/c/tdNV4sx7/550-copying-articles-to-clipboard-loses-the-furniture-of-the-article

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
