### PR TITLE
Fix sorting groups

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -13,7 +13,8 @@ import { ArticleFragment } from 'shared/types/Collection';
 import {
   selectSharedState,
   articleFragmentsSelector,
-  articleFragmentSelector
+  articleFragmentSelector,
+  articleGroupSelector
 } from 'shared/selectors/shared';
 import { ThunkResult, Dispatch } from 'types/Store';
 import { addPersistMetaToAction } from 'util/storeMiddleware';
@@ -233,12 +234,23 @@ const insertArticleFragmentWithCreate = (
       return;
     }
     const sharedState = selectSharedState(getState());
-    const toWithRespectToState = getToGroupIndicesWithRespectToState(to, sharedState, false);
+    const toWithRespectToState = getToGroupIndicesWithRespectToState(
+      to,
+      sharedState,
+      false
+    );
     if (toWithRespectToState) {
       return dispatch(articleFragmentFactory(drop))
         .then(fragment => {
           if (fragment) {
-            dispatch(insertActionCreator(toWithRespectToState.id, toWithRespectToState.index, fragment.uuid, null));
+            dispatch(
+              insertActionCreator(
+                toWithRespectToState.id,
+                toWithRespectToState.index,
+                fragment.uuid,
+                null
+              )
+            );
           }
         })
         .catch(() => {
@@ -254,12 +266,20 @@ const removeArticleFragment = (
   articleFragmentId: string,
   persistTo: 'collection' | 'clipboard'
 ): ThunkResult<void> => {
-  return (dispatch: Dispatch) => {
+  return (dispatch: Dispatch, getState) => {
+    const groupIdFromState =
+      persistTo === 'clipboard'
+        ? 'clipboard'
+        : articleGroupSelector(
+            selectSharedState(getState()),
+            id,
+            articleFragmentId
+          );
     const removeActionCreator = getRemoveActionCreatorFromType(type, persistTo);
-    if (!removeActionCreator) {
+    if (!removeActionCreator || !groupIdFromState) {
       return;
     }
-    dispatch(removeActionCreator(id, articleFragmentId));
+    dispatch(removeActionCreator(groupIdFromState, articleFragmentId));
   };
 };
 

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -278,6 +278,10 @@ const moveArticleFragment = (
     }
 
     const sharedState = selectSharedState(getState());
+
+    // If move actions are happening to/from groups which have article fragments displayed
+    // in them which don't belong to these groups we need to adjust the indices of the move
+    // actions in these groups.
     const fromDetails: {
       fromWithRespectToState: PosSpec | null;
       fromOrphanedGroup: boolean;

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -19,8 +19,8 @@ import { ThunkResult, Dispatch } from 'types/Store';
 import { addPersistMetaToAction } from 'util/storeMiddleware';
 import { cloneFragment } from 'shared/util/articleFragment';
 import {
-  getFromGroupIndecesWithRespectToState,
-  getToGroupIndecesWithRespectToState
+  getFromGroupIndicesWithRespectToState,
+  getToGroupIndicesWithRespectToState
 } from 'util/moveUtils';
 import { PosSpec } from 'lib/dnd';
 import { Action } from 'types/Action';
@@ -281,9 +281,9 @@ const moveArticleFragment = (
     const fromDetails: {
       fromWithRespectToState: PosSpec | null;
       fromOrphanedGroup: boolean;
-    } = getFromGroupIndecesWithRespectToState(from, sharedState);
+    } = getFromGroupIndicesWithRespectToState(from, sharedState);
 
-    const toWithRespectToState: PosSpec | null = getToGroupIndecesWithRespectToState(
+    const toWithRespectToState: PosSpec | null = getToGroupIndicesWithRespectToState(
       to,
       sharedState,
       fromDetails.fromOrphanedGroup

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -224,7 +224,7 @@ const insertArticleFragmentWithCreate = (
   // allow the factory to be injected for testing
   articleFragmentFactory = createArticleFragment
 ): ThunkResult<void> => {
-  return (dispatch: Dispatch) => {
+  return (dispatch: Dispatch, getState) => {
     const insertActionCreator = getInsertionActionCreatorFromType(
       to.type,
       persistTo
@@ -232,15 +232,19 @@ const insertArticleFragmentWithCreate = (
     if (!insertActionCreator) {
       return;
     }
-    return dispatch(articleFragmentFactory(drop))
-      .then(fragment => {
-        if (fragment) {
-          dispatch(insertActionCreator(to.id, to.index, fragment.uuid, null));
-        }
-      })
-      .catch(() => {
-        // @todo: implement once error handling is done
-      });
+    const sharedState = selectSharedState(getState());
+    const toWithRespectToState = getToGroupIndicesWithRespectToState(to, sharedState, false);
+    if (toWithRespectToState) {
+      return dispatch(articleFragmentFactory(drop))
+        .then(fragment => {
+          if (fragment) {
+            dispatch(insertActionCreator(toWithRespectToState.id, toWithRespectToState.index, fragment.uuid, null));
+          }
+        })
+        .catch(() => {
+          // @todo: implement once error handling is done
+        });
+    }
   };
 };
 

--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -62,12 +62,14 @@ const init = () => {
         g1: {
           uuid: 'g1',
           id: 'g1',
-          articleFragments: ['a1', 'a2']
+          articleFragments: ['a1', 'a2'],
+          name: 'g1'
         },
         g2: {
           uuid: 'g2',
           id: 'g2',
-          articleFragments: ['a3', 'a4']
+          articleFragments: ['a3', 'a4'],
+          name: 'g2'
         }
       },
       articleFragments: {

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -170,6 +170,7 @@ class CollectionContext extends React.Component<
                 groupId={group.uuid}
                 onMove={handleMove}
                 onDrop={handleInsert}
+                articleFragmentIds={group.articleFragments}
               >
                 {(articleFragment, getAfNodeProps) => (
                   <>

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -5,11 +5,12 @@ import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
-import { createGroupArticlesSelector } from 'shared/selectors/shared';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
+import { createArticlesFromIdsSelector } from 'shared/selectors/shared';
 
 interface OuterProps {
   groupId: string;
+  articleFragmentIds: string[];
   children: LevelChild<ArticleFragment>;
   onMove: MoveHandler<ArticleFragment>;
   onDrop: DropHandler;
@@ -67,10 +68,10 @@ const GroupLevel = ({
 );
 
 const createMapStateToProps = () => {
-  const groupArticleSelector = createGroupArticlesSelector();
-  return (state: State, { groupId }: OuterProps) => ({
-    articleFragments: groupArticleSelector(state, {
-      groupId
+  const articlesFromIdsSelector = createArticlesFromIdsSelector();
+  return (state: State, { articleFragmentIds }: OuterProps) => ({
+    articleFragments: articlesFromIdsSelector(state, {
+      articleFragmentIds
     })
   });
 };

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -479,6 +479,31 @@ const articleWithSupporting = {
   }
 };
 
+const collectionWithoutGroups = {
+  live: [
+    {
+      id: 'article/draft/1',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    },
+    {
+      id: 'a/long/path/2',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    },
+    {
+      id: 'a/long/path/3',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    }
+  ],
+  id: 'collectionWithoutGroups',
+  displayName: 'Collection Without Groups',
+  type: 'type'
+};
 const collection = {
   live: [
     liveArticle,
@@ -586,11 +611,13 @@ const stateWithCollection: any = {
       abc: {
         id: '1',
         uuid: 'abc',
-        articleFragments: ['95e2bfc0-8999-4e6e-a359-19960967c1e0']
+        articleFragments: ['95e2bfc0-8999-4e6e-a359-19960967c1e0'],
+        name: 'group1'
       },
       def: {
         id: null,
         uuid: 'def',
+        name: 'group2',
         articleFragments: [
           '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
           '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d'
@@ -734,5 +761,6 @@ export {
   stateWithSnaplinksAndArticles,
   liveArticle,
   articleWithSupporting,
-  collectionConfig
+  collectionConfig,
+  collectionWithoutGroups
 };

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -424,11 +424,27 @@ describe('Shared selectors', () => {
           { ...state, ...{ groups: newGroups } },
           {
             collectionId: 'c6',
-            collectionSet: 'live',
-            groupName: 'group1'
+            collectionSet: 'live'
           }
         )
-      ).toEqual(['af6', 'af2']);
+      ).toEqual(['af6', 'af2', 'af1']);
+    });
+    it('should put articles which are in groups that don`t exis in the config in the first group even when none of the groups have names', () => {
+      const selector = createArticlesInCollectionGroupSelector();
+      const newGroups = {
+        ...{ g1: { uuid: 'g1', articleFragments: ['af4'] } },
+        ...{ g2: { uuid: 'g2', id: 'group6', articleFragments: ['af5'] } },
+        ...{ g7: { uuid: 'g7', id: 'group7', articleFragments: ['af6'] } }
+      };
+      expect(
+        selector(
+          { ...state, ...{ groups: newGroups } },
+          {
+            collectionId: 'c6',
+            collectionSet: 'live'
+          }
+        )
+      ).toEqual(['af5', 'af6', 'af4']);
     });
     it('should return articles in supporting positions', () => {
       const selector = createArticlesInCollectionGroupSelector();

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -39,12 +39,14 @@ const state: any = {
     g1: {
       uuid: 'g1',
       id: 'group1',
-      articleFragments: ['af2']
+      articleFragments: ['af2'],
+      name: 'g1'
     },
     g2: {
       uuid: 'g2',
       id: 'group2',
-      articleFragments: ['af1']
+      articleFragments: ['af1'],
+      name: 'g2'
     },
     g3: {
       uuid: 'g3',

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -32,6 +32,11 @@ const state: any = {
         id: 'c5',
         groups: ['group6'],
         live: ['g6']
+      },
+      c6: {
+        id: 'c1',
+        groups: ['group1', 'group2'],
+        live: ['g1', 'g2', 'g7']
       }
     }
   },
@@ -195,6 +200,9 @@ const state: any = {
       id: 'ea4'
     },
     af5: {
+      uuid: 'af5'
+    },
+    af6: {
       uuid: 'af5'
     },
     afWithTagKicker: {
@@ -403,6 +411,24 @@ describe('Shared selectors', () => {
           groupName: 'group1'
         })
       ).toEqual(['af3', 'af4']);
+    });
+    it('should put articles which are in groups that don`t exis in the config in the first group', () => {
+      const selector = createArticlesInCollectionGroupSelector();
+      const currentGroups = state.groups;
+      const newGroups = {
+        ...currentGroups,
+        ...{ g7: { uuid: 'g7', id: 'group7', articleFragments: ['af6'] } }
+      };
+      expect(
+        selector(
+          { ...state, ...{ groups: newGroups } },
+          {
+            collectionId: 'c6',
+            collectionSet: 'live',
+            groupName: 'group1'
+          }
+        )
+      ).toEqual(['af6', 'af2']);
     });
     it('should return articles in supporting positions', () => {
       const selector = createArticlesInCollectionGroupSelector();

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -469,6 +469,23 @@ const groupSiblingsSelector = (state: State, groupId: string) => {
   );
 };
 
+const articleGroupSelector = (
+  state: State,
+  groupIdFromAction: string,
+  fragmentId: string
+) => {
+  const groups = groupsSelector(state);
+  if (groups[groupIdFromAction].articleFragments.includes(fragmentId)) {
+    return groupIdFromAction;
+  }
+
+  const actualFragmentGroup = Object.values(groups).find(group =>
+    group.articleFragments.includes(fragmentId)
+  );
+
+  return actualFragmentGroup && actualFragmentGroup.uuid;
+};
+
 const groupsArticleCount = (groups: Group[]) =>
   groups.reduce((acc, group) => acc + group.articleFragments.length, 0);
 
@@ -517,6 +534,7 @@ export {
   articleTagSelector,
   indexInGroupSelector,
   groupsSelector,
+  articleGroupSelector,
   groupsArticleCount,
   externalArticleIdFromArticleFragmentSelector,
   selectCollectionItemHasMediaOverrides,

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -192,14 +192,16 @@ const createCollectionStageGroupsSelector = () => {
         return grps;
       }
 
-      // Groups without names are groups which no longer exist in the config because
+      // Groups without names and ids are groups which no longer exist in the config because
       // the collection layout has changed. We need to collect the article fragments in these
       // groups and display them in the top group.
       const orphanedFragments: string[] = grps
-        .filter(grp => !grp.name)
+        .filter(grp => !grp.name && grp.id)
         .reduce((frags: string[], g) => frags.concat(g.articleFragments), []);
 
-      const finalGroups = grps.filter(grp => grp.name);
+      // The final array of groups consist of groups where all groups without names but with ids
+      // are filtered out as these groups no longer exist in the config of the collection.
+      const finalGroups = grps.filter(grp => grp.name || !grp.id);
       if (finalGroups.length > 0) {
         const grpF = finalGroups ? finalGroups[0].articleFragments : [];
         const firstGroupFragments = orphanedFragments.concat(grpF);

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -200,13 +200,15 @@ const createCollectionStageGroupsSelector = () => {
         .reduce((frags: string[], g) => frags.concat(g.articleFragments), []);
 
       const finalGroups = grps.filter(grp => grp.name);
-      const grpF = finalGroups ? finalGroups[0].articleFragments : [];
-      const firstGroupFragments = orphanedFragments.concat(grpF);
-      const firstGroup = {
-        ...finalGroups[0],
-        ...{ articleFragments: firstGroupFragments }
-      };
-      finalGroups[0] = firstGroup;
+      if (finalGroups.length > 0) {
+        const grpF = finalGroups ? finalGroups[0].articleFragments : [];
+        const firstGroupFragments = orphanedFragments.concat(grpF);
+        const firstGroup = {
+          ...finalGroups[0],
+          ...{ articleFragments: firstGroupFragments }
+        };
+        finalGroups[0] = firstGroup;
+      }
       return finalGroups;
     }
   );

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -203,8 +203,10 @@ const createCollectionStageGroupsSelector = () => {
       // are filtered out as these groups no longer exist in the config of the collection.
       const finalGroups = grps.filter(grp => grp.name || !grp.id);
       if (finalGroups.length > 0) {
-        const grpF = finalGroups ? finalGroups[0].articleFragments : [];
-        const firstGroupFragments = orphanedFragments.concat(grpF);
+        const originalFirstGroupFragments = finalGroups[0].articleFragments;
+        const firstGroupFragments = orphanedFragments.concat(
+          originalFirstGroupFragments
+        );
         const firstGroup = {
           ...finalGroups[0],
           ...{ articleFragments: firstGroupFragments }

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -292,7 +292,7 @@ const createArticlesInCollectionGroupSelector = () => {
       if (!includeSupportingArticles) {
         return groupArticleFragmentIds;
       }
-      const res = groupArticleFragmentIds.reduce(
+      return groupArticleFragmentIds.reduce(
         (acc, id) => {
           const articleFragment = articleFragments[id];
           if (
@@ -307,7 +307,6 @@ const createArticlesInCollectionGroupSelector = () => {
         },
         [] as string[]
       );
-      return res;
     }
   );
 };

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -2,7 +2,7 @@ import { Diff } from 'utility-types';
 import { FrontsToolSettings } from 'types/FaciaApi';
 
 interface Group {
-  id: string;
+  id: string | null;
   name: string | null;
   uuid: string;
   articleFragments: string[];

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -159,28 +159,24 @@ describe('Shared utilities', () => {
       expect(result.groups[groupId].articleFragments).toHaveLength(3);
     });
     it('should create different groups for article fragments belonging to different groups even if they are not specificied in the config', () => {
-      console.log('hello');
-      const result = normaliseCollectionWithNestedArticles(
-        collection,
-        {
-          ...collectionConfig,
-          groups: undefined
-        }
-      );
+      const result = normaliseCollectionWithNestedArticles(collection, {
+        ...collectionConfig,
+        groups: undefined
+      });
       const groupId1 = result.normalisedCollection.live![0];
       expect(result.groups[groupId1].articleFragments).toHaveLength(1);
       const groupId2 = result.normalisedCollection.live![1];
       expect(result.groups[groupId2].articleFragments).toHaveLength(2);
     });
-    it('should create empty groups for groups in the config which don\'t have collections in them', () => {
-      const configWithExtraGroup = { ...collectionConfig, ...{groups: ['extra', 'large', 'medium', 'small' ]}};
-      const result = normaliseCollectionWithNestedArticles(
-        collection,
-        {
-          ...configWithExtraGroup,
-          groups: undefined
-        }
-      );
+    it("should create empty groups for groups in the config which don't have collections in them", () => {
+      const configWithExtraGroup = {
+        ...collectionConfig,
+        ...{ groups: ['extra', 'large', 'medium', 'small'] }
+      };
+      const result = normaliseCollectionWithNestedArticles(collection, {
+        ...configWithExtraGroup,
+        groups: undefined
+      });
       expect(Object.keys(result.groups)).toHaveLength(4);
     });
   });

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -168,7 +168,7 @@ describe('Shared utilities', () => {
       const groupId2 = result.normalisedCollection.live![1];
       expect(result.groups[groupId2].articleFragments).toHaveLength(2);
     });
-    it("should create empty groups for groups in the config which don't have collections in them", () => {
+    it("should create empty groups for groups in the config which don't have article fragments in them", () => {
       const configWithExtraGroup = {
         ...collectionConfig,
         ...{ groups: ['extra', 'large', 'medium', 'small'] }

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -158,5 +158,30 @@ describe('Shared utilities', () => {
       const groupId = result.normalisedCollection.live![0];
       expect(result.groups[groupId].articleFragments).toHaveLength(3);
     });
+    it('should create different groups for article fragments belonging to different groups even if they are not specificied in the config', () => {
+      console.log('hello');
+      const result = normaliseCollectionWithNestedArticles(
+        collection,
+        {
+          ...collectionConfig,
+          groups: undefined
+        }
+      );
+      const groupId1 = result.normalisedCollection.live![0];
+      expect(result.groups[groupId1].articleFragments).toHaveLength(1);
+      const groupId2 = result.normalisedCollection.live![1];
+      expect(result.groups[groupId2].articleFragments).toHaveLength(2);
+    });
+    it('should create empty groups for groups in the config which don\'t have collections in them', () => {
+      const configWithExtraGroup = { ...collectionConfig, ...{groups: ['extra', 'large', 'medium', 'small' ]}};
+      const result = normaliseCollectionWithNestedArticles(
+        collection,
+        {
+          ...configWithExtraGroup,
+          groups: undefined
+        }
+      );
+      expect(Object.keys(result.groups)).toHaveLength(4);
+    });
   });
 });

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -1,6 +1,7 @@
 import {
   collection,
   collectionConfig,
+  collectionWithoutGroups,
   collectionWithSupportingArticles,
   stateWithCollection,
   stateWithCollectionAndSupporting
@@ -147,10 +148,13 @@ describe('Shared utilities', () => {
     });
 
     it('should create a single group with with all article fragments when the collection config has no groups', () => {
-      const result = normaliseCollectionWithNestedArticles(collection, {
-        ...collectionConfig,
-        groups: undefined
-      });
+      const result = normaliseCollectionWithNestedArticles(
+        collectionWithoutGroups,
+        {
+          ...collectionConfig,
+          groups: undefined
+        }
+      );
       const groupId = result.normalisedCollection.live![0];
       expect(result.groups[groupId].articleFragments).toHaveLength(3);
     });

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -34,6 +34,17 @@ const getAllArticleFragments = (groups: Group[]) =>
     [] as string[]
   );
 
+const configGroupIndexExistsInGroups = (
+  groupsToSearch: Group[],
+  index: number
+): boolean =>
+  groupsToSearch.some(group => {
+    if (group.id) {
+      return parseInt(group.id, 10) === index;
+    }
+    return index === 0;
+  });
+
 const addGroupsForStage = (
   groupIds: string[],
   entities: { [id: string]: Group },
@@ -55,16 +66,9 @@ const addGroupsForStage = (
   // We may have empty groups in the config which would not show up in the normalised
   // groups result. We need to add these into the groups array.
   if (collectionConfig.groups) {
-    collectionConfig.groups.forEach((group, index) => {
-      if (
-        !groupsWithNames.some(addedGroup => {
-          if (addedGroup.id) {
-            return parseInt(addedGroup.id, 10) === index;
-          }
-          return index === 0;
-        })
-      ) {
-        groupsWithNames.push(createGroup(`${index}`, group));
+    collectionConfig.groups.forEach((group, configGroupIndex) => {
+      if (!configGroupIndexExistsInGroups(groupsWithNames, configGroupIndex)) {
+        groupsWithNames.push(createGroup(`${configGroupIndex}`, group));
       }
     });
   }

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -34,7 +34,7 @@ const getAllArticleFragments = (groups: Group[]) =>
     [] as string[]
   );
 
-const addEmptyGroupsFromCollectionConfigForStage = (
+const addGroupsForStage = (
   groupIds: string[],
   entities: { [id: string]: Group },
   collectionConfig: CollectionConfig
@@ -104,16 +104,13 @@ interface ReduceResult {
   addedGroups: { [key: string]: Group };
 }
 
-const addEmptyGroupsFromCollectionConfig = (
+const addGroups = (
   normalisedCollection: any,
   collectionConfig: CollectionConfig
 ) =>
   (['live', 'previously', 'draft'] as ['live', 'previously', 'draft']).reduce(
     (acc, key) => {
-      const {
-        addedGroups,
-        groupIds
-      } = addEmptyGroupsFromCollectionConfigForStage(
+      const { addedGroups, groupIds } = addGroupsForStage(
         normalisedCollection.result[key],
         normalisedCollection.entities.groups,
         collectionConfig
@@ -139,12 +136,7 @@ const normaliseCollectionWithNestedArticles = (
   articleFragments: { [key: string]: ArticleFragment };
 } => {
   const normalisedCollection = normalize(collection);
-  const {
-    addedGroups,
-    live,
-    draft,
-    previously
-  } = addEmptyGroupsFromCollectionConfig(
+  const { addedGroups, live, draft, previously } = addGroups(
     normalisedCollection,
     collectionConfig
   );

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -14,7 +14,7 @@ import v4 from 'uuid/v4';
 import keyBy from 'lodash/keyBy';
 
 const createGroup = (
-  id: string,
+  id: string | null,
   name: string | null,
   articleFragments: string[] = []
 ): Group => ({
@@ -26,7 +26,7 @@ const createGroup = (
 
 const getUUID = <T extends { uuid: string }>({ uuid }: T) => uuid;
 
-const getGroupIndex = (id?: string): number => parseInt(id || '0', 10);
+const getGroupIndex = (id: string | null): number => parseInt(id || '0', 10);
 
 const getAllArticleFragments = (groups: Group[]) =>
   groups.reduce(
@@ -72,7 +72,7 @@ const addEmptyGroupsFromCollectionConfigForStage = (
   // If we have no article fragments and no groups in a collection we still need to create
   // and empty group for articles.
   if (groupsWithNames.length === 0) {
-    groupsWithNames = [createGroup('0', null, getAllArticleFragments(groups))];
+    groupsWithNames = [createGroup(null, null, getAllArticleFragments(groups))];
   }
 
   // Finally we need to sort the groups according to their ids.

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -12,6 +12,7 @@ import { normalize, denormalize } from './schema';
 import { CollectionConfig } from 'types/FaciaApi';
 import v4 from 'uuid/v4';
 import keyBy from 'lodash/keyBy';
+import sortBy from 'lodash/sortBy';
 
 const createGroup = (
   id: string | null,
@@ -80,24 +81,10 @@ const addGroupsForStage = (
   }
 
   // Finally we need to sort the groups according to their ids.
-  groupsWithNames.sort((g1, g2) => {
-    const index1 = getGroupIndex(g1.id);
-    const index2 = getGroupIndex(g2.id);
-
-    if (index1 > index2) {
-      return -1;
-    }
-
-    if (index1 < index2) {
-      return 1;
-    }
-
-    return 0;
-  });
-
+  const sortedGroupsWithNames = sortBy(groupsWithNames, group => -getGroupIndex(group.id));
   return {
-    addedGroups: keyBy(groupsWithNames, getUUID),
-    groupIds: groupsWithNames.map(getUUID).slice()
+    addedGroups: keyBy(sortedGroupsWithNames, getUUID),
+    groupIds: sortedGroupsWithNames.map(getUUID)
   };
 };
 

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -52,7 +52,7 @@ const addGroupsForStage = (
   collectionConfig: CollectionConfig
 ) => {
   const groups = groupIds.map(id => entities[id]);
-  let groupsWithNames = groups.map(group => {
+  const groupsWithNames = groups.map(group => {
     let name: string | null = null;
     const groupNumberAsInt = getGroupIndex(group.id);
     if (
@@ -77,11 +77,16 @@ const addGroupsForStage = (
   // If we have no article fragments and no groups in a collection we still need to create
   // and empty group for articles.
   if (groupsWithNames.length === 0) {
-    groupsWithNames = [createGroup(null, null, getAllArticleFragments(groups))];
+    groupsWithNames.push(
+      createGroup(null, null, getAllArticleFragments(groups))
+    );
   }
 
   // Finally we need to sort the groups according to their ids.
-  const sortedGroupsWithNames = sortBy(groupsWithNames, group => -getGroupIndex(group.id));
+  const sortedGroupsWithNames = sortBy(
+    groupsWithNames,
+    group => -getGroupIndex(group.id)
+  );
   return {
     addedGroups: keyBy(sortedGroupsWithNames, getUUID),
     groupIds: sortedGroupsWithNames.map(getUUID)

--- a/client-v2/src/util/__tests__/moveUtils.spec.ts
+++ b/client-v2/src/util/__tests__/moveUtils.spec.ts
@@ -51,7 +51,7 @@ describe('Move utilities', () => {
         id: 'group6',
         name: 'group6',
         articleFragments: ['af7', 'af8']
-      },
+      }
     }
   };
 
@@ -149,15 +149,14 @@ describe('Move utilities', () => {
       expect(toWithRespectToState).toBeNull();
     });
     it('does not adjust to position if ', () => {
-
-      const position = { type: 'group', id: 'g6', index: 1 };
+      const nonOrphanedPosition = { type: 'group', id: 'g6', index: 1 };
       const toWithRespectToState = getToGroupIndicesWithRespectToState(
-        position,
+        nonOrphanedPosition,
         state,
         false
       );
 
-      expect(toWithRespectToState).toEqual(position);
+      expect(toWithRespectToState).toEqual(nonOrphanedPosition);
     });
   });
 });

--- a/client-v2/src/util/__tests__/moveUtils.spec.ts
+++ b/client-v2/src/util/__tests__/moveUtils.spec.ts
@@ -1,6 +1,6 @@
 import {
-  getFromGroupIndecesWithRespectToState,
-  getToGroupIndecesWithRespectToState
+  getFromGroupIndicesWithRespectToState,
+  getToGroupIndicesWithRespectToState
 } from '../moveUtils';
 
 describe('Move utilities', () => {
@@ -52,9 +52,9 @@ describe('Move utilities', () => {
   const position = { type: 'group', id: 'g1', index: 2 };
   const positionWithOrphanedGroups = { type: 'group', id: 'g3', index: 3 };
   const positionInOrphanedGroup = { type: 'group', id: 'g3', index: 0 };
-  describe('getFromGroupIndecesWithRespectToState', () => {
+  describe('getFromGroupIndicesWithRespectToState', () => {
     it('it returns null if position is null', () => {
-      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
         null,
         state
       );
@@ -63,7 +63,7 @@ describe('Move utilities', () => {
     });
 
     it('does not modify the position if there are no orphaned groups', () => {
-      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
         position,
         state
       );
@@ -72,7 +72,7 @@ describe('Move utilities', () => {
     });
 
     it('moves the article from the correct index when orphaned groups', () => {
-      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
         positionWithOrphanedGroups,
         state
       );
@@ -84,7 +84,7 @@ describe('Move utilities', () => {
     });
 
     it('moves articles correctly from orphaned groups', () => {
-      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
         positionInOrphanedGroup,
         state
       );
@@ -96,9 +96,9 @@ describe('Move utilities', () => {
     });
   });
 
-  describe('getToGroupIndecesWithRespectToState', () => {
+  describe('getToGroupIndicesWithRespectToState', () => {
     it('does not modify the position if there are no orphaned groups', () => {
-      const notTransformedPosition = getToGroupIndecesWithRespectToState(
+      const notTransformedPosition = getToGroupIndicesWithRespectToState(
         position,
         state,
         false
@@ -108,7 +108,7 @@ describe('Move utilities', () => {
     });
 
     it('moves the article to the correct index when there are orphaned groups', () => {
-      const toWithRespectToState = getToGroupIndecesWithRespectToState(
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
         positionWithOrphanedGroups,
         state,
         false
@@ -121,7 +121,7 @@ describe('Move utilities', () => {
     });
 
     it('moves articles coming from orphaned groups correctly', () => {
-      const toWithRespectToState = getToGroupIndecesWithRespectToState(
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
         positionWithOrphanedGroups,
         state,
         true
@@ -134,7 +134,7 @@ describe('Move utilities', () => {
     });
 
     it('does not move articles to orphaned groups', () => {
-      const toWithRespectToState = getToGroupIndecesWithRespectToState(
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
         positionInOrphanedGroup,
         state,
         true

--- a/client-v2/src/util/__tests__/moveUtils.spec.ts
+++ b/client-v2/src/util/__tests__/moveUtils.spec.ts
@@ -1,0 +1,146 @@
+import {
+  getFromGroupIndecesWithRespectToState,
+  getToGroupIndecesWithRespectToState
+} from '../moveUtils';
+
+describe('Move utilities', () => {
+  const state: any = {
+    collections: {
+      data: {
+        c1: {
+          id: 'c1',
+          groups: ['group1', 'group2'],
+          live: ['g1', 'g2']
+        },
+        c2: {
+          id: 'c2',
+          groups: ['group3', 'group4', 'group5'],
+          draft: ['g5', 'g4', 'g3']
+        }
+      }
+    },
+    groups: {
+      g1: {
+        uuid: 'g1',
+        name: 'g1'
+      },
+      g2: {
+        uuid: 'g2',
+        id: 'group2',
+        articleFragments: ['af1'],
+        name: 'g2'
+      },
+      g3: {
+        uuid: 'g3',
+        id: 'group3',
+        name: 'group3',
+        articleFragments: ['af3', 'af4']
+      },
+      g4: {
+        uuid: 'g4',
+        id: 'group4',
+        articleFragments: ['af5']
+      },
+      g5: {
+        uuid: 'g5',
+        id: 'group5',
+        articleFragments: ['af6']
+      }
+    }
+  };
+
+  const position = { type: 'group', id: 'g1', index: 2 };
+  const positionWithOrphanedGroups = { type: 'group', id: 'g3', index: 3 };
+  const positionInOrphanedGroup = { type: 'group', id: 'g3', index: 0 };
+  describe('getFromGroupIndecesWithRespectToState', () => {
+    it('it returns null if position is null', () => {
+      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+        null,
+        state
+      );
+
+      expect(fromWithRespectToState).toBeNull();
+    });
+
+    it('does not modify the position if there are no orphaned groups', () => {
+      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+        position,
+        state
+      );
+
+      expect(fromWithRespectToState).toEqual(position);
+    });
+
+    it('moves the article from the correct index when orphaned groups', () => {
+      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+        positionWithOrphanedGroups,
+        state
+      );
+
+      expect(fromWithRespectToState).toEqual({
+        ...positionWithOrphanedGroups,
+        index: 1
+      });
+    });
+
+    it('moves articles correctly from orphaned groups', () => {
+      const { fromWithRespectToState } = getFromGroupIndecesWithRespectToState(
+        positionInOrphanedGroup,
+        state
+      );
+      expect(fromWithRespectToState).toEqual({
+        ...positionInOrphanedGroup,
+        index: 0,
+        id: 'g5'
+      });
+    });
+  });
+
+  describe('getToGroupIndecesWithRespectToState', () => {
+    it('does not modify the position if there are no orphaned groups', () => {
+      const notTransformedPosition = getToGroupIndecesWithRespectToState(
+        position,
+        state,
+        false
+      );
+
+      expect(position).toEqual(notTransformedPosition);
+    });
+
+    it('moves the article to the correct index when there are orphaned groups', () => {
+      const toWithRespectToState = getToGroupIndecesWithRespectToState(
+        positionWithOrphanedGroups,
+        state,
+        false
+      );
+
+      expect(toWithRespectToState).toEqual({
+        ...positionWithOrphanedGroups,
+        index: 1
+      });
+    });
+
+    it('moves articles coming from orphaned groups correctly', () => {
+      const toWithRespectToState = getToGroupIndecesWithRespectToState(
+        positionWithOrphanedGroups,
+        state,
+        true
+      );
+
+      expect(toWithRespectToState).toEqual({
+        ...positionWithOrphanedGroups,
+        index: 2
+      });
+    });
+
+    it('does not move articles to orphaned groups', () => {
+      const toWithRespectToState = getToGroupIndecesWithRespectToState(
+        positionInOrphanedGroup,
+        state,
+        true
+      );
+
+      expect(toWithRespectToState).toBeNull();
+    });
+  });
+});

--- a/client-v2/src/util/__tests__/moveUtils.spec.ts
+++ b/client-v2/src/util/__tests__/moveUtils.spec.ts
@@ -15,7 +15,7 @@ describe('Move utilities', () => {
         c2: {
           id: 'c2',
           groups: ['group3', 'group4', 'group5'],
-          draft: ['g5', 'g4', 'g3']
+          draft: ['g5', 'g4', 'g3', 'g6']
         }
       }
     },
@@ -45,7 +45,13 @@ describe('Move utilities', () => {
         uuid: 'g5',
         id: 'group5',
         articleFragments: ['af6']
-      }
+      },
+      g6: {
+        uuid: 'g6',
+        id: 'group6',
+        name: 'group6',
+        articleFragments: ['af7', 'af8']
+      },
     }
   };
 
@@ -141,6 +147,17 @@ describe('Move utilities', () => {
       );
 
       expect(toWithRespectToState).toBeNull();
+    });
+    it('does not adjust to position if ', () => {
+
+      const position = { type: 'group', id: 'g6', index: 1 };
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
+        position,
+        state,
+        false
+      );
+
+      expect(toWithRespectToState).toEqual(position);
     });
   });
 });

--- a/client-v2/src/util/moveUtils.ts
+++ b/client-v2/src/util/moveUtils.ts
@@ -77,7 +77,8 @@ function getToGroupIndicesWithRespectToState(
   return { ...position, ...{ index: adjustedIndex } };
 }
 
-const isOrphanedGroup = (group: Group) => !group.name && group.id && group.id !== '0';
+const isOrphanedGroup = (group: Group) =>
+  !group.name && group.id && group.id !== '0';
 
 function getGroupIndicesWithRespectToState(
   position: PosSpec,
@@ -85,7 +86,10 @@ function getGroupIndicesWithRespectToState(
 ): { articleCount: number; groupSiblings: Group[] } {
   const groupId = position.id;
   const groupSiblings = groupSiblingsSelector(state, groupId);
-  const currentGroupIndex = findIndex(groupSiblings, group => group.uuid === groupId);
+  const currentGroupIndex = findIndex(
+    groupSiblings,
+    group => group.uuid === groupId
+  );
   const groupAbove = groupSiblings[currentGroupIndex - 1];
   if (groupAbove && !isOrphanedGroup(groupAbove)) {
     return { groupSiblings, articleCount: 0 };

--- a/client-v2/src/util/moveUtils.ts
+++ b/client-v2/src/util/moveUtils.ts
@@ -3,7 +3,7 @@ import { State } from 'shared/types/State';
 import { groupSiblingsSelector } from 'shared/selectors/shared';
 import { Group } from 'shared/types/Collection';
 
-function getFromGroupIndecesWithRespectToState(
+function getFromGroupIndicesWithRespectToState(
   position: PosSpec | null,
   state: State
 ): { fromWithRespectToState: PosSpec | null; fromOrphanedGroup: boolean } {
@@ -14,7 +14,7 @@ function getFromGroupIndecesWithRespectToState(
   if (position.type === 'clipboard') {
     return { fromWithRespectToState: position, fromOrphanedGroup: false };
   }
-  const { articleCount, groupSiblings } = getGroupIndecesWithRespectToState(
+  const { articleCount, groupSiblings } = getGroupIndicesWithRespectToState(
     position,
     state
   );
@@ -54,7 +54,7 @@ function getFromGroupIndecesWithRespectToState(
   };
 }
 
-function getToGroupIndecesWithRespectToState(
+function getToGroupIndicesWithRespectToState(
   position: PosSpec,
   state: State,
   fromOrphanedGroup: boolean
@@ -62,7 +62,7 @@ function getToGroupIndecesWithRespectToState(
   if (position.type === 'clipboard') {
     return position;
   }
-  const { articleCount } = getGroupIndecesWithRespectToState(position, state);
+  const { articleCount } = getGroupIndicesWithRespectToState(position, state);
   const adjustedArticleCount = fromOrphanedGroup
     ? articleCount - 1
     : articleCount;
@@ -76,7 +76,7 @@ function getToGroupIndecesWithRespectToState(
   return { ...position, ...{ index: adjustedIndex } };
 }
 
-function getGroupIndecesWithRespectToState(
+function getGroupIndicesWithRespectToState(
   position: PosSpec,
   state: State
 ): { articleCount: number; groupSiblings: Group[] } {
@@ -96,6 +96,6 @@ function getGroupIndecesWithRespectToState(
 }
 
 export {
-  getToGroupIndecesWithRespectToState,
-  getFromGroupIndecesWithRespectToState
+  getToGroupIndicesWithRespectToState,
+  getFromGroupIndicesWithRespectToState
 };

--- a/client-v2/src/util/moveUtils.ts
+++ b/client-v2/src/util/moveUtils.ts
@@ -1,0 +1,101 @@
+import { PosSpec } from 'lib/dnd';
+import { State } from 'shared/types/State';
+import { groupSiblingsSelector } from 'shared/selectors/shared';
+import { Group } from 'shared/types/Collection';
+
+function getFromGroupIndecesWithRespectToState(
+  position: PosSpec | null,
+  state: State
+): { fromWithRespectToState: PosSpec | null; fromOrphanedGroup: boolean } {
+  if (!position) {
+    return { fromWithRespectToState: null, fromOrphanedGroup: false };
+  }
+
+  if (position.type === 'clipboard') {
+    return { fromWithRespectToState: position, fromOrphanedGroup: false };
+  }
+  const { articleCount, groupSiblings } = getGroupIndecesWithRespectToState(
+    position,
+    state
+  );
+
+  // We allow dragging from orphaned groups but we need to do extra work
+  // to figure out the current group and index of these articles
+  if (position.index < articleCount) {
+    const getGroupSiblingAndIndex = (
+      siblingIndex: number,
+      remainingGroupSiblings: Group[]
+    ): { groupId: string; index: number } => {
+      const currentGroup = remainingGroupSiblings[0];
+      if (siblingIndex < currentGroup.articleFragments.length) {
+        return { index: siblingIndex, groupId: currentGroup.uuid };
+      }
+      return getGroupSiblingAndIndex(
+        siblingIndex - currentGroup.articleFragments.length,
+        remainingGroupSiblings.slice(1)
+      );
+    };
+
+    const { groupId, index } = getGroupSiblingAndIndex(
+      position.index,
+      groupSiblings
+    );
+
+    return {
+      fromWithRespectToState: { ...position, ...{ index, id: groupId } },
+      fromOrphanedGroup: true
+    };
+  }
+
+  const adjustedIndex = position.index - articleCount;
+  return {
+    fromWithRespectToState: { ...position, ...{ index: adjustedIndex } },
+    fromOrphanedGroup: false
+  };
+}
+
+function getToGroupIndecesWithRespectToState(
+  position: PosSpec,
+  state: State,
+  fromOrphanedGroup: boolean
+): PosSpec | null {
+  if (position.type === 'clipboard') {
+    return position;
+  }
+  const { articleCount } = getGroupIndecesWithRespectToState(position, state);
+  const adjustedArticleCount = fromOrphanedGroup
+    ? articleCount - 1
+    : articleCount;
+
+  // We don`t allow dragging to orphaned group positions because it would
+  // be unclear which group these articles should end up in
+  if (position.index < adjustedArticleCount) {
+    return null;
+  }
+  const adjustedIndex = position.index - adjustedArticleCount;
+  return { ...position, ...{ index: adjustedIndex } };
+}
+
+function getGroupIndecesWithRespectToState(
+  position: PosSpec,
+  state: State
+): { articleCount: number; groupSiblings: Group[] } {
+  const groupId = position.id;
+  const groupSiblings = groupSiblingsSelector(state, groupId);
+  const articleCount = groupSiblings.reduce(
+    (orphanedArticleCount: number, group) => {
+      if (!group.name && group.id && group.id !== '0') {
+        orphanedArticleCount += group.articleFragments.length;
+      }
+      return orphanedArticleCount;
+    },
+    0
+  );
+
+  return { groupSiblings, articleCount };
+}
+
+export {
+  getToGroupIndecesWithRespectToState,
+  getFromGroupIndecesWithRespectToState
+};


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Collections layouts get switched frequently and the number of groups in a collection can change 
### Example: we can go from having 4 groups to having 2 groups to having 4 four groups again. 
- If we switch from 4 groups to 2 groups we should display all the articles in the old top two groups in the new top group. In addition, we need to keep the information about the groups these articles originally belonged to so that when we switch back to the layout containing four groups, all the stories are displayed in their original positions. To achieve this, I have changed the reducer logic so that all old/current groups are stored in state and selector logic so that articles belonging to groups which don't currently exist in config still get displayed in the current top group. 

- In addition, when we move articles around the indices we get for these moves are indices and ids of groups in the selected state and we need to adjust these indices so that they have the correct values with respect to our stored state. We don't allow dragging articles to positions which are occupied by articles belonging to groups which don't currently exist in config. This might be slightly buggy behaviour but the same behaviour exists in the old tool, no one has ever complained and Mariana is happy with this. 

I've tried to keep the code as simple as possible and provide comments were necessary, please let me know if it's not clear. 

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
