### PR TITLE
CLIPBOARD: remove headline truncation and set font-size to 12px

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { styled } from 'shared/constants/theme';
-import truncate from 'lodash/truncate';
 
 import { ArticleBodyProps } from './ArticleBodyDefault';
 import { getArticleLabel } from 'util/clipboardUtils';
@@ -22,6 +21,10 @@ const PillaredSection = styled('span')<{ pillar?: string; isLive?: boolean }>`
     getPillarColor(pillar, isLive || true) || 'inherit'};
   font-size: 13px;
   font-weight: bold;
+`;
+
+const HeadlinePolaroidSpan = styled('span')`
+  font-size: 12px;
 `;
 
 const ArticlePolaroidComponent = ({
@@ -62,9 +65,7 @@ const ArticlePolaroidComponent = ({
             <PillaredSection pillar={pillarId} isLive={isLive}>
               {articleLabel}
             </PillaredSection>
-            {` ${truncate(headline, {
-              length: 45 - articleLabel.length
-            })}`}
+            <HeadlinePolaroidSpan>{headline}</HeadlinePolaroidSpan>
           </>
         )}
       </CollectionItemContent>


### PR DESCRIPTION
## What's changed?
Previously headlines were truncated when in the clipboard... now they are not. 

Also we want to make the headline size `12px` instead of `13px`.

This is part of the overall work to reduce the size of items in Clipboard. @Reettaphant is doing work separately to make images smaller. 
BEFORE 
![Screenshot 2019-05-01 at 14 48 35](https://user-images.githubusercontent.com/10324129/57020145-5c038a80-6c20-11e9-8c13-c619ecdff5aa.png)

AFTER 
![Screenshot 2019-05-01 at 14 48 57](https://user-images.githubusercontent.com/10324129/57020155-62920200-6c20-11e9-9513-8c4fa84c215b.png)

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
