### PR TITLE
Add a drop level container

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -16,7 +16,7 @@ import {
   editorOpenClipboard,
   editorCloseClipboard
 } from 'bundles/frontsUIBundle';
-import { clipboardId, collectionDropZoneBlacklist } from 'constants/fronts';
+import { clipboardId } from 'constants/fronts';
 import {
   ArticleFragment as TArticleFragment,
   ArticleFragmentMeta,
@@ -178,14 +178,8 @@ class Clipboard extends React.Component<ClipboardProps> {
             {this.props.isClipboardOpen && (
               <Root
                 id="clipboard"
-                blacklistedDataTransferTypes={collectionDropZoneBlacklist}
                 data-testid="clipboard"
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  flex: '1',
-                  width: '140px'
-                }}
+                style={{ display: 'flex', flex: 1 }}
               >
                 <ClipboardLevel
                   onMove={this.handleMove}

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -16,7 +16,7 @@ import {
   editorOpenClipboard,
   editorCloseClipboard
 } from 'bundles/frontsUIBundle';
-import { clipboardId } from 'constants/fronts';
+import { clipboardId, collectionDropZoneBlacklist } from 'constants/fronts';
 import {
   ArticleFragment as TArticleFragment,
   ArticleFragmentMeta,
@@ -178,6 +178,7 @@ class Clipboard extends React.Component<ClipboardProps> {
             {this.props.isClipboardOpen && (
               <Root
                 id="clipboard"
+                blacklistedDataTransferTypes={collectionDropZoneBlacklist}
                 data-testid="clipboard"
                 style={{
                   display: 'flex',

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -22,11 +22,9 @@ import {
   validateImageEvent,
   ValidationResponse
 } from 'shared/util/validateImageSrc';
-import {
-  articleFragmentImageCriteria as imageCriteria,
-  gridDataTransferTypes
-} from 'constants/image';
+import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
 import Sublinks from './Sublinks';
+import { collectionEventsBlacklist } from 'constants/fronts';
 
 interface ContainerProps {
   uuid: string;
@@ -111,7 +109,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             fade={!isSelected}
             size={size}
             displayType={displayType}
-            imageDropTypes={Object.values(gridDataTransferTypes)}
+            imageDropTypes={collectionEventsBlacklist}
             onImageDrop={this.getDropHandler(this.props.onImageDrop)}
           >
             <Sublinks

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -24,7 +24,7 @@ import {
 } from 'shared/util/validateImageSrc';
 import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
 import Sublinks from './Sublinks';
-import { collectionEventsBlacklist } from 'constants/fronts';
+import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 interface ContainerProps {
   uuid: string;
@@ -109,7 +109,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             fade={!isSelected}
             size={size}
             displayType={displayType}
-            imageDropTypes={collectionEventsBlacklist}
+            imageDropTypes={collectionDropZoneBlacklist}
             onImageDrop={this.getDropHandler(this.props.onImageDrop)}
           >
             <Sublinks

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -7,8 +7,8 @@ import CollectionItemContainer from 'shared/components/collectionItem/Collection
 import CollectionItemContent from 'shared/components/collectionItem/CollectionItemContent';
 import CollectionItemMetaContainer from 'shared/components/collectionItem/CollectionItemMetaContainer';
 import DragIntentContainer from 'shared/components/DragIntentContainer';
-import { dragEventIsBlacklisted } from 'lib/dnd/Root';
 import { collectionDropZoneBlacklist } from 'constants/fronts';
+import { dragEventIsBlacklisted } from 'lib/dnd/Level';
 
 const SublinkCollectionItemBody = styled(CollectionItemBody)<{
   dragHoverActive: boolean;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -7,6 +7,8 @@ import CollectionItemContainer from 'shared/components/collectionItem/Collection
 import CollectionItemContent from 'shared/components/collectionItem/CollectionItemContent';
 import CollectionItemMetaContainer from 'shared/components/collectionItem/CollectionItemMetaContainer';
 import DragIntentContainer from 'shared/components/DragIntentContainer';
+import { dragEventIsBlacklisted } from 'lib/dnd/Root';
+import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 const SublinkCollectionItemBody = styled(CollectionItemBody)<{
   dragHoverActive: boolean;
@@ -75,6 +77,7 @@ class Sublinks extends React.Component<SublinkProps> {
               this.setState({ dragHoverActive: false });
             }}
             delay={300}
+            filterRegisterEvent={this.dragEventNotBlacklisted}
             onIntentConfirm={() => {
               toggleShowArticleSublinks();
             }}
@@ -110,6 +113,9 @@ class Sublinks extends React.Component<SublinkProps> {
       </>
     );
   }
+
+  private dragEventNotBlacklisted = (e: React.DragEvent) =>
+    !dragEventIsBlacklisted(e, collectionDropZoneBlacklist);
 }
 
 export default Sublinks;

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -22,7 +22,6 @@ import FrontDetailView from './FrontDetailView';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 import { setFocusState } from 'bundles/focusBundle';
 import Collection from './Collection';
-import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
@@ -124,11 +123,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         </div>
         <FrontContainer>
           <FrontContentContainer>
-            <Root
-              id={this.props.id}
-              data-testid={this.props.id}
-              blacklistedDataTransferTypes={collectionDropZoneBlacklist}
-            >
+            <Root id={this.props.id} data-testid={this.props.id}>
               {front.collections.map(collectionId => (
                 <Collection
                   key={collectionId}

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -22,6 +22,7 @@ import FrontDetailView from './FrontDetailView';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 import { setFocusState } from 'bundles/focusBundle';
 import Collection from './Collection';
+import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
@@ -123,7 +124,11 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         </div>
         <FrontContainer>
           <FrontContentContainer>
-            <Root id={this.props.id} data-testid={this.props.id}>
+            <Root
+              id={this.props.id}
+              data-testid={this.props.id}
+              blacklistedDataTransferTypes={collectionDropZoneBlacklist}
+            >
               {front.collections.map(collectionId => (
                 <Collection
                   key={collectionId}

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -7,7 +7,7 @@ import { CollectionItemDisplayTypes } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createSupportingArticlesSelector } from 'shared/selectors/shared';
-import { collectionEventsBlacklist } from 'constants/fronts';
+import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 interface OuterProps {
   articleFragmentId: string;
@@ -35,7 +35,7 @@ const ArticleFragmentLevel = ({
 }: Props) => (
   <Level
     arr={supporting || []}
-    blacklistedDataTransferTypes={collectionEventsBlacklist}
+    blacklistedDataTransferTypes={collectionDropZoneBlacklist}
     parentType="articleFragment"
     parentId={articleFragmentId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -7,7 +7,7 @@ import { CollectionItemDisplayTypes } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createSupportingArticlesSelector } from 'shared/selectors/shared';
-import { gridDataTransferTypes } from 'constants/image';
+import { collectionEventsBlacklist } from 'constants/fronts';
 
 interface OuterProps {
   articleFragmentId: string;
@@ -35,7 +35,7 @@ const ArticleFragmentLevel = ({
 }: Props) => (
   <Level
     arr={supporting || []}
-    blacklistedDataTransferTypes={Object.values(gridDataTransferTypes)}
+    blacklistedDataTransferTypes={collectionEventsBlacklist}
     parentType="articleFragment"
     parentId={articleFragmentId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -35,7 +35,7 @@ const ArticleFragmentLevel = ({
 }: Props) => (
   <Level
     arr={supporting || []}
-    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
+    blacklistedDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="articleFragment"
     parentId={articleFragmentId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
-import { collectionEventsBlacklist } from 'constants/fronts';
+import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 interface OuterProps {
   children: LevelChild<ArticleFragment>;
@@ -27,7 +27,7 @@ const ClipboardLevel = ({
   onDrop
 }: Props) => (
   <Level
-    blacklistedDataTransferTypes={collectionEventsBlacklist}
+    blacklistedDataTransferTypes={collectionDropZoneBlacklist}
     arr={articleFragments}
     parentType="clipboard"
     parentId="clipboard"

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -7,6 +7,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { collectionDropZoneBlacklist } from 'constants/fronts';
+import { styled } from 'constants/theme';
 
 interface OuterProps {
   children: LevelChild<ArticleFragment>;
@@ -20,6 +21,13 @@ interface InnerProps {
 
 type Props = OuterProps & InnerProps;
 
+const ClipboardItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 140px;
+`;
+
 const ClipboardLevel = ({
   children,
   articleFragments,
@@ -27,6 +35,7 @@ const ClipboardLevel = ({
   onDrop
 }: Props) => (
   <Level
+    containerElement={ClipboardItemContainer}
     blacklistedDataTransferTypes={collectionDropZoneBlacklist}
     arr={articleFragments}
     parentType="clipboard"

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
-import { gridDataTransferTypes } from 'constants/image';
+import { collectionEventsBlacklist } from 'constants/fronts';
 
 interface OuterProps {
   children: LevelChild<ArticleFragment>;
@@ -27,7 +27,7 @@ const ClipboardLevel = ({
   onDrop
 }: Props) => (
   <Level
-    blacklistedDataTransferTypes={Object.values(gridDataTransferTypes)}
+    blacklistedDataTransferTypes={collectionEventsBlacklist}
     arr={articleFragments}
     parentType="clipboard"
     parentId="clipboard"

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -27,7 +27,7 @@ const ClipboardLevel = ({
   onDrop
 }: Props) => (
   <Level
-    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
+    blacklistedDataTransferTypes={Object.values(gridDataTransferTypes)}
     arr={articleFragments}
     parentType="clipboard"
     parentId="clipboard"

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -6,7 +6,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
-import { gridDataTransferTypes } from 'constants/image';
+import { collectionEventsBlacklist } from 'constants/fronts';
 
 interface OuterProps {
   groupId: string;
@@ -32,7 +32,7 @@ const GroupLevel = ({
 }: Props) => (
   <Level
     arr={articleFragments}
-    blacklistedDataTransferTypes={Object.values(gridDataTransferTypes)}
+    blacklistedDataTransferTypes={collectionEventsBlacklist}
     parentType="group"
     parentId={groupId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -32,7 +32,7 @@ const GroupLevel = ({
 }: Props) => (
   <Level
     arr={articleFragments}
-    blockingDataTransferTypes={Object.values(gridDataTransferTypes)}
+    blacklistedDataTransferTypes={Object.values(gridDataTransferTypes)}
     parentType="group"
     parentId={groupId}
     type="articleFragment"

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -6,7 +6,7 @@ import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
-import { collectionEventsBlacklist } from 'constants/fronts';
+import { collectionDropZoneBlacklist } from 'constants/fronts';
 
 interface OuterProps {
   groupId: string;
@@ -32,7 +32,7 @@ const GroupLevel = ({
 }: Props) => (
   <Level
     arr={articleFragments}
-    blacklistedDataTransferTypes={collectionEventsBlacklist}
+    blacklistedDataTransferTypes={collectionDropZoneBlacklist}
     parentType="group"
     parentId={groupId}
     type="articleFragment"

--- a/client-v2/src/constants/fronts.ts
+++ b/client-v2/src/constants/fronts.ts
@@ -1,4 +1,5 @@
 import { Stages, CollectionItemSets } from 'shared/types/Collection';
+import { gridDataTransferTypes } from './image';
 
 export const breakingNewsFrontId: string = 'breaking-news';
 
@@ -23,6 +24,8 @@ export const liveBlogTones: { [key: string]: string } = {
   dead: 'dead',
   live: 'live'
 };
+
+export const collectionEventsBlacklist = Object.values(gridDataTransferTypes);
 
 export const detectPressFailureMs = 10000;
 

--- a/client-v2/src/constants/fronts.ts
+++ b/client-v2/src/constants/fronts.ts
@@ -25,7 +25,9 @@ export const liveBlogTones: { [key: string]: string } = {
   live: 'live'
 };
 
-export const collectionEventsBlacklist = Object.values(gridDataTransferTypes);
+// All of the drag event types that we'd like our collection drop zones
+// to ignore, at any level.
+export const collectionDropZoneBlacklist = Object.values(gridDataTransferTypes);
 
 export const detectPressFailureMs = 10000;
 

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -72,7 +72,7 @@ interface OuterProps<T> {
     | null;
   // any occurence of these in the data transfer will cause all dragging
   // behaviour to be bypassed
-  blockingDataTransferTypes?: string[];
+  blacklistedDataTransferTypes?: string[];
 }
 
 interface ContextProps {
@@ -145,7 +145,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 
   private dragEventIsBlacklisted(e: React.DragEvent) {
     return e.dataTransfer.types.some(type =>
-      (this.props.blockingDataTransferTypes || []).includes(type)
+      (this.props.blacklistedDataTransferTypes || []).includes(type)
     );
   }
 

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import Node, { ChildrenProps as NodeChildrenProps } from './Node';
-import { StoreConsumer, isMove, isInside } from './Root';
+import {
+  StoreConsumer,
+  isMove,
+  isInside,
+  dragEventIsBlacklisted
+} from './Root';
 import { Store } from './store';
 import AddParentInfo, { PathConsumer, Parent } from './AddParentInfo';
 import { TRANSFER_TYPE, NO_STORE_ERROR } from './constants';
@@ -70,8 +75,8 @@ interface OuterProps<T> {
         index: number
       ) => React.ReactNode)
     | null;
-  // any occurence of these in the data transfer will cause all dragging
-  // behaviour to be bypassed
+  // Any occurence of these in the data transfer will cause all dragging
+  // behaviour to be bypassed.
   blacklistedDataTransferTypes?: string[];
 }
 
@@ -143,12 +148,6 @@ class Level<T> extends React.Component<Props<T>, State> {
     );
   }
 
-  private dragEventIsBlacklisted(e: React.DragEvent) {
-    return e.dataTransfer.types.some(type =>
-      (this.props.blacklistedDataTransferTypes || []).includes(type)
-    );
-  }
-
   private getDropIndex(e: React.DragEvent, i: number, isNode: boolean) {
     return i + (isNode ? getDropIndexOffset(e) : 0);
   }
@@ -157,7 +156,10 @@ class Level<T> extends React.Component<Props<T>, State> {
     if (!this.props.store) {
       throw new Error(NO_STORE_ERROR);
     }
-    if (e.defaultPrevented || this.dragEventIsBlacklisted(e)) {
+    if (
+      e.defaultPrevented ||
+      dragEventIsBlacklisted(e, this.props.blacklistedDataTransferTypes)
+    ) {
       return;
     }
     e.preventDefault();
@@ -165,7 +167,10 @@ class Level<T> extends React.Component<Props<T>, State> {
   };
 
   private onDrop = (i: number, isNode: boolean) => (e: React.DragEvent) => {
-    if (e.defaultPrevented || this.dragEventIsBlacklisted(e)) {
+    if (
+      e.defaultPrevented ||
+      dragEventIsBlacklisted(e, this.props.blacklistedDataTransferTypes)
+    ) {
       return;
     }
 

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -31,7 +31,7 @@ export default class Root extends React.Component<Props, State> {
   public state = { store: createStore() };
 
   public render() {
-    const { id, ...divProps } = this.props;
+    const { id, blacklistedDataTransferTypes, ...divProps } = this.props;
     return (
       <div
         {...divProps}
@@ -50,11 +50,14 @@ export default class Root extends React.Component<Props, State> {
   }
 
   private onDragOver = (e: React.DragEvent) => {
-    if (
-      !e.defaultPrevented ||
-      dragEventIsBlacklisted(e, this.props.blacklistedDataTransferTypes)
-    ) {
-      this.reset(false);
+    const isBlacklisted = dragEventIsBlacklisted(
+      e,
+      this.props.blacklistedDataTransferTypes
+    );
+    if (!e.defaultPrevented || isBlacklisted) {
+      // Don't alter the dragOver state if we're dealing with a
+      // blacklisted drag type.
+      this.reset(!isBlacklisted);
       return;
     }
     const state = this.state.store.getState();

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -6,8 +6,18 @@ const { Provider: StoreProvider, Consumer: StoreConsumer } = createContext(
   null as Store | null
 );
 
+const dragEventIsBlacklisted = (
+  e: React.DragEvent,
+  blacklist: string[] | undefined
+) => {
+  return e.dataTransfer.types.some(type => (blacklist || []).includes(type));
+};
+
 interface OuterProps {
   id: string;
+  // Any occurence of these in the data transfer will cause all dragging
+  // behaviour to be bypassed.
+  blacklistedDataTransferTypes?: string[];
 }
 
 type Props = OuterProps &
@@ -40,7 +50,10 @@ export default class Root extends React.Component<Props, State> {
   }
 
   private onDragOver = (e: React.DragEvent) => {
-    if (!e.defaultPrevented) {
+    if (
+      !e.defaultPrevented ||
+      dragEventIsBlacklisted(e, this.props.blacklistedDataTransferTypes)
+    ) {
       this.reset(true);
       return;
     }
@@ -66,4 +79,4 @@ export default class Root extends React.Component<Props, State> {
   };
 }
 
-export { StoreConsumer, isMove, isInside };
+export { StoreConsumer, isMove, isInside, dragEventIsBlacklisted };

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -54,7 +54,7 @@ export default class Root extends React.Component<Props, State> {
       !e.defaultPrevented ||
       dragEventIsBlacklisted(e, this.props.blacklistedDataTransferTypes)
     ) {
-      this.reset(true);
+      this.reset(false);
       return;
     }
     const state = this.state.store.getState();


### PR DESCRIPTION
## What's changed?

Adds a drop level container, which lets us avoid having to depend on the drop root to listen for dragover events. This means a) we're not listening in two places, and b) we can avoid passing in a blacklist to the root element -- important for #724.

## Implementation notes

@RichieAHB -- I wasn't quite sure how to write a test for this -- be interested in your thoughts!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
