### PR TITLE
Add integration tests to run-checks

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -16,7 +16,7 @@
     "test": "yarn jest",
     "test-integration": "yarn build && node ./integration/run.js",
     "test-integration-ci": "node ./integration/run.js",
-    "run-checks": "yarn test && yarn lint"
+    "run-checks": "yarn test && yarn lint && yarn test-integration"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.44",


### PR DESCRIPTION
## What's changed?

Add the integration tests to the `run-checks` command -- I always forget! I presume we always want to run these as run-checks is in my mind some defence against getting caught by CI, but please let me know if you think differently.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
