### PR TITLE
VERTICAL COMPRESSION 2: Make all images smaller

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -65,7 +65,7 @@ const ClipboardTitle = styled.h2`
 `;
 
 const ClipboardBody = styled.div`
-  padding: 10px;
+  padding: 0 10px;
   flex: 1;
   display: flex;
 `;
@@ -86,7 +86,7 @@ const SupportingDivider = styled.hr`
 const FullDivider = styled('hr')`
   border: 0;
   border-top: 1px solid #ccc;
-  margin: 8px -10px 4px;
+  margin: 8px -10px 0px;
   width: 115%;
 `;
 

--- a/client-v2/src/shared/components/PolaroidThumbnail.tsx
+++ b/client-v2/src/shared/components/PolaroidThumbnail.tsx
@@ -1,7 +1,6 @@
 import { styled } from 'shared/constants/theme';
-import Thumbnail from './Thumbnail';
+import { ThumbnailSmall } from './Thumbnail';
 
-export default styled(Thumbnail)`
+export default styled(ThumbnailSmall)`
   margin-bottom: 0.25em;
-  width: 100%;
 `;

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -37,6 +37,7 @@ const ArticleBodyContainer = styled(CollectionItemBody)<{
       color: ${({ theme }) => theme.shared.base.colors.textMuted};
     }
   }
+  height: 100%;
 `;
 
 interface ArticleComponentProps {

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -11,7 +11,7 @@ import CollectionItemMetaContainer from '../collectionItem/CollectionItemMetaCon
 import CollectionItemContent from '../collectionItem/CollectionItemContent';
 import { notLiveLabels } from 'constants/fronts';
 import TextPlaceholder from 'shared/components/TextPlaceholder';
-import Thumbnail from '../Thumbnail';
+import { ThumbnailSmall } from '../Thumbnail';
 import CollectionItemMetaHeading from '../collectionItem/CollectionItemMetaHeading';
 import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
 import {
@@ -28,8 +28,8 @@ import ColouredQuote from '../collectionItem/CollectionItemQuote';
 import DraggableArticleImageContainer from './DraggableArticleImageContainer';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
-  width: 130px;
-  height: 100%;
+  width: 83px;
+  height: 50px;
 `;
 
 const NotLiveContainer = styled(CollectionItemMetaHeading)`
@@ -232,7 +232,7 @@ const articleBodyDefault = ({
                 </SlideshowIcon>
               </ArticleSlideshow>
             )}
-            <Thumbnail
+            <ThumbnailSmall
               style={{
                 backgroundImage: `url('${thumbnail}')`,
                 opacity: imageHide ? 0.5 : 1

--- a/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
@@ -23,7 +23,7 @@ export default styled('div')<{
   ${({ displayType, size }) =>
     displayType === 'polaroid' &&
     `font-size: ${size === 'small' ? '12px' : '13px'};`}
-  min-height: ${({ size }) => (size === 'small' ? '25px' : '67px')};
+  min-height: ${({ size }) => (size === 'small' ? '25px' : '50px')};
   cursor: pointer;
   background-color: ${({ displayType, theme }) =>
     displayType === 'default'

--- a/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
@@ -13,7 +13,7 @@ const CollectionItemContent = styled('div')<{
     if (displayType === 'default') {
       if (displaySize !== 'small') {
         return css`
-          width: calc(100% - 210px);
+          width: calc(100% - 163px);
           padding: 0 8px;
         `;
       }

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -6,7 +6,7 @@ import upperFirst from 'lodash/upperFirst';
 import CollectionItemContainer from '../collectionItem/CollectionItemContainer';
 import CollectionItemMetaContainer from '../collectionItem/CollectionItemMetaContainer';
 import CollectionItemMetaHeading from '../collectionItem/CollectionItemMetaHeading';
-import Thumbnail from '../Thumbnail';
+import { ThumbnailSmall } from '../Thumbnail';
 import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
 import { HoverDeleteButton } from '../input/HoverActionButtons';
 import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
@@ -92,7 +92,7 @@ const SnapLink = ({
             </>
           )}
         </CollectionItemContent>
-        {size === 'default' && displayType === 'default' && <Thumbnail />}
+        {size === 'default' && displayType === 'default' && <ThumbnailSmall />}
         <HoverActionsAreaOverlay
           disabled={isUneditable}
           justify={displayType === 'polaroid' ? 'flex-end' : 'space-between'}


### PR DESCRIPTION
## What's changed?

In our effort to save space we want to make all the images smaller in the collection and clipboard panes. 

**New small images**
![Screenshot 2019-05-02 at 18 04 21](https://user-images.githubusercontent.com/10324129/57093099-e7eee280-6d04-11e9-806a-5199fc2200b5.png)

**------------------------------------------------------------------------------------------**
**Old big images**
![Screenshot 2019-05-02 at 18 05 02](https://user-images.githubusercontent.com/10324129/57093108-ef15f080-6d04-11e9-8719-88ee45f48dc0.png)

## Implementation notes

The size Akemi requested: `width: 83px; height: 50px;` for the pictures is the same as `ThumbnailSmall` so I've swapped this in where we previously used the standard Thumbnail. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
