### PR TITLE
Consistent presentation/positioning for dragging collectionItems/feedItems

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -23,7 +23,11 @@ import { liveBlogTones } from 'constants/fronts';
 import { ThumbnailSmall } from 'shared/components/Thumbnail';
 import { CapiArticle } from 'types/Capi';
 import { getThumbnail } from 'util/CAPIUtils';
-import { ArticleDragComponent, dragOffsetX, dragOffsetY } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import {
+  ArticleDragComponent,
+  dragOffsetX,
+  dragOffsetY
+} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 
 const Container = styled('div')`
   display: flex;
@@ -216,12 +220,14 @@ class FeedItem extends React.Component<FeedItemProps> {
     );
   }
 
-  private handleDragStart = (
-    event: React.DragEvent<HTMLDivElement>
-  ) => {
+  private handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     event.dataTransfer.setData('capi', JSON.stringify(this.props.article));
     if (this.dragNode.current) {
-      event.dataTransfer.setDragImage(this.dragNode.current, dragOffsetX, dragOffsetY);
+      event.dataTransfer.setDragImage(
+        this.dragNode.current,
+        dragOffsetX,
+        dragOffsetY
+      );
     }
   };
 }

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -23,6 +23,7 @@ import { liveBlogTones } from 'constants/fronts';
 import { ThumbnailSmall } from 'shared/components/Thumbnail';
 import { CapiArticle } from 'types/Capi';
 import { getThumbnail } from 'util/CAPIUtils';
+import { ArticleDragComponent, dragOffsetX, dragOffsetY } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 
 const Container = styled('div')`
   display: flex;
@@ -59,6 +60,7 @@ const VisitedWrapper = styled.a`
   display: flex;
   color: inherit;
   width: 100%;
+  height: 100%;
   :visited ${Title} {
     color: ${({ theme }) => theme.capiInterface.textVisited};
   }
@@ -99,13 +101,6 @@ interface FeedItemProps {
   onAddToClipboard: (article: CapiArticle) => void;
 }
 
-const dragStart = (
-  article: CapiArticle,
-  event: React.DragEvent<HTMLDivElement>
-) => {
-  event.dataTransfer.setData('capi', JSON.stringify(article));
-};
-
 const isLive = (article: CapiArticle) =>
   !article.fields.isLive || article.fields.isLive === 'true';
 
@@ -129,78 +124,107 @@ const getArticleLabel = (article: CapiArticle) => {
   return startCase(sectionName);
 };
 
-const FeedItem = ({ article, onAddToClipboard = noop }: FeedItemProps) => (
-  <Container
-    data-testid="feed-item"
-    draggable={true}
-    onDragStart={event => dragStart(article, event)}
-  >
-    <VisitedWrapper
-      href={getPaths(article.id).live}
-      onClick={e => e.preventDefault()}
-      aria-disabled
-    >
-      <MetaContainer>
-        <Tone
+class FeedItem extends React.Component<FeedItemProps> {
+  private dragNode: React.RefObject<HTMLDivElement>;
+  public constructor(props: FeedItemProps) {
+    super(props);
+    this.dragNode = React.createRef();
+  }
+  public render() {
+    const { article, onAddToClipboard = noop } = this.props;
+    return (
+      <Container
+        data-testid="feed-item"
+        draggable={true}
+        onDragStart={this.handleDragStart}
+      >
+        <div
           style={{
-            color:
-              getPillarColor(
-                article.pillarId,
-                isLive(article),
-                article.frontsMeta.tone === liveBlogTones.dead
-              ) || styleTheme.capiInterface.textLight
+            position: 'absolute',
+            transform: 'translateX(-9999px)'
           }}
+          ref={this.dragNode}
         >
-          {getArticleLabel(article)}
-        </Tone>
-        {article.fields.scheduledPublicationDate && (
-          <ScheduledPublication>
-            {distanceInWordsStrict(
-              new Date(article.fields.scheduledPublicationDate),
-              Date.now()
+          <ArticleDragComponent headline={article.webTitle} />
+        </div>
+
+        <VisitedWrapper
+          href={getPaths(article.id).live}
+          onClick={e => e.preventDefault()}
+          aria-disabled
+        >
+          <MetaContainer>
+            <Tone
+              style={{
+                color:
+                  getPillarColor(
+                    article.pillarId,
+                    isLive(article),
+                    article.frontsMeta.tone === liveBlogTones.dead
+                  ) || styleTheme.capiInterface.textLight
+              }}
+            >
+              {getArticleLabel(article)}
+            </Tone>
+            {article.fields.scheduledPublicationDate && (
+              <ScheduledPublication>
+                {distanceInWordsStrict(
+                  new Date(article.fields.scheduledPublicationDate),
+                  Date.now()
+                )}
+              </ScheduledPublication>
             )}
-          </ScheduledPublication>
-        )}
-        {article.webPublicationDate && (
-          <FirstPublished>
-            {distanceInWordsStrict(
-              Date.now(),
-              new Date(article.webPublicationDate)
+            {article.webPublicationDate && (
+              <FirstPublished>
+                {distanceInWordsStrict(
+                  Date.now(),
+                  new Date(article.webPublicationDate)
+                )}
+              </FirstPublished>
             )}
-          </FirstPublished>
-        )}
-        <ShortVerticalPinline />
-      </MetaContainer>
-      <Body>
-        <Title data-testid="headline">{article.webTitle}</Title>
-      </Body>
-      <ArticleThumbnail
-        style={{
-          backgroundImage: `url('${getThumbnail(
-            article,
-            article.frontsMeta.defaults
-          )}')`
-        }}
-      />
-    </VisitedWrapper>
-    <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
-      <HoverActionsButtonWrapper
-        buttons={[
-          { text: 'View', component: HoverViewButton },
-          { text: 'Ophan', component: HoverOphanButton },
-          { text: 'Clipboard', component: HoverAddToClipboardButton }
-        ]}
-        buttonProps={{
-          isLive: isLive(article),
-          urlPath: article.id,
-          onAddToClipboard: () => onAddToClipboard(article)
-        }}
-        toolTipPosition={'top'}
-        toolTipAlign={'right'}
-      />
-    </HoverActionsAreaOverlay>
-  </Container>
-);
+            <ShortVerticalPinline />
+          </MetaContainer>
+          <Body>
+            <Title data-testid="headline">{article.webTitle}</Title>
+          </Body>
+          <ArticleThumbnail
+            style={{
+              backgroundImage: `url('${getThumbnail(
+                article,
+                article.frontsMeta.defaults
+              )}')`
+            }}
+          />
+        </VisitedWrapper>
+        <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
+          <HoverActionsButtonWrapper
+            buttons={[
+              { text: 'View', component: HoverViewButton },
+              { text: 'Ophan', component: HoverOphanButton },
+              { text: 'Clipboard', component: HoverAddToClipboardButton }
+            ]}
+            buttonProps={{
+              isLive: isLive(article),
+              urlPath: article.id,
+              onAddToClipboard: () => onAddToClipboard(article)
+            }}
+            toolTipPosition={'top'}
+            toolTipAlign={'right'}
+          />
+        </HoverActionsAreaOverlay>
+      </Container>
+    );
+  }
+
+  private handleDragStart = (
+    event: React.DragEvent<HTMLDivElement>
+  ) => {
+    event.dataTransfer.setData('capi', JSON.stringify(this.props.article));
+    if (this.dragNode.current) {
+      event.dataTransfer.setDragImage(this.dragNode.current, dragOffsetX, dragOffsetY);
+    }
+  };
+}
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
@@ -5,46 +5,49 @@ import {
   selectSharedState
 } from 'shared/selectors/shared';
 import { State } from 'types/State';
-import { DerivedArticle } from 'shared/types/Article';
-import { theme } from '../../../constants/theme';
+import { theme, styled } from '../../../constants/theme';
 
 interface ContainerProps {
   id: string;
 }
 
-type ComponentProps = {
-  article: DerivedArticle | void;
-} & ContainerProps;
+interface ComponentProps {
+  headline?: string;
+}
 
-const ArticleDrag = ({ article }: ComponentProps) => (
-  <>
-    {article && (
-      <div
-        style={{
-          background: `${theme.shared.base.colors.backgroundColorFocused}`,
-          borderRadius: '4px',
-          boxShadow: '-2px -2px 5px 0 rgba(0, 0, 0, 0.5)',
-          overflow: 'hidden',
-          padding: '8px',
-          textOverflow: 'ellipsis',
-          width: '300px',
-          whiteSpace: 'nowrap'
-        }}
-      >
-        {article.headline}
-      </div>
-    )}
-  </>
-);
+// These constants can be added to setDragImage to
+// position the drag component in a consistent way.
+export const dragOffsetX = -5;
+export const dragOffsetY = 40;
+
+const DragContainer = styled.div`
+  position: relative;
+  padding: 0 0 10px 10px;
+`;
+
+const DragContent = styled.div`
+  background: ${theme.shared.base.colors.backgroundColorFocused};
+  border-radius: 4px;
+  overflow: hidden;
+  padding: 8px;
+  text-overflow: ellipsis;
+  width: 300px;
+  white-space: nowrap;
+`;
+
+export const ArticleDragComponent = ({ headline }: ComponentProps) =>
+  headline ? (
+    <DragContainer>
+      <DragContent>{headline}</DragContent>
+    </DragContainer>
+  ) : null;
 
 const createMapStateToProps = () => {
   const articleSelector = createArticleFromArticleFragmentSelector();
-  return (
-    state: State,
-    props: ContainerProps
-  ): { article: DerivedArticle | void } => ({
-    article: articleSelector(selectSharedState(state), props.id)
-  });
+  return (state: State, props: ContainerProps): { headline?: string } => {
+    const article = articleSelector(selectSharedState(state), props.id);
+    return { headline: article && article.headline };
+  };
 };
 
-export default connect(createMapStateToProps)(ArticleDrag);
+export default connect(createMapStateToProps)(ArticleDragComponent);

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -4,7 +4,10 @@ import { State } from 'types/State';
 import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import { CollectionItemDisplayTypes } from 'shared/types/Collection';
-import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import ArticleDrag, {
+  dragOffsetX,
+  dragOffsetY
+} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createSupportingArticlesSelector } from 'shared/selectors/shared';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
@@ -43,6 +46,8 @@ const ArticleFragmentLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     renderDrag={af => <ArticleDrag id={af.uuid} />}
+    dragImageOffsetX={dragOffsetX}
+    dragImageOffsetY={dragOffsetY}
     renderDrop={
       isUneditable
         ? null

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -4,7 +4,10 @@ import { State } from 'types/State';
 import { clipboardArticlesSelector } from 'selectors/clipboardSelectors';
 import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
-import ArticleDrag, { dragOffsetX, dragOffsetY } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import ArticleDrag, {
+  dragOffsetX,
+  dragOffsetY
+} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
 import { styled } from 'constants/theme';

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -4,7 +4,7 @@ import { State } from 'types/State';
 import { clipboardArticlesSelector } from 'selectors/clipboardSelectors';
 import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
-import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import ArticleDrag, { dragOffsetX, dragOffsetY } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
 import { styled } from 'constants/theme';
@@ -41,6 +41,8 @@ const ClipboardLevel = ({
     parentType="clipboard"
     parentId="clipboard"
     type="articleFragment"
+    dragImageOffsetX={dragOffsetX}
+    dragImageOffsetY={dragOffsetY}
     getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -3,7 +3,7 @@ import { Level, LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import { State } from 'types/State';
 import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
-import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import ArticleDrag, { dragOffsetX, dragOffsetY } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
@@ -36,6 +36,8 @@ const GroupLevel = ({
     parentType="group"
     parentId={groupId}
     type="articleFragment"
+    dragImageOffsetX={dragOffsetX}
+    dragImageOffsetY={dragOffsetY}
     getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -3,7 +3,10 @@ import { Level, LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import { State } from 'types/State';
 import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
-import ArticleDrag, { dragOffsetX, dragOffsetY } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import ArticleDrag, {
+  dragOffsetX,
+  dragOffsetY
+} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { createGroupArticlesSelector } from 'shared/selectors/shared';
 import { collectionDropTypeBlacklist } from 'constants/fronts';

--- a/client-v2/src/lib/dnd/Level.tsx
+++ b/client-v2/src/lib/dnd/Level.tsx
@@ -69,6 +69,8 @@ interface OuterProps<T> {
   parentId: string;
   parentType: string;
   type: string;
+  dragImageOffsetX?: number;
+  dragImageOffsetY?: number;
   getId: (t: T) => string;
   onMove: (move: Move<T>) => void;
   onDrop: (e: React.DragEvent, to: PosSpec) => void;
@@ -115,7 +117,9 @@ class Level<T> extends React.Component<Props<T>, State> {
       children,
       arr,
       getId,
-      type
+      type,
+      dragImageOffsetX,
+      dragImageOffsetY
     } = this.props;
     const Container = this.props.containerElement || DefaultContainer;
     return (
@@ -130,6 +134,8 @@ class Level<T> extends React.Component<Props<T>, State> {
             </DropZone>
             <Node
               renderDrag={renderDrag}
+              dragImageOffsetX={dragImageOffsetX}
+              dragImageOffsetY={dragImageOffsetY}
               id={getId(node)}
               type={type}
               index={i}

--- a/client-v2/src/lib/dnd/Node.tsx
+++ b/client-v2/src/lib/dnd/Node.tsx
@@ -12,6 +12,8 @@ interface OuterProps<T> {
     getProps: (forceClone: boolean) => ChildrenProps
   ) => React.ReactNode;
   renderDrag?: (data: T) => React.ReactNode;
+  dragImageOffsetX?: number;
+  dragImageOffsetY?: number;
   type: string;
   id: string;
   index: number;
@@ -57,7 +59,12 @@ class Node<T> extends React.Component<Props<T>> {
       return;
     }
     if (this.dragImage) {
-      e.dataTransfer.setDragImage(this.dragImage, 10, 10);
+      const { dragImageOffsetX = 10, dragImageOffsetY = 10 } = this.props;
+      e.dataTransfer.setDragImage(
+        this.dragImage,
+        dragImageOffsetX,
+        dragImageOffsetY
+      );
     }
     const { parents, type, id, index, data } = this.props;
     e.dataTransfer.setData(


### PR DESCRIPTION
## What's changed?

This PR has us use the same drag images across collectionItems and feedItems, and positions them a little further out of the way of our drop zones so users can see where they are dropping better.

![drag](https://user-images.githubusercontent.com/7767575/57128771-66429780-6d8c-11e9-998e-1bfaf32cb8b8.gif)

## Implementation notes

I've parameterized the drag image offsets in Level.tsx. We have to pass them through the Level component to the Node component, which is a bit of a trek -- let me know if there's a better way.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
