### PR TITLE
Toggle only one image metadata field at a time

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -173,6 +173,23 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       imageReplace
     } = this.props;
 
+    // only one of the image fields can be set to true at any time.
+    const changeImageField = (fieldToSet: string) => {
+      const allImageFields = [
+        'imageHide',
+        'imageCutoutReplace',
+        'imageSlideshowReplace',
+        'imageReplace'
+      ];
+      allImageFields.forEach(field => {
+        if (field === fieldToSet) {
+          change(field, true);
+        } else {
+          change(field, false);
+        }
+      });
+    };
+
     return (
       <FormContainer onSubmit={handleSubmit}>
         <CollectionHeadingPinline>
@@ -391,10 +408,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     id={getInputId(articleFragmentId, 'image-replace')}
                     type="checkbox"
                     default={false}
-                    onChange={e => {
-                      change('imageHide', false);
-                      change('imageReplace', true);
-                    }}
+                    onChange={_ => changeImageField('imageReplace')}
                   />
                 </InputGroup>
                 <InputGroup>
@@ -406,10 +420,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     id={getInputId(articleFragmentId, 'hide-media')}
                     type="checkbox"
                     default={false}
-                    onChange={e => {
-                      change('imageReplace', false);
-                      change('imageHide', true);
-                    }}
+                    onChange={_ => changeImageField('imageHide')}
                   />
                 </InputGroup>
               </Col>
@@ -443,6 +454,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     id={getInputId(articleFragmentId, 'use-cutout')}
                     type="checkbox"
                     default={false}
+                    onChange={_ => changeImageField('imageCutoutReplace')}
                   />
                 </InputGroup>
               </Col>
@@ -462,6 +474,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               label="Slideshow"
               id={getInputId(articleFragmentId, 'slideshow')}
               type="checkbox"
+              onChange={_ => changeImageField('imageSlideshowReplace')}
             />
           </InputGroup>
           {imageSlideshowReplace && (


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Only of the image metadata fields can be turned off at a time.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
