### PR TITLE
Revert "Revert "Fix sorting groups""

### DIFF
--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -62,12 +62,14 @@ const init = () => {
         g1: {
           uuid: 'g1',
           id: 'g1',
-          articleFragments: ['a1', 'a2']
+          articleFragments: ['a1', 'a2'],
+          name: 'g1'
         },
         g2: {
           uuid: 'g2',
           id: 'g2',
-          articleFragments: ['a3', 'a4']
+          articleFragments: ['a3', 'a4'],
+          name: 'g2'
         }
       },
       articleFragments: {

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -170,6 +170,7 @@ class CollectionContext extends React.Component<
                 groupId={group.uuid}
                 onMove={handleMove}
                 onDrop={handleInsert}
+                articleFragmentIds={group.articleFragments}
               >
                 {(articleFragment, getAfNodeProps) => (
                   <>

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -5,11 +5,12 @@ import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
-import { createGroupArticlesSelector } from 'shared/selectors/shared';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
+import { createArticlesFromIdsSelector } from 'shared/selectors/shared';
 
 interface OuterProps {
   groupId: string;
+  articleFragmentIds: string[];
   children: LevelChild<ArticleFragment>;
   onMove: MoveHandler<ArticleFragment>;
   onDrop: DropHandler;
@@ -67,10 +68,10 @@ const GroupLevel = ({
 );
 
 const createMapStateToProps = () => {
-  const groupArticleSelector = createGroupArticlesSelector();
-  return (state: State, { groupId }: OuterProps) => ({
-    articleFragments: groupArticleSelector(state, {
-      groupId
+  const articlesFromIdsSelector = createArticlesFromIdsSelector();
+  return (state: State, { articleFragmentIds }: OuterProps) => ({
+    articleFragments: articlesFromIdsSelector(state, {
+      articleFragmentIds
     })
   });
 };

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -479,6 +479,31 @@ const articleWithSupporting = {
   }
 };
 
+const collectionWithoutGroups = {
+  live: [
+    {
+      id: 'article/draft/1',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    },
+    {
+      id: 'a/long/path/2',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    },
+    {
+      id: 'a/long/path/3',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    }
+  ],
+  id: 'collectionWithoutGroups',
+  displayName: 'Collection Without Groups',
+  type: 'type'
+};
 const collection = {
   live: [
     liveArticle,
@@ -586,11 +611,13 @@ const stateWithCollection: any = {
       abc: {
         id: '1',
         uuid: 'abc',
-        articleFragments: ['95e2bfc0-8999-4e6e-a359-19960967c1e0']
+        articleFragments: ['95e2bfc0-8999-4e6e-a359-19960967c1e0'],
+        name: 'group1'
       },
       def: {
         id: null,
         uuid: 'def',
+        name: 'group2',
         articleFragments: [
           '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
           '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d'
@@ -734,5 +761,6 @@ export {
   stateWithSnaplinksAndArticles,
   liveArticle,
   articleWithSupporting,
-  collectionConfig
+  collectionConfig,
+  collectionWithoutGroups
 };

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -32,6 +32,11 @@ const state: any = {
         id: 'c5',
         groups: ['group6'],
         live: ['g6']
+      },
+      c6: {
+        id: 'c1',
+        groups: ['group1', 'group2'],
+        live: ['g1', 'g2', 'g7']
       }
     }
   },
@@ -39,12 +44,14 @@ const state: any = {
     g1: {
       uuid: 'g1',
       id: 'group1',
-      articleFragments: ['af2']
+      articleFragments: ['af2'],
+      name: 'g1'
     },
     g2: {
       uuid: 'g2',
       id: 'group2',
-      articleFragments: ['af1']
+      articleFragments: ['af1'],
+      name: 'g2'
     },
     g3: {
       uuid: 'g3',
@@ -193,6 +200,9 @@ const state: any = {
       id: 'ea4'
     },
     af5: {
+      uuid: 'af5'
+    },
+    af6: {
       uuid: 'af5'
     },
     afWithTagKicker: {
@@ -401,6 +411,40 @@ describe('Shared selectors', () => {
           groupName: 'group1'
         })
       ).toEqual(['af3', 'af4']);
+    });
+    it('should put articles which are in groups that don`t exis in the config in the first group', () => {
+      const selector = createArticlesInCollectionGroupSelector();
+      const currentGroups = state.groups;
+      const newGroups = {
+        ...currentGroups,
+        ...{ g7: { uuid: 'g7', id: 'group7', articleFragments: ['af6'] } }
+      };
+      expect(
+        selector(
+          { ...state, ...{ groups: newGroups } },
+          {
+            collectionId: 'c6',
+            collectionSet: 'live'
+          }
+        )
+      ).toEqual(['af6', 'af2', 'af1']);
+    });
+    it('should put articles which are in groups that don`t exis in the config in the first group even when none of the groups have names', () => {
+      const selector = createArticlesInCollectionGroupSelector();
+      const newGroups = {
+        ...{ g1: { uuid: 'g1', articleFragments: ['af4'] } },
+        ...{ g2: { uuid: 'g2', id: 'group6', articleFragments: ['af5'] } },
+        ...{ g7: { uuid: 'g7', id: 'group7', articleFragments: ['af6'] } }
+      };
+      expect(
+        selector(
+          { ...state, ...{ groups: newGroups } },
+          {
+            collectionId: 'c6',
+            collectionSet: 'live'
+          }
+        )
+      ).toEqual(['af5', 'af6', 'af4']);
     });
     it('should return articles in supporting positions', () => {
       const selector = createArticlesInCollectionGroupSelector();

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -2,7 +2,7 @@ import { Diff } from 'utility-types';
 import { FrontsToolSettings } from 'types/FaciaApi';
 
 interface Group {
-  id: string;
+  id: string | null;
   name: string | null;
   uuid: string;
   articleFragments: string[];

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -1,6 +1,7 @@
 import {
   collection,
   collectionConfig,
+  collectionWithoutGroups,
   collectionWithSupportingArticles,
   stateWithCollection,
   stateWithCollectionAndSupporting
@@ -147,12 +148,36 @@ describe('Shared utilities', () => {
     });
 
     it('should create a single group with with all article fragments when the collection config has no groups', () => {
+      const result = normaliseCollectionWithNestedArticles(
+        collectionWithoutGroups,
+        {
+          ...collectionConfig,
+          groups: undefined
+        }
+      );
+      const groupId = result.normalisedCollection.live![0];
+      expect(result.groups[groupId].articleFragments).toHaveLength(3);
+    });
+    it('should create different groups for article fragments belonging to different groups even if they are not specificied in the config', () => {
       const result = normaliseCollectionWithNestedArticles(collection, {
         ...collectionConfig,
         groups: undefined
       });
-      const groupId = result.normalisedCollection.live![0];
-      expect(result.groups[groupId].articleFragments).toHaveLength(3);
+      const groupId1 = result.normalisedCollection.live![0];
+      expect(result.groups[groupId1].articleFragments).toHaveLength(1);
+      const groupId2 = result.normalisedCollection.live![1];
+      expect(result.groups[groupId2].articleFragments).toHaveLength(2);
+    });
+    it("should create empty groups for groups in the config which don't have article fragments in them", () => {
+      const configWithExtraGroup = {
+        ...collectionConfig,
+        ...{ groups: ['extra', 'large', 'medium', 'small'] }
+      };
+      const result = normaliseCollectionWithNestedArticles(collection, {
+        ...configWithExtraGroup,
+        groups: undefined
+      });
+      expect(Object.keys(result.groups)).toHaveLength(4);
     });
   });
 });

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -12,9 +12,10 @@ import { normalize, denormalize } from './schema';
 import { CollectionConfig } from 'types/FaciaApi';
 import v4 from 'uuid/v4';
 import keyBy from 'lodash/keyBy';
+import sortBy from 'lodash/sortBy';
 
 const createGroup = (
-  id: string,
+  id: string | null,
   name: string | null,
   articleFragments: string[] = []
 ): Group => ({
@@ -26,9 +27,7 @@ const createGroup = (
 
 const getUUID = <T extends { uuid: string }>({ uuid }: T) => uuid;
 
-// this is horrible but is the only way to do it!
-const groupByIndex = (groups: Group[], index: number): Group | undefined =>
-  groups.find(g => parseInt(g.id || '0', 10) === index);
+const getGroupIndex = (id: string | null): number => parseInt(id || '0', 10);
 
 const getAllArticleFragments = (groups: Group[]) =>
   groups.reduce(
@@ -36,28 +35,61 @@ const getAllArticleFragments = (groups: Group[]) =>
     [] as string[]
   );
 
-const addEmptyGroupsFromCollectionConfigForStage = (
+const configGroupIndexExistsInGroups = (
+  groupsToSearch: Group[],
+  index: number
+): boolean =>
+  groupsToSearch.some(group => {
+    if (group.id) {
+      return parseInt(group.id, 10) === index;
+    }
+    return index === 0;
+  });
+
+const addGroupsForStage = (
   groupIds: string[],
   entities: { [id: string]: Group },
   collectionConfig: CollectionConfig
 ) => {
   const groups = groupIds.map(id => entities[id]);
-  const addedGroups = collectionConfig.groups
-    ? collectionConfig.groups.map((name, i) => {
-        const existingGroup = groupByIndex(groups, i);
+  const groupsWithNames = groups.map(group => {
+    let name: string | null = null;
+    const groupNumberAsInt = getGroupIndex(group.id);
+    if (
+      collectionConfig.groups &&
+      groupNumberAsInt < collectionConfig.groups.length
+    ) {
+      name = collectionConfig.groups[groupNumberAsInt];
+    }
+    return { ...group, name };
+  });
 
-        return existingGroup
-          ? { ...existingGroup, name }
-          : createGroup(`${i}`, name);
-      })
-    : [createGroup('0', null, getAllArticleFragments(groups))];
+  // We may have empty groups in the config which would not show up in the normalised
+  // groups result. We need to add these into the groups array.
+  if (collectionConfig.groups) {
+    collectionConfig.groups.forEach((group, configGroupIndex) => {
+      if (!configGroupIndexExistsInGroups(groupsWithNames, configGroupIndex)) {
+        groupsWithNames.push(createGroup(`${configGroupIndex}`, group));
+      }
+    });
+  }
 
+  // If we have no article fragments and no groups in a collection we still need to create
+  // and empty group for articles.
+  if (groupsWithNames.length === 0) {
+    groupsWithNames.push(
+      createGroup(null, null, getAllArticleFragments(groups))
+    );
+  }
+
+  // Finally we need to sort the groups according to their ids.
+  const sortedGroupsWithNames = sortBy(
+    groupsWithNames,
+    group => -getGroupIndex(group.id)
+  );
   return {
-    addedGroups: keyBy(addedGroups, getUUID),
-    groupIds: addedGroups
-      .map(getUUID)
-      .slice()
-      .reverse()
+    addedGroups: keyBy(sortedGroupsWithNames, getUUID),
+    groupIds: sortedGroupsWithNames.map(getUUID)
   };
 };
 
@@ -68,16 +100,13 @@ interface ReduceResult {
   addedGroups: { [key: string]: Group };
 }
 
-const addEmptyGroupsFromCollectionConfig = (
+const addGroups = (
   normalisedCollection: any,
   collectionConfig: CollectionConfig
 ) =>
   (['live', 'previously', 'draft'] as ['live', 'previously', 'draft']).reduce(
     (acc, key) => {
-      const {
-        addedGroups,
-        groupIds
-      } = addEmptyGroupsFromCollectionConfigForStage(
+      const { addedGroups, groupIds } = addGroupsForStage(
         normalisedCollection.result[key],
         normalisedCollection.entities.groups,
         collectionConfig
@@ -103,12 +132,7 @@ const normaliseCollectionWithNestedArticles = (
   articleFragments: { [key: string]: ArticleFragment };
 } => {
   const normalisedCollection = normalize(collection);
-  const {
-    addedGroups,
-    live,
-    draft,
-    previously
-  } = addEmptyGroupsFromCollectionConfig(
+  const { addedGroups, live, draft, previously } = addGroups(
     normalisedCollection,
     collectionConfig
   );
@@ -119,10 +143,7 @@ const normaliseCollectionWithNestedArticles = (
       draft,
       previously
     },
-    groups: {
-      ...(normalisedCollection.entities.groups || {}),
-      ...addedGroups
-    },
+    groups: addedGroups,
     articleFragments: normalisedCollection.entities.articleFragments || {}
   };
 };

--- a/client-v2/src/util/__tests__/moveUtils.spec.ts
+++ b/client-v2/src/util/__tests__/moveUtils.spec.ts
@@ -1,0 +1,162 @@
+import {
+  getFromGroupIndicesWithRespectToState,
+  getToGroupIndicesWithRespectToState
+} from '../moveUtils';
+
+describe('Move utilities', () => {
+  const state: any = {
+    collections: {
+      data: {
+        c1: {
+          id: 'c1',
+          groups: ['group1', 'group2'],
+          live: ['g1', 'g2']
+        },
+        c2: {
+          id: 'c2',
+          groups: ['group3', 'group4', 'group5'],
+          draft: ['g5', 'g4', 'g3', 'g6']
+        }
+      }
+    },
+    groups: {
+      g1: {
+        uuid: 'g1',
+        name: 'g1'
+      },
+      g2: {
+        uuid: 'g2',
+        id: 'group2',
+        articleFragments: ['af1'],
+        name: 'g2'
+      },
+      g3: {
+        uuid: 'g3',
+        id: 'group3',
+        name: 'group3',
+        articleFragments: ['af3', 'af4']
+      },
+      g4: {
+        uuid: 'g4',
+        id: 'group4',
+        articleFragments: ['af5']
+      },
+      g5: {
+        uuid: 'g5',
+        id: 'group5',
+        articleFragments: ['af6']
+      },
+      g6: {
+        uuid: 'g6',
+        id: 'group6',
+        name: 'group6',
+        articleFragments: ['af7', 'af8']
+      }
+    }
+  };
+
+  const position = { type: 'group', id: 'g1', index: 2 };
+  const positionWithOrphanedGroups = { type: 'group', id: 'g3', index: 3 };
+  const positionInOrphanedGroup = { type: 'group', id: 'g3', index: 0 };
+  describe('getFromGroupIndicesWithRespectToState', () => {
+    it('it returns null if position is null', () => {
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
+        null,
+        state
+      );
+
+      expect(fromWithRespectToState).toBeNull();
+    });
+
+    it('does not modify the position if there are no orphaned groups', () => {
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
+        position,
+        state
+      );
+
+      expect(fromWithRespectToState).toEqual(position);
+    });
+
+    it('moves the article from the correct index when orphaned groups', () => {
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
+        positionWithOrphanedGroups,
+        state
+      );
+
+      expect(fromWithRespectToState).toEqual({
+        ...positionWithOrphanedGroups,
+        index: 1
+      });
+    });
+
+    it('moves articles correctly from orphaned groups', () => {
+      const { fromWithRespectToState } = getFromGroupIndicesWithRespectToState(
+        positionInOrphanedGroup,
+        state
+      );
+      expect(fromWithRespectToState).toEqual({
+        ...positionInOrphanedGroup,
+        index: 0,
+        id: 'g5'
+      });
+    });
+  });
+
+  describe('getToGroupIndicesWithRespectToState', () => {
+    it('does not modify the position if there are no orphaned groups', () => {
+      const notTransformedPosition = getToGroupIndicesWithRespectToState(
+        position,
+        state,
+        false
+      );
+
+      expect(position).toEqual(notTransformedPosition);
+    });
+
+    it('moves the article to the correct index when there are orphaned groups', () => {
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
+        positionWithOrphanedGroups,
+        state,
+        false
+      );
+
+      expect(toWithRespectToState).toEqual({
+        ...positionWithOrphanedGroups,
+        index: 1
+      });
+    });
+
+    it('moves articles coming from orphaned groups correctly', () => {
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
+        positionWithOrphanedGroups,
+        state,
+        true
+      );
+
+      expect(toWithRespectToState).toEqual({
+        ...positionWithOrphanedGroups,
+        index: 2
+      });
+    });
+
+    it('does not move articles to orphaned groups', () => {
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
+        positionInOrphanedGroup,
+        state,
+        true
+      );
+
+      expect(toWithRespectToState).toBeNull();
+    });
+    it('does not adjust to position if ', () => {
+      const nonOrphanedPosition = { type: 'group', id: 'g6', index: 1 };
+      const toWithRespectToState = getToGroupIndicesWithRespectToState(
+        nonOrphanedPosition,
+        state,
+        false
+      );
+
+      expect(toWithRespectToState).toEqual(nonOrphanedPosition);
+    });
+  });
+});

--- a/client-v2/src/util/moveUtils.ts
+++ b/client-v2/src/util/moveUtils.ts
@@ -12,7 +12,7 @@ function getFromGroupIndicesWithRespectToState(
     return { fromWithRespectToState: null, fromOrphanedGroup: false };
   }
 
-  if (position.type === 'clipboard') {
+  if (position.type !== 'group') {
     return { fromWithRespectToState: position, fromOrphanedGroup: false };
   }
   const { articleCount, groupSiblings } = getGroupIndicesWithRespectToState(
@@ -60,7 +60,7 @@ function getToGroupIndicesWithRespectToState(
   state: State,
   fromOrphanedGroup: boolean
 ): PosSpec | null {
-  if (position.type === 'clipboard') {
+  if (position.type !== 'group') {
     return position;
   }
   const { articleCount } = getGroupIndicesWithRespectToState(position, state);

--- a/client-v2/src/util/moveUtils.ts
+++ b/client-v2/src/util/moveUtils.ts
@@ -1,0 +1,113 @@
+import { PosSpec } from 'lib/dnd';
+import { State } from 'shared/types/State';
+import { groupSiblingsSelector } from 'shared/selectors/shared';
+import { Group } from 'shared/types/Collection';
+import findIndex from 'lodash/findIndex';
+
+function getFromGroupIndicesWithRespectToState(
+  position: PosSpec | null,
+  state: State
+): { fromWithRespectToState: PosSpec | null; fromOrphanedGroup: boolean } {
+  if (!position) {
+    return { fromWithRespectToState: null, fromOrphanedGroup: false };
+  }
+
+  if (position.type === 'clipboard') {
+    return { fromWithRespectToState: position, fromOrphanedGroup: false };
+  }
+  const { articleCount, groupSiblings } = getGroupIndicesWithRespectToState(
+    position,
+    state
+  );
+
+  // We allow dragging from orphaned groups but we need to do extra work
+  // to figure out the current group and index of these articles
+  if (position.index < articleCount) {
+    const getGroupSiblingAndIndex = (
+      siblingIndex: number,
+      remainingGroupSiblings: Group[]
+    ): { groupId: string; index: number } => {
+      const currentGroup = remainingGroupSiblings[0];
+      if (siblingIndex < currentGroup.articleFragments.length) {
+        return { index: siblingIndex, groupId: currentGroup.uuid };
+      }
+      return getGroupSiblingAndIndex(
+        siblingIndex - currentGroup.articleFragments.length,
+        remainingGroupSiblings.slice(1)
+      );
+    };
+
+    const { groupId, index } = getGroupSiblingAndIndex(
+      position.index,
+      groupSiblings
+    );
+
+    return {
+      fromWithRespectToState: { ...position, ...{ index, id: groupId } },
+      fromOrphanedGroup: true
+    };
+  }
+
+  const adjustedIndex = position.index - articleCount;
+  return {
+    fromWithRespectToState: { ...position, ...{ index: adjustedIndex } },
+    fromOrphanedGroup: false
+  };
+}
+
+function getToGroupIndicesWithRespectToState(
+  position: PosSpec,
+  state: State,
+  fromOrphanedGroup: boolean
+): PosSpec | null {
+  if (position.type === 'clipboard') {
+    return position;
+  }
+  const { articleCount } = getGroupIndicesWithRespectToState(position, state);
+  const adjustedArticleCount = fromOrphanedGroup
+    ? articleCount - 1
+    : articleCount;
+
+  // We don`t allow dragging to orphaned group positions because it would
+  // be unclear which group these articles should end up in
+  if (position.index < adjustedArticleCount) {
+    return null;
+  }
+  const adjustedIndex = position.index - adjustedArticleCount;
+  return { ...position, ...{ index: adjustedIndex } };
+}
+
+const isOrphanedGroup = (group: Group) =>
+  !group.name && group.id && group.id !== '0';
+
+function getGroupIndicesWithRespectToState(
+  position: PosSpec,
+  state: State
+): { articleCount: number; groupSiblings: Group[] } {
+  const groupId = position.id;
+  const groupSiblings = groupSiblingsSelector(state, groupId);
+  const currentGroupIndex = findIndex(
+    groupSiblings,
+    group => group.uuid === groupId
+  );
+  const groupAbove = groupSiblings[currentGroupIndex - 1];
+  if (groupAbove && !isOrphanedGroup(groupAbove)) {
+    return { groupSiblings, articleCount: 0 };
+  }
+  const articleCount = groupSiblings.reduce(
+    (orphanedArticleCount: number, group) => {
+      if (isOrphanedGroup(group)) {
+        orphanedArticleCount += group.articleFragments.length;
+      }
+      return orphanedArticleCount;
+    },
+    0
+  );
+
+  return { groupSiblings, articleCount };
+}
+
+export {
+  getToGroupIndicesWithRespectToState,
+  getFromGroupIndicesWithRespectToState
+};


### PR DESCRIPTION
Reverts guardian/facia-tool#730

With a small change to check we are only adjusting indeces inside groups so we can still move article fragments around.