### PR TITLE
Remove criteria for cutout images

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -439,7 +439,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     name="cutoutImage"
                     component={InputImage}
                     disabled={imageHide}
-                    criteria={imageCriteria}
                     frontId={frontId}
                   />
                 </ImageWrapper>


### PR DESCRIPTION
## What's changed?

Remove criteria for cutout images ... they're not there in the old tool! 5x3 and ~6x4~ 6x5 are both valid options, I think (@paperboyo?), and in the absence of being able to check for both at once let's revert to the old behaviour.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
