### PR TITLE
Save form values that have been changed to false

### DIFF
--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -43,9 +43,13 @@ const formValues = {
 const createStateWithChangedFormFields = (
   cleanState: State,
   articleId: string,
-  fieldValueMap: { [field: string]: any }
+  fieldValueMap: { [field: string]: any },
+  additionalFormValues: any = {}
 ) => {
-  const formState = reducer(undefined, initialize(articleId, formValues));
+  const formState = reducer(
+    undefined,
+    initialize(articleId, { formValues, ...additionalFormValues })
+  );
   return {
     ...cleanState,
     form: Object.keys(fieldValueMap).reduce(
@@ -295,6 +299,39 @@ describe('ArticleFragmentForm transform functions', () => {
           }
         ]
       });
+    });
+    it('should remove undefined values from the meta', () => {
+      const values = {
+        showQuotedHeadline: undefined
+      };
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        values
+      );
+      expect(
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', {
+          ...formValues,
+          ...values
+        } as any)
+      ).toEqual({ headline: 'Bill Shorten' });
+    });
+    it('should keep false values', () => {
+      const values = {
+        showQuotedHeadline: false
+      };
+      const state = createStateWithChangedFormFields(
+        initialState,
+        'exampleId',
+        values,
+        { showQuotedHeadline: true }
+      );
+      expect(
+        getArticleFragmentMetaFromFormValues(state, 'exampleId', {
+          ...formValues,
+          ...values
+        })
+      ).toEqual({ showQuotedHeadline: false, headline: 'Bill Shorten' });
     });
   });
 });

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -214,6 +214,6 @@ export const getArticleFragmentMetaFromFormValues = (
     if (Array.isArray(value)) {
       return value.length === 0;
     }
-    return !value;
+    return value === undefined;
   });
 };


### PR DESCRIPTION
## What's changed?

Save form values that have been changed to false. This allows us to revert truthy defaults on articles. (I'm not sure how these defaults are set -- @Reettaphant @RichieAHB any ideas?)

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
