### PR TITLE
Set imageReplace value when images are dropped into articles

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -375,10 +375,12 @@ const addImageToArticleFragment = (
   uuid: string,
   imageData: ValidationResponse
 ) =>
-  updateArticleFragmentMeta(
-    uuid,
-    getImageMetaFromValidationResponse(imageData)
-  );
+  updateArticleFragmentMeta(uuid, {
+    ...getImageMetaFromValidationResponse(imageData),
+    imageReplace: true,
+    imageCutoutReplace: false,
+    imageSlideshowReplace: false
+  });
 
 export {
   insertArticleFragmentWithCreate as insertArticleFragment,

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -354,7 +354,10 @@ describe('ArticleFragments actions', () => {
         imageSrcThumb: thumb,
         imageSrcOrigin: origin,
         imageSrcWidth: width.toString(),
-        imageSrcHeight: height.toString()
+        imageSrcHeight: height.toString(),
+        imageReplace: true,
+        imageSlideshowReplace: false,
+        imageCutoutReplace: false
       });
     });
   });


### PR DESCRIPTION
## What's changed?

Set imageReplace to `true` when images are dropped into articles. Right now, it's not set, and images dropped into articles don't have the desired effect of appearing as the current image override.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
