### PR TITLE
Image drag quality of life changes

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -375,10 +375,12 @@ const addImageToArticleFragment = (
   uuid: string,
   imageData: ValidationResponse
 ) =>
-  updateArticleFragmentMeta(
-    uuid,
-    getImageMetaFromValidationResponse(imageData)
-  );
+  updateArticleFragmentMeta(uuid, {
+    ...getImageMetaFromValidationResponse(imageData),
+    imageReplace: true,
+    imageCutoutReplace: false,
+    imageSlideshowReplace: false
+  });
 
 export {
   insertArticleFragmentWithCreate as insertArticleFragment,

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -354,7 +354,10 @@ describe('ArticleFragments actions', () => {
         imageSrcThumb: thumb,
         imageSrcOrigin: origin,
         imageSrcWidth: width.toString(),
-        imageSrcHeight: height.toString()
+        imageSrcHeight: height.toString(),
+        imageReplace: true,
+        imageSlideshowReplace: false,
+        imageCutoutReplace: false
       });
     });
   });

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -176,12 +176,6 @@ class CollectionContext extends React.Component<
                     >
                       <CollectionItem
                         frontId={this.props.id}
-                        onImageDrop={imageData => {
-                          this.props.addImageToArticleFragment(
-                            articleFragment.uuid,
-                            imageData
-                          );
-                        }}
                         uuid={articleFragment.uuid}
                         parentId={group.uuid}
                         isUneditable={isUneditable}

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -46,7 +46,7 @@ const CollectionWrapper = styled('div')`
 
 const Notification = styled.span`
   display: inline-block;
-  margin-left 0.25em;
+  margin-left: 0.25em;
 `;
 
 const selectGrey = ({ theme }: { theme: Theme }) =>
@@ -107,7 +107,6 @@ type ConnectedCollectionContextProps = CollectionContextProps & {
     articleFragment: TArticleFragment,
     frontId: string
   ) => void;
-  addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   removeCollectionItem: (parentId: string, id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
   handleBlur: () => void;

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -21,6 +21,7 @@ import { connect } from 'react-redux';
 import { State } from 'types/State';
 import { createArticleVisibilityDetailsSelector } from 'selectors/frontsSelectors';
 import FocusWrapper from 'components/FocusWrapper';
+import { ValidationResponse } from 'shared/util/validateImageSrc';
 
 const getArticleNotifications = (
   id: string,

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -11,7 +11,6 @@ import GroupLevel from 'components/clipboard/GroupLevel';
 import CollectionItem from './CollectionComponents/CollectionItem';
 import ArticleFragmentLevel from 'components/clipboard/ArticleFragmentLevel';
 import { PosSpec, Move } from 'lib/dnd';
-import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { Dispatch } from 'types/Store';
 import {
   removeArticleFragment,

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -42,7 +42,6 @@ interface ContainerProps {
   getNodeProps: () => object;
   onSelect: (uuid: string) => void;
   onDelete: (uuid: string) => void;
-  onImageDrop?: (data: ValidationResponse) => void;
   parentId: string;
   displayType?: CollectionItemDisplayTypes;
   size?: 'small' | 'default';
@@ -76,9 +75,6 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
   };
 
   public handleDrop = (e: React.DragEvent<HTMLElement>) => {
-    if (!this.props.onImageDrop) {
-      return;
-    }
     e.preventDefault();
     e.persist();
 
@@ -91,7 +87,9 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
 
     // Our drag contains Grid data
     validateImageEvent(e, this.props.frontId, imageCriteria)
-      .then(this.props.onImageDrop)
+      .then(imageData =>
+        this.props.addImageToArticleFragment(this.props.uuid, imageData)
+      )
       .catch(err => {
         // swallowing errors here as the drop may well be an articleFragment
         // rather than an image which is expected - TBD

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -28,12 +28,13 @@ import {
 } from 'shared/util/validateImageSrc';
 import {
   articleFragmentImageCriteria as imageCriteria,
-  DRAG_COLLECTION_ITEM_IMAGE
+  DRAG_DATA_COLLECTION_ITEM_IMAGE
 } from 'constants/image';
 import Sublinks from './Sublinks';
 import { gridDropTypes } from 'constants/fronts';
+import { DragDataCollectionItemImage } from 'shared/components/article/DraggableArticleImageContainer';
 
-const imageDropTypes = [...gridDropTypes, DRAG_COLLECTION_ITEM_IMAGE];
+const imageDropTypes = [...gridDropTypes, DRAG_DATA_COLLECTION_ITEM_IMAGE];
 
 interface ContainerProps {
   uuid: string;
@@ -74,13 +75,18 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     }
   };
 
-  public handleDrop = (e: React.DragEvent<HTMLElement>) => {
+  public handleImageDrop = (e: React.DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.persist();
 
     // Our drag is a copy event, from another CollectionItem
-    const articleUuid = e.dataTransfer.getData(DRAG_COLLECTION_ITEM_IMAGE);
-    if (articleUuid) {
+    const collectionItemImageJson = e.dataTransfer.getData(
+      DRAG_DATA_COLLECTION_ITEM_IMAGE
+    );
+    if (collectionItemImageJson) {
+      const { id: articleUuid }: DragDataCollectionItemImage = JSON.parse(
+        collectionItemImageJson
+      );
       this.props.copyCollectionItemImageMeta(articleUuid, this.props.uuid);
       return;
     }
@@ -129,7 +135,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             size={size}
             displayType={displayType}
             imageDropTypes={imageDropTypes}
-            onImageDrop={this.handleDrop}
+            onImageDrop={this.handleImageDrop}
           >
             <Sublinks
               numSupportingArticles={numSupportingArticles}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -17,7 +17,8 @@ import {
 import SnapLink from 'shared/components/snapLink/SnapLink';
 import {
   cloneArticleFragmentToTarget,
-  copyArticleFragmentImageMetaWithPersist
+  copyArticleFragmentImageMetaWithPersist,
+  addImageToArticleFragment
 } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import { selectEditorArticleFragment } from 'bundles/frontsUIBundle';
@@ -54,6 +55,7 @@ type ArticleContainerProps = ContainerProps & {
     uuid: string
   ) => void;
   copyCollectionItemImageMeta: (from: string, to: string) => void;
+  addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   type: CollectionItemTypes;
   isSelected: boolean;
   externalArticleId: string | undefined;
@@ -95,7 +97,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
         // rather than an image which is expected - TBD
         // console.log('@todo:handle error', err);
       });
-  }
+  };
 
   public render() {
     const {
@@ -215,7 +217,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       dispatch(cloneArticleFragmentToTarget(uuid, 'clipboard'));
     },
     copyCollectionItemImageMeta: (from: string, to: string) =>
-      dispatch(copyArticleFragmentImageMetaWithPersist(from, to))
+      dispatch(copyArticleFragmentImageMetaWithPersist(from, to)),
+    addImageToArticleFragment: (id: string, response: ValidationResponse) =>
+      dispatch(addImageToArticleFragment(id, response))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -15,16 +15,24 @@ import {
   CollectionItemDisplayTypes
 } from 'shared/types/Collection';
 import SnapLink from 'shared/components/snapLink/SnapLink';
-import { cloneArticleFragmentToTarget } from 'actions/ArticleFragments';
+import {
+  cloneArticleFragmentToTarget,
+  copyArticleFragmentImageMetaWithPersist
+} from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import { selectEditorArticleFragment } from 'bundles/frontsUIBundle';
 import {
   validateImageEvent,
   ValidationResponse
 } from 'shared/util/validateImageSrc';
-import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
+import {
+  articleFragmentImageCriteria as imageCriteria,
+  DRAG_COLLECTION_ITEM_IMAGE
+} from 'constants/image';
 import Sublinks from './Sublinks';
 import { gridDropTypes } from 'constants/fronts';
+
+const imageDropTypes = [...gridDropTypes, DRAG_COLLECTION_ITEM_IMAGE];
 
 interface ContainerProps {
   uuid: string;
@@ -45,6 +53,7 @@ type ArticleContainerProps = ContainerProps & {
     externalArticleId: string | undefined,
     uuid: string
   ) => void;
+  copyCollectionItemImageMeta: (from: string, to: string) => void;
   type: CollectionItemTypes;
   isSelected: boolean;
   externalArticleId: string | undefined;
@@ -64,21 +73,28 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     }
   };
 
-  public getDropHandler(onDrop?: (data: ValidationResponse) => void) {
-    if (!onDrop) {
+  public handleDrop = (e: React.DragEvent<HTMLElement>) => {
+    if (!this.props.onImageDrop) {
       return;
     }
-    return (e: React.DragEvent<HTMLElement>) => {
-      e.preventDefault();
-      e.persist();
-      validateImageEvent(e, this.props.frontId, imageCriteria)
-        .then(onDrop)
-        .catch(err => {
-          // swallowing errors here as the drop may well be an articleFragment
-          // rather than an image which is expected - TBD
-          // console.log('@todo:handle error', err);
-        });
-    };
+    e.preventDefault();
+    e.persist();
+
+    // Our drag is a copy event, from another CollectionItem
+    const articleUuid = e.dataTransfer.getData(DRAG_COLLECTION_ITEM_IMAGE);
+    if (articleUuid) {
+      this.props.copyCollectionItemImageMeta(articleUuid, this.props.uuid);
+      return;
+    }
+
+    // Our drag contains Grid data
+    validateImageEvent(e, this.props.frontId, imageCriteria)
+      .then(this.props.onImageDrop)
+      .catch(err => {
+        // swallowing errors here as the drop may well be an articleFragment
+        // rather than an image which is expected - TBD
+        // console.log('@todo:handle error', err);
+      });
   }
 
   public render() {
@@ -112,8 +128,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
             fade={!isSelected}
             size={size}
             displayType={displayType}
-            imageDropTypes={gridDropTypes}
-            onImageDrop={this.getDropHandler(this.props.onImageDrop)}
+            imageDropTypes={imageDropTypes}
+            onImageDrop={this.handleDrop}
           >
             <Sublinks
               numSupportingArticles={numSupportingArticles}
@@ -197,7 +213,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
         return;
       }
       dispatch(cloneArticleFragmentToTarget(uuid, 'clipboard'));
-    }
+    },
+    copyCollectionItemImageMeta: (from: string, to: string) =>
+      dispatch(copyArticleFragmentImageMetaWithPersist(from, to))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -32,7 +32,6 @@ import {
 } from 'constants/image';
 import Sublinks from './Sublinks';
 import { gridDropTypes } from 'constants/fronts';
-import { DragDataCollectionItemImage } from 'shared/components/article/DraggableArticleImageContainer';
 
 const imageDropTypes = [...gridDropTypes, DRAG_DATA_COLLECTION_ITEM_IMAGE];
 
@@ -80,13 +79,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     e.persist();
 
     // Our drag is a copy event, from another CollectionItem
-    const collectionItemImageJson = e.dataTransfer.getData(
-      DRAG_DATA_COLLECTION_ITEM_IMAGE
-    );
-    if (collectionItemImageJson) {
-      const { id: articleUuid }: DragDataCollectionItemImage = JSON.parse(
-        collectionItemImageJson
-      );
+    const articleUuid = e.dataTransfer.getData(DRAG_DATA_COLLECTION_ITEM_IMAGE);
+    if (articleUuid) {
       this.props.copyCollectionItemImageMeta(articleUuid, this.props.uuid);
       return;
     }

--- a/client-v2/src/constants/fronts.ts
+++ b/client-v2/src/constants/fronts.ts
@@ -1,5 +1,8 @@
 import { Stages, CollectionItemSets } from 'shared/types/Collection';
-import { gridDataTransferTypes, DRAG_DATA_COLLECTION_ITEM_IMAGE } from './image';
+import {
+  gridDataTransferTypes,
+  DRAG_DATA_COLLECTION_ITEM_IMAGE
+} from './image';
 
 export const breakingNewsFrontId: string = 'breaking-news';
 

--- a/client-v2/src/constants/fronts.ts
+++ b/client-v2/src/constants/fronts.ts
@@ -1,5 +1,5 @@
 import { Stages, CollectionItemSets } from 'shared/types/Collection';
-import { gridDataTransferTypes, DRAG_COLLECTION_ITEM_IMAGE } from './image';
+import { gridDataTransferTypes, DRAG_DATA_COLLECTION_ITEM_IMAGE } from './image';
 
 export const breakingNewsFrontId: string = 'breaking-news';
 
@@ -32,7 +32,7 @@ export const gridDropTypes = Object.values(gridDataTransferTypes);
 
 export const collectionDropTypeBlacklist = [
   ...gridDropTypes,
-  DRAG_COLLECTION_ITEM_IMAGE
+  DRAG_DATA_COLLECTION_ITEM_IMAGE
 ];
 
 export const detectPressFailureMs = 10000;

--- a/client-v2/src/constants/image.ts
+++ b/client-v2/src/constants/image.ts
@@ -10,4 +10,4 @@ export const gridDataTransferTypes = {
   imageData: 'application/vnd.mediaservice.image+json'
 };
 
-export const DRAG_COLLECTION_ITEM_IMAGE = '@@drag_collection_item_image@@';
+export const DRAG_DATA_COLLECTION_ITEM_IMAGE = '@@drag_collection_item_image@@';

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -22,11 +22,23 @@ import {
 } from 'shared/types/Collection';
 import { getPillarColor } from 'shared/util/getPillarColor';
 import DragIntentContainer from '../DragIntentContainer';
+import { theme as globalTheme } from 'shared/constants/theme';
+
+const DragIntentIndicator = styled.div`
+  display: none;
+  position: absolute;
+  height: 10px;
+  bottom: 0;
+  width: 100%;
+  background-color: ${globalTheme.colors.orange};
+`;
 
 const ArticleBodyContainer = styled(CollectionItemBody)<{
   pillarId: string | undefined;
   isLive: boolean;
+  isDraggingImageOver: boolean;
 }>`
+  position: relative;
   border-top-color: ${({ size, pillarId, isLive, theme }) =>
     size === 'default' && pillarId && isLive
       ? getPillarColor(pillarId, isLive)
@@ -36,6 +48,9 @@ const ArticleBodyContainer = styled(CollectionItemBody)<{
     ${CollectionItemMetaHeading} {
       color: ${({ theme }) => theme.shared.base.colors.textMuted};
     }
+  }
+  ${DragIntentIndicator} {
+    ${({ isDraggingImageOver }) => isDraggingImageOver && `display: block;`}
   }
   height: 100%;
 `;
@@ -75,13 +90,17 @@ const articleBodyComponentMap: {
   polaroid: ArticleBodyPolaroid
 };
 
-class ArticleComponent extends React.Component<ComponentProps> {
+interface ComponentState {
+  isDraggingImageOver: boolean;
+}
+
+class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
   public state = {
-    isHoveredWithImage: false
+    isDraggingImageOver: false
   };
 
-  public setIsHovered = (isHoveredWithImage: boolean) =>
-    this.setState({ isHoveredWithImage });
+  public setIsHovered = (isDraggingImageOver: boolean) =>
+    this.setState({ isDraggingImageOver });
 
   public render() {
     const {
@@ -145,16 +164,12 @@ class ArticleComponent extends React.Component<ComponentProps> {
         >
           <ArticleBodyContainer
             data-testid="article-body"
-            style={{
-              boxShadow: this.state.isHoveredWithImage
-                ? 'inset 0 0 0 1px orange'
-                : 'none'
-            }}
             size={size}
             fade={fade}
             displayType={displayType}
             pillarId={article && article.pillarId}
             isLive={!!article && article.isLive}
+            isDraggingImageOver={this.state.isDraggingImageOver}
           >
             <ArticleBody
               {...getArticleData()}
@@ -164,6 +179,7 @@ class ArticleComponent extends React.Component<ComponentProps> {
               onAddToClipboard={onAddToClipboard}
               displayPlaceholders={isLoading}
             />
+            <DragIntentIndicator />
           </ArticleBodyContainer>
         </DragIntentContainer>
         {children}

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { styled } from 'shared/constants/theme';
 import startCase from 'lodash/startCase';
 import distanceInWordsStrict from 'date-fns/distance_in_words_strict';
-import { MdCollections } from 'react-icons/md';
+import { MdCollections, MdImage } from 'react-icons/md';
 
 import CollectionItemHeading from '../collectionItem/CollectionItemHeading';
 import BasePlaceholder from '../BasePlaceholder';
@@ -57,7 +57,7 @@ const ArticleBodyQuoteContainer = styled('span')`
   margin-right: 0.1rem;
 `;
 
-const ArticleSlideshow = styled('div')`
+const ImageOverrideContainer = styled('div')`
   position: absolute;
   background: ${({ theme }) => theme.shared.colors.white};
   width: 24px;
@@ -69,7 +69,7 @@ const ArticleSlideshow = styled('div')`
   right: 2px;
 `;
 
-const SlideshowIcon = styled('div')`
+const ImageOverrideIcon = styled('div')`
   position: absolute;
   top: 4px;
   left: 4px;
@@ -103,6 +103,7 @@ interface ArticleBodyProps {
   showQuotedHeadline?: boolean;
   imageHide?: boolean;
   imageSlideshowReplace?: boolean;
+  imageReplace?: boolean;
   isBreaking?: boolean;
   type?: string;
 }
@@ -143,6 +144,7 @@ const articleBodyDefault = ({
   showQuotedHeadline,
   imageHide,
   imageSlideshowReplace,
+  imageReplace,
   isBreaking,
   type,
   uuid
@@ -226,11 +228,18 @@ const articleBodyDefault = ({
         ) : (
           <DraggableArticleImageContainer id={uuid}>
             {imageSlideshowReplace && (
-              <ArticleSlideshow>
-                <SlideshowIcon>
+              <ImageOverrideContainer title="This article has a slideshow override">
+                <ImageOverrideIcon>
                   <MdCollections />
-                </SlideshowIcon>
-              </ArticleSlideshow>
+                </ImageOverrideIcon>
+              </ImageOverrideContainer>
+            )}
+            {imageReplace && (
+              <ImageOverrideContainer title="This article has an image override">
+                <ImageOverrideIcon>
+                  <MdImage />
+                </ImageOverrideIcon>
+              </ImageOverrideContainer>
             )}
             <ThumbnailSmall
               style={{

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -7,7 +7,13 @@ import {
   selectCollectionItemHasMediaOverrides
 } from 'shared/selectors/shared';
 import imageDragIcon from 'images/icons/image-drag-icon.svg';
-import { DRAG_COLLECTION_ITEM_IMAGE } from 'constants/image';
+import { DRAG_DATA_COLLECTION_ITEM_IMAGE } from 'constants/image';
+import { createSelectActiveImageUrl } from 'shared/selectors/collectionItem';
+
+export interface DragDataCollectionItemImage {
+  id: string;
+  imageUrl: string;
+}
 
 interface ContainerProps {
   id: string;
@@ -15,6 +21,7 @@ interface ContainerProps {
 
 interface ComponentProps extends ContainerProps {
   canDrag: boolean;
+  activeImageUrl: string | undefined;
 }
 
 const DragIntentContainer = styled.div<{
@@ -51,14 +58,27 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
 
   private handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    e.dataTransfer.setData(DRAG_COLLECTION_ITEM_IMAGE, this.props.id);
+    e.dataTransfer.setData(
+      DRAG_DATA_COLLECTION_ITEM_IMAGE,
+      JSON.stringify({
+        id: this.props.id,
+        imageUrl: this.props.activeImageUrl
+      })
+    );
     e.dataTransfer.setDragImage(dragImage, -25, 50);
     this.setState({ isDragging: true });
   };
 }
 
-const mapStateToProps = (state: State, { id }: ContainerProps) => ({
-  canDrag: selectCollectionItemHasMediaOverrides(selectSharedState(state), id)
-});
+const mapStateToProps = () => {
+  const selectActiveImageUrl = createSelectActiveImageUrl();
+  return (state: State, { id }: ContainerProps) => ({
+    canDrag: selectCollectionItemHasMediaOverrides(
+      selectSharedState(state),
+      id
+    ),
+    activeImageUrl: selectActiveImageUrl(selectSharedState(state), id)
+  });
+};
 
 export default connect(mapStateToProps)(DraggableArticleImageContainer);

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -8,12 +8,6 @@ import {
 } from 'shared/selectors/shared';
 import imageDragIcon from 'images/icons/image-drag-icon.svg';
 import { DRAG_DATA_COLLECTION_ITEM_IMAGE } from 'constants/image';
-import { createSelectActiveImageUrl } from 'shared/selectors/collectionItem';
-
-export interface DragDataCollectionItemImage {
-  id: string;
-  imageUrl: string;
-}
 
 interface ContainerProps {
   id: string;
@@ -21,7 +15,6 @@ interface ContainerProps {
 
 interface ComponentProps extends ContainerProps {
   canDrag: boolean;
-  activeImageUrl: string | undefined;
 }
 
 const DragIntentContainer = styled.div<{
@@ -58,27 +51,14 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
 
   private handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    e.dataTransfer.setData(
-      DRAG_DATA_COLLECTION_ITEM_IMAGE,
-      JSON.stringify({
-        id: this.props.id,
-        imageUrl: this.props.activeImageUrl
-      })
-    );
+    e.dataTransfer.setData(DRAG_DATA_COLLECTION_ITEM_IMAGE, this.props.id);
     e.dataTransfer.setDragImage(dragImage, -25, 50);
     this.setState({ isDragging: true });
   };
 }
 
-const mapStateToProps = () => {
-  const selectActiveImageUrl = createSelectActiveImageUrl();
-  return (state: State, { id }: ContainerProps) => ({
-    canDrag: selectCollectionItemHasMediaOverrides(
-      selectSharedState(state),
-      id
-    ),
-    activeImageUrl: selectActiveImageUrl(selectSharedState(state), id)
-  });
-};
+const mapStateToProps = (state: State, { id }: ContainerProps) => ({
+  canDrag: selectCollectionItemHasMediaOverrides(selectSharedState(state), id)
+});
 
 export default connect(mapStateToProps)(DraggableArticleImageContainer);

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { styled } from 'shared/constants/theme';
 import { connect } from 'react-redux';
-import { Dispatch } from 'types/Store';
 import { State } from 'types/State';
 import {
   selectSharedState,
   selectCollectionItemHasMediaOverrides
 } from 'shared/selectors/shared';
 import imageDragIcon from 'images/icons/image-drag-icon.svg';
-import { theme } from 'constants/theme';
-import { copyArticleFragmentImageMetaWithPersist } from 'actions/ArticleFragments';
 import { DRAG_COLLECTION_ITEM_IMAGE } from 'constants/image';
 
 interface ContainerProps {
@@ -17,54 +14,24 @@ interface ContainerProps {
 }
 
 interface ComponentProps extends ContainerProps {
-  copyCollectionItemImageMeta: (from: string, to: string) => void;
   canDrag: boolean;
 }
 
-const DragIntentIndicator = styled.div`
-  display: none;
-  position: absolute;
-  height: 10px;
-  bottom: 0;
-  width: 100%;
-  background-color: ${theme.shared.colors.orange};
-`;
 const DragIntentContainer = styled.div<{
-  isDraggingOver: boolean;
-  isDragging: boolean;
   canDrag: boolean;
 }>`
   position: relative;
-  ${DragIntentIndicator} {
-    ${({ isDraggingOver }) => isDraggingOver && `display: block;`}
-  }
   ${({ canDrag }) =>
     canDrag &&
     `&:hover {
     opacity: 0.6;
   }`};
-  ${({ isDragging }) => isDragging && `opacity: 0.6;`};
 `;
-
-interface ComponentState {
-  isDraggingOver: boolean;
-  isDragging: boolean;
-}
 
 const dragImage = new Image();
 dragImage.src = imageDragIcon;
 
-const initialState = {
-  isDraggingOver: false,
-  isDragging: false
-};
-
-class DraggableArticleImageContainer extends React.Component<
-  ComponentProps,
-  ComponentState
-> {
-  public state = initialState;
-
+class DraggableArticleImageContainer extends React.Component<ComponentProps> {
   constructor(props: ComponentProps) {
     super(props);
   }
@@ -74,18 +41,10 @@ class DraggableArticleImageContainer extends React.Component<
       <DragIntentContainer
         draggable={this.props.canDrag}
         onDragStart={this.handleDragStart}
-        onDragEnd={this.handleDragEnd}
-        onDragEnter={this.handleDragEnter}
-        onDragOver={this.handleDragOver}
-        onDragLeave={this.handleDragLeave}
-        onDrop={this.handleDrop}
-        isDraggingOver={this.state.isDraggingOver}
         canDrag={this.props.canDrag}
-        isDragging={this.state.isDragging}
         title="Drag this media to add it to other articles"
       >
         {children}
-        <DragIntentIndicator />
       </DragIntentContainer>
     );
   }
@@ -96,54 +55,10 @@ class DraggableArticleImageContainer extends React.Component<
     e.dataTransfer.setDragImage(dragImage, -25, 50);
     this.setState({ isDragging: true });
   };
-
-  private handleDragEnd = () => this.setState({ isDragging: false });
-
-  private handleDragEnter = (e: React.DragEvent<HTMLDivElement>) =>
-    e.preventDefault();
-
-  private handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    if (
-      e.dataTransfer.types.includes(DRAG_COLLECTION_ITEM_IMAGE) &&
-      !this.state.isDragging &&
-      !this.state.isDraggingOver
-    ) {
-      this.setState({ isDraggingOver: true });
-    }
-  };
-
-  private handleDragLeave = () => {
-    if (this.state.isDraggingOver) {
-      this.setState({ isDraggingOver: false });
-    }
-  };
-
-  private handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    if (this.state.isDragging) {
-      return;
-    }
-    const articleUuid = e.dataTransfer.getData(DRAG_COLLECTION_ITEM_IMAGE);
-    if (!articleUuid) {
-      return;
-    }
-    this.props.copyCollectionItemImageMeta(articleUuid, this.props.id);
-    this.resetDragState();
-  };
-
-  private resetDragState = () => this.setState(initialState);
 }
 
 const mapStateToProps = (state: State, { id }: ContainerProps) => ({
   canDrag: selectCollectionItemHasMediaOverrides(selectSharedState(state), id)
 });
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  copyCollectionItemImageMeta: (from: string, to: string) =>
-    dispatch(copyArticleFragmentImageMetaWithPersist(from, to))
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DraggableArticleImageContainer);
+export default connect(mapStateToProps)(DraggableArticleImageContainer);

--- a/client-v2/src/shared/selectors/collectionItem.ts
+++ b/client-v2/src/shared/selectors/collectionItem.ts
@@ -1,5 +1,8 @@
 import { createSelector } from 'reselect';
-import { articleFragmentSelector } from './shared';
+import {
+  articleFragmentSelector,
+  externalArticleFromArticleFragmentSelector
+} from './shared';
 import { validateId } from 'shared/util/snap';
 import CollectionItemTypes from 'shared/constants/collectionItemTypes';
 
@@ -13,4 +16,31 @@ const createCollectionItemTypeSelector = () =>
     }
   );
 
-export { createCollectionItemTypeSelector };
+const createSelectActiveImageUrl = () =>
+  createSelector(
+    articleFragmentSelector,
+    externalArticleFromArticleFragmentSelector,
+    (articleFragment, externalArticle): string | undefined => {
+      if (!articleFragment || !articleFragment.meta) {
+        return;
+      }
+      if (articleFragment.meta.imageReplace) {
+        return articleFragment.meta.imageSrc;
+      }
+      if (articleFragment.meta.imageCutoutReplace) {
+        return articleFragment.meta.imageCutoutSrc;
+      }
+      if (articleFragment.meta.imageSlideshowReplace) {
+        return (
+          articleFragment.meta.slideshow &&
+          articleFragment.meta.slideshow[0] &&
+          articleFragment.meta.slideshow[0].src
+        );
+      }
+      return externalArticle && externalArticle.fields.thumbnail
+        ? externalArticle.fields.thumbnail
+        : undefined;
+    }
+  );
+
+export { createCollectionItemTypeSelector, createSelectActiveImageUrl };

--- a/client-v2/src/shared/selectors/collectionItem.ts
+++ b/client-v2/src/shared/selectors/collectionItem.ts
@@ -1,8 +1,5 @@
 import { createSelector } from 'reselect';
-import {
-  articleFragmentSelector,
-  externalArticleFromArticleFragmentSelector
-} from './shared';
+import { articleFragmentSelector } from './shared';
 import { validateId } from 'shared/util/snap';
 import CollectionItemTypes from 'shared/constants/collectionItemTypes';
 
@@ -16,31 +13,4 @@ const createCollectionItemTypeSelector = () =>
     }
   );
 
-const createSelectActiveImageUrl = () =>
-  createSelector(
-    articleFragmentSelector,
-    externalArticleFromArticleFragmentSelector,
-    (articleFragment, externalArticle): string | undefined => {
-      if (!articleFragment || !articleFragment.meta) {
-        return;
-      }
-      if (articleFragment.meta.imageReplace) {
-        return articleFragment.meta.imageSrc;
-      }
-      if (articleFragment.meta.imageCutoutReplace) {
-        return articleFragment.meta.imageCutoutSrc;
-      }
-      if (articleFragment.meta.imageSlideshowReplace) {
-        return (
-          articleFragment.meta.slideshow &&
-          articleFragment.meta.slideshow[0] &&
-          articleFragment.meta.slideshow[0].src
-        );
-      }
-      return externalArticle && externalArticle.fields.thumbnail
-        ? externalArticle.fields.thumbnail
-        : undefined;
-    }
-  );
-
-export { createCollectionItemTypeSelector, createSelectActiveImageUrl };
+export { createCollectionItemTypeSelector };


### PR DESCRIPTION
## What's changed?

Image dropping for collection items is now always handled by the CollectionItem, whether the image is coming from the Grid or another CollectionItem. This means a larger drag target and simpler code 👍 

![drag2](https://user-images.githubusercontent.com/7767575/57642568-899cec00-75af-11e9-9ff4-870e62e00220.gif)

## Implementation notes

I renamed a few bits and pieces to better indicate what we're aiming at here -- hopefully that's to the good, comments welcome!

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
