### PR TITLE
Add TTI to GA

### DIFF
--- a/client-v2/modules.d.ts
+++ b/client-v2/modules.d.ts
@@ -35,3 +35,7 @@ declare module 'normalise-with-fields' {
   export const createFieldType: any;
 }
 
+declare module 'tti-polyfill' {
+  const content: any;
+  export default content;
+}

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -128,6 +128,7 @@
     "shallowequal": "^1.1.0",
     "styled-components": "^3.2.5",
     "ts-optchain": "^0.1.2",
+    "tti-polyfill": "^0.2.2",
     "uuid": "^3.2.1"
   }
 }

--- a/client-v2/src/index.tsx
+++ b/client-v2/src/index.tsx
@@ -1,3 +1,4 @@
+import './util/tti';
 import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -75,4 +75,4 @@ const events = {
     })
 };
 
-export { init, events };
+export { init, events, gtag };

--- a/client-v2/src/util/tti.ts
+++ b/client-v2/src/util/tti.ts
@@ -1,0 +1,11 @@
+import ttiPolyfill from 'tti-polyfill';
+import { gtag } from 'services/GA';
+
+ttiPolyfill.getFirstConsistentlyInteractive().then((tti: any) => {
+  gtag('send', 'event', {
+    eventCategory: 'Performance Metrics',
+    eventAction: 'TTI',
+    eventValue: tti,
+    nonInteraction: true
+  });
+});

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -9899,6 +9899,11 @@ tsutils@^2.27.2:
   dependencies:
     tslib "^1.8.1"
 
+tti-polyfill@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/tti-polyfill/-/tti-polyfill-0.2.2.tgz#f7bbf71b13afa9edf60c8bb0d0c05f134e1513b9"
+  integrity sha512-URIoJxvsHThbQEJij29hIBUDHx9UNoBBCQVjy7L8PnzkqY8N6lsAI6h8JrT1Wt2lA0avus/DkuiJxd9qpfCpqw==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"


### PR DESCRIPTION
## What's changed?

Adds a Google Analytics event for TTI. Note this only works on Chrome at present as it seems no other browsers currently expose any form of API to get a meaningful API number.

## Implementation notes

As per usual, I'm not quite sure how this will look in GA but the best way to test is in PROD right?!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
