### PR TITLE
[FIX]: Don't remove additional meta when replacing image data on drop

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -383,7 +383,7 @@ const addImageToArticleFragment = (
       imageCutoutReplace: false,
       imageSlideshowReplace: false
     },
-    true
+    { merge: true }
   );
 
 export {

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -375,12 +375,16 @@ const addImageToArticleFragment = (
   uuid: string,
   imageData: ValidationResponse
 ) =>
-  updateArticleFragmentMeta(uuid, {
-    ...getImageMetaFromValidationResponse(imageData),
-    imageReplace: true,
-    imageCutoutReplace: false,
-    imageSlideshowReplace: false
-  });
+  updateArticleFragmentMeta(
+    uuid,
+    {
+      ...getImageMetaFromValidationResponse(imageData),
+      imageReplace: true,
+      imageCutoutReplace: false,
+      imageSlideshowReplace: false
+    },
+    true
+  );
 
 export {
   insertArticleFragmentWithCreate as insertArticleFragment,

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -375,7 +375,7 @@ const addImageToArticleFragment = (
   uuid: string,
   imageData: ValidationResponse
 ) =>
-  updateArticleFragmentMeta(
+  updateArticleFragmentMetaWithPersist(
     uuid,
     {
       ...getImageMetaFromValidationResponse(imageData),

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -36,13 +36,15 @@ export const COPY_ARTICLE_FRAGMENT_IMAGE_META =
 
 function updateArticleFragmentMeta(
   id: string,
-  meta: ArticleFragmentMeta
+  meta: ArticleFragmentMeta,
+  mergeWithCurrentMeta: boolean = false
 ): UpdateArticleFragmentMeta {
   return {
     type: UPDATE_ARTICLE_FRAGMENT_META,
     payload: {
       id,
-      meta
+      meta,
+      mergeWithCurrentMeta
     }
   };
 }

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -37,14 +37,14 @@ export const COPY_ARTICLE_FRAGMENT_IMAGE_META =
 function updateArticleFragmentMeta(
   id: string,
   meta: ArticleFragmentMeta,
-  mergeWithCurrentMeta: boolean = false
+  { merge }: { merge: boolean } = { merge: false }
 ): UpdateArticleFragmentMeta {
   return {
     type: UPDATE_ARTICLE_FRAGMENT_META,
     payload: {
       id,
       meta,
-      mergeWithCurrentMeta
+      merge
     }
   };
 }

--- a/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
+++ b/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
@@ -29,4 +29,22 @@ describe('articleFragmentsReducer', () => {
       headline: 'headline'
     });
   });
+  it('should merge properties if the merge flag is set', () => {
+    expect(
+      reducer(
+        stateWithClipboard.shared.articleFragments as any,
+        updateArticleFragmentMeta(
+          'article2',
+          {
+            headline: 'headline'
+          },
+          true
+        ),
+        stateWithClipboard.shared
+      ).article2.meta
+    ).toEqual({
+      headline: 'headline',
+      supporting: ['article3']
+    });
+  });
 });

--- a/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
+++ b/client-v2/src/shared/reducers/__tests__/articleFragmentsReducer.spec.ts
@@ -38,7 +38,7 @@ describe('articleFragmentsReducer', () => {
           {
             headline: 'headline'
           },
-          true
+          { merge: true }
         ),
         stateWithClipboard.shared
       ).article2.meta

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -24,7 +24,7 @@ const articleFragments = (
         ...state,
         [id]: {
           ...state[id],
-          meta: action.payload.mergeWithCurrentMeta
+          meta: action.payload.merge
             ? { ...(state[id].meta || {}), ...action.payload.meta }
             : action.payload.meta
         }

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -24,7 +24,9 @@ const articleFragments = (
         ...state,
         [id]: {
           ...state[id],
-          meta: action.payload.meta
+          meta: action.payload.mergeWithCurrentMeta
+            ? { ...(state[id].meta || {}), ...action.payload.meta }
+            : action.payload.meta
         }
       };
     }

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -25,7 +25,7 @@ interface UpdateArticleFragmentMeta {
   payload: {
     id: string;
     meta: ArticleFragmentMeta;
-    mergeWithCurrentMeta: boolean;
+    merge: boolean;
   };
 }
 

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -22,7 +22,11 @@ interface GroupsReceived {
 }
 interface UpdateArticleFragmentMeta {
   type: 'SHARED/UPDATE_ARTICLE_FRAGMENT_META';
-  payload: { id: string; meta: ArticleFragmentMeta };
+  payload: {
+    id: string;
+    meta: ArticleFragmentMeta;
+    mergeWithCurrentMeta: boolean;
+  };
 }
 
 interface InsertArticleFragmentPayload {


### PR DESCRIPTION
## What's changed?

At the moment, dropping an image into a collection item stomps on other article meta, which is bad and wrong. This PR should fix this issue.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
