### PR TITLE
Nb mss 715 upgrade notifications client

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -91,7 +91,8 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
       },
       importance = parseImportance(trail.group),
       topic =  parseTopic(trail.topic),
-      debug = false
+      debug = false,
+      dryRun = Some(false)
     )
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.gu" %% "fapi-client-play26" % "3.0.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "mobile-notifications-client" % "1.5",
+    "com.gu" %% "mobile-notifications-client" % "1.6",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",
 
     "com.gu" %% "scanamo" % "1.0.0-M7",


### PR DESCRIPTION
## What's changed?

Upgrades the mobile-notifications-service. This is to incorporate this change here: https://github.com/guardian/mobile-n10n/pull/410 which sends breaking news alerts as sequential futures. This is to ensure  that they reach the UK audience first

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [not relevant ] 🤖 Relevant tests added
- [tick ] ✅ CI checks / tests run locally
- [ tick] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
