### PR TITLE
Create edition templates

### DIFF
--- a/app/editions/EditionTemplates.scala
+++ b/app/editions/EditionTemplates.scala
@@ -44,6 +44,17 @@ case class FrontTemplate(
   hidden: Boolean = false
 )
 
+case class EditionTemplate(
+  name: String,
+  fronts: List[(FrontTemplate, Periodicity)],
+  availability: Periodicity
+)
+case class EditionTemplateForDate(
+  name: String,
+  fronts: List[FrontTemplate],
+  availability: Periodicity
+)
+
 
 // ??? Is this how we want to model collections??
 object Sport {
@@ -73,14 +84,24 @@ object Fronts {
 }
 
 object DailyEdition {
-  val dailyEdition: List[(Front, Periodicity)] =
+  val dailyEdition: EditionTemplate = EditionTemplate(
+    "dailyEdition",
     List(
-      (Fronts.ukNews, Daily),
-      (Fronts.sports, Daily),
+      (Fronts.ukNews, Daily()),
+      (Fronts.sports, Daily()),
       (Fronts.opinion, WeekDays(List(Thurs, Wed))),
       (Fronts.technology, WeekDays(List(Thurs)))
-    )
+    ),
+    Daily()
+  )
 }
 
+object EditionTemplateHelpers {
+  def generateEditionTemplate(date: LocalDate, edition: EditionTemplate): EditionTemplateForDate = {
+
+    EditionTemplateForDate("template", List(), Daily())
+  }
+
+}
 
 

--- a/app/editions/EditionTemplates.scala
+++ b/app/editions/EditionTemplates.scala
@@ -8,7 +8,6 @@ object WeekDay extends Enumeration(0) {
   type WeekDay = Value
   val Mon, Tues, Wed, Thurs, Fri, Sat, Sun = Value
   implicit def WeekDayToInt(weekDay: WeekDay): Int = weekDay.id
-  implicit def IntToWeekDay(int: Int): WeekDay = WeekDay(int)
 }
 
 case class FrontPresentation()

--- a/app/editions/EditionTemplates.scala
+++ b/app/editions/EditionTemplates.scala
@@ -1,0 +1,86 @@
+package editions
+
+import java.time.LocalDate
+
+object WeekDay extends Enumeration(0) {
+
+  implicit lazy val implicitConversions = scala.language.implicitConversions
+
+  type WeekDay = Value
+  val Mon, Tues, Wed, Thurs, Fri, Sat, Sun = Value
+  implicit def WeekDayToInt(weekDay: WeekDay): Int = weekDay.id
+  implicit def IntToWeekDay(int: Int): WeekDay = WeekDay(int)
+  //def LocalDateToWeekday: WeekDay = ???
+}
+
+/*
+ * Things we want to model
+ * 1. what the collection template looks like
+ * 2. what the front template looks like
+ * 3. what the daily edition template as a whole looks like
+*/
+
+case class FrontPresentation()
+case class CollectionPresentation()
+
+case class CapiQuery(query: String) extends AnyVal
+
+import WeekDay._
+trait Periodicity
+case class Daily() extends Periodicity
+case class WeekDays(days: List[WeekDay]) extends Periodicity
+
+case class CollectionTemplate(
+  name: String,
+  prefill: CapiQuery,
+  presentation: CollectionPresentation,
+  hidden: Boolean = false
+)
+
+case class FrontTemplate(
+  name: String,
+  collections: List[CollectionTemplate],
+  presentation: FrontPresentation,
+  hidden: Boolean = false
+)
+
+
+// ??? Is this how we want to model collections??
+object Sport {
+  val emptyCollectionPresentation = CollectionPresentation()
+  val football: CollectionTemplate = new CollectionTemplate("Football", CapiQuery("???"), emptyCollectionPresentation)
+  val cricket: CollectionTemplate = new CollectionTemplate("Cricket", CapiQuery("???"), emptyCollectionPresentation)
+}
+
+object Fronts {
+  val emptyFrontPresentation = FrontPresentation()
+  val ukNews: FrontTemplate = FrontTemplate("UK news", List(), emptyFrontPresentation)
+  val sports: FrontTemplate = FrontTemplate(
+    "Sport",
+    List(
+      Sport.football,
+      Sport.cricket,
+    ),
+    emptyFrontPresentation
+  )
+  val technology: FrontTemplate = FrontTemplate(
+    "Technology",
+    List(),
+    emptyFrontPresentation
+  )
+
+  val opinion: FrontTemplate = FrontTemplate("Opinion", List(), emptyFrontPresentation)
+}
+
+object DailyEdition {
+  val dailyEdition: List[(Front, Periodicity)] =
+    List(
+      (Fronts.ukNews, Daily),
+      (Fronts.sports, Daily),
+      (Fronts.opinion, WeekDays(List(Thurs, Wed))),
+      (Fronts.technology, WeekDays(List(Thurs)))
+    )
+}
+
+
+

--- a/app/editions/EditionTemplates.scala
+++ b/app/editions/EditionTemplates.scala
@@ -9,7 +9,6 @@ object WeekDay extends Enumeration(0) {
   val Mon, Tues, Wed, Thurs, Fri, Sat, Sun = Value
   implicit def WeekDayToInt(weekDay: WeekDay): Int = weekDay.id
   implicit def IntToWeekDay(int: Int): WeekDay = WeekDay(int)
-  //def LocalDateToWeekday: WeekDay = ???
 }
 
 case class FrontPresentation()
@@ -52,47 +51,6 @@ case class EditionTemplateForDate(
   name: String,
   fronts: List[FrontTemplate],
 )
-
-
-// ??? Is this how we want to model collections??
-object Sport {
-  val emptyCollectionPresentation = CollectionPresentation()
-  val football: CollectionTemplate = new CollectionTemplate("Football", CapiQuery("???"), emptyCollectionPresentation)
-  val cricket: CollectionTemplate = new CollectionTemplate("Cricket", CapiQuery("???"), emptyCollectionPresentation)
-}
-
-object Fronts {
-  val emptyFrontPresentation = FrontPresentation()
-  val ukNews: FrontTemplate = FrontTemplate("UK news", List(), emptyFrontPresentation)
-  val sports: FrontTemplate = FrontTemplate(
-    "Sport",
-    List(
-      Sport.football,
-      Sport.cricket,
-    ),
-    emptyFrontPresentation
-  )
-  val technology: FrontTemplate = FrontTemplate(
-    "Technology",
-    List(),
-    emptyFrontPresentation
-  )
-
-  val opinion: FrontTemplate = FrontTemplate("Opinion", List(), emptyFrontPresentation)
-}
-
-object DailyEdition {
-  val dailyEdition: EditionTemplate = EditionTemplate(
-    "dailyEdition",
-    List(
-      (Fronts.ukNews, Daily()),
-      (Fronts.sports, Daily()),
-      (Fronts.opinion, WeekDays(List(Thurs, Wed))),
-      (Fronts.technology, WeekDays(List(Thurs)))
-    ),
-    Daily()
-  )
-}
 
 object EditionTemplateHelpers {
   def generateEditionTemplate(date: DateTime, edition: EditionTemplate): Option[EditionTemplateForDate] = {

--- a/app/editions/EditionTemplates.scala
+++ b/app/editions/EditionTemplates.scala
@@ -1,7 +1,8 @@
 package editions
 import org.joda.time.DateTime
 
-object WeekDay extends Enumeration(0) {
+
+object WeekDay extends Enumeration(1) {
 
   implicit lazy val implicitConversions = scala.language.implicitConversions
 

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -7,15 +7,28 @@ class editionTemplateTest extends FreeSpec with Matchers {
 
   "createEdition" - {
     "should return Monday's content for Monday" in {
-      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-11"), DailyEdition.dailyEdition).get.fronts.length should be (2)
+      val editionTemplateFronts = EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-11"), DailyEdition.dailyEdition).get.fronts
+      println(editionTemplateFronts(1))
+      editionTemplateFronts.length should be (2)
+      editionTemplateFronts(0) should matchPattern { case FrontTemplate("UK news", _, _, _) => }
+      editionTemplateFronts(1) should matchPattern { case FrontTemplate("Sport", _, _, _) => }
     }
 
     "should return Wednesday's content for Wednesday" in {
-      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-13"), DailyEdition.dailyEdition).get.fronts.length should be (3)
+      val editionTemplateFronts = EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-13"), DailyEdition.dailyEdition).get.fronts
+      editionTemplateFronts.length should be (3)
+      editionTemplateFronts(0) should matchPattern { case FrontTemplate("UK news", _, _, _) => }
+      editionTemplateFronts(1) should matchPattern { case FrontTemplate("Sport", _, _, _) => }
+      editionTemplateFronts(2) should matchPattern { case FrontTemplate("Opinion", _, _, _) => }
     }
 
     "should return Thursday's content for Thursday" in {
-      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-14"), DailyEdition.dailyEdition).get.fronts.length should be (4)
+      val editionTemplateFronts = EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-14"), DailyEdition.dailyEdition).get.fronts
+      editionTemplateFronts.length should be (4)
+      editionTemplateFronts(0) should matchPattern { case FrontTemplate("UK news", _, _, _) => }
+      editionTemplateFronts(2) should matchPattern { case FrontTemplate("Opinion", _, _, _) => }
+      editionTemplateFronts(1) should matchPattern { case FrontTemplate("Sport", _, _, _) => }
+      editionTemplateFronts(3) should matchPattern { case FrontTemplate("Technology", _, _, _) => }
     }
   }
 }

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -7,30 +7,15 @@ class editionTemplateTest extends FreeSpec with Matchers {
 
   "createEdition" - {
     "should return Monday's content for Monday" in {
-      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-12"), DailyEdition.dailyEdition) should be
-      Some(
-        EditionTemplateForDate("dailyEdition",
-          List(Fronts.ukNews, Fronts.sports)
-        )
-      )
+      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-11"), DailyEdition.dailyEdition).get.fronts.length should be (2)
     }
 
     "should return Wednesday's content for Wednesday" in {
-      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-13"), DailyEdition.dailyEdition) should be
-      Some(
-        EditionTemplateForDate("dailyEdition",
-          List(Fronts.ukNews, Fronts.sports, Fronts.opinion)
-        )
-      )
+      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-13"), DailyEdition.dailyEdition).get.fronts.length should be (3)
     }
 
     "should return Thursday's content for Thursday" in {
-      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-14"), DailyEdition.dailyEdition) should be
-      Some(
-        EditionTemplateForDate("dailyEdition",
-          List(Fronts.ukNews, Fronts.sports, Fronts.opinion)
-        )
-      )
+      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-14"), DailyEdition.dailyEdition).get.fronts.length should be (4)
     }
   }
 }

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -1,0 +1,36 @@
+package editions
+
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+
+class editionTemplateTest extends FreeSpec with Matchers {
+
+  "createEdition" - {
+    "should return Monday's content for Monday" in {
+      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-12"), DailyEdition.dailyEdition) should be
+      Some(
+        EditionTemplateForDate("dailyEdition",
+          List(Fronts.ukNews, Fronts.sports)
+        )
+      )
+    }
+
+    "should return Wednesday's content for Wednesday" in {
+      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-13"), DailyEdition.dailyEdition) should be
+      Some(
+        EditionTemplateForDate("dailyEdition",
+          List(Fronts.ukNews, Fronts.sports, Fronts.opinion)
+        )
+      )
+    }
+
+    "should return Thursday's content for Thursday" in {
+      EditionTemplateHelpers.generateEditionTemplate(DateTime.parse("2019-03-14"), DailyEdition.dailyEdition) should be
+      Some(
+        EditionTemplateForDate("dailyEdition",
+          List(Fronts.ukNews, Fronts.sports, Fronts.opinion)
+        )
+      )
+    }
+  }
+}

--- a/test/editions/fixtures/TestEdition.scala
+++ b/test/editions/fixtures/TestEdition.scala
@@ -1,0 +1,43 @@
+package editions
+
+import WeekDay._
+
+object Sport {
+  val emptyCollectionPresentation = CollectionPresentation()
+  val football: CollectionTemplate = new CollectionTemplate("Football", CapiQuery("???"), emptyCollectionPresentation)
+  val cricket: CollectionTemplate = new CollectionTemplate("Cricket", CapiQuery("???"), emptyCollectionPresentation)
+}
+
+object Fronts {
+  val emptyFrontPresentation = FrontPresentation()
+  val ukNews: FrontTemplate = FrontTemplate("UK news", List(), emptyFrontPresentation)
+  val sports: FrontTemplate = FrontTemplate(
+    "Sport",
+    List(
+      Sport.football,
+      Sport.cricket,
+    ),
+    emptyFrontPresentation
+  )
+  val technology: FrontTemplate = FrontTemplate(
+    "Technology",
+    List(),
+    emptyFrontPresentation
+  )
+
+  val opinion: FrontTemplate = FrontTemplate("Opinion", List(), emptyFrontPresentation)
+}
+
+object DailyEdition {
+  val dailyEdition: EditionTemplate = EditionTemplate(
+    "dailyEdition",
+    List(
+      (Fronts.ukNews, Daily()),
+      (Fronts.sports, Daily()),
+      (Fronts.opinion, WeekDays(List(Thurs, Wed))),
+      (Fronts.technology, WeekDays(List(Thurs)))
+    ),
+    Daily()
+  )
+}
+


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Based on our collaborative coding session and chats with David, Jon and I wrote models for editions, fronts and collections and wrote a function which returns a template for a given day. 

## Implementation notes

After talking to David we decided that fronts should be associated with a periodicity, collections should not. 

All this needs now is a real editions template! 
_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
