### PR TITLE
[FIX]: Delete supporting articles in the clipboard

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -268,8 +268,8 @@ const removeArticleFragment = (
 ): ThunkResult<void> => {
   return (dispatch: Dispatch, getState) => {
     const getGroupIdFromState = () => {
-      if (persistTo === 'clipboard') {
-        return 'clipboard';
+      if (id === 'clipboard') {
+        return id;
       }
       // The article fragment may belong to an orphaned group -
       // we need to find the actual group the article fragment belongs to

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -17,6 +17,7 @@ import {
 } from './utils';
 import {
   moveArticleFragment,
+  removeArticleFragment,
   insertArticleFragment,
   addImageToArticleFragment,
   cloneArticleFragmentToTarget
@@ -59,7 +60,7 @@ const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
     ['k', '11', undefined]
   ];
   const clipboard: ArticleFragmentSpec[] = [
-    ['d', '4', undefined],
+    ['d', '4', [['g', '7']]],
     ['e', '5', undefined],
     ['f', '6', undefined]
   ];
@@ -171,6 +172,25 @@ const move = (
   if (collectionCapInfo && collectionCapInfo.accept !== null) {
     dispatch(endConfirmModal(collectionCapInfo.accept));
   }
+
+  return getState();
+};
+
+const remove = (
+  id: string,
+  parentId: string,
+  type: 'collection' | 'clipboard' | 'articleFragment'
+) => {
+  const { dispatch, getState } = buildStore(
+    ['uuid', 'id', undefined],
+    Infinity
+  );
+  dispatch(removeArticleFragment(
+    type,
+    parentId,
+    id,
+    'clipboard' // doesn't matter where we persist
+  ) as any);
 
   return getState();
 };
@@ -304,6 +324,22 @@ describe('ArticleFragments actions', () => {
         accept: null
       });
       expect(groupArticlesSelector(s1, 'a')).toEqual(['b', 'c', 'a']);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes article fragments that exist in the state', async () => {
+      expect(
+        clipboardSelector(await remove('d', 'clipboard', 'clipboard'))
+      ).toEqual(['e', 'f']);
+    });
+    it('removes article fragments from supporting positions', async () => {
+      expect(
+        supportingArticlesSelector(
+          await remove('g', 'd', 'articleFragment'),
+          'd'
+        )
+      ).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## What's changed?

There was a recent regression as a part of the groups sorting work (#720) that meant we couldn't delete supporting articles on the clipboard. This should solve that issue.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
