### PR TITLE
TESTS: New integration tests

### DIFF
--- a/client-v2/integration/fixtures/collection2.js
+++ b/client-v2/integration/fixtures/collection2.js
@@ -1,0 +1,67 @@
+module.exports = {
+  live: [],
+  draft: [
+    {
+      id: 'internal-code/page/2309422',
+      frontPublicationDate: 1540379258808,
+      meta: {
+        trailText:
+          'Social media gives people a megaphone. But if companies keep giving that megaphone to trolls intending to hurt people, they start to look complicit',
+        headline: 'Test2',
+        isBreaking: false,
+        isBoosted: false,
+        imageHide: false,
+        showKickerCustom: false,
+        showByline: false,
+        showQuotedHeadline: false,
+        imageSlideshowReplace: false,
+        supporting: [
+          {
+            id: 'internal-code/page/2309422',
+            frontPublicationDate: 1540379258808,
+            meta: {}
+          },
+          {
+            id: 'internal-code/page/5224281',
+            frontPublicationDate: 1540381197498,
+            meta: {}
+          }
+        ],
+        byline: 'Jess Zimmerman',
+        imageReplace: false,
+        imageCutoutReplace: false,
+        showBoostedHeadline: false,
+        customKicker: ''
+      }
+    }
+  ],
+  lastUpdated: 1540558153850,
+  updatedBy: 'Richard Beddington',
+  updatedEmail: 'richard.beddington@guardian.co.uk',
+  displayName: 'Main',
+  previously: [
+    {
+      id: 'internal-code/page/5252100',
+      frontPublicationDate: 1540379258808,
+      meta: {
+        isBreaking: false,
+        isBoosted: false,
+        imageHide: false,
+        showKickerCustom: false,
+        showByline: false,
+        showQuotedHeadline: false,
+        imageSlideshowReplace: false,
+        supporting: [],
+        imageReplace: false,
+        imageCutoutReplace: false,
+        showBoostedHeadline: false,
+        customKicker: ''
+      }
+    }
+  ],
+  lastUpdated: 1540558153850,
+  updatedBy: 'Richard Beddington',
+  updatedEmail: 'richard.beddington@guardian.co.uk',
+  displayName: 'Second Collection',
+  previously: []
+};

--- a/client-v2/integration/fixtures/collection2.js
+++ b/client-v2/integration/fixtures/collection2.js
@@ -7,7 +7,7 @@ module.exports = {
       meta: {
         trailText:
           'Social media gives people a megaphone. But if companies keep giving that megaphone to trolls intending to hurt people, they start to look complicit',
-        headline: 'Test2',
+        headline: 'Test3',
         isBreaking: false,
         isBoosted: false,
         imageHide: false,
@@ -35,33 +35,8 @@ module.exports = {
       }
     }
   ],
-  lastUpdated: 1540558153850,
+  lastUpdated: 1540558153650,
   updatedBy: 'Richard Beddington',
   updatedEmail: 'richard.beddington@guardian.co.uk',
-  displayName: 'Main',
-  previously: [
-    {
-      id: 'internal-code/page/5252100',
-      frontPublicationDate: 1540379258808,
-      meta: {
-        isBreaking: false,
-        isBoosted: false,
-        imageHide: false,
-        showKickerCustom: false,
-        showByline: false,
-        showQuotedHeadline: false,
-        imageSlideshowReplace: false,
-        supporting: [],
-        imageReplace: false,
-        imageCutoutReplace: false,
-        showBoostedHeadline: false,
-        customKicker: ''
-      }
-    }
-  ],
-  lastUpdated: 1540558153850,
-  updatedBy: 'Richard Beddington',
-  updatedEmail: 'richard.beddington@guardian.co.uk',
-  displayName: 'Second Collection',
-  previously: []
+  displayName: 'Second Collection 2'
 };

--- a/client-v2/integration/fixtures/collection3.js
+++ b/client-v2/integration/fixtures/collection3.js
@@ -1,0 +1,8 @@
+module.exports = {
+  live: [],
+  draft: [],
+  lastUpdated: 1540558153650,
+  updatedBy: 'Richard Beddington',
+  updatedEmail: 'richard.beddington@guardian.co.uk',
+  displayName: 'Second Collection after discard'
+};

--- a/client-v2/integration/fixtures/config.js
+++ b/client-v2/integration/fixtures/config.js
@@ -15,12 +15,7 @@ module.exports = {
       type: 'fixed/small/slow-IV'
     },
     'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
-      displayName: 'Second Collection',
-      metadata: [
-        {
-          type: 'Branded'
-        }
-      ],
+      displayName: 'Second Collection 2',
       type: 'fixed/large/slow-XIV'
     }
   }

--- a/client-v2/integration/fixtures/config.js
+++ b/client-v2/integration/fixtures/config.js
@@ -1,7 +1,10 @@
 module.exports = {
   fronts: {
     'test/front': {
-      collections: ['13b2fc5d-ab47-4926-9a26-ee76184be485'],
+      collections: [
+        '13b2fc5d-ab47-4926-9a26-ee76184be485',
+        'e59785e9-ba82-48d8-b79a-0a80b2f9f808'
+      ],
       isHidden: true,
       canonical: '13b2fc5d-ab47-4926-9a26-ee76184be485'
     }
@@ -10,6 +13,15 @@ module.exports = {
     '13b2fc5d-ab47-4926-9a26-ee76184be485': {
       displayName: 'Main',
       type: 'fixed/small/slow-IV'
+    },
+    'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
+      displayName: 'Second Collection',
+      metadata: [
+        {
+          type: 'Branded'
+        }
+      ],
+      type: 'fixed/large/slow-XIV'
     }
   }
 };

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -92,6 +92,14 @@ export const collectionItemDeleteButton = (collectionIndex, itemIndex = 0) =>
     `[data-testid="${DELETE_BUTTON}"]`
   );
 
+export const collectionItemAddToClipboardButton = (
+  collectionIndex,
+  itemIndex = 0
+) =>
+  collectionItem(collectionIndex, itemIndex).find(
+    `[data-testid="${ADD_TO_CLIPBOARD_BUTTON}"]`
+  );
+
 // Edit form //
 export const editForm = maybeGetNth(select(EDIT_FORM));
 

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -1,5 +1,4 @@
 import { select } from '../helpers';
-import { Selector } from 'testcafe';
 
 const FRONT_SELECTOR = 'test/front';
 const FEED_ITEM_SELECTOR = 'feed-item';
@@ -15,7 +14,6 @@ const SNAP_SELECTOR = 'snap';
 const COLLECTION_SELECTOR = 'collection';
 const COLLECTION_ITEM_SELECTOR = 'article-body';
 const COLLECTION_DISCARD_BUTTON = 'collection-discard-button';
-const HOVER_ACTIONS_WRAPPER = 'hover-actions-wrapper';
 const DELETE_BUTTON = 'delete-hover-button';
 const EDIT_FORM = 'edit-form';
 const EDIT_FORM_HEADLINE_FIELD = 'edit-form-headline-field';
@@ -48,9 +46,6 @@ export const clipboardItem = maybeGetNth(
 export const feedItemAddToClipboardHoverButton = maybeGetNth(
   select(FEED_ITEM_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
 );
-export const clipboardHoverActionsWrapper = maybeGetNth(
-  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, HOVER_ACTIONS_WRAPPER)
-);
 export const clipboardItemHeadline = maybeGetNth(
   select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, HEADLINE_SELECTOR)
 );
@@ -62,19 +57,13 @@ export const clipboardItemDeleteButton = maybeGetNth(
 export const collection = maybeGetNth(select(COLLECTION_SELECTOR));
 
 export const allCollectionItems = collectionIndex => {
-  const collectionInIndex = collection(collectionIndex);
-  const articles = collectionInIndex.find(
-    `[data-testid="${COLLECTION_ITEM_SELECTOR}"]`
-  );
-  return articles;
+  const collectionSelected = collection(collectionIndex);
+  return collectionSelected.find(`[data-testid="${COLLECTION_ITEM_SELECTOR}"]`);
 };
 
 export const allCollectionDropZones = collectionIndex => {
-  const collectionInIndex = collection(collectionIndex);
-  const dropZones = collectionInIndex.find(
-    `[data-testid="${DROP_ZONE_SELECTOR}"]`
-  );
-  return dropZones;
+  const collectionSelected = collection(collectionIndex);
+  return collectionSelected.find(`[data-testid="${DROP_ZONE_SELECTOR}"]`);
 };
 
 export const collectionItem = (collectionIndex, itemIndex = 0) =>
@@ -92,25 +81,25 @@ export const collectionItemKicker = (collectionIndex, itemIndex = 0) =>
   collectionItem(collectionIndex, itemIndex).find(
     `[data-testid="${KICKER_SELECTOR}"]`
   );
+
 export const collectionDiscardButton = collectionIndex =>
   collection(collectionIndex).find(
     `[data-testid="${COLLECTION_DISCARD_BUTTON}"]`
   );
 
-export const collectionItemHoverZone = maybeGetNth(
-  select(COLLECTION_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
-);
-
-export const collectionItemDeleteButton = maybeGetNth(
-  select(COLLECTION_ITEM_SELECTOR, DELETE_BUTTON)
-);
+export const collectionItemDeleteButton = (collectionIndex, itemIndex = 0) =>
+  collectionItem(collectionIndex, itemIndex).find(
+    `[data-testid="${DELETE_BUTTON}"]`
+  );
 
 // Edit form //
 export const editForm = maybeGetNth(select(EDIT_FORM));
+
 export const editFormHeadlineInput = maybeGetNth(
   select(EDIT_FORM, EDIT_FORM_HEADLINE_FIELD)
 );
-export const editFormSaveButton = select(EDIT_FORM_SAVE_BUTTON);
+
+export const editFormSaveButton = maybeGetNth(select(EDIT_FORM_SAVE_BUTTON));
 
 export const editFormBreakingNewsToggle = maybeGetNth(
   select(EDIT_FORM_BREAKING_NEWS_TOGGLE)

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -1,16 +1,27 @@
 import { select } from '../helpers';
+import { Selector } from 'testcafe';
 
 const FRONT_SELECTOR = 'test/front';
 const FEED_ITEM_SELECTOR = 'feed-item';
-const COLLECTION_ITEM_SELECTOR = 'article-body';
 const CLIPBOARD_SELECTOR = 'clipboard';
 const PREVIOUSLY_SELECTOR = 'previously';
 const CLIPBOARD_WRAPPER_SELECTOR = 'clipboard-wrapper';
 const HEADLINE_SELECTOR = 'headline';
 const DROP_ZONE_SELECTOR = 'drop-zone';
+const KICKER_SELECTOR = 'kicker';
 const HOVER_OVERLAY_SELECTOR = 'hover-overlay';
 const ADD_TO_CLIPBOARD_BUTTON = 'add-to-clipboard-hover-button';
 const SNAP_SELECTOR = 'snap';
+const COLLECTION_SELECTOR = 'collection';
+const COLLECTION_ITEM_SELECTOR = 'article-body';
+const COLLECTION_DISCARD_BUTTON = 'collection-discard-button';
+const HOVER_ACTIONS_WRAPPER = 'hover-actions-wrapper';
+const DELETE_BUTTON = 'delete-hover-button';
+const EDIT_FORM = 'edit-form';
+const EDIT_FORM_HEADLINE_FIELD = 'edit-form-headline-field';
+const EDIT_FORM_SAVE_BUTTON = 'edit-form-save-button';
+const EDIT_FORM_BREAKING_NEWS_TOGGLE = 'edit-form-breaking-news-toggle';
+
 // Html Mocks //
 const GUARDIAN_TAG_ANCHOR = 'guardian-tag';
 const EXTERNAL_LINK_ANCHOR = 'external-link';
@@ -34,11 +45,75 @@ export const clipboardDropZone = maybeGetNth(
 export const clipboardItem = maybeGetNth(
   select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR)
 );
-export const clipboardItemTruncatedHeadline = maybeGetNth(
-  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, HEADLINE_SELECTOR)
-);
 export const feedItemAddToClipboardHoverButton = maybeGetNth(
   select(FEED_ITEM_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
+);
+export const clipboardHoverActionsWrapper = maybeGetNth(
+  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, HOVER_ACTIONS_WRAPPER)
+);
+export const clipboardItemHeadline = maybeGetNth(
+  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, HEADLINE_SELECTOR)
+);
+export const clipboardItemDeleteButton = maybeGetNth(
+  select(CLIPBOARD_SELECTOR, COLLECTION_ITEM_SELECTOR, DELETE_BUTTON)
+);
+
+// Collections //
+export const collection = maybeGetNth(select(COLLECTION_SELECTOR));
+
+export const allCollectionItems = collectionIndex => {
+  const collectionInIndex = collection(collectionIndex);
+  const articles = collectionInIndex.find(
+    `[data-testid="${COLLECTION_ITEM_SELECTOR}"]`
+  );
+  return articles;
+};
+
+export const allCollectionDropZones = collectionIndex => {
+  const collectionInIndex = collection(collectionIndex);
+  const dropZones = collectionInIndex.find(
+    `[data-testid="${DROP_ZONE_SELECTOR}"]`
+  );
+  return dropZones;
+};
+
+export const collectionItem = (collectionIndex, itemIndex = 0) =>
+  allCollectionItems(collectionIndex).nth(itemIndex);
+
+export const collectionDropZone = (collectionIndex, dropZoneIndex = 0) =>
+  allCollectionDropZones(collectionIndex).nth(dropZoneIndex);
+
+export const collectionItemHeadline = (collectionIndex, itemIndex = 0) =>
+  collectionItem(collectionIndex, itemIndex).find(
+    `[data-testid="${HEADLINE_SELECTOR}"]`
+  );
+
+export const collectionItemKicker = (collectionIndex, itemIndex = 0) =>
+  collectionItem(collectionIndex, itemIndex).find(
+    `[data-testid="${KICKER_SELECTOR}"]`
+  );
+export const collectionDiscardButton = collectionIndex =>
+  collection(collectionIndex).find(
+    `[data-testid="${COLLECTION_DISCARD_BUTTON}"]`
+  );
+
+export const collectionItemHoverZone = maybeGetNth(
+  select(COLLECTION_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
+);
+
+export const collectionItemDeleteButton = maybeGetNth(
+  select(COLLECTION_ITEM_SELECTOR, DELETE_BUTTON)
+);
+
+// Edit form //
+export const editForm = maybeGetNth(select(EDIT_FORM));
+export const editFormHeadlineInput = maybeGetNth(
+  select(EDIT_FORM, EDIT_FORM_HEADLINE_FIELD)
+);
+export const editFormSaveButton = select(EDIT_FORM_SAVE_BUTTON);
+
+export const editFormBreakingNewsToggle = maybeGetNth(
+  select(EDIT_FORM_BREAKING_NEWS_TOGGLE)
 );
 
 // Fronts //
@@ -50,9 +125,6 @@ export const frontDropZone = maybeGetNth(
 );
 export const frontItemAddToClipboardHoverButton = maybeGetNth(
   select(FRONT_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
-);
-export const collectionItemHoverZone = maybeGetNth(
-  select(COLLECTION_ITEM_SELECTOR, HOVER_OVERLAY_SELECTOR)
 );
 
 // Snaps //

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -5,6 +5,7 @@ const port = 3456;
 
 const config = require('../fixtures/config');
 const collection = require('../fixtures/collection');
+const collection2 = require('../fixtures/collection2');
 const capiCollection = require('../fixtures/capi-collection');
 const capiSearch = require('../fixtures/capi-search');
 const snapTag = require('../fixtures/snap-tag');
@@ -117,7 +118,12 @@ module.exports = async () =>
     app.get('/api/preview/*', handler);
 
     app.get('/config', (_, res) => res.json(config));
-    app.get('/collection/:id', (_, res) => res.json(collection));
+    app.get('/collection/13b2fc5d-ab47-4926-9a26-ee76184be485', (_, res) =>
+      res.json(collection)
+    );
+    app.get('/collection/e59785e9-ba82-48d8-b79a-0a80b2f9f808', (_, res) =>
+      res.json(collection2)
+    );
     app.post('/collections*', (req, res) =>
       res.json([
         {

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -5,7 +5,8 @@ const port = 3456;
 
 const config = require('../fixtures/config');
 const collection = require('../fixtures/collection');
-const collection2 = require('../fixtures/collection2');
+const collectionTwo = require('../fixtures/collection2');
+const collectionThree = require('../fixtures/collection3');
 const capiCollection = require('../fixtures/capi-collection');
 const capiSearch = require('../fixtures/capi-search');
 const snapTag = require('../fixtures/snap-tag');
@@ -111,21 +112,13 @@ module.exports = async () =>
       return res.json(result);
     };
 
-    // Attempts at a capture group:
-    // /api/(preview|live)/*
-    // /api/(?:preview|live)/
     app.get('/api/live/*', handler);
     app.get('/api/preview/*', handler);
 
     app.get('/config', (_, res) => res.json(config));
-    app.get('/collection/13b2fc5d-ab47-4926-9a26-ee76184be485', (_, res) =>
-      res.json(collection)
-    );
-    app.get('/collection/e59785e9-ba82-48d8-b79a-0a80b2f9f808', (_, res) =>
-      res.json(collection2)
-    );
-    app.post('/collections*', (req, res) =>
-      res.json([
+
+    app.post('/collections*', (req, res) => {
+      return res.json([
         {
           id: req.body[0].id,
           collection,
@@ -133,8 +126,31 @@ module.exports = async () =>
             live: { desktop: 4, mobile: 4 },
             draft: { desktop: 4, mobile: 4 }
           }
+        },
+        {
+          id: req.body[1].id,
+          collection: collectionTwo,
+          storiesVisibleByStage: {
+            live: { desktop: 4, mobile: 4 },
+            draft: { desktop: 4, mobile: 4 }
+          }
         }
-      ])
+      ]);
+    });
+
+    // catch requests to discard collection endpoint
+    app.post(
+      '/collection/v2Discard/e59785e9-ba82-48d8-b79a-0a80b2f9f808',
+      (req, res) => {
+        return res.json({
+          id: req.body.collectionId,
+          collection: collectionThree,
+          storiesVisibleByStage: {
+            live: { desktop: 4, mobile: 4 },
+            draft: { desktop: 4, mobile: 4 }
+          }
+        });
+      }
     );
 
     // send the assets from dist

--- a/client-v2/integration/tests/edit-item-metadata.spec.js
+++ b/client-v2/integration/tests/edit-item-metadata.spec.js
@@ -18,10 +18,9 @@ fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
   .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
   .after(teardown);
 
-// ? Why can the headline input be defined ahead of the test but not the save button?
 test('Metadata edits are persisted in collections- headline', async t => {
-  const firstCollectionStory = await collectionItem(0, 0);
-  const headlineInput = await editFormHeadlineInput();
+  const firstCollectionStory = collectionItem(0, 0);
+  const headlineInput = editFormHeadlineInput();
   await t
     .click(firstCollectionStory)
     .click(headlineInput)
@@ -33,8 +32,8 @@ test('Metadata edits are persisted in collections- headline', async t => {
 });
 
 test('Metadata edits are persisted in clipboard - headline', async t => {
-  const firstClipboardStory = await clipboardItem(0);
-  const headlineInput = await editFormHeadlineInput();
+  const firstClipboardStory = clipboardItem(0);
+  const headlineInput = editFormHeadlineInput();
   await t
     .click(firstClipboardStory)
     .click(headlineInput)
@@ -45,9 +44,9 @@ test('Metadata edits are persisted in clipboard - headline', async t => {
     .eql('A better headline');
 });
 
-test.only('Metadata edits are persisted in collections- "breaking news" toggle button', async t => {
-  const firstCollectionStory = await collectionItem(0, 0);
-  const breakingNewsToggle = await editFormBreakingNewsToggle();
+test('Metadata edits are persisted in collections- "breaking news" toggle button', async t => {
+  const firstCollectionStory = collectionItem(0, 0);
+  const breakingNewsToggle = editFormBreakingNewsToggle();
   await t
     .click(firstCollectionStory)
     .click(breakingNewsToggle)
@@ -56,10 +55,10 @@ test.only('Metadata edits are persisted in collections- "breaking news" toggle b
     .eql(`Breaking news`);
 });
 
-test.only('Metadata edits are persisted in clipboard- "breaking news" toggle button', async t => {
-  const firstClipboardStory = await clipboardItem(0);
-  const breakingNewsToggle = await editFormBreakingNewsToggle();
-  const firstCollectionFirstDropZone = await collectionDropZone(0, 0);
+test('Metadata edits are persisted in clipboard- "breaking news" toggle button', async t => {
+  const firstClipboardStory = clipboardItem(0);
+  const breakingNewsToggle = editFormBreakingNewsToggle();
+  const firstCollectionFirstDropZone = collectionDropZone(0, 0);
   await t
     .click(firstClipboardStory)
     .click(breakingNewsToggle)

--- a/client-v2/integration/tests/edit-item-metadata.spec.js
+++ b/client-v2/integration/tests/edit-item-metadata.spec.js
@@ -1,0 +1,70 @@
+import setup from '../server/setup';
+import teardown from '../server/teardown';
+import {
+  clipboardItem,
+  clipboardItemHeadline,
+  collection,
+  collectionItem,
+  collectionItemHeadline,
+  collectionItemKicker,
+  editFormHeadlineInput,
+  editFormSaveButton,
+  editFormBreakingNewsToggle,
+  collectionDropZone
+} from '../selectors';
+
+fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
+  .before(setup)
+  .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
+  .after(teardown);
+
+// ? Why can the headline input be defined ahead of the test but not the save button?
+test('Metadata edits are persisted in collections- headline', async t => {
+  const firstCollectionStory = await collectionItem(0, 0);
+  const headlineInput = await editFormHeadlineInput();
+  await t
+    .click(firstCollectionStory)
+    .click(headlineInput)
+    .selectText(headlineInput)
+    .typeText(headlineInput, 'A better headline')
+    .click(editFormSaveButton())
+    .expect(collectionItemHeadline(0, 0).textContent)
+    .eql('A better headline');
+});
+
+test('Metadata edits are persisted in clipboard - headline', async t => {
+  const firstClipboardStory = await clipboardItem(0);
+  const headlineInput = await editFormHeadlineInput();
+  await t
+    .click(firstClipboardStory)
+    .click(headlineInput)
+    .selectText(headlineInput)
+    .typeText(headlineInput, 'A better headline')
+    .click(editFormSaveButton())
+    .expect(clipboardItemHeadline(0).textContent)
+    .eql('A better headline');
+});
+
+test.only('Metadata edits are persisted in collections- "breaking news" toggle button', async t => {
+  const firstCollectionStory = await collectionItem(0, 0);
+  const breakingNewsToggle = await editFormBreakingNewsToggle();
+  await t
+    .click(firstCollectionStory)
+    .click(breakingNewsToggle)
+    .click(editFormSaveButton())
+    .expect(collectionItemKicker(0, 0).textContent)
+    .eql(`Breaking news`);
+});
+
+test.only('Metadata edits are persisted in clipboard- "breaking news" toggle button', async t => {
+  const firstClipboardStory = await clipboardItem(0);
+  const breakingNewsToggle = await editFormBreakingNewsToggle();
+  const firstCollectionFirstDropZone = await collectionDropZone(0, 0);
+  await t
+    .click(firstClipboardStory)
+    .click(breakingNewsToggle)
+    .click(editFormSaveButton())
+    .dragToElement(clipboardItem(0), firstCollectionFirstDropZone) // Kickers are not visible in clipboard, drag to collection to view
+    .expect(collectionItemKicker(0, 0).textContent)
+    .eql(`Breaking news`);
+});

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -91,7 +91,7 @@ test('Deleting an article from clipboard works', async t => {
   const clipboardStoryCount = await clipboardItem().count;
   const deleteButton = await clipboardItemDeleteButton();
   await t
-    .hover(clipboardStory, { speed: 0.7 })
+    .hover(clipboardStory)
     .click(deleteButton)
     .expect(clipboardItem().count)
     .eql(clipboardStoryCount - 1);
@@ -102,7 +102,7 @@ test('Deleting an article from a collection works', async t => {
   const firstCollectionStoryCount = await allCollectionItems(0).count;
   const deleteButton = await collectionItemDeleteButton(0, 0);
   await t
-    .hover(firstCollectionItem, { speed: 0.7 }) // mouse speed needs to be slowed down for hover to trigger correctly
+    .hover(firstCollectionItem)
     .click(deleteButton)
     .expect(allCollectionItems(0).count)
     .eql(firstCollectionStoryCount - 1);

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -22,7 +22,6 @@ import {
   allCollectionDropZones,
   collectionItemDeleteButton,
   collectionDiscardButton,
-  // clipboardHoverActionsWrapper,
   clipboardItemDeleteButton
 } from '../selectors';
 
@@ -101,9 +100,10 @@ test('Deleting an article from clipboard works', async t => {
 test('Deleting an article from a collection works', async t => {
   const firstCollectionItem = await collectionItem(0, 0);
   const firstCollectionStoryCount = await allCollectionItems(0).count;
+  const deleteButton = await collectionItemDeleteButton(0, 0);
   await t
     .hover(firstCollectionItem, { speed: 0.7 }) // mouse speed needs to be slowed down for hover to trigger correctly
-    .click(collectionItemDeleteButton(0, 0))
+    .click(deleteButton)
     .expect(allCollectionItems(0).count)
     .eql(firstCollectionStoryCount - 1);
 });

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -12,7 +12,16 @@ import {
   previouslyDropZone,
   previouslyItem,
   clipboardWrapper,
-  clipboardItem
+  clipboardItem,
+  collection,
+  collectionItem,
+  collectionDropZone,
+  allCollectionItems,
+  allCollectionDropZones,
+  collectionItemDeleteButton,
+  collectionDiscardButton,
+  clipboardHoverActionsWrapper,
+  clipboardItemDeleteButton
 } from '../selectors';
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
@@ -52,6 +61,56 @@ test('Drag and drop', async t => {
     .notEql(topFeedHeadline)
     .expect(frontHeadline().textContent)
     .eql(topFrontHeadline);
+});
+
+test('Drag between two collections', async t => {
+  const firstCollectionStory = collectionItem(0, 0);
+  const secondCollectionDropZone = collectionDropZone(1, 0);
+  await t
+    .dragToElement(firstCollectionStory, secondCollectionDropZone)
+    .expect(allCollectionItems(0).count)
+    .eql(0)
+    .expect(allCollectionItems(1).count)
+    .eql(1);
+});
+
+test('Drag from clipboard to collection', async t => {
+  const firstCollectionStoryCount = await allCollectionItems(0).count;
+  const clipboardStoryCount = await clipboardItem().count;
+  await t
+    .dragToElement(clipboardItem(), collection(0))
+    .expect(allCollectionItems(0).count)
+    .eql(firstCollectionStoryCount + 1)
+    .expect(clipboardItem().count)
+    .eql(clipboardStoryCount);
+});
+
+test('Deleting an article from clipboard works', async t => {
+  // const actionsWrapper = await clipboardHoverActionsWrapper();
+  // console.log(actionsWrapper);
+  const clipboardStory = await clipboardItem();
+  const clipboardStoryCount = await clipboardItem().count;
+  const deleteButton = await clipboardItemDeleteButton();
+  //test cafe is interpreting the CSS correctly... visibility:hidden is set on these elements, and yet I can see them. WHY?
+  await t
+    .hover(clipboardStory)
+    .debug()
+    .click(deleteButton)
+    .expect(clipboardItem().count)
+    .eql(clipboardStoryCount - 1);
+});
+
+test('Deleting an article from a collection works', async t => {});
+
+test.only('Discarding a collection words', async t => {
+  const secondCollection = await collection(1);
+  const numberCollections = await collection().count;
+  const discardButton = await collectionDiscardButton(1);
+  await t
+    .click(discardButton)
+    .debug()
+    .expect(collection().count)
+    .eql(numberCollections - 1);
 });
 
 test('Snap Links - Guardian', async t => {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -87,42 +87,6 @@ test('Drag from clipboard to collection', async t => {
     .eql(clipboardStoryCount);
 });
 
-test('Send item from collection to clipboard using hover button', async t => {
-  const firstCollectionItem = await collectionItem(0, 0);
-  const firstCollectionStoryCount = await allCollectionItems(0).count;
-  const clipboardStoryCount = await clipboardItem().count;
-  const sendToClipboardButton = await collectionItemAddToClipboardButton(0, 0);
-  await t
-    .hover(firstCollectionItem, { speed: 0.5 })
-    .click(sendToClipboardButton)
-    .expect(allCollectionItems(0).count)
-    .eql(firstCollectionStoryCount - 1)
-    .expect(clipboardItem().count)
-    .eql(clipboardStoryCount + 1);
-});
-
-test('Deleting an article from clipboard works', async t => {
-  const clipboardStory = await clipboardItem();
-  const clipboardStoryCount = await clipboardItem().count;
-  const deleteButton = await clipboardItemDeleteButton();
-  await t
-    .hover(clipboardStory)
-    .click(deleteButton)
-    .expect(clipboardItem().count)
-    .eql(clipboardStoryCount - 1);
-});
-
-test('Deleting an article from a collection works', async t => {
-  const firstCollectionItem = await collectionItem(0, 0);
-  const firstCollectionStoryCount = await allCollectionItems(0).count;
-  const deleteButton = await collectionItemDeleteButton(0, 0);
-  await t
-    .hover(firstCollectionItem)
-    .click(deleteButton)
-    .expect(allCollectionItems(0).count)
-    .eql(firstCollectionStoryCount - 1);
-});
-
 test('Discarding changes to a collection works', async t => {
   await t
     .click(collectionDiscardButton(1))

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -13,14 +13,16 @@ import {
   previouslyItem,
   clipboardWrapper,
   clipboardItem,
+  hoverOverlay,
   collection,
   collectionItem,
   collectionDropZone,
+  collectionItemHoverZone,
   allCollectionItems,
   allCollectionDropZones,
   collectionItemDeleteButton,
   collectionDiscardButton,
-  clipboardHoverActionsWrapper,
+  // clipboardHoverActionsWrapper,
   clipboardItemDeleteButton
 } from '../selectors';
 
@@ -86,31 +88,31 @@ test('Drag from clipboard to collection', async t => {
 });
 
 test('Deleting an article from clipboard works', async t => {
-  // const actionsWrapper = await clipboardHoverActionsWrapper();
-  // console.log(actionsWrapper);
   const clipboardStory = await clipboardItem();
   const clipboardStoryCount = await clipboardItem().count;
   const deleteButton = await clipboardItemDeleteButton();
-  //test cafe is interpreting the CSS correctly... visibility:hidden is set on these elements, and yet I can see them. WHY?
   await t
-    .hover(clipboardStory)
-    .debug()
+    .hover(clipboardStory, { speed: 0.7 })
     .click(deleteButton)
     .expect(clipboardItem().count)
     .eql(clipboardStoryCount - 1);
 });
 
-test('Deleting an article from a collection works', async t => {});
-
-test.only('Discarding a collection words', async t => {
-  const secondCollection = await collection(1);
-  const numberCollections = await collection().count;
-  const discardButton = await collectionDiscardButton(1);
+test('Deleting an article from a collection works', async t => {
+  const firstCollectionItem = await collectionItem(0, 0);
+  const firstCollectionStoryCount = await allCollectionItems(0).count;
   await t
-    .click(discardButton)
-    .debug()
-    .expect(collection().count)
-    .eql(numberCollections - 1);
+    .hover(firstCollectionItem, { speed: 0.7 }) // mouse speed needs to be slowed down for hover to trigger correctly
+    .click(collectionItemDeleteButton(0, 0))
+    .expect(allCollectionItems(0).count)
+    .eql(firstCollectionStoryCount - 1);
+});
+
+test('Discarding changes to a collection works', async t => {
+  await t
+    .click(collectionDiscardButton(1))
+    .expect(allCollectionItems(1).count) // discarding overwrites a collection's draft content with its live content
+    .eql(0);
 });
 
 test('Snap Links - Guardian', async t => {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -22,6 +22,7 @@ import {
   allCollectionDropZones,
   collectionItemDeleteButton,
   collectionDiscardButton,
+  collectionItemAddToClipboardButton,
   clipboardItemDeleteButton
 } from '../selectors';
 
@@ -84,6 +85,20 @@ test('Drag from clipboard to collection', async t => {
     .eql(firstCollectionStoryCount + 1)
     .expect(clipboardItem().count)
     .eql(clipboardStoryCount);
+});
+
+test('Send item from collection to clipboard using hover button', async t => {
+  const firstCollectionItem = await collectionItem(0, 0);
+  const firstCollectionStoryCount = await allCollectionItems(0).count;
+  const clipboardStoryCount = await clipboardItem().count;
+  const sendToClipboardButton = await collectionItemAddToClipboardButton(0, 0);
+  await t
+    .hover(firstCollectionItem, { speed: 0.5 })
+    .click(sendToClipboardButton)
+    .expect(allCollectionItems(0).count)
+    .eql(firstCollectionStoryCount - 1)
+    .expect(clipboardItem().count)
+    .eql(clipboardStoryCount + 1);
 });
 
 test('Deleting an article from clipboard works', async t => {

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -63,7 +63,7 @@
     "react-testing-library": "^5.2.1",
     "redux-mock-store": "^1.5.3",
     "style-loader": "^0.23.1",
-    "testcafe": "^0.23.2",
+    "testcafe": "^1.1.4",
     "ts-jest": "^23.10.4",
     "ts-loader": "^5.2.2",
     "tsconfig-paths-webpack-plugin": "^3.2.0",

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -191,7 +191,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     };
 
     return (
-      <FormContainer onSubmit={handleSubmit}>
+      <FormContainer onSubmit={handleSubmit} data-testid="edit-form">
         <CollectionHeadingPinline>
           Edit
           <ButtonContainer>
@@ -203,6 +203,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               onClick={handleSubmit}
               disabled={pristine || !articleExists}
               size="l"
+              data-testid="edit-form-save-button"
             >
               Save
             </Button>
@@ -295,6 +296,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               useHeadlineFont
               rows="2"
               originalValue={articleCapiFieldValues.headline}
+              data-testid="edit-form-headline-field"
             />
             <ConditionalField
               permittedFields={editableFields}
@@ -335,6 +337,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               label="Breaking News"
               id={getInputId(articleFragmentId, 'breaking-news')}
               type="checkbox"
+              dataTestId="edit-form-breaking-news-toggle"
             />
             <ConditionalField
               permittedFields={editableFields}

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -131,7 +131,7 @@ class CollectionContext extends React.Component<
       lastMobileArticle
     } = this.props;
     return (
-      <CollectionWrapper>
+      <CollectionWrapper data-testid="collection">
         <Collection
           key={id}
           id={id}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -134,6 +134,7 @@ class Collection extends React.Component<CollectionProps> {
                 priority="default"
                 onClick={() => discardDraftChanges(id)}
                 tabIndex={-1}
+                data-testid="collection-discard-button"
                 title={
                   isEditFormOpen
                     ? 'You cannot discard changes to this collection whilst the edit form is open.'

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -198,6 +198,7 @@ const articleBodyDefault = React.memo(
               <KickerHeading
                 displaySize={size}
                 style={{ color: getPillarColor(pillarId, true) }}
+                data-testid="kicker"
               >
                 {kickerToDisplay}
               </KickerHeading>

--- a/client-v2/src/shared/components/input/HoverActionButtonWrapper.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtonWrapper.tsx
@@ -71,7 +71,10 @@ class HoverActionsButtonWrapper<ButtonProps> extends React.Component<
     const { isToolTipVisible, toolTipText } = this.state;
 
     return (
-      <HoverActionsWrapper size={this.props.size}>
+      <HoverActionsWrapper
+        size={this.props.size}
+        data-testid="hover-actions-wrapper"
+      >
         {isToolTipVisible ? (
           <ToolTipWrapper
             toolTipPosition={toolTipPosition}

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -66,16 +66,18 @@ const Checkbox = styled('input')`
 type Props = {
   label?: string;
   id: string;
+  dataTestId: string;
 } & WrappedFieldProps;
 
 export default ({
   label,
   id,
+  dataTestId,
   input: { onChange, ...inputRest },
   ...rest
 }: Props) => (
   <>
-    <InputContainer>
+    <InputContainer data-testid={dataTestId}>
       <CheckboxContainer>
         <Label htmlFor={id} size="sm">
           {label}

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -760,6 +760,11 @@
   resolved "https://registry.yarnpkg.com/@types/error-stack-parser/-/error-stack-parser-1.3.18.tgz#e01c9f8c85ca83b610320c62258b0c9026ade0f7"
   integrity sha1-4ByfjIXKg7YQMgxiJYsMkCat4Pc=
 
+"@types/estree@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/fetch-mock@^6.0.4":
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-6.0.4.tgz#fbe20ab0cc151fe67b2e1b71e7ef29a986a90f1f"
@@ -808,6 +813,11 @@
   version "10.12.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
   integrity sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ==
+
+"@types/node@^10.12.19":
+  version "10.14.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.7.tgz#1854f0a9aa8d2cd6818d607b3d091346c6730362"
+  integrity sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==
 
 "@types/prop-types@*":
   version "15.5.6"
@@ -1140,6 +1150,13 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-hammerhead@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-hammerhead/-/acorn-hammerhead-0.2.0.tgz#46b3baf430bfb3c62436d663e4f33a9e1dad7794"
+  integrity sha512-kbX1s/0ZikW0WEBY6IrooFgX3AP2D9ycTg0OhxRYLF0Tew/bDK2+8lTxFR4cDdoCZm6Ax8eVf8EV6gbTtr8EYQ==
+  dependencies:
+    "@types/estree" "^0.0.39"
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
@@ -1236,13 +1253,6 @@ ansi-colors@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.1.tgz#9638047e4213f3428a11944a7d4b31cba0a3ff95"
   integrity sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ==
-
-ansi-cyan@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
-  integrity sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=
-  dependencies:
-    ansi-wrap "0.1.0"
 
 ansi-escapes@^2.0.0:
   version "2.0.0"
@@ -1341,14 +1351,6 @@ argparse@~0.1.15:
     underscore "~1.7.0"
     underscore.string "~2.4.0"
 
-arr-diff@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
-  integrity sha1-aHwydYFjWI/vfeezb6vklesaOZo=
-  dependencies:
-    arr-flatten "^1.0.1"
-    array-slice "^0.2.3"
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -1365,11 +1367,6 @@ arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
   integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
-
-arr-union@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-2.1.0.tgz#20f9eab5ec70f5c7d215b1077b1c39161d292c7d"
-  integrity sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=
 
 arr-union@^3.1.0:
   version "3.1.0"
@@ -1395,11 +1392,6 @@ array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
   integrity sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=
-
-array-slice@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
-  integrity sha1-3Tz7gO15c6dRF82sabC5nshhhvU=
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -2121,13 +2113,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz#3d75b4d949ad81af157570273846fb59aeb0d57c"
-  integrity sha1-PXW02Umtga8VdXAnOEb7Wa6w1Xw=
-  dependencies:
-    babel-runtime "^6.9.0"
-
 babel-plugin-transform-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
@@ -2252,7 +2237,7 @@ babel-runtime@^5.6.15, babel-runtime@^5.8.34:
   dependencies:
     core-js "^1.0.0"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -3004,11 +2989,6 @@ connect-history-api-fallback@^1.3.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
   integrity sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=
 
-connected-domain@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/connected-domain/-/connected-domain-1.0.0.tgz#bfe77238c74be453a79f0cb6058deeb4f2358e93"
-  integrity sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM=
-
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -3125,14 +3105,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-cross-spawn@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.0.tgz#8254774ab4786b8c5b3cf4dfba66ce563932c252"
-  integrity sha1-glR3SrR4a4xbPPTfumbOVjkywlI=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -3984,6 +3956,13 @@ eslint@^5.12.0:
     table "^5.0.2"
     text-table "^0.2.0"
 
+esotope-hammerhead@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/esotope-hammerhead/-/esotope-hammerhead-0.2.1.tgz#c7afdb624d9125b07f0555dd88ae2dcffc70def6"
+  integrity sha512-IicdvCt1BIFTIM4nbjxGp98whIakOYZ4lA0UaDXnXpJpB11jYBX11Uv3x2f5ncSlFmxyZRdrN5skH5wK4TCWFQ==
+  dependencies:
+    "@types/estree" "^0.0.39"
+
 espree@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.0.tgz#fc7f984b62b36a0f543b13fb9cd7b9f4a7f5b65c"
@@ -4181,13 +4160,6 @@ express@^4.16.2, express@^4.16.4:
     type-is "~1.6.16"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-extend-shallow@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
-  integrity sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=
-  dependencies:
-    kind-of "^1.1.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -4781,6 +4753,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
+graphlib@^2.1.5:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.7.tgz#b6a69f9f44bd9de3963ce6804a2fc9e73d86aecc"
+  integrity sha512-TyI9jIy2J4j0qgPmOOrHTCtpPqJGN/aurBwc6ZT+bRii+di1I+Wv3obRhVrmBEXet+qkMaEX67dXrwsd3QQM6w==
+  dependencies:
+    lodash "^4.17.5"
+
 gray-matter@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-2.1.1.tgz#3042d9adec2a1ded6a7707a9ed2380f8a17a430e"
@@ -4801,33 +4780,6 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-gulp-clone@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-clone/-/gulp-clone-2.0.1.tgz#cf4ecb28ca46d032f6949271e8bf7986e78e6ff9"
-  integrity sha512-SLg/KsHBbinR/pCX3PF5l1YlR28hLp0X+bcpf77PtMJ6zvAQ5kRjtCPV5Wt1wHXsXWZN0eTUZ15R8ZYpi/CdCA==
-  dependencies:
-    plugin-error "^0.1.2"
-    through2 "^2.0.3"
-
-gulp-data@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/gulp-data/-/gulp-data-1.3.1.tgz#3304d5d1203d554d3385e42de78ee9204f61c8a2"
-  integrity sha512-fvpQJvgVyhkwRcFP3Y9QUS9sWvIFsAlJDinQjhLuknmHZz52jH0gHmTujYBFjr9aTlTHlrAayY5m1d0tA1HzGQ==
-  dependencies:
-    plugin-error "^0.1.2"
-    through2 "^2.0.0"
-    util-extend "^1.0.1"
-
-gulp-run-command@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/gulp-run-command/-/gulp-run-command-0.0.9.tgz#cf3fe1ca7ead50a883f4ba4004caa34ca63a63cc"
-  integrity sha512-8/Gzh+zfe6CFLqaL+LxwqLPj5fk/N1eCHEr36K5p9Al40iuxpbVnq1aZRGXMj+4DlWBzjjAAxas3EkMNI/6Vcw==
-  dependencies:
-    babel-plugin-transform-runtime "6.15.0"
-    cross-spawn "4.0.0"
-    spawn-args "0.2.0"
-    timeout-as-promise "^1.0.0"
 
 handle-thing@^1.2.5:
   version "1.2.5"
@@ -5390,6 +5342,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-docker@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-1.1.0.tgz#f04374d4eee5310e9a8e113bf1495411e46176a1"
+  integrity sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -5473,6 +5430,11 @@ is-glob@^4.0.0:
   integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
   dependencies:
     is-extglob "^2.1.1"
+
+is-jquery-obj@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-jquery-obj/-/is-jquery-obj-0.1.1.tgz#e8d9cc9737b1ab0733b50303e33a38ed7cc2f60b"
+  integrity sha512-18toSebUVF7y717dgw/Dzn6djOCqrkiDp3MhB8P6TdKyCVkbD1ZwE7Uz8Hwx6hUPTvKjbyYH9ncXT4ts4qLaSA==
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -6210,7 +6172,7 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
-json5@2.x:
+json5@2.x, json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
@@ -6243,11 +6205,6 @@ killable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
-
-kind-of@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
-  integrity sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -6496,12 +6453,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
-"lodash@4.6.1 || ^4.16.1", lodash@^4.1.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.11, "lodash@4.6.1 || ^4.16.1", lodash@^4.1.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -7678,17 +7630,6 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-plugin-error@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-0.1.2.tgz#3b9bb3335ccf00f425e07437e19276967da47ace"
-  integrity sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=
-  dependencies:
-    ansi-cyan "^0.1.1"
-    ansi-red "^0.1.1"
-    arr-diff "^1.0.1"
-    arr-union "^2.0.1"
-    extend-shallow "^1.1.2"
-
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -7875,13 +7816,6 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
-
-ps-node@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ps-node/-/ps-node-0.1.6.tgz#9af67a99d7b1d0132e51a503099d38a8d2ace2c3"
-  integrity sha1-mvZ6mdex0BMuUaUDCZ04qNKs4sM=
-  dependencies:
-    table-parser "^0.1.3"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -9141,11 +9075,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-spawn-args@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/spawn-args/-/spawn-args-0.2.0.tgz#fb7d0bd1d70fd4316bd9e3dec389e65f9d6361bb"
-  integrity sha1-+30L0dcP1DFr2ePew4nmX51jYbs=
-
 spdx-correct@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
@@ -9472,13 +9401,6 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
-table-parser@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/table-parser/-/table-parser-0.1.3.tgz#0441cfce16a59481684c27d1b5a67ff15a43c7b0"
-  integrity sha1-BEHPzhallIFoTCfRtaZ/8VpDx7A=
-  dependencies:
-    connected-domain "^1.0.0"
-
 table@^5.0.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/table/-/table-5.2.1.tgz#e78463702b1be9f7131c39860bcfb1b81114c2a1"
@@ -9518,10 +9440,10 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-testcafe-browser-tools@1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/testcafe-browser-tools/-/testcafe-browser-tools-1.6.5.tgz#8b41ebf844dccc810e82e7f19cc9d257f8c6ad86"
-  integrity sha512-VsdAxRCRo7pSUYUNO0fw6uX8w84ooOhg8ZMAUBmMkTU9xOYBKpJF/Kvh40fBs2tOB4r/q8yPYnT/Y8z8HsekcA==
+testcafe-browser-tools@1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/testcafe-browser-tools/-/testcafe-browser-tools-1.6.8.tgz#74ace1ee4c21a20bd6d88238f0d9bc97c596b8fb"
+  integrity sha512-xFgwmcAOutSJR6goqO8uUFGF5IF2xRC/Ssh4pB5QZ+bTjYsN5amnjgM+813bDBLelC+HmXKqylviz7Dzxbtbcw==
   dependencies:
     array-find "^1.0.0"
     babel-runtime "^5.6.15"
@@ -9535,19 +9457,19 @@ testcafe-browser-tools@1.6.5:
     read-file-relative "^1.2.0"
     which-promise "^1.0.0"
 
-testcafe-hammerhead@14.4.7:
-  version "14.4.7"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.4.7.tgz#9b2794864199b40a3445859c1f987191d3b9650f"
-  integrity sha512-9Su+yt0dSsc9y/LHZaRuZApN8yAc5zL6t5nx3CPXRhdgxi6OJ3hw+xAG32NRufaZrS8H/VXwknmfe+Pqw7d8KA==
+testcafe-hammerhead@14.6.3:
+  version "14.6.3"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.6.3.tgz#61d22650a4fe3b6ee7af721acff5d4f78afcb1af"
+  integrity sha512-vMQGfO7d6Vy0wkyzAdBUQ4Rin7vLqJGrBvgjlvBaj2ec1oH+RX0IlOwCB3HFMA/JljM7BpVD7y97Jq9Ebcgs4g==
   dependencies:
+    acorn-hammerhead "^0.2.0"
     bowser "1.6.0"
     brotli "^1.3.1"
     crypto-md5 "^1.0.0"
     css "2.2.3"
-    gulp-clone "^2.0.1"
-    gulp-run-command "0.0.9"
+    esotope-hammerhead "^0.2.1"
     iconv-lite "0.4.11"
-    lodash "4.17.10"
+    lodash "4.17.11"
     lru-cache "2.6.3"
     match-url-wildcard "0.0.2"
     merge-stream "^1.0.1"
@@ -9564,15 +9486,16 @@ testcafe-hammerhead@14.4.7:
     tunnel-agent "0.6.0"
     webauth "^1.1.0"
 
-testcafe-legacy-api@3.1.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-3.1.9.tgz#9f1a730aeae56c72484f3b4e65cd58bdeac6bd0e"
-  integrity sha512-oV6Ej2+YWiirLjJEHs+GbgmPnwf2KuoegDoFg//0rZ6uIK0O3zPtTNTV+pZERwQReaNY7M3e9Jz8t0ZjDweZyA==
+testcafe-legacy-api@3.1.11:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/testcafe-legacy-api/-/testcafe-legacy-api-3.1.11.tgz#f6a1704c0ee57bd18b32bc8c383775f2bad74819"
+  integrity sha512-JWv8Exc9FAEBbKw+IP97Ebd+0FzA3nzgRv9iQCNh/+JlZyUox7NWiojs9BAXqgxIltl54rdo7TxPkNslxb+Ltw==
   dependencies:
     async "0.2.6"
     babel-runtime "^5.8.34"
     dedent "^0.6.0"
     highlight-es "^1.0.0"
+    is-jquery-obj "^0.1.0"
     lodash "^4.14.0"
     moment "^2.14.1"
     mustache "^2.2.1"
@@ -9607,11 +9530,12 @@ testcafe-reporter-xunit@^2.1.0:
   resolved "https://registry.yarnpkg.com/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz#e6d66c572ce15af266706af0fd610b2a841dd443"
   integrity sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=
 
-testcafe@^0.23.2:
-  version "0.23.3"
-  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-0.23.3.tgz#8f9c6511b43ac99593d532bb08ae06c55ff72b5c"
-  integrity sha512-/ykDZ/Pvbb9oCK5kI/47DNm9nKYr8d7eY6U4nm7or5ETREkL9yEQwEzzyb2pC3Nt7iYzK+ZyPAcPWN4QFGiOXA==
+testcafe@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.1.4.tgz#8c03542b3790d91e47af3439f4c77ff67d1d32ad"
+  integrity sha512-2c0erAxmRd8o018e0sQ1SVVyX1JlTXwUHlRIITF3u7bPAe40IFINhPGBA8KhDYwWDSaOUZp4ft6bxDef2g8Zgg==
   dependencies:
+    "@types/node" "^10.12.19"
     async-exit-hook "^1.1.2"
     babel-core "^6.22.1"
     babel-plugin-transform-class-properties "^6.24.1"
@@ -9639,13 +9563,15 @@ testcafe@^0.23.2:
     error-stack-parser "^1.3.6"
     globby "^3.0.1"
     graceful-fs "^4.1.11"
-    gulp-data "^1.3.1"
+    graphlib "^2.1.5"
     import-lazy "^3.1.0"
     indent-string "^1.2.2"
     is-ci "^1.0.10"
+    is-docker "^1.1.0"
     is-glob "^2.0.1"
     is-stream "^1.1.0"
-    lodash "^4.17.10"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
     log-update-async-hook "^2.0.2"
     make-dir "^1.3.0"
     map-reverse "^1.0.1"
@@ -9660,7 +9586,6 @@ testcafe@^0.23.2:
     pinkie "^2.0.4"
     pngjs "^3.3.1"
     promisify-event "^1.0.0"
-    ps-node "^0.1.6"
     qrcode-terminal "^0.10.0"
     read-file-relative "^1.2.0"
     replicator "^1.0.3"
@@ -9669,9 +9594,9 @@ testcafe@^0.23.2:
     sanitize-filename "^1.6.0"
     source-map-support "^0.5.5"
     strip-bom "^2.0.0"
-    testcafe-browser-tools "1.6.5"
-    testcafe-hammerhead "14.4.7"
-    testcafe-legacy-api "3.1.9"
+    testcafe-browser-tools "1.6.8"
+    testcafe-hammerhead "14.6.3"
+    testcafe-legacy-api "3.1.11"
     testcafe-reporter-json "^2.1.0"
     testcafe-reporter-list "^2.1.0"
     testcafe-reporter-minimal "^2.1.0"
@@ -9680,7 +9605,7 @@ testcafe@^0.23.2:
     time-limit-promise "^1.0.2"
     tmp "0.0.28"
     tree-kill "^1.1.0"
-    typescript "^2.2.2"
+    typescript "^3.3.3"
     useragent "^2.1.7"
 
 text-table@^0.2.0:
@@ -9693,7 +9618,7 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-through2@^2.0.0, through2@^2.0.3:
+through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   integrity sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=
@@ -9720,11 +9645,6 @@ timed-out@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
-timeout-as-promise@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/timeout-as-promise/-/timeout-as-promise-1.0.0.tgz#7367e811fc992acfcdcdaabf2e50dfaf8b21576f"
-  integrity sha1-c2foEfyZKs/Nzaq/LlDfr4shV28=
 
 timers-browserify@^2.0.4:
   version "2.0.10"
@@ -10000,15 +9920,15 @@ typescript-plugin-styled-components@^1.0.0:
   resolved "https://registry.yarnpkg.com/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.0.0.tgz#b4de4ecd668fedd225d5c94bb5fe9cafbc0f045d"
   integrity sha512-uvndKU708YsCsud8bnBtSjosMEnUh/MXbUPswbNKjMY7GIumExp2xGEW/+2o3B+6zs98XHX4Z76iS81P5T3XUw==
 
-typescript@^2.2.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
-
 typescript@^3.2:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
   integrity sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==
+
+typescript@^3.3.3:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"
@@ -10185,11 +10105,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-util-extend@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
-  integrity sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=
 
 util.promisify@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION

## What's changed?
This adds 6 new paths to the integration tests:

1) Drag article between two collections 
2) Drag article from clipboard to collection + check that article remains in the clipboard 
3) Check that the delete button on articles works ❌ _(moved to separate PR hover state not working)_
4) Metadata edits (Headline change / Breaking news toggle button)
5) Discard collection (this means copying what is in a collections `live` property to its `draft` property. 
6) Add to clipboard button on individual stories works ❌ _(moved to separate PR hover state not working)_

## Implementation notes

* Adding a 2nd collection has made it necessary to create more complex functions in `selectors/index.js`. Now we need to select  the collection as well as the item within that collection.

* This breaks some of the nicer code we had wrapping this - open to ways of improving, if you have any thoughts

### Problems with hover state

We have had significant problems with the `hover state` (used to trigger the delete buttons on stories for example). In many runs of this code, the "test mouse" hasn't triggered the hover state, where a "real mouse" has. 

This appears to be a problem when triggering hover on styled components - but doesn't have a fix
https://github.com/DevExpress/testcafe/issues/3830

--> have moved [integration tests involving hover states to a separate PR](https://github.com/guardian/facia-tool/pull/760)

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE
