### PR TITLE
Rv collapse completely

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -24,7 +24,9 @@ import {
   selectEditorFrontIds,
   selectEditorFrontIdsByPriority,
   selectEditorFavouriteFrontIds,
-  selectEditorFavouriteFrontIdsByPriority
+  selectEditorFavouriteFrontIdsByPriority,
+  editorSelectArticleFragment,
+  selectEditorArticleFragment
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import { Action } from 'types/Action';
@@ -377,16 +379,45 @@ describe('frontsUIBundle', () => {
       expect(selectIsCollectionOpen(state, 'collection1')).toBe(false);
       expect(selectIsCollectionOpen(state, 'collection1')).toBe(false);
     });
-    it('should open and close a front overview', () => {
-      const state = reducer(
-        { closedOverviews: [] } as any,
-        editorCloseOverview('front1')
-      );
-      expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(false);
-      expect(selectIsFrontOverviewOpen(state, 'front2')).toBe(true);
-      const state2 = reducer(state.editor, editorOpenOverview('front1'));
-      expect(selectIsFrontOverviewOpen(state2, 'front1')).toBe(true);
-      expect(selectIsFrontOverviewOpen(state2, 'front2')).toBe(true);
+    describe('Front overviews', () => {
+      it('should open and close a front overview', () => {
+        let state = reducer(
+          { closedOverviews: [] } as any,
+          editorCloseOverview('front1')
+        );
+        expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(false);
+        expect(selectIsFrontOverviewOpen(state, 'front2')).toBe(true);
+        state = reducer(state.editor, editorOpenOverview('front1'));
+        expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(true);
+        expect(selectIsFrontOverviewOpen(state, 'front2')).toBe(true);
+      });
+      it('should close an overview when a form for that front is opened', () => {
+        let state = reducer(
+          { closedOverviews: [] } as any,
+          editorOpenOverview('front1')
+        );
+        expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(true);
+        state = reducer(
+          state.editor,
+          editorSelectArticleFragment('front1', 'exampleArticleFragment')
+        );
+        expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(false);
+      });
+    });
+    describe('Collection item form display', () => {
+      it('should open and close a collection item form', () => {
+        let state = reducer(
+          undefined,
+          editorSelectArticleFragment('front1', 'exampleArticleFragment')
+        );
+        expect(selectEditorArticleFragment(state, 'front1')).toEqual({
+          id: 'exampleArticleFragment',
+          isSupporting: false
+        });
+        state = reducer(state.editor, editorOpenOverview('front1'));
+        expect(selectEditorArticleFragment(state, 'front1')).toBe(undefined);
+      });
+      it('should close a collection item form when the overview for that front is opened', () => {});
     });
     it('should open and close all editing fronts', () => {
       const state = reducer(

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -491,6 +491,7 @@ const reducer = (state: State = defaultState, action: Action): State => {
     case EDITOR_SELECT_ARTICLE_FRAGMENT: {
       return {
         ...state,
+        closedOverviews: state.closedOverviews.concat(action.payload.frontId),
         selectedArticleFragments: {
           ...state.selectedArticleFragments,
           [action.payload.frontId]: {
@@ -533,12 +534,13 @@ const reducer = (state: State = defaultState, action: Action): State => {
       };
     }
     case EDITOR_OPEN_OVERVIEW: {
-      return {
+      const newState = {
         ...state,
         closedOverviews: state.closedOverviews.filter(
           id => id !== action.payload.frontId
         )
       };
+      return clearArticleFragmentSelection(newState, action.payload.frontId)
     }
     case EDITOR_CLOSE_OVERVIEW: {
       return {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -540,7 +540,7 @@ const reducer = (state: State = defaultState, action: Action): State => {
           id => id !== action.payload.frontId
         )
       };
-      return clearArticleFragmentSelection(newState, action.payload.frontId)
+      return clearArticleFragmentSelection(newState, action.payload.frontId);
     }
     case EDITOR_CLOSE_OVERVIEW: {
       return {

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -13,8 +13,6 @@ import {
   editorSelectArticleFragment,
   editorClearArticleFragmentSelection,
   selectIsClipboardOpen,
-  editorOpenClipboard,
-  editorCloseClipboard
 } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
 import {
@@ -26,7 +24,6 @@ import ClipboardLevel from './clipboard/ClipboardLevel';
 import ArticleFragmentLevel from './clipboard/ArticleFragmentLevel';
 import CollectionItem from './FrontsEdit/CollectionComponents/CollectionItem';
 import { styled } from 'constants/theme';
-import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 import DragIntentContainer from 'shared/components/DragIntentContainer';
 import {
   setFocusState,
@@ -52,21 +49,6 @@ const ClipboardWrapper = styled<
     border-top: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
     outline: none;
   }
-`;
-
-const ClipboardHeader = styled.div`
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: ${({ theme }) =>
-    `1px solid ${theme.shared.base.colors.borderColor}`};
-  display: flex;
-  padding: 10px;
-`;
-
-const ClipboardTitle = styled.h2`
-  font-size: 14px;
-  line-height: 1;
-  margin: 0;
 `;
 
 const ClipboardBody = styled.div`
@@ -101,7 +83,6 @@ interface ClipboardProps {
   removeCollectionItem: (id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
   isClipboardOpen: boolean;
-  toggleClipboard: (open: boolean) => void;
   handleFocus: () => void;
   handleArticleFocus: (articleFragment: TArticleFragment) => void;
   handleBlur: () => void;
@@ -164,22 +145,7 @@ class Clipboard extends React.Component<ClipboardProps> {
           delay={300}
           onDragIntentStart={() => this.setState({ preActive: true })}
           onDragIntentEnd={() => this.setState({ preActive: false })}
-          onIntentConfirm={() => this.props.toggleClipboard(true)}
         >
-          <ClipboardHeader>
-            {this.props.isClipboardOpen && (
-              <ClipboardTitle>Clipboard</ClipboardTitle>
-            )}
-            <ButtonCircularCaret
-              tabIndex={-1}
-              openDir="right"
-              active={this.props.isClipboardOpen}
-              preActive={this.state.preActive}
-              onClick={() =>
-                this.props.toggleClipboard(!this.props.isClipboardOpen)
-              }
-            />
-          </ClipboardHeader>
           <ClipboardBody>
             {this.props.isClipboardOpen && (
               <Root
@@ -301,8 +267,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       removeArticleFragment('articleFragment', parentId, uuid, 'clipboard')
     );
   },
-  toggleClipboard: (open: boolean) =>
-    dispatch(open ? editorOpenClipboard() : editorCloseClipboard()),
   updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) =>
     dispatch(updateArticleFragmentMeta(id, meta)),
   handleFocus: () =>

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -12,7 +12,7 @@ import {
 import {
   editorSelectArticleFragment,
   editorClearArticleFragmentSelection,
-  selectIsClipboardOpen,
+  selectIsClipboardOpen
 } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
 import {
@@ -134,97 +134,99 @@ class Clipboard extends React.Component<ClipboardProps> {
 
   public render() {
     return (
-      <ClipboardWrapper
-        tabIndex={0}
-        onFocus={this.handleFocus}
-        onBlur={this.handleBlur}
-        innerRef={this.clipboardWrapper as Ref}
-      >
-        <StyledDragIntentContainer
-          active={!this.props.isClipboardOpen}
-          delay={300}
-          onDragIntentStart={() => this.setState({ preActive: true })}
-          onDragIntentEnd={() => this.setState({ preActive: false })}
-        >
-          <ClipboardBody>
-            {this.props.isClipboardOpen && (
-              <Root
-                id="clipboard"
-                data-testid="clipboard"
-                style={{ display: 'flex', flex: 1 }}
-              >
-                <ClipboardLevel
-                  onMove={this.handleMove}
-                  onDrop={this.handleInsert}
+      <React.Fragment>
+        {this.props.isClipboardOpen && (
+          <ClipboardWrapper
+            tabIndex={0}
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
+            innerRef={this.clipboardWrapper as Ref}
+          >
+            <StyledDragIntentContainer
+              active={!this.props.isClipboardOpen}
+              delay={300}
+              onDragIntentStart={() => this.setState({ preActive: true })}
+              onDragIntentEnd={() => this.setState({ preActive: false })}
+            >
+              <ClipboardBody>
+                <Root
+                  id="clipboard"
+                  data-testid="clipboard"
+                  style={{ display: 'flex', flex: 1 }}
                 >
-                  {(articleFragment, getAfProps) => (
-                    <>
-                      <FocusWrapper
-                        tabIndex={0}
-                        onFocus={e =>
-                          this.handleArticleFocus(e, articleFragment)
-                        }
-                        area="clipboard"
-                        onBlur={this.handleBlur}
-                        uuid={articleFragment.uuid}
-                      >
-                        <CollectionItem
-                          uuid={articleFragment.uuid}
-                          parentId={clipboardId}
-                          frontId={clipboardId}
-                          getNodeProps={getAfProps}
-                          displayType="polaroid"
-                          onSelect={this.props.selectArticleFragment}
-                          onDelete={() =>
-                            this.props.removeCollectionItem(
-                              articleFragment.uuid
-                            )
+                  <ClipboardLevel
+                    onMove={this.handleMove}
+                    onDrop={this.handleInsert}
+                  >
+                    {(articleFragment, getAfProps) => (
+                      <>
+                        <FocusWrapper
+                          tabIndex={0}
+                          onFocus={e =>
+                            this.handleArticleFocus(e, articleFragment)
                           }
+                          area="clipboard"
+                          onBlur={this.handleBlur}
+                          uuid={articleFragment.uuid}
                         >
-                          {hasSupporting(articleFragment) && (
-                            <SupportingDivider />
-                          )}
-                          <ArticleFragmentLevel
-                            articleFragmentId={articleFragment.uuid}
-                            onMove={this.handleMove}
-                            onDrop={this.handleInsert}
+                          <CollectionItem
+                            uuid={articleFragment.uuid}
+                            parentId={clipboardId}
+                            frontId={clipboardId}
+                            getNodeProps={getAfProps}
                             displayType="polaroid"
+                            onSelect={this.props.selectArticleFragment}
+                            onDelete={() =>
+                              this.props.removeCollectionItem(
+                                articleFragment.uuid
+                              )
+                            }
                           >
-                            {(supporting, getSProps, i, arr) => (
-                              <CollectionItem
-                                uuid={supporting.uuid}
-                                frontId={clipboardId}
-                                parentId={articleFragment.uuid}
-                                getNodeProps={getSProps}
-                                size="small"
-                                displayType="polaroid"
-                                onSelect={id =>
-                                  this.props.selectArticleFragment(id, true)
-                                }
-                                onDelete={() =>
-                                  this.props.removeSupportingCollectionItem(
-                                    articleFragment.uuid,
-                                    supporting.uuid
-                                  )
-                                }
-                              >
-                                {i < arr.length - 1 ? (
-                                  <SupportingDivider />
-                                ) : null}
-                              </CollectionItem>
+                            {hasSupporting(articleFragment) && (
+                              <SupportingDivider />
                             )}
-                          </ArticleFragmentLevel>
-                        </CollectionItem>
-                      </FocusWrapper>
-                      <FullDivider />
-                    </>
-                  )}
-                </ClipboardLevel>
-              </Root>
-            )}
-          </ClipboardBody>
-        </StyledDragIntentContainer>
-      </ClipboardWrapper>
+                            <ArticleFragmentLevel
+                              articleFragmentId={articleFragment.uuid}
+                              onMove={this.handleMove}
+                              onDrop={this.handleInsert}
+                              displayType="polaroid"
+                            >
+                              {(supporting, getSProps, i, arr) => (
+                                <CollectionItem
+                                  uuid={supporting.uuid}
+                                  frontId={clipboardId}
+                                  parentId={articleFragment.uuid}
+                                  getNodeProps={getSProps}
+                                  size="small"
+                                  displayType="polaroid"
+                                  onSelect={id =>
+                                    this.props.selectArticleFragment(id, true)
+                                  }
+                                  onDelete={() =>
+                                    this.props.removeSupportingCollectionItem(
+                                      articleFragment.uuid,
+                                      supporting.uuid
+                                    )
+                                  }
+                                >
+                                  {i < arr.length - 1 ? (
+                                    <SupportingDivider />
+                                  ) : null}
+                                </CollectionItem>
+                              )}
+                            </ArticleFragmentLevel>
+                          </CollectionItem>
+                        </FocusWrapper>
+                        <FullDivider />
+                      </>
+                    )}
+                  </ClipboardLevel>
+                </Root>
+              </ClipboardBody>
+            </StyledDragIntentContainer>
+          </ClipboardWrapper>
+        )}
+      </React.Fragment>
     );
   }
 

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -41,8 +41,7 @@ const ClipboardWrapper = styled<
 >('div').attrs({
   'data-testid': 'clipboard-wrapper'
 })`
-  border: 1px solid #c9c9c9;
-  border-top: 1px solid black;
+  border-top: 1px solid ${({ theme }) => theme.shared.colors.greyLightPinkish};
   overflow-y: scroll;
   &:focus {
     border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Dispatch } from 'types/Store';
+import { connect } from 'react-redux';
+import {
+  selectIsClipboardOpen,
+  editorOpenClipboard,
+  editorCloseClipboard
+} from 'bundles/frontsUIBundle';
+import { State } from 'types/State';
+import { styled } from 'constants/theme';
+import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
+
+interface ClipboardHeaderProps {
+  isClipboardOpen: boolean;
+  toggleClipboard: (open: boolean) => void;
+}
+
+const Header = styled.div`
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: ${({ theme }) =>
+    `1px solid ${theme.shared.base.colors.borderColor}`};
+  display: flex;
+  padding: 10px;
+`;
+
+const ClipboardTitle = styled.h2`
+  font-size: 14px;
+  line-height: 1;
+  margin: 0;
+`;
+
+class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
+  public state = {
+    preActive: false
+  };
+  public render() {
+    return (
+      <Header>
+        {this.props.isClipboardOpen && (
+          <ClipboardTitle>Clipboard</ClipboardTitle>
+        )}
+        <ButtonCircularCaret
+          tabIndex={-1}
+          openDir="right"
+          active={this.props.isClipboardOpen}
+          preActive={this.state.preActive}
+          onClick={() =>
+            this.props.toggleClipboard(!this.props.isClipboardOpen)
+          }
+        />
+      </Header>
+    );
+  }
+}
+
+const mapStateToProps = (state: State) => ({
+  isClipboardOpen: selectIsClipboardOpen(state)
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  toggleClipboard: (open: boolean) =>
+    dispatch(open ? editorOpenClipboard() : editorCloseClipboard())
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ClipboardHeader);

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
 import { Dispatch } from 'types/Store';
 import { connect } from 'react-redux';
-import {
-  selectIsClipboardOpen,
-  editorOpenClipboard,
-  editorCloseClipboard
-} from 'bundles/frontsUIBundle';
+import { selectIsClipboardOpen, editorOpenClipboard, editorCloseClipboard } from 'bundles/frontsUIBundle';
 import { State } from 'types/State';
 import { styled } from 'constants/theme';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
+import DragIntentContainer from 'shared/components/DragIntentContainer';
+
 
 interface ClipboardHeaderProps {
   isClipboardOpen: boolean;
   toggleClipboard: (open: boolean) => void;
 }
+
+const StyledDragIntentContainer = styled(DragIntentContainer)`
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+`;
 
 const Header = styled.div`
   align-items: center;
@@ -30,28 +34,37 @@ const ClipboardTitle = styled.h2`
   margin: 0;
 `;
 
+
 class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
   public state = {
     preActive: false
   };
   public render() {
     return (
-      <Header>
-        {this.props.isClipboardOpen && (
-          <ClipboardTitle>Clipboard</ClipboardTitle>
-        )}
-        <ButtonCircularCaret
-          tabIndex={-1}
-          openDir="right"
-          active={this.props.isClipboardOpen}
-          preActive={this.state.preActive}
-          onClick={() =>
-            this.props.toggleClipboard(!this.props.isClipboardOpen)
-          }
-        />
-      </Header>
+      <StyledDragIntentContainer
+          active={!this.props.isClipboardOpen}
+          delay={300}
+          onDragIntentStart={() => this.setState({ preActive: true })}
+          onDragIntentEnd={() => this.setState({ preActive: false })}
+          onIntentConfirm={() => this.props.toggleClipboard(true)}
+      >
+        <Header>
+          {this.props.isClipboardOpen && (
+            <ClipboardTitle>Clipboard</ClipboardTitle>
+          )}
+          <ButtonCircularCaret
+            tabIndex={-1}
+            openDir="right"
+            active={this.props.isClipboardOpen}
+            preActive={this.state.preActive}
+            onClick={() =>
+              this.props.toggleClipboard(!this.props.isClipboardOpen)
+            }
+          />
+        </Header>
+      </StyledDragIntentContainer>
     );
-  }
+  };
 }
 
 const mapStateToProps = (state: State) => ({
@@ -60,10 +73,8 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   toggleClipboard: (open: boolean) =>
-    dispatch(open ? editorOpenClipboard() : editorCloseClipboard())
+    dispatch(open ? editorOpenClipboard() : editorCloseClipboard()),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ClipboardHeader);
+export default connect(mapStateToProps, mapDispatchToProps)(ClipboardHeader);
+

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -25,14 +25,18 @@ const StyledDragIntentContainer = styled(DragIntentContainer)`
 const Header = styled.div`
   align-items: center;
   justify-content: space-between;
-  border-bottom: ${({ theme }) =>
+  border-right: none;
+  border: ${({ theme }) =>
     `1px solid ${theme.shared.base.colors.borderColor}`};
   display: flex;
   padding: 10px;
+  height: 52px;
+  width: 100%;
+  margin-left: 8px;
 `;
 
 const ClipboardTitle = styled.h2`
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1;
   margin: 0;
 `;
@@ -51,17 +55,15 @@ class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
         onIntentConfirm={() => this.props.toggleClipboard(true)}
       >
         <Header>
-          {this.props.isClipboardOpen && (
-            <ClipboardTitle>Clipboard</ClipboardTitle>
-          )}
+          <ClipboardTitle>Clipboard</ClipboardTitle>
           <ButtonCircularCaret
-            tabIndex={-1}
             openDir="right"
             active={this.props.isClipboardOpen}
             preActive={this.state.preActive}
             onClick={() =>
               this.props.toggleClipboard(!this.props.isClipboardOpen)
             }
+            small={true}
           />
         </Header>
       </StyledDragIntentContainer>

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -22,23 +22,29 @@ const StyledDragIntentContainer = styled(DragIntentContainer)`
   min-height: 100%;
 `;
 
-const Header = styled.div`
+const Header = styled.div<{
+  isOpen: boolean;
+}>`
   align-items: center;
   justify-content: space-between;
   border-right: none;
-  border: ${({ theme }) =>
-    `1px solid ${theme.shared.base.colors.borderColor}`};
+  border: ${({ theme }) => `1px solid ${theme.shared.base.colors.borderColor}`};
+  border-right: none;
   display: flex;
   padding: 10px;
   height: 52px;
-  width: 100%;
   margin-left: 8px;
+  box-shadow: ${({ theme, isOpen }) =>
+    `2px 0 0 -1px ${
+      isOpen ? theme.shared.base.colors.backgroundColor : 'none'
+    }`};
 `;
 
 const ClipboardTitle = styled.h2`
   font-size: 12px;
   line-height: 1;
   margin: 0;
+  padding: 5px;
 `;
 
 class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
@@ -54,7 +60,7 @@ class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
         onDragIntentEnd={() => this.setState({ preActive: false })}
         onIntentConfirm={() => this.props.toggleClipboard(true)}
       >
-        <Header>
+        <Header isOpen={this.props.isClipboardOpen}>
           <ClipboardTitle>Clipboard</ClipboardTitle>
           <ButtonCircularCaret
             openDir="right"

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -63,7 +63,9 @@ class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
         onIntentConfirm={() => this.props.toggleClipboard(true)}
       >
         <Header isOpen={this.props.isClipboardOpen}>
-          <ClipboardTitle htmlFor="btn-clipboard-toggle">Clipboard</ClipboardTitle>
+          <ClipboardTitle htmlFor="btn-clipboard-toggle">
+            Clipboard
+          </ClipboardTitle>
           <ButtonCircularCaret
             id="btn-clipboard-toggle"
             openDir="right"

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Dispatch } from 'types/Store';
 import { connect } from 'react-redux';
-import { selectIsClipboardOpen, editorOpenClipboard, editorCloseClipboard } from 'bundles/frontsUIBundle';
+import {
+  selectIsClipboardOpen,
+  editorOpenClipboard,
+  editorCloseClipboard
+} from 'bundles/frontsUIBundle';
 import { State } from 'types/State';
 import { styled } from 'constants/theme';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 import DragIntentContainer from 'shared/components/DragIntentContainer';
-
 
 interface ClipboardHeaderProps {
   isClipboardOpen: boolean;
@@ -34,7 +37,6 @@ const ClipboardTitle = styled.h2`
   margin: 0;
 `;
 
-
 class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
   public state = {
     preActive: false
@@ -42,11 +44,11 @@ class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
   public render() {
     return (
       <StyledDragIntentContainer
-          active={!this.props.isClipboardOpen}
-          delay={300}
-          onDragIntentStart={() => this.setState({ preActive: true })}
-          onDragIntentEnd={() => this.setState({ preActive: false })}
-          onIntentConfirm={() => this.props.toggleClipboard(true)}
+        active={!this.props.isClipboardOpen}
+        delay={300}
+        onDragIntentStart={() => this.setState({ preActive: true })}
+        onDragIntentEnd={() => this.setState({ preActive: false })}
+        onIntentConfirm={() => this.props.toggleClipboard(true)}
       >
         <Header>
           {this.props.isClipboardOpen && (
@@ -64,7 +66,7 @@ class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
         </Header>
       </StyledDragIntentContainer>
     );
-  };
+  }
 }
 
 const mapStateToProps = (state: State) => ({
@@ -73,8 +75,10 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   toggleClipboard: (open: boolean) =>
-    dispatch(open ? editorOpenClipboard() : editorCloseClipboard()),
+    dispatch(open ? editorOpenClipboard() : editorCloseClipboard())
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(ClipboardHeader);
-
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ClipboardHeader);

--- a/client-v2/src/components/ClipboardHeader.tsx
+++ b/client-v2/src/components/ClipboardHeader.tsx
@@ -40,11 +40,13 @@ const Header = styled.div<{
     }`};
 `;
 
-const ClipboardTitle = styled.h2`
+const ClipboardTitle = styled.label`
   font-size: 12px;
+  font-weight: bold;
   line-height: 1;
   margin: 0;
   padding: 5px;
+  cursor: pointer;
 `;
 
 class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
@@ -61,8 +63,9 @@ class ClipboardHeader extends React.Component<ClipboardHeaderProps> {
         onIntentConfirm={() => this.props.toggleClipboard(true)}
       >
         <Header isOpen={this.props.isClipboardOpen}>
-          <ClipboardTitle>Clipboard</ClipboardTitle>
+          <ClipboardTitle htmlFor="btn-clipboard-toggle">Clipboard</ClipboardTitle>
           <ButtonCircularCaret
+            id="btn-clipboard-toggle"
             openDir="right"
             active={this.props.isClipboardOpen}
             preActive={this.state.preActive}

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -11,10 +11,12 @@ const FeedSectionContainer = styled('div')`
   background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
 `;
 
+const FeedSectionContent = styled(SectionContent)`
+  padding-right: 0px;
+`;
+
 const FeedWrapper = styled('div')`
   width: 409px;
-  padding-right: 10px;
-  margin-right: 10px;
   border-right: ${({ theme }) =>
     `solid 1px ${theme.shared.base.colors.borderColor}`};
 `;
@@ -22,7 +24,7 @@ const FeedWrapper = styled('div')`
 export default () => (
   <FeedSectionContainer>
     <FeedSectionHeader />
-    <SectionContent>
+    <FeedSectionContent>
       <FeedWrapper>
         <FeedContainer />
       </FeedWrapper>
@@ -30,6 +32,6 @@ export default () => (
       <div>
         <ClipboardMeta />
       </div>
-    </SectionContent>
+    </FeedSectionContent>
   </FeedSectionContainer>
 );

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -13,6 +13,7 @@ const FeedSectionContainer = styled('div')`
 
 const FeedSectionContent = styled(SectionContent)`
   padding-right: 0px;
+  margin-top: 10px;
 `;
 
 const FeedWrapper = styled('div')`

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -7,6 +7,10 @@ import Clipboard from './Clipboard';
 import ClipboardMeta from './ClipboardMeta';
 import FeedSectionHeader from './FeedSectionHeader';
 
+interface Props {
+  isClipboardOpen: boolean;
+}
+
 const FeedSectionContainer = styled('div')`
   background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
 `;
@@ -16,17 +20,19 @@ const FeedSectionContent = styled(SectionContent)`
   padding-top: 10px;
 `;
 
-const FeedWrapper = styled('div')`
+const FeedWrapper = styled('div')<{ isClipboardOpen: boolean }>`
   width: 409px;
-  border-right: ${({ theme }) =>
-    `solid 1px ${theme.shared.base.colors.borderColor}`};
+  border-right: ${({ theme, isClipboardOpen }) =>
+    isClipboardOpen
+      ? `solid 1px ${theme.shared.base.colors.borderColor}`
+      : null};
 `;
 
-export default () => (
+export default ({ isClipboardOpen }: Props) => (
   <FeedSectionContainer>
     <FeedSectionHeader />
     <FeedSectionContent>
-      <FeedWrapper>
+      <FeedWrapper isClipboardOpen={isClipboardOpen}>
         <FeedContainer />
       </FeedWrapper>
       <Clipboard />

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -13,7 +13,7 @@ const FeedSectionContainer = styled('div')`
 
 const FeedSectionContent = styled(SectionContent)`
   padding-right: 0px;
-  margin-top: 10px;
+  padding-top: 10px;
 `;
 
 const FeedWrapper = styled('div')`

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -24,6 +24,7 @@ import { IPagination } from 'lib/createAsyncResourceBundle';
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
 import { DEFAULT_PARAMS } from 'services/faciaApi';
 import ScrollContainer from './ScrollContainer';
+import ClipboardHeader from 'components/ClipboardHeader';
 
 interface FeedsContainerProps {
   fetchLive: (params: object, isResource: boolean) => void;
@@ -310,6 +311,7 @@ class FeedsContainer extends React.Component<
                 displaySearchFilters={this.state.displaySearchFilters}
                 onUpdate={this.handleParamsUpdate}
                 showReviewSearch={false}
+                rightHandContainer={<ClipboardHeader />}
               />
               {!this.state.displaySearchFilters && this.renderFixedContent()}
             </>

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -29,9 +29,14 @@ interface SearchInputProps {
   rightHandContainer?: React.ReactElement<any>;
 }
 
+const TextInputContainer = styled('div')`
+  flex-grow: 2;
+`;
+
 const InputContainer = styled('div')`
   margin-bottom: 10px;
   display: flex;
+  justify-content: space-between;
 `;
 
 const CloseButton = styled(ButtonDefault)`
@@ -113,21 +118,23 @@ class SearchInput extends React.Component<SearchInputProps, SearchInputState> {
     return (
       <React.Fragment>
         <InputContainer>
-          <TextInput
-            placeholder="Search content"
-            value={query || ''}
-            onClick={this.showSearchFilters}
-            onChange={this.handleSearchInput}
-            onClear={this.clearInput}
-            onSearch={this.hideSearchFilters}
-            searchTermsExist={this.searchTermsExist}
-            onDisplaySearchFilters={this.handleDisplaySearchFilters}
-            onKeyUp={e => {
-              if (e.keyCode === 13) {
-                this.hideSearchFilters();
-              }
-            }}
-          />
+          <TextInputContainer>
+            <TextInput
+              placeholder="Search content"
+              value={query || ''}
+              onClick={this.showSearchFilters}
+              onChange={this.handleSearchInput}
+              onClear={this.clearInput}
+              onSearch={this.hideSearchFilters}
+              searchTermsExist={this.searchTermsExist}
+              onDisplaySearchFilters={this.handleDisplaySearchFilters}
+              onKeyUp={e => {
+                if (e.keyCode === 13) {
+                  this.hideSearchFilters();
+                }
+              }}
+            />
+          </TextInputContainer>
           {rightHandContainer}
         </InputContainer>
         {tags.map(tag => (

--- a/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/SearchInput.tsx
@@ -26,11 +26,12 @@ interface SearchInputProps {
   displaySearchFilters: boolean;
   updateDisplaySearchFilters: (value: boolean) => void;
   showReviewSearch: boolean;
+  rightHandContainer?: React.ReactElement<any>;
 }
 
 const InputContainer = styled('div')`
-  background: ${({ theme }) => theme.capiInterface.backgroundWhite};
   margin-bottom: 10px;
+  display: flex;
 `;
 
 const CloseButton = styled(ButtonDefault)`
@@ -97,7 +98,7 @@ class SearchInput extends React.Component<SearchInputProps, SearchInputState> {
   };
 
   public render() {
-    const { displaySearchFilters } = this.props;
+    const { displaySearchFilters, rightHandContainer } = this.props;
 
     const {
       query,
@@ -127,6 +128,7 @@ class SearchInput extends React.Component<SearchInputProps, SearchInputState> {
               }
             }}
           />
+          {rightHandContainer}
         </InputContainer>
         {tags.map(tag => (
           <FilterItem

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -9,7 +9,8 @@ import {
   editorFavouriteFront,
   editorUnfavouriteFront,
   selectEditorFrontIdsByPriority,
-  selectIsCurrentFrontsMenuOpen
+  selectIsCurrentFrontsMenuOpen,
+  selectIsClipboardOpen
 } from 'bundles/frontsUIBundle';
 import { State } from 'types/State';
 import { ActionError } from 'types/Action';
@@ -32,6 +33,7 @@ interface Props {
   editorUnfavouriteFront: (frontId: string, priority: string) => void;
   getFrontsConfig: () => void;
   isCurrentFrontsMenuOpen: boolean;
+  isClipboardOpen: boolean;
 }
 
 const FrontsEditContainer = styled('div')`
@@ -75,7 +77,7 @@ class FrontsEdit extends React.Component<Props> {
         <PressFailAlert staleFronts={this.props.staleFronts} />
         <SectionsContainer>
           <FeedContainer>
-            <FeedSection />
+            <FeedSection isClipboardOpen={this.props.isClipboardOpen} />
           </FeedContainer>
           <FrontsContainer
             id={frontsContainerId}
@@ -117,7 +119,8 @@ const mapStateToProps = (state: State, props: Props) => ({
     state,
     props.match.params.priority || ''
   ),
-  isCurrentFrontsMenuOpen: selectIsCurrentFrontsMenuOpen(state)
+  isCurrentFrontsMenuOpen: selectIsCurrentFrontsMenuOpen(state),
+  isClipboardOpen: selectIsClipboardOpen(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch, props: Props) => ({

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -52,12 +52,13 @@ const OverviewToggleContainer = styled('div')`
   padding-left: 10px;
   padding-top: 3px;
   border-left: ${({ theme }) =>
-    `solid 1px  ${theme.shared.colors.greyVeryLight}`}
+    `solid 1px  ${theme.shared.colors.greyVeryLight}`};
   padding-top: 13px;
 `;
 
-const OverviewHeading = styled('span')`
+const OverviewHeading = styled('label')`
   margin-right: 5px;
+  cursor: pointer;
 `;
 
 const CollapseAllButton = styled(ButtonRoundedWithLabel)`
@@ -188,10 +189,11 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                 label={'Collapse all'}
               />
               <OverviewToggleContainer>
-                <OverviewHeading>
+                <OverviewHeading htmlFor="btn-overview-toggle">
                   {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
                 </OverviewHeading>
                 <ButtonCircularCaret
+                  id="btn-overview-toggle"
                   style={{
                     margin: '0'
                   }}

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -12,7 +12,8 @@ import {
   editorOpenCollections,
   editorOpenOverview,
   editorCloseOverview,
-  selectIsFrontOverviewOpen
+  selectIsFrontOverviewOpen,
+  editorClearArticleFragmentSelection
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
@@ -32,6 +33,7 @@ import { DownCaretIcon } from 'shared/components/icons/Icons';
 import { theme as sharedTheme } from 'shared/constants/theme';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLabel';
+import { batchActions } from 'redux-batched-actions';
 
 const FrontContainer = styled('div')`
   display: flex;
@@ -281,10 +283,16 @@ const mapDispatchToProps = (
           frontId
         })
       ),
-    toggleOverview: (open: boolean) =>
-      dispatch(
-        open ? editorOpenOverview(props.id) : editorCloseOverview(props.id)
-      ),
+    toggleOverview: (open: boolean) => {
+      if (open) {
+        dispatch(editorOpenOverview(props.id))
+      } else {
+        dispatch(batchActions([
+          editorCloseOverview(props.id),
+          editorClearArticleFragmentSelection(props.id)
+        ]))
+      }
+    },
     closeAllCollections: (collections: string[]) =>
       dispatch(closeCollections(collections))
   };

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -285,12 +285,14 @@ const mapDispatchToProps = (
       ),
     toggleOverview: (open: boolean) => {
       if (open) {
-        dispatch(editorOpenOverview(props.id))
+        dispatch(editorOpenOverview(props.id));
       } else {
-        dispatch(batchActions([
-          editorCloseOverview(props.id),
-          editorClearArticleFragmentSelection(props.id)
-        ]))
+        dispatch(
+          batchActions([
+            editorCloseOverview(props.id),
+            editorClearArticleFragmentSelection(props.id)
+          ])
+        );
       }
     },
     closeAllCollections: (collections: string[]) =>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -76,6 +76,7 @@ const CollapseAllButton = styled(ButtonRoundedWithLabel)`
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
 const FrontContentContainer = styled('div')`
+  height: 100%;
   min-height: 0;
 `;
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled, theme } from 'constants/theme';
+import { styled } from 'constants/theme';
 import { connect } from 'react-redux';
 import { Root, Move, PosSpec } from 'lib/dnd';
 import { State } from 'types/State';
@@ -9,7 +9,10 @@ import { insertArticleFragmentFromDropEvent } from 'util/collectionUtils';
 import { AlsoOnDetail } from 'types/Collection';
 import {
   editorSelectArticleFragment,
-  editorOpenCollections
+  editorOpenCollections,
+  editorOpenOverview,
+  editorCloseOverview,
+  selectIsFrontOverviewOpen
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
@@ -19,20 +22,66 @@ import { getFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
 import { events } from 'services/GA';
 import FrontDetailView from './FrontDetailView';
-import { initialiseCollectionsForFront } from 'actions/Collections';
+import {
+  initialiseCollectionsForFront,
+  closeCollections
+} from 'actions/Collections';
 import { setFocusState } from 'bundles/focusBundle';
 import Collection from './Collection';
+import { DownCaretIcon } from 'shared/components/icons/Icons';
+import { theme as sharedTheme } from 'shared/constants/theme';
+import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
+import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLabel';
+
+const FrontContainer = styled('div')`
+  display: flex;
+`;
+
+const SectionContentMetaContainer = styled('div')`
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+  margin-right: 5px;
+`;
+
+const OverviewToggleContainer = styled('div')`
+  font-size: 13px;
+  font-weight: bold;
+  padding-left: 10px;
+  padding-top: 3px;
+  border-left: ${({ theme }) =>
+    `solid 1px  ${theme.shared.colors.greyVeryLight}`}
+  padding-top: 13px;
+`;
+
+const OverviewHeading = styled('span')`
+  margin-right: 5px;
+`;
+
+const CollapseAllButton = styled(ButtonRoundedWithLabel)`
+  & svg {
+    transform: rotate(180deg);
+    vertical-align: middle;
+  }
+  :hover {
+    background-color: ${({ theme }) =>
+      theme.shared.base.colors.backgroundColorFocused};
+  }
+  margin-right: 10px;
+  font-size: 12px;
+  margin-bottom: 10px;
+  margin-top: 10px;
+`;
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
-const FrontContainer = styled('div')`
-  display: flex;
+const FrontContentContainer = styled('div')`
   min-height: 0;
 `;
 
-const FrontContentContainer = styled('div')`
-  max-height: 100%;
+const FrontCollectionsContainer = styled('div')`
   overflow-y: scroll;
+  max-height: 100%;
   padding-top: 1px;
 `;
 
@@ -56,6 +105,9 @@ type FrontProps = FrontPropsBeforeState & {
     articleFragment: TArticleFragment,
     frontId: string
   ) => void;
+  toggleOverview: (open: boolean) => void;
+  overviewIsOpen: boolean;
+  closeAllCollections: (collections: string[]) => void;
 };
 
 interface FrontState {
@@ -112,7 +164,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
       <React.Fragment>
         <div
           style={{
-            background: theme.shared.base.colors.backgroundColorLight,
+            background: sharedTheme.base.colors.backgroundColorLight,
             display: this.state.error ? 'block' : 'none',
             padding: '1em',
             position: 'absolute',
@@ -123,24 +175,53 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         </div>
         <FrontContainer>
           <FrontContentContainer>
-            <Root id={this.props.id} data-testid={this.props.id}>
-              {front.collections.map(collectionId => (
-                <Collection
-                  key={collectionId}
-                  id={collectionId}
-                  frontId={this.props.id}
-                  priority={front.priority}
-                  browsingStage={this.props.browsingStage}
-                  alsoOn={this.props.alsoOn}
-                  handleInsert={this.handleInsert}
-                  handleMove={this.handleMove}
-                  selectArticleFragment={this.props.selectArticleFragment(
-                    this.props.id
-                  )}
-                  handleArticleFocus={this.handleArticleFocus}
+            <SectionContentMetaContainer>
+              <CollapseAllButton
+                onClick={e => {
+                  e.preventDefault();
+                  this.props.closeAllCollections(this.props.collectionIds);
+                }}
+                icon={<DownCaretIcon fill={sharedTheme.base.colors.text} />}
+                label={'Collapse all'}
+              />
+              <OverviewToggleContainer>
+                <OverviewHeading>
+                  {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
+                </OverviewHeading>
+                <ButtonCircularCaret
+                  style={{
+                    margin: '0'
+                  }}
+                  openDir="right"
+                  active={this.props.overviewIsOpen}
+                  preActive={false}
+                  onClick={() =>
+                    this.props.toggleOverview(!this.props.overviewIsOpen)
+                  }
+                  small={true}
                 />
-              ))}
-            </Root>
+              </OverviewToggleContainer>
+            </SectionContentMetaContainer>
+            <FrontCollectionsContainer>
+              <Root id={this.props.id} data-testid={this.props.id}>
+                {front.collections.map(collectionId => (
+                  <Collection
+                    key={collectionId}
+                    id={collectionId}
+                    frontId={this.props.id}
+                    priority={front.priority}
+                    browsingStage={this.props.browsingStage}
+                    alsoOn={this.props.alsoOn}
+                    handleInsert={this.handleInsert}
+                    handleMove={this.handleMove}
+                    selectArticleFragment={this.props.selectArticleFragment(
+                      this.props.id
+                    )}
+                    handleArticleFocus={this.handleArticleFocus}
+                  />
+                ))}
+              </Root>
+            </FrontCollectionsContainer>
           </FrontContentContainer>
           <FrontContentContainer>
             <FrontDetailView
@@ -165,7 +246,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
 
 const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
   return {
-    front: getFront(state, { frontId: props.id })
+    front: getFront(state, { frontId: props.id }),
+    overviewIsOpen: selectIsFrontOverviewOpen(state, props.id)
   };
 };
 
@@ -197,7 +279,13 @@ const mapDispatchToProps = (
           articleFragment,
           frontId
         })
-      )
+      ),
+    toggleOverview: (open: boolean) =>
+      dispatch(
+        open ? editorOpenOverview(props.id) : editorCloseOverview(props.id)
+      ),
+    closeAllCollections: (collections: string[]) =>
+      dispatch(closeCollections(collections))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -81,7 +81,7 @@ const FrontContentContainer = styled('div')`
 
 const FrontCollectionsContainer = styled('div')`
   overflow-y: scroll;
-  max-height: 100%;
+  max-height: calc(100% - 43px);
   padding-top: 1px;
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -32,7 +32,7 @@ const Container = styled(ContentContainer)<ContainerProps>`
   margin-left: 10px;
   margin-top: 43px;
   max-height: calc(100% - 43px);
-  overflow: hidden;
+  overflow-y: scroll;
   ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
 `;
 
@@ -46,7 +46,7 @@ const FrontCollectionsOverview = ({
   browsingStage
 }: FrontCollectionOverviewProps) => (
   <Container setBack isClosed={false}>
-    <ContainerHeadingPinline>'Overview'</ContainerHeadingPinline>
+    <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
     <ContainerBody>
       {front.collections.map(collectionId => (
         <CollectionOverview

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { styled } from 'constants/theme';
 import { State } from 'types/State';
-import { Dispatch } from 'types/Store';
 import { getFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
 import CollectionOverview from './CollectionOverview';
 import { CollectionItemSets } from 'shared/types/Collection';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
-import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
-import {
-  selectIsFrontOverviewOpen,
-  editorOpenOverview,
-  editorCloseOverview
-} from 'bundles/frontsUIBundle';
 
 interface FrontContainerProps {
   id: string;
@@ -23,8 +16,6 @@ interface FrontContainerProps {
 
 type FrontCollectionOverviewProps = FrontContainerProps & {
   front: FrontConfig;
-  overviewIsOpen: boolean;
-  toggleOverview: (open: boolean) => void;
 };
 
 interface ContainerProps {
@@ -50,52 +41,24 @@ const FrontCollectionsOverview = ({
   id,
   front,
   browsingStage,
-  overviewIsOpen,
-  toggleOverview
 }: FrontCollectionOverviewProps) => (
-  <Container setBack isClosed={!overviewIsOpen}>
-    <ContainerHeadingPinline>
-      {overviewIsOpen && 'Overview'}
-      <ButtonCircularCaret
-        style={{
-          margin: overviewIsOpen ? '0' : '10px'
-        }}
-        openDir="right"
-        active={overviewIsOpen}
-        preActive={false}
-        onClick={() => toggleOverview(!overviewIsOpen)}
-      />
-    </ContainerHeadingPinline>
-    {overviewIsOpen && (
-      <ContainerBody>
-        {front.collections.map(collectionId => (
-          <CollectionOverview
-            frontId={id}
-            key={collectionId}
-            collectionId={collectionId}
-            browsingStage={browsingStage}
-          />
-        ))}
-      </ContainerBody>
-    )}
+  <Container setBack isClosed={false}>
+    <ContainerHeadingPinline>'Overview'</ContainerHeadingPinline>
+    <ContainerBody>
+      {front.collections.map(collectionId => (
+        <CollectionOverview
+          frontId={id}
+          key={collectionId}
+          collectionId={collectionId}
+          browsingStage={browsingStage}
+        />
+      ))}
+    </ContainerBody>
   </Container>
 );
 
 const mapStateToProps = (state: State, props: FrontContainerProps) => ({
-  front: getFront(state, { frontId: props.id }),
-  overviewIsOpen: selectIsFrontOverviewOpen(state, props.id)
+  front: getFront(state, { frontId: props.id })
 });
 
-const mapDispatchToProps = (
-  dispatch: Dispatch,
-  props: FrontContainerProps
-) => ({
-  toggleOverview: (open: boolean) =>
-    dispatch(
-      open ? editorOpenOverview(props.id) : editorCloseOverview(props.id)
-    )
-});
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(FrontCollectionsOverview);
+export default connect(mapStateToProps)(FrontCollectionsOverview);

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -30,6 +30,7 @@ const Container = styled(ContentContainer)<ContainerProps>`
   flex-direction: column;
   flex: 1;
   margin-left: 10px;
+  margin-top: 43px;
   ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -31,6 +31,8 @@ const Container = styled(ContentContainer)<ContainerProps>`
   flex: 1;
   margin-left: 10px;
   margin-top: 43px;
+  max-height: calc(100% - 43px);
+  overflow: hidden;
   ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -40,7 +40,7 @@ const ContainerBody = styled.div`
 const FrontCollectionsOverview = ({
   id,
   front,
-  browsingStage,
+  browsingStage
 }: FrontCollectionOverviewProps) => (
   <Container setBack isClosed={false}>
     <ContainerHeadingPinline>'Overview'</ContainerHeadingPinline>

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -182,10 +182,12 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
               label={'Collapse all'}
             />
             <OverviewToggleContainer>
-              <OverviewHeading>{this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}</OverviewHeading>
+              <OverviewHeading>
+                {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
+              </OverviewHeading>
               <ButtonCircularCaret
                 style={{
-                  margin: this.props.overviewIsOpen ? '0' : '10px'
+                  margin: '0'
                 }}
                 openDir="right"
                 active={this.props.overviewIsOpen}

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -53,7 +53,6 @@ const SectionContentMetaContainer = styled('div')`
   display: flex;
   flex-shrink: 0;
   justify-content: flex-end;
-  margin-bottom: 10px;
 `;
 
 const StageSelectButtons = styled('div')`
@@ -70,6 +69,10 @@ const CollapseAllButton = styled(ButtonRoundedWithLabel)`
     background-color: ${({ theme }) =>
       theme.shared.base.colors.backgroundColorFocused};
   }
+  margin-right: 10px;
+  font-size: 12px;
+  margin-bottom: 10px;
+  margin-top: 10px;
 `;
 
 const FrontsContainer = styled('div')`
@@ -81,6 +84,15 @@ const OverviewToggleContainer = styled('div')`
   font-size: 13px;
   font-weight: bold;
   margin-right: 190px;
+  padding-left: 10px;
+  padding-top: 3px;
+  border-left: ${({ theme }) =>
+    `solid 1px  ${theme.shared.colors.greyVeryLight}`}
+  padding-top: 13px;
+`;
+
+const OverviewHeading = styled('span')`
+  margin-right: 5px;
 `;
 
 interface FrontsContainerProps {
@@ -170,7 +182,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
               label={'Collapse all'}
             />
             <OverviewToggleContainer>
-              {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
+              <OverviewHeading>{this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}</OverviewHeading>
               <ButtonCircularCaret
                 style={{
                   margin: this.props.overviewIsOpen ? '0' : '10px'

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -80,6 +80,7 @@ const FrontsContainer = styled('div')`
 const OverviewToggleContainer = styled('div')`
   font-size: 13px;
   font-weight: bold;
+  margin-right: 190px;
 `;
 
 interface FrontsContainerProps {

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -4,13 +4,8 @@ import startCase from 'lodash/startCase';
 import { styled } from 'constants/theme';
 import { Dispatch } from 'types/Store';
 import { fetchLastPressed } from 'actions/Fronts';
-import { updateCollection, closeCollections } from 'actions/Collections';
-import {
-  editorCloseFront,
-  selectIsFrontOverviewOpen,
-  editorOpenOverview,
-  editorCloseOverview
-} from 'bundles/frontsUIBundle';
+import { updateCollection } from 'actions/Collections';
+import { editorCloseFront } from 'bundles/frontsUIBundle';
 import Button from 'shared/components/input/ButtonDefault';
 import { frontStages } from 'constants/fronts';
 import { FrontConfig } from 'types/FaciaApi';
@@ -23,10 +18,6 @@ import SectionContent from '../layout/SectionContent';
 import { CollectionItemSets, Collection } from 'shared/types/Collection';
 import { toTitleCase } from 'util/stringUtils';
 import { RadioButton, RadioGroup } from 'components/inputs/RadioButtons';
-import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLabel';
-import { DownCaretIcon } from 'shared/components/icons/Icons';
-import { theme as sharedTheme } from 'shared/constants/theme';
-import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 
 const FrontHeader = styled(SectionHeader)`
   display: flex;
@@ -49,50 +40,14 @@ const FrontsHeaderText = styled('span')`
   color: ${({ theme }) => theme.shared.colors.blackDark};
 `;
 
-const SectionContentMetaContainer = styled('div')`
-  display: flex;
-  flex-shrink: 0;
-  justify-content: flex-end;
-`;
-
 const StageSelectButtons = styled('div')`
   color: ${({ theme }) => theme.shared.colors.blackDark};
   padding: 0px 30px;
 `;
 
-const CollapseAllButton = styled(ButtonRoundedWithLabel)`
-  & svg {
-    transform: rotate(180deg);
-    vertical-align: middle;
-  }
-  :hover {
-    background-color: ${({ theme }) =>
-      theme.shared.base.colors.backgroundColorFocused};
-  }
-  margin-right: 10px;
-  font-size: 12px;
-  margin-bottom: 10px;
-  margin-top: 10px;
-`;
-
 const FrontsContainer = styled('div')`
   height: 100%;
   transform: translate3d(0, 0, 0);
-`;
-
-const OverviewToggleContainer = styled('div')`
-  font-size: 13px;
-  font-weight: bold;
-  margin-right: 190px;
-  padding-left: 10px;
-  padding-top: 3px;
-  border-left: ${({ theme }) =>
-    `solid 1px  ${theme.shared.colors.greyVeryLight}`}
-  padding-top: 13px;
-`;
-
-const OverviewHeading = styled('span')`
-  margin-right: 5px;
 `;
 
 interface FrontsContainerProps {
@@ -102,13 +57,10 @@ interface FrontsContainerProps {
 type FrontsComponentProps = FrontsContainerProps & {
   selectedFront: FrontConfig;
   alsoOn: { [id: string]: AlsoOnDetail };
-  overviewIsOpen: boolean;
   frontsActions: {
     fetchLastPressed: (frontId: string) => void;
     editorCloseFront: (frontId: string) => void;
     updateCollection: (collection: Collection) => void;
-    closeAllCollections: (collections: string[]) => void;
-    toggleOverview: (open: boolean) => void;
   };
 };
 
@@ -170,37 +122,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
           </FrontHeader>
         </>
         <SectionContent direction="column">
-          <SectionContentMetaContainer>
-            <CollapseAllButton
-              onClick={e => {
-                e.preventDefault();
-                this.props.frontsActions.closeAllCollections(
-                  this.props.selectedFront.collections
-                );
-              }}
-              icon={<DownCaretIcon fill={sharedTheme.base.colors.text} />}
-              label={'Collapse all'}
-            />
-            <OverviewToggleContainer>
-              <OverviewHeading>
-                {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
-              </OverviewHeading>
-              <ButtonCircularCaret
-                style={{
-                  margin: '0'
-                }}
-                openDir="right"
-                active={this.props.overviewIsOpen}
-                preActive={false}
-                onClick={() =>
-                  this.props.frontsActions.toggleOverview(
-                    !this.props.overviewIsOpen
-                  )
-                }
-                small={true}
-              />
-            </OverviewToggleContainer>
-          </SectionContentMetaContainer>
           {this.props.selectedFront && (
             <Front
               id={this.props.frontId}
@@ -219,8 +140,7 @@ const createMapStateToProps = () => {
   const alsoOnSelector = createAlsoOnSelector();
   return (state: State, props: FrontsContainerProps) => ({
     selectedFront: getFront(state, { frontId: props.frontId }),
-    alsoOn: alsoOnSelector(state, { frontId: props.frontId }),
-    overviewIsOpen: selectIsFrontOverviewOpen(state, props.frontId)
+    alsoOn: alsoOnSelector(state, { frontId: props.frontId })
   });
 };
 
@@ -232,15 +152,7 @@ const mapDispatchToProps = (
     fetchLastPressed: (id: string) => dispatch(fetchLastPressed(id)),
     updateCollection: (collection: Collection) =>
       dispatch(updateCollection(collection)),
-    editorCloseFront: (id: string) => dispatch(editorCloseFront(id)),
-    closeAllCollections: (collections: string[]) =>
-      dispatch(closeCollections(collections)),
-    toggleOverview: (open: boolean) =>
-      dispatch(
-        open
-          ? editorOpenOverview(props.frontId)
-          : editorCloseOverview(props.frontId)
-      )
+    editorCloseFront: (id: string) => dispatch(editorCloseFront(id))
   }
 });
 

--- a/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
@@ -18,13 +18,13 @@ import { State } from 'types/State';
 interface ContainerProps {
   id: string;
   browsingStage: CollectionItemSets;
-  overviewIsOpen: boolean;
 }
 
 interface ComponentProps extends ContainerProps {
   selectedArticleFragment: { id: string; isSupporting: boolean } | void;
   updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) => void;
   clearArticleFragmentSelection: (id: string) => void;
+  overviewIsOpen: boolean;
 }
 
 const FrontsDetailView = ({

--- a/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
@@ -9,7 +9,8 @@ import {
 import { updateArticleFragmentMeta as updateArticleFragmentMetaAction } from 'actions/ArticleFragments';
 import {
   editorClearArticleFragmentSelection,
-  selectEditorArticleFragment
+  selectEditorArticleFragment,
+  selectIsFrontOverviewOpen
 } from 'bundles/frontsUIBundle';
 import { Dispatch } from 'types/Store';
 import { State } from 'types/State';
@@ -17,6 +18,7 @@ import { State } from 'types/State';
 interface ContainerProps {
   id: string;
   browsingStage: CollectionItemSets;
+  overviewIsOpen: boolean;
 }
 
 interface ComponentProps extends ContainerProps {
@@ -30,27 +32,34 @@ const FrontsDetailView = ({
   id,
   browsingStage,
   clearArticleFragmentSelection,
-  updateArticleFragmentMeta
-}: ComponentProps) =>
-  selectedArticleFragment ? (
-    <ArticleFragmentForm
-      articleFragmentId={selectedArticleFragment.id}
-      isSupporting={selectedArticleFragment.isSupporting}
-      key={selectedArticleFragment.id}
-      form={selectedArticleFragment.id}
-      frontId={id}
-      onSave={(meta: ArticleFragmentMeta) => {
-        updateArticleFragmentMeta(selectedArticleFragment.id, meta);
-        clearArticleFragmentSelection(id);
-      }}
-      onCancel={() => clearArticleFragmentSelection(id)}
-    />
-  ) : (
-    <FrontCollectionsOverview id={id} browsingStage={browsingStage} />
-  );
+  updateArticleFragmentMeta,
+  overviewIsOpen
+}: ComponentProps) => {
+  if (selectedArticleFragment) {
+    return (
+      <ArticleFragmentForm
+        articleFragmentId={selectedArticleFragment.id}
+        isSupporting={selectedArticleFragment.isSupporting}
+        key={selectedArticleFragment.id}
+        form={selectedArticleFragment.id}
+        frontId={id}
+        onSave={(meta: ArticleFragmentMeta) => {
+          updateArticleFragmentMeta(selectedArticleFragment.id, meta);
+          clearArticleFragmentSelection(id);
+        }}
+        onCancel={() => clearArticleFragmentSelection(id)}
+      />
+    );
+  }
+  if (overviewIsOpen) {
+    return <FrontCollectionsOverview id={id} browsingStage={browsingStage} />;
+  }
+  return null;
+};
 
 const mapStateToProps = (state: State, props: ContainerProps) => ({
-  selectedArticleFragment: selectEditorArticleFragment(state, props.id)
+  selectedArticleFragment: selectEditorArticleFragment(state, props.id),
+  overviewIsOpen: selectIsFrontOverviewOpen(state, props.id)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/client-v2/src/components/ScrollContainer.tsx
+++ b/client-v2/src/components/ScrollContainer.tsx
@@ -23,6 +23,7 @@ const ScrollInner = styled(`div`)`
   overflow-y: scroll;
   display: block;
   height: 100%;
+  border-top: 1px solid shared.colors.greyLightPinkish;
 `;
 
 const ScrollContainer = ({ fixed, children }: ScrollContainerProps) => (

--- a/client-v2/src/components/layout/SectionContent.tsx
+++ b/client-v2/src/components/layout/SectionContent.tsx
@@ -5,7 +5,6 @@ export default styled('div')<{ direction?: 'column' | 'row' }>`
   border-right: ${({ theme }) =>
     `solid 1px ${theme.shared.base.colors.borderColor}`};
   flex-direction: ${({ direction = 'row' }) => direction};
-  padding: 10px;
   flex: 1;
   align-self: start;
   min-height: 100%;

--- a/client-v2/src/components/layout/SectionContent.tsx
+++ b/client-v2/src/components/layout/SectionContent.tsx
@@ -5,6 +5,7 @@ export default styled('div')<{ direction?: 'column' | 'row' }>`
   border-right: ${({ theme }) =>
     `solid 1px ${theme.shared.base.colors.borderColor}`};
   flex-direction: ${({ direction = 'row' }) => direction};
+  padding: 10px;
   flex: 1;
   align-self: start;
   min-height: 100%;


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Clipboard and front overviews will now collapse completely as per designs. 

## Implementation notes

The clipboard header is now passed to the feed container as a right hand component so that it can be placed to the left of the clipboard. 

The collapse overview and collapse collection controls have now also moved to the fronts component so we can display then nicely on top of the fronts content. 

Made some other changes as well to margins/paddings but I think the layout makes more sense now and the components which should be in in control or margins around them are now doing so. 

![Screenshot 2019-05-31 at 08 42 59](https://user-images.githubusercontent.com/3066534/58689875-23221700-8380-11e9-9f22-95d2080b42b1.png)

![Screenshot 2019-05-31 at 08 27 03](https://user-images.githubusercontent.com/3066534/58689076-fcfb7780-837d-11e9-93a8-716a03e55630.png)



_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
