### PR TITLE
Sticky container headings

### DIFF
--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -21,7 +21,9 @@ import {
 } from '../selectors/shared';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
-import ContentContainer from './layout/ContentContainer';
+import ContentContainer, {
+  contentContainerMargin
+} from './layout/ContentContainer';
 import { css } from 'styled-components';
 import { events } from 'services/GA';
 import CollectionMetaContainer from './collection/CollectionMetaContainer';
@@ -109,6 +111,16 @@ const ItemCountMeta = styled(CollectionMetaBase)`
   flex: 0;
 `;
 
+const CollectionHeadingSticky = styled(ContainerHeadingPinline)`
+  position: sticky;
+  top: 0;
+  background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
+  box-shadow: 0 -1px 0 ${({ theme }) => theme.shared.base.colors.text};
+  z-index: 20;
+  margin: 0 -${contentContainerMargin};
+  padding: 0 ${contentContainerMargin};
+`;
+
 const CollectionHeadlineWithConfigContainer = styled('div')`
   flex-grow: 1;
   display: flex;
@@ -118,6 +130,7 @@ const CollectionHeadlineWithConfigContainer = styled('div')`
 
 const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
   display: inline-block;
+  width: 100%;
   white-space: nowrap;
   ${({ isLoading, theme }) =>
     isLoading &&
@@ -126,6 +139,8 @@ const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
     `} white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border-bottom: 1px solid
+    ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
 const CollectionToggleContainer = styled('div')`
@@ -209,7 +224,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
         onBlur={handleBlur}
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
       >
-        <ContainerHeadingPinline tabIndex={-1}>
+        <CollectionHeadingSticky setBack tabIndex={-1}>
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText isLoading={!collection} title={displayName}>
               {displayName}
@@ -238,7 +253,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               {headlineContent}
             </HeadlineContentContainer>
           ) : null}
-        </ContainerHeadingPinline>
+        </CollectionHeadingSticky>
         <DragIntentContainer
           delay={300}
           onIntentConfirm={this.toggleVisibility}

--- a/client-v2/src/shared/components/collection/CollectionMetaContainer.tsx
+++ b/client-v2/src/shared/components/collection/CollectionMetaContainer.tsx
@@ -8,7 +8,5 @@ export default styled('div')`
   font-weight: normal;
   justify-content: space-between;
   margin-bottom: 0.5em;
-  border-top: ${({ theme }) =>
-    `1px solid ${theme.shared.base.colors.borderColor}`};
   cursor: pointer;
 `;

--- a/client-v2/src/shared/components/layout/ContentContainer.ts
+++ b/client-v2/src/shared/components/layout/ContentContainer.ts
@@ -1,12 +1,14 @@
 import { styled } from '../../constants/theme';
 
+export const contentContainerMargin = '10px';
+
 export default styled('div')<{
   setBack?: boolean;
 }>`
   background-color: ${({ setBack, theme }) =>
     setBack ? 'transparent' : theme.shared.base.colors.backgroundColor};
   position: relative;
-  padding: 0 10px 10px 10px;
+  padding: 0 ${contentContainerMargin} ${contentContainerMargin} ${contentContainerMargin};
   box-shadow: ${({ theme }) => `0 -1px 0 ${theme.shared.base.colors.text}`};
   border: ${({ setBack, theme }) =>
     setBack ? 'none' : `1px solid ${theme.shared.base.colors.borderColor}`};

--- a/client-v2/src/shared/components/layout/ContentContainer.ts
+++ b/client-v2/src/shared/components/layout/ContentContainer.ts
@@ -8,7 +8,8 @@ export default styled('div')<{
   background-color: ${({ setBack, theme }) =>
     setBack ? 'transparent' : theme.shared.base.colors.backgroundColor};
   position: relative;
-  padding: 0 ${contentContainerMargin} ${contentContainerMargin} ${contentContainerMargin};
+  padding: 0 ${contentContainerMargin} ${contentContainerMargin}
+    ${contentContainerMargin};
   box-shadow: ${({ theme }) => `0 -1px 0 ${theme.shared.base.colors.text}`};
   border: ${({ setBack, theme }) =>
     setBack ? 'none' : `1px solid ${theme.shared.base.colors.borderColor}`};

--- a/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
@@ -1,9 +1,14 @@
+import { styled } from 'constants/theme';
 import ContainerHeading from './ContainerHeading';
 
-export default ContainerHeading.extend`
+export default styled(ContainerHeading)<{ setBack?: boolean }>`
   align-items: center;
   height: 40px;
   line-height: 40px;
   vertical-align: middle;
   justify-content: space-between;
+  border-bottom: ${({ theme, setBack }) =>
+    setBack
+      ? 'transparent'
+      : `1px solid ${theme.shared.base.colors.borderColor}`};
 `;


### PR DESCRIPTION
## What's changed?

The container headings are now sticky. Oh good!

![sticky](https://user-images.githubusercontent.com/7767575/58323278-6ed23f00-7e1b-11e9-8df1-e3d8f1bc26c3.gif)

## Implementation notes

God bless position:sticky, this would have been a lot more effort in JS.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
