### PR TITLE
Save button confusions

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -195,15 +195,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
         <CollectionHeadingPinline>
           Edit
           <ButtonContainer>
-            <Button
-              priority="primary"
-              onClick={onCancel}
-              type="button"
-              size="l"
-            >
+            <Button onClick={onCancel} type="button" size="l">
               Cancel
             </Button>
             <Button
+              priority="primary"
               onClick={handleSubmit}
               disabled={pristine || !articleExists}
               size="l"

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -130,14 +130,14 @@ class Collection extends React.Component<CollectionProps> {
         onChangeOpenState={() => onChangeOpenState(id, isOpen)}
         headlineContent={
           hasUnpublishedChanges &&
-          canPublish && (
+          canPublish &&
+          !isEditFormOpen && (
             <React.Fragment>
               <Button
                 size="l"
                 priority="default"
                 onClick={() => discardDraftChanges(id)}
                 tabIndex={-1}
-                disabled={isEditFormOpen}
                 title={
                   isEditFormOpen
                     ? 'You cannot discard changes to this collection whilst the edit form is open.'
@@ -151,7 +151,6 @@ class Collection extends React.Component<CollectionProps> {
                 priority="primary"
                 onClick={() => publish(id, frontId)}
                 tabIndex={-1}
-                disabled={isEditFormOpen}
                 title={
                   isEditFormOpen
                     ? 'You cannot launch this collection whilst the edit form is open.'

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -43,7 +43,7 @@ const fontSizeMap = {
 const colorMap = {
   disabled: {
     default: theme.colors.white,
-    primary: theme.colors.white,
+    primary: theme.colors.greyLight,
     muted: theme.colors.blackLight
   },
   selected: {
@@ -61,7 +61,7 @@ const colorMap = {
 const backgroundMap = {
   disabled: {
     default: theme.colors.greyMediumLight,
-    primary: theme.colors.orangeFaded,
+    primary: theme.colors.whiteMedium,
     muted: theme.colors.greyLight
   },
   selected: {
@@ -138,7 +138,7 @@ export default styled(`button`)`
   :disabled:hover {
     cursor: not-allowed;
   }
-  :hover {
+  :hover:enabled {
     background: ${mapAction(backgroundHoverMap)};
     cursor: pointer;
   }


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_
Form save button is now a primary button and cancel button has been downgraded to a normal button. I've also adjusted the primary button's colours when disabled as instructed by Akemi and hidden the launch buttons when the edit form is open.
![Screenshot 2019-05-24 at 14 01 46](https://user-images.githubusercontent.com/3066534/58330052-f759db00-7e2d-11e9-8642-d1a0032e90ab.png)


## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
