### PR TITLE
[DRAFT]: First pass at responsive, revisited

### DIFF
--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -305,11 +305,9 @@ const selectEditorFavouriteFrontIdsByPriority = (
 ): string[] =>
   state.editor.favouriteFrontIdsByPriority[priority] || defaultFavouriteFronts;
 
-const selectHasMultipleFrontsOpen = createSelector(
+const selectOpenFrontsCount = createSelector(
   selectEditorFrontIdsByPriority,
-  frontIdsByPriority => {
-    return frontIdsByPriority.length > 1;
-  }
+  frontIdsByPriority => frontIdsByPriority.length
 );
 
 const selectEditorArticleFragment = <T extends { editor: State }>(
@@ -596,7 +594,7 @@ export {
   editorCloseAllOverviews,
   selectIsClipboardOpen,
   selectIsFrontOverviewOpen,
-  selectHasMultipleFrontsOpen
+  selectOpenFrontsCount
 };
 
 export default reducer;

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -46,6 +46,7 @@ const ClipboardWrapper = styled<
 })`
   border: 1px solid #c9c9c9;
   border-top: 1px solid black;
+  height: 100%;
   overflow-y: scroll;
   &:focus {
     border: 1px solid ${({ theme }) => theme.shared.base.colors.focusColor};
@@ -92,7 +93,6 @@ const FullDivider = styled('hr')`
   border: 0;
   border-top: 1px solid #ccc;
   margin: 8px -10px 0px;
-  width: 115%;
 `;
 
 interface ClipboardProps {

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -9,15 +9,18 @@ import FeedSectionHeader from './FeedSectionHeader';
 
 const FeedSectionContainer = styled('div')`
   background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
+  width: 100%;
 `;
 
 const FeedWrapper = styled('div')`
-  width: 409px;
+  flex: 3 1 20vw;
   padding-right: 10px;
   margin-right: 10px;
   border-right: ${({ theme }) =>
     `solid 1px ${theme.shared.base.colors.borderColor}`};
 `;
+
+const ClipboardWrapper = styled.div``;
 
 export default () => (
   <FeedSectionContainer>
@@ -26,10 +29,10 @@ export default () => (
       <FeedWrapper>
         <FeedContainer />
       </FeedWrapper>
-      <Clipboard />
-      <div>
-        <ClipboardMeta />
-      </div>
+      <ClipboardWrapper>
+        <Clipboard />
+      </ClipboardWrapper>
+      <ClipboardMeta />
     </SectionContent>
   </FeedSectionContainer>
 );

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -13,7 +13,7 @@ const FeedSectionContainer = styled('div')`
 `;
 
 const FeedWrapper = styled('div')`
-  flex: 3 1 20vw;
+  max-width: 600px;
   padding-right: 10px;
   margin-right: 10px;
   border-right: ${({ theme }) =>

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -22,12 +22,12 @@ const FeedWrapper = styled('div')`
 
 const ClipboardWrapper = styled.div``;
 
-export default () => (
+export default ({ fontSize = '14px' }: { fontSize?: string }) => (
   <FeedSectionContainer>
     <FeedSectionHeader />
     <SectionContent>
       <FeedWrapper>
-        <FeedContainer />
+        <FeedContainer fontSize={fontSize} />
       </FeedWrapper>
       <ClipboardWrapper>
         <Clipboard />

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -36,6 +36,7 @@ interface FeedsContainerProps {
   previewError: string | null;
   livePagination: IPagination | null;
   previewPagination: IPagination | null;
+  fontSize: string;
 }
 
 interface FeedsContainerState {
@@ -316,7 +317,11 @@ class FeedsContainer extends React.Component<
             </>
           }
         >
-          <Feed error={error} articles={articles} />
+          <Feed
+            error={error}
+            articles={articles}
+            fontSize={this.props.fontSize}
+          />
         </ScrollContainer>
       </FeedsContainerWrapper>
     );

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -85,6 +85,7 @@ const FeedsContainerWrapper = styled('div')`
 
 const PaginationContainer = styled('div')`
   margin-left: auto;
+  white-space: nowrap;
 `;
 
 const ResultsHeadingContainer = styled('div')`

--- a/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/Feed.tsx
@@ -6,6 +6,7 @@ import { CapiArticle } from 'types/Capi';
 interface FeedProps {
   articles?: CapiArticle[];
   error: string | null;
+  fontSize: string;
 }
 
 interface ErrorDisplayProps {
@@ -20,12 +21,14 @@ const NoResults = styled('div')`
   margin: 4px;
 `;
 
-const Feed = ({ articles = [], error }: FeedProps) => (
+const Feed = ({ articles = [], error, fontSize }: FeedProps) => (
   <ErrorDisplay error={error}>
     {articles.length ? (
       articles
         .filter(result => result.webTitle)
-        .map(article => <FeedItem key={article.id} article={article} />)
+        .map(article => (
+          <FeedItem key={article.id} article={article} fontSize={fontSize} />
+        ))
     ) : (
       <NoResults>No results found</NoResults>
     )}

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -51,11 +51,11 @@ const Container = styled('div')`
   }
 `;
 
-const Title = styled(`h2`)`
+const Title = styled(`h2`)<{ fontSize: string }>`
   margin: 2px 0 0;
   vertical-align: top;
   font-family: GHGuardianHeadline;
-  font-size: 15px;
+  font-size: ${({ fontSize }) => fontSize};
   font-weight: 500;
 `;
 
@@ -103,6 +103,7 @@ const Body = styled('div')`
 interface FeedItemProps {
   article: CapiArticle;
   onAddToClipboard: (article: CapiArticle) => void;
+  fontSize: string;
 }
 
 const isLive = (article: CapiArticle) =>
@@ -189,7 +190,9 @@ class FeedItem extends React.Component<FeedItemProps> {
             <ShortVerticalPinline />
           </MetaContainer>
           <Body>
-            <Title data-testid="headline">{article.webTitle}</Title>
+            <Title fontSize={this.props.fontSize} data-testid="headline">
+              {article.webTitle}
+            </Title>
           </Body>
           <ArticleThumbnail
             style={{

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -67,7 +67,6 @@ type Props = ComponentProps &
 const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;
   flex-direction: column;
-  flex: 1;
   width: 380px;
   margin-left: 10px;
   height: 100%;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -23,7 +23,6 @@ import {
   selectIsCollectionOpen,
   editorOpenCollections,
   editorCloseCollections,
-  selectHasMultipleFrontsOpen,
   selectEditorArticleFragment
 } from 'bundles/frontsUIBundle';
 import { getArticlesForCollections } from 'actions/Collections';
@@ -59,7 +58,6 @@ type CollectionProps = CollectionPropsBeforeState & {
   isCollectionLocked: boolean;
   isEditFormOpen: boolean;
   isOpen: boolean;
-  hasMultipleFrontsOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
   fetchPreviousCollectionArticles: (id: string) => void;
 };
@@ -108,7 +106,6 @@ class Collection extends React.Component<CollectionProps> {
       isCollectionLocked,
       isOpen,
       onChangeOpenState,
-      hasMultipleFrontsOpen,
       isEditFormOpen,
       discardDraftChangesToCollection: discardDraftChanges
     } = this.props;
@@ -126,7 +123,6 @@ class Collection extends React.Component<CollectionProps> {
         isUneditable={isUneditable}
         isLocked={isCollectionLocked}
         isOpen={isOpen}
-        hasMultipleFrontsOpen={hasMultipleFrontsOpen}
         onChangeOpenState={() => onChangeOpenState(id, isOpen)}
         headlineContent={
           hasUnpublishedChanges &&
@@ -222,7 +218,6 @@ const createMapStateToProps = () => {
         collectionId: id
       }),
       isOpen: selectIsCollectionOpen(state, id),
-      hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
       isEditFormOpen:
         !!selectedArticleFragmentData &&
         selectIsArticleInCollection(state.shared, {

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -61,6 +61,9 @@ const Container = styled.div`
 const TextContainerLeft = styled.div`
   flex: 1 1;
   font-size: 14px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
 `;
 
 const TextContainerRight = styled.div`

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -62,7 +62,6 @@ const NoFrontContainer = styled.div`
 `;
 
 const FeedContainer = styled(SectionContainer)`
-  flex: 1 2 auto;
   height: 100%;
 `;
 
@@ -72,6 +71,7 @@ const FrontsContainer = styled(SectionContainer)<{
   display: flex;
   flex: 1 1 auto;
   height: 100%;
+  max-width: 1000px;
   overflow-y: hidden;
   overflow-x: scroll;
   transition: transform 0.15s;

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -45,9 +45,9 @@ const FrontsEditContainer = styled('div')`
 `;
 
 const SingleFrontContainer = styled('div')`
-  flex: 1 1 auto;
+  flex: 1 1 100%;
   height: 100%;
-  min-width: 626px;
+  max-width: 900px;
 `;
 
 // This is just to stop the feed / clipboard from filling the screen when no fronts
@@ -71,7 +71,6 @@ const FrontsContainer = styled(SectionContainer)<{
   display: flex;
   flex: 1 1 auto;
   height: 100%;
-  max-width: 1000px;
   overflow-y: hidden;
   overflow-x: scroll;
   transition: transform 0.15s;

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -9,7 +9,8 @@ import {
   editorFavouriteFront,
   editorUnfavouriteFront,
   selectEditorFrontIdsByPriority,
-  selectIsCurrentFrontsMenuOpen
+  selectIsCurrentFrontsMenuOpen,
+  selectOpenFrontsCount
 } from 'bundles/frontsUIBundle';
 import { State } from 'types/State';
 import { ActionError } from 'types/Action';
@@ -33,6 +34,7 @@ interface Props {
   editorUnfavouriteFront: (frontId: string, priority: string) => void;
   getFrontsConfig: () => void;
   isCurrentFrontsMenuOpen: boolean;
+  feedFontSize: string;
 }
 
 const FrontsEditContainer = styled('div')`
@@ -92,7 +94,7 @@ class FrontsEdit extends React.Component<Props> {
         <PressFailAlert staleFronts={this.props.staleFronts} />
         <SectionsContainer>
           <FeedContainer>
-            <FeedSection />
+            <FeedSection fontSize={this.props.feedFontSize} />
           </FeedContainer>
           <FrontsContainer
             id={frontsContainerId}
@@ -144,7 +146,11 @@ const mapStateToProps = (state: State, props: Props) => ({
     state,
     props.match.params.priority || ''
   ),
-  isCurrentFrontsMenuOpen: selectIsCurrentFrontsMenuOpen(state)
+  isCurrentFrontsMenuOpen: selectIsCurrentFrontsMenuOpen(state),
+  feedFontSize:
+    selectOpenFrontsCount(state, props.match.params.priority) > 1
+      ? '13px'
+      : '15px'
 });
 
 const mapDispatchToProps = (dispatch: Dispatch, props: Props) => ({

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -21,6 +21,7 @@ import SectionsContainer from '../layout/SectionsContainer';
 import FrontsMenu from './FrontsMenu';
 import PressFailAlert from '../PressFailAlert';
 import { frontsContainerId, createFrontId } from 'util/editUtils';
+import { MoreIcon } from 'shared/components/icons/Icons';
 
 interface Props {
   match: match<{ priority: string }>;
@@ -42,16 +43,31 @@ const FrontsEditContainer = styled('div')`
 `;
 
 const SingleFrontContainer = styled('div')`
+  flex: 1 1 auto;
   height: 100%;
 `;
 
+// This is just to stop the feed / clipboard from filling the screen when no fronts
+// are selected
+const NoFrontContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  font-size: 24px;
+  color: #aaa;
+  width: 50vw;
+`;
+
 const FeedContainer = styled(SectionContainer)`
+  flex: 1 2 auto;
   height: 100%;
 `;
 
 const FrontsContainer = styled(SectionContainer)<{
   makeRoomForExtraHeader: boolean;
 }>`
+  display: flex;
+  flex: 1 1 auto;
   height: 100%;
   overflow-y: hidden;
   overflow-x: scroll;
@@ -81,11 +97,21 @@ class FrontsEdit extends React.Component<Props> {
             id={frontsContainerId}
             makeRoomForExtraHeader={this.props.isCurrentFrontsMenuOpen}
           >
-            {this.props.frontIds.map(id => (
-              <SingleFrontContainer key={id} id={createFrontId(id)}>
-                <FrontContainer frontId={id} />
-              </SingleFrontContainer>
-            ))}
+            {this.props.frontIds.length ? (
+              this.props.frontIds.map(id => (
+                <SingleFrontContainer key={id} id={createFrontId(id)}>
+                  <FrontContainer frontId={id} />
+                </SingleFrontContainer>
+              ))
+            ) : (
+              <NoFrontContainer>
+                <span>
+                  Select a front with the{' '}
+                  <MoreIcon verticalAlign="bottom" fill="#aaa" size={'xxl'} />{' '}
+                  button
+                </span>
+              </NoFrontContainer>
+            )}
           </FrontsContainer>
         </SectionsContainer>
         <FrontsMenu

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -45,6 +45,7 @@ const FrontsEditContainer = styled('div')`
 const SingleFrontContainer = styled('div')`
   flex: 1 1 auto;
   height: 100%;
+  min-width: 626px;
 `;
 
 // This is just to stop the feed / clipboard from filling the screen when no fronts

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -28,12 +28,21 @@ import Collection from './Collection';
 const FrontContainer = styled('div')`
   display: flex;
   min-height: 0;
+  height: 100%;
 `;
 
 const FrontContentContainer = styled('div')`
   max-height: 100%;
   overflow-y: scroll;
   padding-top: 1px;
+`;
+
+const CollectionsContainer = styled(FrontContentContainer)`
+  flex: 4 0 400px;
+`;
+
+const DetailContainer = styled(FrontContentContainer)`
+  flex: 0 0 auto;
 `;
 
 interface FrontPropsBeforeState {
@@ -122,7 +131,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
           {this.state.error || ''}
         </div>
         <FrontContainer>
-          <FrontContentContainer>
+          <CollectionsContainer>
             <Root id={this.props.id} data-testid={this.props.id}>
               {front.collections.map(collectionId => (
                 <Collection
@@ -141,13 +150,13 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                 />
               ))}
             </Root>
-          </FrontContentContainer>
-          <FrontContentContainer>
+          </CollectionsContainer>
+          <DetailContainer>
             <FrontDetailView
               id={this.props.id}
               browsingStage={this.props.browsingStage}
             />
-          </FrontContentContainer>
+          </DetailContainer>
         </FrontContainer>
       </React.Fragment>
     );

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -39,11 +39,7 @@ const Container = styled(ContentContainer)<ContainerProps>`
   flex-direction: column;
   flex: 1;
   margin-left: 10px;
-  ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
-`;
-
-const ContainerBody = styled.div`
-  width: 130px;
+  ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : 'width: 180px;')}
 `;
 
 const FrontCollectionsOverview = ({
@@ -66,18 +62,15 @@ const FrontCollectionsOverview = ({
         onClick={() => toggleOverview(!overviewIsOpen)}
       />
     </ContainerHeadingPinline>
-    {overviewIsOpen && (
-      <ContainerBody>
-        {front.collections.map(collectionId => (
-          <CollectionOverview
-            frontId={id}
-            key={collectionId}
-            collectionId={collectionId}
-            browsingStage={browsingStage}
-          />
-        ))}
-      </ContainerBody>
-    )}
+    {overviewIsOpen &&
+      front.collections.map(collectionId => (
+        <CollectionOverview
+          frontId={id}
+          key={collectionId}
+          collectionId={collectionId}
+          browsingStage={browsingStage}
+        />
+      ))}
   </Container>
 );
 

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -46,7 +46,6 @@ type Props = ContainerProps & {
   isUneditable?: boolean;
   isLocked?: boolean;
   isOpen?: boolean;
-  hasMultipleFrontsOpen?: boolean;
   onChangeOpenState?: (isOpen: boolean) => void;
   handleFocus: (id: string) => void;
   handleBlur: () => void;
@@ -56,12 +55,8 @@ interface CollectionState {
   hasDragOpenIntent: boolean;
 }
 
-const CollectionContainer = ContentContainer.extend<{
-  hasMultipleFrontsOpen?: boolean;
-}>`
+const CollectionContainer = styled(ContentContainer)`
   flex: 1;
-  width: ${({ hasMultipleFrontsOpen }) =>
-    hasMultipleFrontsOpen ? '510px' : '590px'};
 
   &:focus {
     border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
@@ -110,10 +105,9 @@ const ItemCountMeta = styled(CollectionMetaBase)`
 `;
 
 const CollectionHeadlineWithConfigContainer = styled('div')`
-  flex-grow: 1;
+  flex: 1 1 0;
   display: flex;
   min-width: 0;
-  flex-basis: 100%;
 `;
 
 const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
@@ -194,7 +188,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       metaContent,
       isUneditable,
       isLocked,
-      hasMultipleFrontsOpen,
       children,
       handleFocus,
       handleBlur
@@ -207,7 +200,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
         tabIndex={0}
         onFocus={() => handleFocus(id)}
         onBlur={handleBlur}
-        hasMultipleFrontsOpen={hasMultipleFrontsOpen}
       >
         <ContainerHeadingPinline tabIndex={-1}>
           <CollectionHeadlineWithConfigContainer>

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -5,6 +5,7 @@ interface IconProps {
   fill?: string;
   size?: IconSizes;
   title?: string | null;
+  verticalAlign?: string | undefined;
 }
 
 type IconSizes = 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'fill';
@@ -172,11 +173,15 @@ const ClearIcon = ({
 const MoreIcon = ({
   fill = theme.colors.white,
   size = 'm',
-  title = null
+  title = null,
+  verticalAlign = void 0
 }: IconProps) => (
   <svg
     width={mapSize(size)}
     height={mapSize(size)}
+    style={{
+      verticalAlign
+    }}
     viewBox="0 0 30 30"
     xmlns="http://www.w3.org/2000/svg"
     xmlnsXlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
## What's changed?

First pass at making the edit page responsive. Makes a few changes based on feedback from #739 -- if you've reviewed this before, just check out my commits at the end 👍 

This is in a draft state, as feedback from Katherine indicated parts of the responsive-ness might be more trouble than they're worth!
 
### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included