### PR TITLE
EDITIONS: Set up basic UI for picking a date, creating or opening a Front

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -24,7 +24,8 @@ import FrontsEdit from './FrontsEdit/Edit';
 import Home from './Home';
 import NotFound from './NotFound';
 import ConfirmModal from './ConfirmModal';
-import { frontsEdit } from 'constants/routes';
+import { frontsEdit, editions } from 'constants/routes';
+import ManagedView from './Editions/ManageView';
 
 // tslint:disable:no-unused-expression
 injectGlobal`
@@ -106,6 +107,7 @@ const App = () => (
         <Switch>
           <Route exact path={frontsEdit} component={FrontsEdit} />
           <Route exact path="/" component={Home} />
+          <Route exact path={editions} component={ManagedView} />
           <Route component={NotFound} />
         </Switch>
       </AppContainer>

--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -24,8 +24,8 @@ import FrontsEdit from './FrontsEdit/Edit';
 import Home from './Home';
 import NotFound from './NotFound';
 import ConfirmModal from './ConfirmModal';
-import { frontsEdit, editions } from 'constants/routes';
-import ManagedView from './Editions/ManageView';
+import { frontsEdit, manageEditions } from 'constants/routes';
+import ManageView from './Editions/ManageView';
 
 // tslint:disable:no-unused-expression
 injectGlobal`
@@ -107,7 +107,7 @@ const App = () => (
         <Switch>
           <Route exact path={frontsEdit} component={FrontsEdit} />
           <Route exact path="/" component={Home} />
-          <Route exact path={editions} component={ManagedView} />
+          <Route exact path={manageEditions} component={ManageView} />
           <Route component={NotFound} />
         </Switch>
       </AppContainer>

--- a/client-v2/src/components/Editions/Issue.tsx
+++ b/client-v2/src/components/Editions/Issue.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { EditionIssue } from 'types/Edition';
+import { styled, Theme } from 'constants/theme';
+import moment from 'moment';
+
+interface IssueProps {
+  issue: EditionIssue;
+}
+
+const IssueTable = styled.table`
+  padding: 10px 0;
+  td {
+    padding: 0 5px 0;
+  }
+`;
+
+const Issue = (props: IssueProps) => (
+  <>
+    <IssueTable>
+      <tbody>
+        <tr>
+          <td>Issue name: </td>
+          <td>{props.issue.name}</td>
+        </tr>
+        <tr>
+          <td>Issue date:</td>
+          <td>
+            {moment(props.issue.publishDate, 'YYYY-MM-DD HH:mm:ss-ZZ').format(
+              'Do MMMM YYYY'
+            )}
+          </td>
+        </tr>
+        <tr>
+          <td>Last published:</td>
+          <td>{props.issue.lastPublished}</td>
+        </tr>
+        <tr>
+          <td>Creator:</td>
+          <td>{props.issue.createdBy}</td>
+        </tr>
+        <tr>
+          <td>Creator email:</td>
+          <td>{props.issue.createdEmail}</td>
+        </tr>
+      </tbody>
+    </IssueTable>
+  </>
+);
+
+export default Issue;

--- a/client-v2/src/components/Editions/Issue.tsx
+++ b/client-v2/src/components/Editions/Issue.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EditionIssue } from 'types/Edition';
-import { styled, Theme } from 'constants/theme';
+import { styled } from 'constants/theme';
 import moment from 'moment';
 
 interface IssueProps {
@@ -29,6 +29,10 @@ const Issue = (props: IssueProps) => (
               'Do MMMM YYYY'
             )}
           </td>
+        </tr>
+        <tr>
+          <td>Published:</td>
+          <td>{props.issue.lastPublished ? 'Yes' : 'No'}</td>
         </tr>
         <tr>
           <td>Last published:</td>

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Raven from 'raven-js';
-import { styled, Theme } from 'constants/theme';
+import { styled } from 'constants/theme';
 import { SingleDatePicker } from 'react-dates';
 import moment, { Moment } from 'moment';
 import { EditionIssue } from 'types/Edition';

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { styled, Theme } from 'constants/theme';
+import { SingleDatePicker } from 'react-dates';
+import { Moment } from 'moment';
+
+interface ManageEditionProps {}
+
+interface ManageEditionState {
+  date: Moment | null;
+  isDatePickerOpen: boolean;
+}
+
+class ManageEdition extends React.Component<
+  ManageEditionProps,
+  ManageEditionState
+> {
+  public state = {
+    date: null,
+    isDatePickerOpen: false
+  };
+
+  constructor(props: ManageEditionProps) {
+    super(props);
+  }
+
+  public render() {
+    return (
+      <>
+        <h2>Pick a date</h2>
+        <SingleDatePicker
+          date={null}
+          onDateChange={this.handleDateChange}
+          focused={this.state.isDatePickerOpen}
+          onFocusChange={this.handleFocusChange}
+          id="editions-date"
+        />
+      </>
+    );
+  }
+
+  private handleDateChange = (date: Moment | null) => this.setState({ date });
+
+  private handleFocusChange = (isFocussedObj: { focused: boolean | null }) =>
+    this.setState({ isDatePickerOpen: !!isFocussedObj.focused });
+}
+
+export default ManageEdition;

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -1,27 +1,94 @@
 import React from 'react';
-import { styled, Theme } from 'constants/theme';
+import { styled } from 'constants/theme';
 import { SingleDatePicker } from 'react-dates';
-import { Moment } from 'moment';
-
-interface ManageEditionProps {}
+import moment, { Moment } from 'moment';
+import { EditionIssue } from 'types/Edition';
+import Issue from './Issue';
+import ButtonDefault from '../../shared/components/input/ButtonDefault';
+// import * as ButtonDefault from '../shared/components/input/ButtonDefault';
 
 interface ManageEditionState {
   date: Moment | null;
   isDatePickerOpen: boolean;
+  issues: EditionIssue[];
+  currentIssue: EditionIssue | null;
+  createMessage: string;
 }
 
-class ManageEdition extends React.Component<
-  ManageEditionProps,
-  ManageEditionState
-> {
-  public state = {
-    date: null,
-    isDatePickerOpen: false
-  };
+const LinkButton = styled(ButtonDefault.withComponent('a'))`
+  text-decoration: none;
+  padding-top: 12px;
+`;
 
-  constructor(props: ManageEditionProps) {
-    super(props);
+const MsgBox = styled('div')`
+  max-width: 200px;
+  padding: 3px;
+  color: white;
+  background: linear-gradient(45deg, red, blue);
+  background-size: 200% 2000%;
+  animation: Animation 1s ease infinite;
+
+  @keyframes Animation {
+    0% {
+      background-position: 10% 0%;
+    }
+    50% {
+      background-position: 91% 100%;
+    }
+    100% {
+      background-position: 10% 0%;
+    }
   }
+`;
+
+const oneIssue = {
+  id: '12348',
+  name: 'Cool new issue just created',
+  publishDate: '2019-06-29 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
+  lastPublished: '2019-05-29 19:11:25',
+  createdOn: '2016-06-22 19:10:25-07',
+  createdBy: 'annaandjon',
+  createdEmail: 'a@g.com'
+};
+
+const allIssues = [
+  {
+    id: '12345',
+    name: 'MondayIssue',
+    publishDate: '2019-05-29 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
+    lastPublished: '2019-05-29 19:11:25',
+    createdOn: '2016-06-22 19:10:25-07',
+    createdBy: 'annaandjon',
+    createdEmail: 'a@g.com'
+  },
+  {
+    id: '12346',
+    name: 'TuesdayIssue',
+    publishDate: '2019-05-30 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
+    lastPublished: '2019-05-29 19:11:25',
+    createdOn: '2016-06-22 19:10:25-07',
+    createdBy: 'annaandjon',
+    createdEmail: 'a@g.com'
+  },
+  {
+    id: '12347',
+    name: 'WednesdayIssue',
+    publishDate: '2019-05-31 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
+    lastPublished: '2019-05-29 19:11:25',
+    createdOn: '2016-06-22 19:10:25-07',
+    createdBy: 'annaandjon',
+    createdEmail: 'a@g.com'
+  }
+];
+
+class ManageEdition extends React.Component {
+  public state: ManageEditionState = {
+    date: null,
+    isDatePickerOpen: false,
+    issues: [] as EditionIssue[],
+    currentIssue: null,
+    createMessage: ''
+  };
 
   public render() {
     return (
@@ -32,16 +99,102 @@ class ManageEdition extends React.Component<
           onDateChange={this.handleDateChange}
           focused={this.state.isDatePickerOpen}
           onFocusChange={this.handleFocusChange}
+          onNextMonthClick={this.handleMonthClick}
+          onPrevMonthClick={this.handleMonthClick}
           id="editions-date"
+          isDayHighlighted={date => !!this.selectIssueForDate(date)}
         />
+        <div>
+          {this.state.date && (
+            <>
+              <p>You selected {this.state.date.format('Do MMMM YYYY')}</p>
+              {this.state.currentIssue ? (
+                <>
+                  {this.state.createMessage && (
+                    <MsgBox>{this.state.createMessage}</MsgBox>
+                  )}
+                  <Issue issue={this.state.currentIssue} />
+                  <LinkButton
+                    size="l"
+                    href={`editions/${this.state.currentIssue.id}`}
+                  >
+                    Open
+                  </LinkButton>
+                </>
+              ) : (
+                <>
+                  <p>No issue found for this date</p>
+                  <ButtonDefault size="l" onClick={this.createEdition}>
+                    Create
+                  </ButtonDefault>
+                </>
+              )}
+            </>
+          )}
+        </div>
       </>
     );
   }
 
-  private handleDateChange = (date: Moment | null) => this.setState({ date });
+  private createEdition = () => {
+    // select and instantiate template that is valid for this date
+    if (!this.state.date) {
+      return;
+    }
+    this.setState({ createMessage: 'New issue created' });
+    this.createIssue(this.state.date).then(issue =>
+      this.setState({ currentIssue: issue })
+    );
+  };
 
-  private handleFocusChange = (isFocussedObj: { focused: boolean | null }) =>
+  private handleDateChange = (date: Moment | null) => {
+    this.setState({ date });
+    if (!date) {
+      return;
+    }
+    const issue = this.selectIssueForDate(date);
+    if (issue) {
+      this.setState({ currentIssue: issue });
+    } else {
+      this.setState({ currentIssue: null });
+    }
+  };
+
+  private handleFocusChange = (isFocussedObj: { focused: boolean | null }) => {
+    if (isFocussedObj.focused) {
+      const startDate = moment().startOf('month');
+      const endDate = moment()
+        .add(1, 'month')
+        .endOf('month');
+      this.fetchIssuesForDateRange(startDate, endDate).then(issues =>
+        this.setState({ issues })
+      );
+    }
     this.setState({ isDatePickerOpen: !!isFocussedObj.focused });
+  };
+
+  private selectIssueForDate = (date: Moment) =>
+    this.state.issues.find(i =>
+      moment(i.publishDate, 'YYYY-MM-DD HH:mm:ss-ZZ').isSame(date, 'day')
+    );
+
+  private handleMonthClick = (month: Moment) => {
+    const startDate = month.clone().startOf('month');
+    const endDate = month.clone().endOf('month');
+
+    this.fetchIssuesForDateRange(startDate, endDate).then(issues =>
+      this.setState({ issues })
+    );
+  };
+
+  private fetchIssuesForDateRange = async (
+    start: Moment,
+    end: Moment
+  ): Promise<EditionIssue[]> => {
+    return allIssues;
+  };
+
+  private createIssue = async (date: Moment): Promise<EditionIssue> => oneIssue;
 }
 
 export default ManageEdition;

--- a/client-v2/src/components/Editions/ManageView.tsx
+++ b/client-v2/src/components/Editions/ManageView.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { styled, Theme } from 'constants/theme';
 import HomeContainer from '../layout/HomeContainer';
 import ManageEdition from './ManageEdition';
 

--- a/client-v2/src/components/Editions/ManageView.tsx
+++ b/client-v2/src/components/Editions/ManageView.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { styled, Theme } from 'constants/theme';
+import HomeContainer from '../layout/HomeContainer';
+import ManageEdition from './ManageEdition';
+
+const ManagedView = () => (
+  <HomeContainer>
+    <h1>Editions</h1>
+    <ManageEdition />
+  </HomeContainer>
+);
+
+export default ManagedView;

--- a/client-v2/src/components/Editions/ManageView.tsx
+++ b/client-v2/src/components/Editions/ManageView.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import HomeContainer from '../layout/HomeContainer';
 import ManageEdition from './ManageEdition';
 
-const ManagedView = () => (
+const ManageView = () => (
   <HomeContainer>
     <h1>Editions</h1>
     <ManageEdition />
   </HomeContainer>
 );
 
-export default ManagedView;
+export default ManageView;

--- a/client-v2/src/components/Home.tsx
+++ b/client-v2/src/components/Home.tsx
@@ -11,7 +11,12 @@ const renderPriority = (priority: string) => (
 );
 const Home = () => (
   <HomeContainer>
-    <ul>{Object.keys(priorities).map(renderPriority)}</ul>
+    <ul>
+      {Object.keys(priorities).map(renderPriority)}
+      <li>
+        <Link to={`/manage-editions`}>manage editions</Link>
+      </li>
+    </ul>
   </HomeContainer>
 );
 

--- a/client-v2/src/components/Home.tsx
+++ b/client-v2/src/components/Home.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { styled } from 'constants/theme';
 
 import { priorities } from 'constants/priorities';
-
-const HomeContainer = styled('div')`
-  padding-top: 60px;
-`;
+import HomeContainer from './layout/HomeContainer';
 
 const renderPriority = (priority: string) => (
   <li key={priority}>

--- a/client-v2/src/components/layout/HomeContainer.tsx
+++ b/client-v2/src/components/layout/HomeContainer.tsx
@@ -2,6 +2,7 @@ import { styled } from 'constants/theme';
 
 const HomeContainer = styled('div')`
   padding-top: 60px;
+  padding-left: 10px;
 `;
 
 export default HomeContainer;

--- a/client-v2/src/components/layout/HomeContainer.tsx
+++ b/client-v2/src/components/layout/HomeContainer.tsx
@@ -1,0 +1,7 @@
+import { styled } from 'constants/theme';
+
+const HomeContainer = styled('div')`
+  padding-top: 60px;
+`;
+
+export default HomeContainer;

--- a/client-v2/src/constants/routes.ts
+++ b/client-v2/src/constants/routes.ts
@@ -2,4 +2,4 @@ import { priorities } from './priorities';
 
 export const base = '/v2';
 export const frontsEdit = `/:priority(${Object.keys(priorities).join('|')})`;
-export const editions = `/editions`;
+export const manageEditions = `/manage-editions`;

--- a/client-v2/src/constants/routes.ts
+++ b/client-v2/src/constants/routes.ts
@@ -2,3 +2,4 @@ import { priorities } from './priorities';
 
 export const base = '/v2';
 export const frontsEdit = `/:priority(${Object.keys(priorities).join('|')})`;
+export const editions = `/editions`;

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -1,0 +1,9 @@
+export interface EditionIssue {
+  id: string;
+  name: string;
+  publishDate: string; // the date for which edition is made for, in format TimestampZ, eg 2016-06-22 19:10:25-07
+  lastPublished: string; // null if not published
+  createdOn: string;
+  createdBy: string;
+  createdEmail: string;
+}


### PR DESCRIPTION
## What's changed?

This creates an Editions route allowing users to:
* pick a date 
* if an issue exists for that date the user can open the issue
* if an issue does not exist for that date, a user can create one, and then open it

Available on: https://fronts.local.dev-gutools.co.uk/v2/manage-editions

**Pick a date**

![Screenshot 2019-05-30 at 17 19 03](https://user-images.githubusercontent.com/10324129/58647534-b5360b00-82ff-11e9-8b0c-1a5c173014e4.png)

---------------------
**Open an issue**

![Screenshot 2019-05-30 at 17 19 50](https://user-images.githubusercontent.com/10324129/58647583-cd0d8f00-82ff-11e9-8e15-55ba6f8e3887.png)

---------------------
**Create an issue**

![Screenshot 2019-05-30 at 17 19 21](https://user-images.githubusercontent.com/10324129/58647599-d39c0680-82ff-11e9-92e6-8e5d808a1082.png)


## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

- Using example objects hard-coded into the component to mock the API calls 
- Using react-date as a default date picker 
- Error / information messaging is a bit hacky. We should think of the correct UI for this when we get some of Akemi's time.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
