### PR TITLE
FONTS: Change article fonts to sans-serif

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -20,6 +20,9 @@ import GuardianTextSansWoff2 from '../fonts/text/GuardianTextSans-Regular.woff2'
 import GuardianTextSansTtfBold from '../fonts/text/GuardianTextSans-Bold.ttf';
 import GuardianTextSansBoldWoff from '../fonts/text/GuardianTextSans-Bold.woff';
 import GuardianTextSansBoldWoff2 from '../fonts/text/GuardianTextSans-Bold.woff2';
+import GuardianTextSansItalicTtf from '../fonts/text/GuardianTextSans-RegularItalic.ttf';
+import GuardianTextSansItalicWoff from '../fonts/text/GuardianTextSans-RegularItalic.woff';
+import GuardianTextSansItalicWoff2 from '../fonts/text/GuardianTextSans-RegularItalic.woff2';
 import FrontsEdit from './FrontsEdit/Edit';
 import Home from './Home';
 import NotFound from './NotFound';
@@ -28,6 +31,8 @@ import { frontsEdit, manageEditions } from 'constants/routes';
 import ManageView from './Editions/ManageView';
 
 // tslint:disable:no-unused-expression
+// NB the properties described in font-face work as matchers, assigning text to the font imported by the source.
+// this is why we have 2 declarations of font-weight in several of these font-faces. Assigning either hits this font.
 injectGlobal`
   @font-face {
     font-family: GHGuardianHeadline;
@@ -73,6 +78,14 @@ injectGlobal`
     font-weight: 500 800;
   }
 
+  @font-face {
+    font-family: TS3TextSans;
+    src: url(${GuardianTextSansItalicWoff2}) format('woff2'),
+      url(${GuardianTextSansItalicTtf}) format('truetype'),
+      url(${GuardianTextSansItalicWoff}) format('woff');
+    font-style: italic;
+  }
+
   html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial;
     font-size: 16px;
@@ -85,7 +98,7 @@ injectGlobal`
 const AppContainer = styled('div')`
   background-color: ${({ theme }) =>
     theme.shared.base.colors.backgroundColorLight};
-  color: ${({ theme }) => theme.shared.base.colors.text};
+  color: ${({ theme }) => theme.shared.base.colors.textDark};
   height: 100%;
   width: 100%;
 `;

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -52,8 +52,8 @@ const Title = styled.h1`
   padding-top: 2px;
   padding-right: 10px;
   vertical-align: top;
-  font-family: GHGuardianHeadline;
-  font-weight: 600;
+  font-family: TS3TextSans;
+  font-weight: 500;
   font-size: 20px;
   min-width: 80px;
 `;

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -54,9 +54,9 @@ const Container = styled('div')`
 const Title = styled(`h2`)`
   margin: 2px 0 0;
   vertical-align: top;
-  font-family: GHGuardianHeadline;
+  font-family: TS3TextSans;
   font-size: 15px;
-  font-weight: 500;
+  font-weight: 400;
 `;
 
 const VisitedWrapper = styled.a`

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -23,7 +23,7 @@ const SublinkCollectionItemBody = styled(CollectionItemBody)<{
   flex-direction: ${({ isClipboard }) => (isClipboard ? 'column' : 'row')};
   span {
     font-size: 12px;
-    font-weight: bold;
+    font-weight: 400;
   }
   :hover {
     background-color: #ededed;

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -35,8 +35,8 @@ const NotLiveContainer = styled(CollectionItemMetaHeading)`
 `;
 
 const KickerHeading = styled(CollectionItemHeading)`
-  font-family: GHGuardianHeadline;
-  font-weight: bold;
+  font-family: TS3TextSans;
+  font-weight: 500;
   padding-right: 3px;
   font-size: ${({ displaySize }) =>
     displaySize === 'small' ? '13px' : '15px'};
@@ -47,7 +47,7 @@ const ArticleHeadingContainerSmall = styled('div')`
 `;
 
 const ArticleBodyByline = styled('div')`
-  font-family: GHGuardianHeadline;
+  font-family: TS3TextSans;
   font-weight: 500;
   font-size: 15px;
   font-style: italic;

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -20,7 +20,7 @@ const PillaredSection = styled('span')<{ pillar?: string; isLive?: boolean }>`
   color: ${({ pillar, isLive }) =>
     getPillarColor(pillar, isLive || true) || 'inherit'};
   font-size: 13px;
-  font-weight: bold;
+  font-weight: 400;
 `;
 
 const HeadlinePolaroidSpan = styled('span')`

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -6,8 +6,8 @@ const Wrapper = styled('span')<{
   displaySize?: 'small' | 'default';
   showBoostedHeadline?: boolean;
 }>`
-  font-family: GHGuardianHeadline;
-  font-weight: 500;
+  font-family: TS3TextSans;
+  font-weight: 400;
   padding-top: 2px;
   font-size: ${({ displaySize, showBoostedHeadline }) => {
     if (displaySize === 'small') {


### PR DESCRIPTION
## What's changed?
We are changing the article headline and body fonts to a sans-serif.
This makes them easier to read, less like the website and allows them to be more compressed. 

Design request: 
```
Kicker: TS3TextSans, 700,
Headline: TS3TextSans, 400
Byline: TS3TextSans, 500
Sublink Headline: TS3TextSans, 400
```

https://trello.com/c/dUsxIcjm/616-change-kicker-headline-and-byline-in-text-sans

NEW SANS-SERIFED
![Screenshot 2019-05-31 at 15 48 21](https://user-images.githubusercontent.com/10324129/58714059-d8be8b80-83bb-11e9-8a82-4e8f0d7f5ff8.png)


OLD SERIFED
![Screenshot 2019-05-31 at 15 51 22](https://user-images.githubusercontent.com/10324129/58714113-f7248700-83bb-11e9-8bbd-8edb098c2a77.png)



## Implementation notes

- Have added a comment to explain a bit more about font-face properties. 
- Have added "genuine" italics while I'm in here. (If you are not matteus, then you can prove the font is genuine by looking in the firefox inspector and adding `font-synthesis:none` to the text element in the inspector


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
