### PR TITLE
Make tool more responsive to viewport/fronts open

### DIFF
--- a/client-v2/integration/tests/edit-item-metadata.spec.js
+++ b/client-v2/integration/tests/edit-item-metadata.spec.js
@@ -52,7 +52,7 @@ test('Metadata edits are persisted in collections- "breaking news" toggle button
     .click(breakingNewsToggle)
     .click(editFormSaveButton())
     .expect(collectionItemKicker(0, 0).textContent)
-    .eql(`Breaking news`);
+    .contains(`Breaking news`);
 });
 
 test('Metadata edits are persisted in clipboard- "breaking news" toggle button', async t => {
@@ -65,5 +65,5 @@ test('Metadata edits are persisted in clipboard- "breaking news" toggle button',
     .click(editFormSaveButton())
     .dragToElement(clipboardItem(0), firstCollectionFirstDropZone) // Kickers are not visible in clipboard, drag to collection to view
     .expect(collectionItemKicker(0, 0).textContent)
-    .eql(`Breaking news`);
+    .contains(`Breaking news`);
 });

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -87,27 +87,6 @@ test('Drag from clipboard to collection', async t => {
     .eql(clipboardStoryCount);
 });
 
-test('Deleting an article from clipboard works', async t => {
-  const clipboardStory = await clipboardItem();
-  const clipboardStoryCount = await clipboardItem().count;
-  const deleteButton = await clipboardItemDeleteButton();
-  await t
-    .hover(clipboardStory, { speed: 0.7 })
-    .click(deleteButton)
-    .expect(clipboardItem().count)
-    .eql(clipboardStoryCount - 1);
-});
-
-test('Deleting an article from a collection works', async t => {
-  const firstCollectionItem = await collectionItem(0, 0);
-  const firstCollectionStoryCount = await allCollectionItems(0).count;
-  await t
-    .hover(firstCollectionItem, { speed: 0.7 }) // mouse speed needs to be slowed down for hover to trigger correctly
-    .click(collectionItemDeleteButton(0, 0))
-    .expect(allCollectionItems(0).count)
-    .eql(firstCollectionStoryCount - 1);
-});
-
 test('Discarding changes to a collection works', async t => {
   await t
     .click(collectionDiscardButton(1))

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -87,6 +87,27 @@ test('Drag from clipboard to collection', async t => {
     .eql(clipboardStoryCount);
 });
 
+test('Deleting an article from clipboard works', async t => {
+  const clipboardStory = await clipboardItem();
+  const clipboardStoryCount = await clipboardItem().count;
+  const deleteButton = await clipboardItemDeleteButton();
+  await t
+    .hover(clipboardStory, { speed: 0.7 })
+    .click(deleteButton)
+    .expect(clipboardItem().count)
+    .eql(clipboardStoryCount - 1);
+});
+
+test('Deleting an article from a collection works', async t => {
+  const firstCollectionItem = await collectionItem(0, 0);
+  const firstCollectionStoryCount = await allCollectionItems(0).count;
+  await t
+    .hover(firstCollectionItem, { speed: 0.7 }) // mouse speed needs to be slowed down for hover to trigger correctly
+    .click(collectionItemDeleteButton(0, 0))
+    .expect(allCollectionItems(0).count)
+    .eql(firstCollectionStoryCount - 1);
+});
+
 test('Discarding changes to a collection works', async t => {
   await t
     .click(collectionDiscardButton(1))

--- a/client-v2/src/components/FeedSection.tsx
+++ b/client-v2/src/components/FeedSection.tsx
@@ -6,6 +6,7 @@ import FeedContainer from './FeedsContainer';
 import Clipboard from './Clipboard';
 import ClipboardMeta from './ClipboardMeta';
 import FeedSectionHeader from './FeedSectionHeader';
+import { media } from 'shared/util/mediaQueries';
 
 interface Props {
   isClipboardOpen: boolean;
@@ -22,6 +23,7 @@ const FeedSectionContent = styled(SectionContent)`
 
 const FeedWrapper = styled('div')<{ isClipboardOpen: boolean }>`
   width: 409px;
+  ${media.large`width: 335px;`}
   border-right: ${({ theme, isClipboardOpen }) =>
     isClipboardOpen
       ? `solid 1px ${theme.shared.base.colors.borderColor}`

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -25,6 +25,7 @@ import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline'
 import { DEFAULT_PARAMS } from 'services/faciaApi';
 import ScrollContainer from './ScrollContainer';
 import ClipboardHeader from 'components/ClipboardHeader';
+import { media } from 'shared/util/mediaQueries';
 
 interface FeedsContainerProps {
   fetchLive: (params: object, isResource: boolean) => void;
@@ -57,6 +58,10 @@ const Title = styled.h1`
   font-weight: 500;
   font-size: 20px;
   min-width: 80px;
+  ${media.large`
+    min-width: 60px;
+    font-size: 16px;
+  `}
 `;
 
 const RefreshButton = styled.button`

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -28,6 +28,7 @@ import {
   dragOffsetX,
   dragOffsetY
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import { media } from 'shared/util/mediaQueries';
 
 const Container = styled('div')`
   display: flex;
@@ -56,6 +57,7 @@ const Title = styled(`h2`)`
   vertical-align: top;
   font-family: TS3TextSans;
   font-size: 15px;
+  ${media.large`font-size: 13px;`}
   font-weight: 400;
 `;
 
@@ -73,6 +75,7 @@ const VisitedWrapper = styled.a`
 const MetaContainer = styled('div')`
   position: relative;
   min-width: 80px;
+  ${media.large`min-width: 60px;`}
   padding: 0px 2px;
 `;
 

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -74,9 +74,12 @@ const VisitedWrapper = styled.a`
 
 const MetaContainer = styled('div')`
   position: relative;
-  min-width: 80px;
-  ${media.large`min-width: 60px;`}
+  width: 80px;
+  ${media.large`width: 60px;`};
+  flex-shrink: 0;
   padding: 0px 2px;
+  word-break: word;
+  hyphens: auto;
 `;
 
 const ArticleThumbnail = styled(ThumbnailSmall)`

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -64,11 +64,14 @@ type Props = ComponentProps &
     {}
   >;
 
+export const formMinWidth = 250;
+
 const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;
   flex-direction: column;
   flex: 1;
-  width: 380px;
+  min-width: ${formMinWidth}px;
+  max-width: 380px;
   margin-left: 10px;
   height: 100%;
 `;

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -64,7 +64,7 @@ type Props = ComponentProps &
     {}
   >;
 
-export const formMinWidth = 250;
+export const formMinWidth = 300;
 
 const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -81,7 +81,7 @@ class FrontsEdit extends React.Component<Props> {
             makeRoomForExtraHeader={this.props.isCurrentFrontsMenuOpen}
           >
             {this.props.frontIds.map(id => (
-              <FrontContainer frontId={id} />
+              <FrontContainer key={id} frontId={id} />
             ))}
           </FrontsContainer>
         </SectionsContainer>

--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -21,7 +21,7 @@ import SectionContainer from '../layout/SectionContainer';
 import SectionsContainer from '../layout/SectionsContainer';
 import FrontsMenu from './FrontsMenu';
 import PressFailAlert from '../PressFailAlert';
-import { frontsContainerId, createFrontId } from 'util/editUtils';
+import { frontsContainerId } from 'util/editUtils';
 
 interface Props {
   match: match<{ priority: string }>;
@@ -43,10 +43,6 @@ const FrontsEditContainer = styled('div')`
   overflow: hidden;
 `;
 
-const SingleFrontContainer = styled('div')`
-  height: 100%;
-`;
-
 const FeedContainer = styled(SectionContainer)`
   height: 100%;
 `;
@@ -54,6 +50,7 @@ const FeedContainer = styled(SectionContainer)`
 const FrontsContainer = styled(SectionContainer)<{
   makeRoomForExtraHeader: boolean;
 }>`
+  display: flex;
   height: 100%;
   overflow-y: hidden;
   overflow-x: scroll;
@@ -84,9 +81,7 @@ class FrontsEdit extends React.Component<Props> {
             makeRoomForExtraHeader={this.props.isCurrentFrontsMenuOpen}
           >
             {this.props.frontIds.map(id => (
-              <SingleFrontContainer key={id} id={createFrontId(id)}>
-                <FrontContainer frontId={id} />
-              </SingleFrontContainer>
+              <FrontContainer frontId={id} />
             ))}
           </FrontsContainer>
         </SectionsContainer>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -12,8 +12,7 @@ import {
   editorOpenCollections,
   editorOpenOverview,
   editorCloseOverview,
-  selectIsFrontOverviewOpen,
-  editorClearArticleFragmentSelection
+  selectIsFrontOverviewOpen
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
@@ -33,7 +32,6 @@ import { DownCaretIcon } from 'shared/components/icons/Icons';
 import { theme as sharedTheme } from 'shared/constants/theme';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLabel';
-import { batchActions } from 'redux-batched-actions';
 
 const FrontContainer = styled('div')`
   height: 100%;
@@ -92,13 +90,8 @@ const FrontDetailContainer = styled(FrontContentContainer)`
 `;
 
 const FrontCollectionsContainer = styled('div')`
-<<<<<<< HEAD
   overflow-y: scroll;
   max-height: calc(100% - 43px);
-=======
-  overflow: hidden;
-  max-height: 100%;
->>>>>>> 68bd68fff2... Lots of small tweaks to keep the layouts sane
   padding-top: 1px;
 `;
 
@@ -299,18 +292,10 @@ const mapDispatchToProps = (
           frontId
         })
       ),
-    toggleOverview: (open: boolean) => {
-      if (open) {
-        dispatch(editorOpenOverview(props.id));
-      } else {
-        dispatch(
-          batchActions([
-            editorCloseOverview(props.id),
-            editorClearArticleFragmentSelection(props.id)
-          ])
-        );
-      }
-    },
+    toggleOverview: (open: boolean) =>
+      dispatch(
+        open ? editorOpenOverview(props.id) : editorCloseOverview(props.id)
+      ),
     closeAllCollections: (collections: string[]) =>
       dispatch(closeCollections(collections))
   };

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -92,8 +92,13 @@ const FrontDetailContainer = styled(FrontContentContainer)`
 `;
 
 const FrontCollectionsContainer = styled('div')`
+<<<<<<< HEAD
   overflow-y: scroll;
   max-height: calc(100% - 43px);
+=======
+  overflow: hidden;
+  max-height: 100%;
+>>>>>>> 68bd68fff2... Lots of small tweaks to keep the layouts sane
   padding-top: 1px;
 `;
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -82,6 +82,13 @@ const CollapseAllButton = styled(ButtonRoundedWithLabel)`
 const FrontContentContainer = styled('div')`
   height: 100%;
   min-height: 0;
+  /* Min-width is set to allow content within this container to shrink completely */
+  min-width: 0;
+`;
+
+const FrontDetailContainer = styled(FrontContentContainer)`
+  /* We don't want to shrink our overview or form any smaller than the containing content */
+  flex-shrink: 0;
 `;
 
 const FrontCollectionsContainer = styled('div')`
@@ -230,12 +237,12 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
               </Root>
             </FrontCollectionsContainer>
           </FrontContentContainer>
-          <FrontContentContainer>
+          <FrontDetailContainer>
             <FrontDetailView
               id={this.props.id}
               browsingStage={this.props.browsingStage}
             />
-          </FrontContentContainer>
+          </FrontDetailContainer>
         </FrontContainer>
       </React.Fragment>
     );

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -12,7 +12,8 @@ import {
   editorOpenCollections,
   editorOpenOverview,
   editorCloseOverview,
-  selectIsFrontOverviewOpen
+  selectIsFrontOverviewOpen,
+  selectEditorArticleFragment
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
@@ -77,14 +78,18 @@ const CollapseAllButton = styled(ButtonRoundedWithLabel)`
 
 // min-height required here to display scrollbar in Firefox:
 // https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox
-const FrontContentContainer = styled('div')`
+const BaseFrontContentContainer = styled('div')`
   height: 100%;
   min-height: 0;
   /* Min-width is set to allow content within this container to shrink completely */
   min-width: 0;
 `;
 
-const FrontDetailContainer = styled(FrontContentContainer)`
+const FrontContentContainer = styled(BaseFrontContentContainer)`
+  width: 100%;
+`;
+
+const FrontDetailContainer = styled(BaseFrontContentContainer)`
   /* We don't want to shrink our overview or form any smaller than the containing content */
   flex-shrink: 0;
 `;
@@ -105,6 +110,7 @@ interface FrontPropsBeforeState {
 type FrontProps = FrontPropsBeforeState & {
   dispatch: Dispatch;
   initialiseFront: () => void;
+  formIsOpen: boolean;
   selectArticleFragment: (
     frontId: string
   ) => (isSupporting?: boolean) => (id: string) => void;
@@ -169,7 +175,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 
   public render() {
-    const { front } = this.props;
+    const { front, overviewIsOpen, formIsOpen } = this.props;
     const overviewToggleId = `btn-overview-toggle-${this.props.id}`;
     return (
       <React.Fragment>
@@ -235,12 +241,14 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
               </Root>
             </FrontCollectionsContainer>
           </FrontContentContainer>
-          <FrontDetailContainer>
-            <FrontDetailView
-              id={this.props.id}
-              browsingStage={this.props.browsingStage}
-            />
-          </FrontDetailContainer>
+          {(overviewIsOpen || formIsOpen) && (
+            <FrontDetailContainer>
+              <FrontDetailView
+                id={this.props.id}
+                browsingStage={this.props.browsingStage}
+              />
+            </FrontDetailContainer>
+          )}
         </FrontContainer>
       </React.Fragment>
     );
@@ -259,7 +267,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
 const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
   return {
     front: getFront(state, { frontId: props.id }),
-    overviewIsOpen: selectIsFrontOverviewOpen(state, props.id)
+    overviewIsOpen: selectIsFrontOverviewOpen(state, props.id),
+    formIsOpen: !!selectEditorArticleFragment(state, props.id)
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -8,7 +8,6 @@ import CollectionOverview from './CollectionOverview';
 import { CollectionItemSets } from 'shared/types/Collection';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
-import { media } from 'shared/util/mediaQueries';
 
 interface FrontContainerProps {
   id: string;
@@ -24,8 +23,6 @@ interface ContainerProps {
 }
 
 const Container = styled(ContentContainer)<ContainerProps>`
-  ${media.medium`display: none;`}
-  ${media.small`display: none;`}
   border: ${({ isClosed, theme }) =>
     isClosed ? `1px solid ${theme.shared.base.colors.borderColor}` : 'none'};
   border-top: none;

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -40,8 +40,11 @@ const Container = styled(ContentContainer)<ContainerProps>`
   ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
 `;
 
+export const overviewMinWidth = 160;
+
 const ContainerBody = styled.div`
-  max-width: 160px;
+  width: ${overviewMinWidth}px;
+  overflow: hidden;
 `;
 
 const FrontCollectionsOverview = ({

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -8,6 +8,7 @@ import CollectionOverview from './CollectionOverview';
 import { CollectionItemSets } from 'shared/types/Collection';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import ContentContainer from 'shared/components/layout/ContentContainer';
+import { media } from 'shared/util/mediaQueries';
 
 interface FrontContainerProps {
   id: string;
@@ -23,6 +24,8 @@ interface ContainerProps {
 }
 
 const Container = styled(ContentContainer)<ContainerProps>`
+  ${media.medium`display: none;`}
+  ${media.small`display: none;`}
   border: ${({ isClosed, theme }) =>
     isClosed ? `1px solid ${theme.shared.base.colors.borderColor}` : 'none'};
   border-top: none;
@@ -33,11 +36,12 @@ const Container = styled(ContentContainer)<ContainerProps>`
   margin-top: 43px;
   max-height: calc(100% - 43px);
   overflow-y: scroll;
+  padding: 0;
   ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
 `;
 
 const ContainerBody = styled.div`
-  width: 130px;
+  max-width: 160px;
 `;
 
 const FrontCollectionsOverview = ({

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -41,7 +41,7 @@ export const overviewMinWidth = 160;
 
 const ContainerBody = styled.div`
   width: ${overviewMinWidth}px;
-  overflow: hidden;
+  overflow-y: scroll;
 `;
 
 const FrontCollectionsOverview = ({

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -4,7 +4,7 @@ import startCase from 'lodash/startCase';
 import { styled } from 'constants/theme';
 import { Dispatch } from 'types/Store';
 import { fetchLastPressed } from 'actions/Fronts';
-import { updateCollection} from 'actions/Collections';
+import { updateCollection } from 'actions/Collections';
 import {
   editorCloseFront,
   selectIsFrontOverviewOpen,
@@ -59,6 +59,10 @@ const SingleFrontContainer = styled('div')<{
   isOverviewOpen: boolean;
   isFormOpen: boolean;
 }>`
+  /**
+   * We parameterise the min-width of the fronts container to
+   * handle the presence of the form and overview content.
+   */
   min-width: ${({ isOverviewOpen, isFormOpen }) =>
     isOverviewOpen
       ? singleFrontMinWidth + overviewMinWidth + 10
@@ -120,8 +124,8 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
 
   public render() {
     const { frontId, isFormOpen, isOverviewOpen } = this.props;
-    const title = this.props.selectedFront &&
-    startCase(this.props.selectedFront.id);
+    const title =
+      this.props.selectedFront && startCase(this.props.selectedFront.id);
     return (
       <SingleFrontContainer
         key={frontId}
@@ -132,9 +136,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
         <FrontContainer>
           <>
             <FrontHeader greyHeader={true}>
-              <FrontsHeaderText title={title}>
-                {title}
-              </FrontsHeaderText>
+              <FrontsHeaderText title={title}>{title}</FrontsHeaderText>
               <FrontHeaderMeta>
               <a
                 href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -53,15 +53,16 @@ const StageSelectButtons = styled('div')`
   padding: 0px 20px;
 `;
 
-const singleFrontMinWidth = 300;
+const singleFrontMinWidth = 380;
 
 const SingleFrontContainer = styled('div')<{
   isOverviewOpen: boolean;
   isFormOpen: boolean;
 }>`
   /**
-   * We parameterise the min-width of the fronts container to
-   * handle the presence of the form and overview content.
+   * We parameterise the min-width of the fronts
+   * container to handle the presence of the form and overview content.
+   * Min-width provides sensible limits on the
    */
   min-width: ${({ isOverviewOpen, isFormOpen }) =>
     isOverviewOpen

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -24,6 +24,8 @@ import { toTitleCase } from 'util/stringUtils';
 import { RadioButton, RadioGroup } from 'components/inputs/RadioButtons';
 import { PreviewEyeIcon, ClearIcon } from 'shared/components/icons/Icons';
 import { createFrontId } from 'util/editUtils';
+import { formMinWidth } from './ArticleFragmentForm';
+import { overviewMinWidth } from './FrontCollectionsOverview';
 
 const FrontHeader = styled(SectionHeader)`
   display: flex;
@@ -51,12 +53,18 @@ const StageSelectButtons = styled('div')`
   padding: 0px 20px;
 `;
 
+const singleFrontMinWidth = 300;
+
 const SingleFrontContainer = styled('div')<{
   isOverviewOpen: boolean;
   isFormOpen: boolean;
 }>`
   min-width: ${({ isOverviewOpen, isFormOpen }) =>
-    isOverviewOpen ? '400px' : isFormOpen ? '500px' : '300px'};
+    isOverviewOpen
+      ? singleFrontMinWidth + overviewMinWidth
+      : isFormOpen
+      ? singleFrontMinWidth + formMinWidth
+      : singleFrontMinWidth}px;
   flex: 1 1 auto;
   height: 100%;
 `;

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -60,9 +60,11 @@ const SingleFrontContainer = styled('div')<{
   isFormOpen: boolean;
 }>`
   /**
-   * We parameterise the min-width of the fronts
-   * container to handle the presence of the form and overview content.
-   * Min-width provides sensible limits on the
+   * We parameterise the min-width of the fronts container to handle the
+   * presence of the form and overview content. When containers are at their
+   * minimum widths and a form or overview is opened, we increase the min-width
+   * of the front container proportionally to keep the collection container the
+   * same width.
    */
   min-width: ${({ isOverviewOpen, isFormOpen }) =>
     isOverviewOpen

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -61,9 +61,9 @@ const SingleFrontContainer = styled('div')<{
 }>`
   min-width: ${({ isOverviewOpen, isFormOpen }) =>
     isOverviewOpen
-      ? singleFrontMinWidth + overviewMinWidth
+      ? singleFrontMinWidth + overviewMinWidth + 10
       : isFormOpen
-      ? singleFrontMinWidth + formMinWidth
+      ? singleFrontMinWidth + formMinWidth + 10
       : singleFrontMinWidth}px;
   flex: 1 1 auto;
   height: 100%;

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -50,7 +50,7 @@ const FrontsHeaderText = styled('span')`
 
 const StageSelectButtons = styled('div')`
   color: ${({ theme }) => theme.shared.colors.blackDark};
-  padding: 0px 20px;
+  padding: 0px 15px;
 `;
 
 const singleFrontMinWidth = 380;
@@ -137,10 +137,9 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
         isOverviewOpen={isOverviewOpen}
       >
         <FrontContainer>
-          <>
-            <FrontHeader greyHeader={true}>
-              <FrontsHeaderText title={title}>{title}</FrontsHeaderText>
-              <FrontHeaderMeta>
+          <FrontHeader greyHeader={true}>
+            <FrontsHeaderText title={title}>{title}</FrontsHeaderText>
+            <FrontHeaderMeta>
               <a
                 href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
                   this.props.frontId
@@ -169,9 +168,8 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 <ClearIcon size="xl" />
               </FrontHeaderButton>
             </FrontHeaderMeta>
-            </FrontHeader>
-          </>
-          <SectionContent direction="column">
+          </FrontHeader>
+          <FrontSectionContent direction="column">
             {this.props.selectedFront && (
               <Front
                 id={this.props.frontId}
@@ -180,7 +178,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 browsingStage={this.state.collectionSet}
               />
             )}
-          </SectionContent>
+          </FrontSectionContent>
         </FrontContainer>
       </SingleFrontContainer>
     );

--- a/client-v2/src/components/layout/LargeSectionHeader.tsx
+++ b/client-v2/src/components/layout/LargeSectionHeader.tsx
@@ -3,7 +3,7 @@ import { styled } from 'constants/theme';
 export default styled('div')`
   height: 60px;
   padding: 10px;
-  font-size: 32px;
+  font-size: 28px;
   line-height: 40px;
   color: ${({ theme }) => theme.shared.base.colors.textLight};
   font-family: GHGuardianHeadline;

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -103,12 +103,10 @@ const CollectionMetaBase = styled('span')`
 
 const CollectionMeta = styled(CollectionMetaBase)`
   padding-left: 10px;
-  min-width: 120px;
+  flex-grow: 1;
 `;
 
-const ItemCountMeta = styled(CollectionMetaBase)`
-  flex: 0;
-`;
+const ItemCountMeta = CollectionMetaBase;
 
 const CollectionHeadingSticky = styled.div`
   position: sticky;
@@ -131,8 +129,7 @@ const CollectionHeadlineWithConfigContainer = styled('div')`
   flex-basis: 100%;
 `;
 
-const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
-  display: inline-block;
+const CollectionHeadingText = styled('div')<{ isLoading: boolean }>`
   width: 100%;
   white-space: nowrap;
   ${({ isLoading, theme }) =>
@@ -163,10 +160,9 @@ const CollectionConfigContainer = styled('div')`
   font-family: GHGuardianHeadline;
   font-size: 15px;
   color: ${({ theme }) => theme.shared.base.colors.text};
-  height: 40px;
-  line-height: 40px;
   white-space: nowrap;
   margin-left: 3px;
+  vertical-align: bottom;
 `;
 
 const CollectionConfigText = styled('div')`

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -91,6 +91,8 @@ const LockedCollectionFlag = styled('span')`
   color: ${({ theme }) => theme.shared.base.colors.text};
   height: 40px;
   line-height: 40px;
+  border-bottom: 1px solid
+    ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
 const CollectionMetaBase = styled('span')`
@@ -108,7 +110,7 @@ const ItemCountMeta = styled(CollectionMetaBase)`
   flex: 0;
 `;
 
-const CollectionHeadingSticky = styled(ContainerHeadingPinline)`
+const CollectionHeadingSticky = styled.div`
   position: sticky;
   top: 0;
   background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
@@ -118,9 +120,13 @@ const CollectionHeadingSticky = styled(ContainerHeadingPinline)`
   padding: 0 ${contentContainerMargin};
 `;
 
+const CollectionHeadingInner = styled(ContainerHeadingPinline)`
+  border-bottom: 1px solid
+    ${({ theme }) => theme.shared.base.colors.borderColor};
+`;
+
 const CollectionHeadlineWithConfigContainer = styled('div')`
   flex-grow: 1;
-  display: flex;
   min-width: 0;
   flex-basis: 100%;
 `;
@@ -136,8 +142,6 @@ const CollectionHeadingText = styled('span')<{ isLoading: boolean }>`
     `} white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  border-bottom: 1px solid
-    ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
 const CollectionToggleContainer = styled('div')`
@@ -221,7 +225,9 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
         onBlur={handleBlur}
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
       >
-        <CollectionHeadingSticky setBack tabIndex={-1}>
+        <CollectionHeadingSticky tabIndex={-1}>
+          <CollectionHeadingInner>
+
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText isLoading={!collection} title={displayName}>
               {displayName}
@@ -250,6 +256,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               {headlineContent}
             </HeadlineContentContainer>
           ) : null}
+          </CollectionHeadingInner>
         </CollectionHeadingSticky>
         <DragIntentContainer
           delay={300}

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -71,7 +71,7 @@ const CollectionContainer = ContentContainer.extend<{
 
 const HeadlineContentContainer = styled('span')`
   position: relative;
-  right: -11px;
+  margin-right: -11px;
   line-height: 0px;
   display: flex;
 `;
@@ -101,7 +101,7 @@ const CollectionMetaBase = styled('span')`
 
 const CollectionMeta = styled(CollectionMetaBase)`
   padding-left: 10px;
-  min-width: 150px;
+  min-width: 120px;
 `;
 
 const ItemCountMeta = styled(CollectionMetaBase)`
@@ -225,23 +225,23 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
           <CollectionHeadlineWithConfigContainer>
             <CollectionHeadingText isLoading={!collection} title={displayName}>
               {displayName}
+              <CollectionConfigContainer>
+                {oc(collection).metadata[0].type() ? (
+                  <CollectionConfigText>
+                    <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+                    {oc(collection).metadata[0].type()}
+                  </CollectionConfigText>
+                ) : null}
+                {collection &&
+                collection.platform &&
+                collection.platform !== 'Any' ? (
+                  <CollectionConfigText>
+                    <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+                    {`${collection.platform} Only`}
+                  </CollectionConfigText>
+                ) : null}
+              </CollectionConfigContainer>
             </CollectionHeadingText>
-            <CollectionConfigContainer>
-              {oc(collection).metadata[0].type() ? (
-                <CollectionConfigText>
-                  <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-                  {oc(collection).metadata[0].type()}
-                </CollectionConfigText>
-              ) : null}
-              {collection &&
-              collection.platform &&
-              collection.platform !== 'Any' ? (
-                <CollectionConfigText>
-                  <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-                  {`${collection.platform} Only`}
-                </CollectionConfigText>
-              ) : null}
-            </CollectionConfigContainer>
           </CollectionHeadlineWithConfigContainer>
           {isLocked ? (
             <LockedCollectionFlag>Locked</LockedCollectionFlag>

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -61,10 +61,7 @@ interface CollectionState {
 const CollectionContainer = ContentContainer.extend<{
   hasMultipleFrontsOpen?: boolean;
 }>`
-  flex: 1;
-  width: ${({ hasMultipleFrontsOpen }) =>
-    hasMultipleFrontsOpen ? '510px' : '590px'};
-
+  max-width: 590px;
   &:focus {
     border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
     border-top: none;

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -227,35 +227,37 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       >
         <CollectionHeadingSticky tabIndex={-1}>
           <CollectionHeadingInner>
-
-          <CollectionHeadlineWithConfigContainer>
-            <CollectionHeadingText isLoading={!collection} title={displayName}>
-              {displayName}
-              <CollectionConfigContainer>
-                {oc(collection).metadata[0].type() ? (
-                  <CollectionConfigText>
-                    <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-                    {oc(collection).metadata[0].type()}
-                  </CollectionConfigText>
-                ) : null}
-                {collection &&
-                collection.platform &&
-                collection.platform !== 'Any' ? (
-                  <CollectionConfigText>
-                    <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-                    {`${collection.platform} Only`}
-                  </CollectionConfigText>
-                ) : null}
-              </CollectionConfigContainer>
-            </CollectionHeadingText>
-          </CollectionHeadlineWithConfigContainer>
-          {isLocked ? (
-            <LockedCollectionFlag>Locked</LockedCollectionFlag>
-          ) : headlineContent ? (
-            <HeadlineContentContainer>
-              {headlineContent}
-            </HeadlineContentContainer>
-          ) : null}
+            <CollectionHeadlineWithConfigContainer>
+              <CollectionHeadingText
+                isLoading={!collection}
+                title={displayName}
+              >
+                {displayName}
+                <CollectionConfigContainer>
+                  {oc(collection).metadata[0].type() ? (
+                    <CollectionConfigText>
+                      <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+                      {oc(collection).metadata[0].type()}
+                    </CollectionConfigText>
+                  ) : null}
+                  {collection &&
+                  collection.platform &&
+                  collection.platform !== 'Any' ? (
+                    <CollectionConfigText>
+                      <CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+                      {`${collection.platform} Only`}
+                    </CollectionConfigText>
+                  ) : null}
+                </CollectionConfigContainer>
+              </CollectionHeadingText>
+            </CollectionHeadlineWithConfigContainer>
+            {isLocked ? (
+              <LockedCollectionFlag>Locked</LockedCollectionFlag>
+            ) : headlineContent ? (
+              <HeadlineContentContainer>
+                {headlineContent}
+              </HeadlineContentContainer>
+            ) : null}
           </CollectionHeadingInner>
         </CollectionHeadingSticky>
         <DragIntentContainer

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -39,6 +39,7 @@ const ArticleBodyContainer = styled(CollectionItemBody)<{
   isDraggingImageOver: boolean;
 }>`
   position: relative;
+  justify-content: space-between;
   border-top-color: ${({ size, pillarId, isLive, theme }) =>
     size === 'default' && pillarId && isLive
       ? getPillarColor(pillarId, isLive)

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -24,6 +24,7 @@ import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaConte
 import CollectionItemDraftMetaContent from '../collectionItem/CollectionItemDraftMetaContent';
 import ColouredQuote from '../collectionItem/CollectionItemQuote';
 import DraggableArticleImageContainer from './DraggableArticleImageContainer';
+import { media } from 'shared/util/mediaQueries';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   width: 83px;
@@ -40,6 +41,7 @@ const KickerHeading = styled(CollectionItemHeading)`
   padding-right: 3px;
   font-size: ${({ displaySize }) =>
     displaySize === 'small' ? '13px' : '15px'};
+  ${media.large`font-size: 13px;`}
 `;
 
 const ArticleHeadingContainerSmall = styled('div')`

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -202,7 +202,7 @@ const articleBodyDefault = React.memo(
                 style={{ color: getPillarColor(pillarId, true) }}
                 data-testid="kicker"
               >
-                {kickerToDisplay}
+                {`${kickerToDisplay} `}
               </KickerHeading>
             )}
             {showQuotedHeadline && (

--- a/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import {
   CollectionItemDisplayTypes,
   CollectionItemSizes
@@ -9,20 +9,8 @@ const CollectionItemContent = styled('div')<{
   displaySize?: CollectionItemSizes;
 }>`
   position: relative;
-  ${({ displayType, displaySize }) => {
-    if (displayType === 'default') {
-      if (displaySize !== 'small') {
-        return css`
-          width: calc(100% - 163px);
-          padding: 0 8px;
-        `;
-      }
-      return css`
-        width: calc(100% - 100px);
-        padding: 0 8px;
-      `;
-    }
-  }};
+  padding: 0 8px;
+  flex-basis: 100%;
 `;
 
 CollectionItemContent.defaultProps = {

--- a/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
@@ -11,6 +11,8 @@ const CollectionItemContent = styled('div')<{
   position: relative;
   padding: 0 8px;
   flex-basis: 100%;
+  hyphens: auto;
+  word-break: break-word;
 `;
 
 CollectionItemContent.defaultProps = {

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { styled } from 'shared/constants/theme';
 import { sanitizeHTML } from 'shared/util/sanitizeHTML';
+import { media } from 'shared/util/mediaQueries';
 
 const Wrapper = styled('span')<{
   displaySize?: 'small' | 'default';
@@ -18,6 +19,7 @@ const Wrapper = styled('span')<{
     }
     return '15px';
   }};
+  ${media.large`font-size: 13px;`}
 `;
 
 type CollectionItemHeading = {

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
@@ -9,8 +9,9 @@ const metaContainerWidthSmall = 60;
 
 const MetaContainer = styled('div')`
   position: relative;
-width: ${metaContainerWidth}px;
-${media.large`min-width: ${metaContainerWidthSmall}px;`}
+  min-width: ${metaContainerWidth}px;
+  ${media.large`min-width: ${metaContainerWidthSmall}px;`}
+  ${media.large`word-break: break-word`}
   padding: 0 4px;
 `;
 

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { styled } from 'shared/constants/theme';
 
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
+import { media } from 'shared/util/mediaQueries';
+
+const metaContainerWidth = 80;
+const metaContainerWidthSmall = 60;
 
 const MetaContainer = styled('div')`
   position: relative;
-  width: 80px;
+width: ${metaContainerWidth}px;
+${media.large`min-width: ${metaContainerWidthSmall}px;`}
   padding: 0 4px;
 `;
 

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -31,7 +31,7 @@ const heightMap = {
 const paddingMap = {
   s: '5px',
   m: '15px',
-  l: '25px'
+  l: '15px'
 };
 
 const fontSizeMap = {

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -40,6 +40,7 @@ const CheckboxLabel = styled('label')`
     content: '';
     display: block;
     width: 24px;
+    height: 24px;
     margin: 0px;
     background: ${({ theme }) => theme.shared.input.checkboxColorInactive};
     position: absolute;

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -27,6 +27,8 @@ const ImageContainer = styled('div')<{
   isHovering?: boolean;
   hasImage?: boolean;
 }>`
+  display: flex;
+  flex-direction: column;
   position: relative;
   width: 100%;
   max-width: ${props => (props.small ? '100px' : '180px')};

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -24,6 +24,7 @@ import { CollectionItemDisplayTypes } from 'shared/types/Collection';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
+  justify-content: space-between;
   border-top-color: ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
@@ -46,6 +47,10 @@ interface ContainerProps {
 interface SnapLinkProps extends ContainerProps {
   articleFragment: ArticleFragment;
 }
+
+const SnapThumbnail = styled(ThumbnailSmall)`
+  align-self: flex-end;
+`;
 
 const SnapLink = ({
   id,
@@ -92,7 +97,7 @@ const SnapLink = ({
             </>
           )}
         </CollectionItemContent>
-        {size === 'default' && displayType === 'default' && <ThumbnailSmall />}
+        {size === 'default' && displayType === 'default' && <SnapThumbnail />}
         <HoverActionsAreaOverlay
           disabled={isUneditable}
           justify={displayType === 'polaroid' ? 'flex-end' : 'space-between'}

--- a/client-v2/src/shared/components/typography/ContainerHeading.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeading.ts
@@ -5,7 +5,6 @@ const ContainerHeading = styled('div')`
   font-family: GHGuardianHeadline;
   font-weight: bold;
   font-size: 22px;
-  line-height: 22px;
   color: ${({ theme }) => theme.shared.base.colors.text};
 `;
 

--- a/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
@@ -6,7 +6,6 @@ export default styled(ContainerHeading)<{ setBack?: boolean }>`
   height: 40px;
   line-height: 40px;
   vertical-align: middle;
-  overflow: hidden;
   justify-content: space-between;
   border-bottom: ${({ theme, setBack }) =>
     setBack

--- a/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
+++ b/client-v2/src/shared/components/typography/ContainerHeadingPinline.ts
@@ -6,6 +6,7 @@ export default styled(ContainerHeading)<{ setBack?: boolean }>`
   height: 40px;
   line-height: 40px;
   vertical-align: middle;
+  overflow: hidden;
   justify-content: space-between;
   border-bottom: ${({ theme, setBack }) =>
     setBack

--- a/client-v2/src/shared/util/mediaQueries.ts
+++ b/client-v2/src/shared/util/mediaQueries.ts
@@ -1,0 +1,53 @@
+import {
+  css,
+  InterpolationValue,
+  SimpleInterpolation
+} from 'styled-components';
+
+type Breakpoints = 'large' | 'medium' | 'small';
+
+type BreakpointMap = { [Breakpoint in Breakpoints]: number };
+
+const sizes = {
+  large: 1280,
+  medium: 992,
+  small: 768
+} as BreakpointMap;
+
+type MediaQueryMap = {
+  [Key in Breakpoints]: (
+    strings: TemplateStringsArray,
+    ...interpolations: SimpleInterpolation[]
+  ) => InterpolationValue[]
+};
+
+/**
+ * This object contains properties whose names correspond to breakpoints.
+ * They contain values that accept tagged template literals, and we can use
+ * them to construct media queries.
+ *
+ * For example --
+ *
+ * const Content = styled.div`
+ *  ${media.desktop`background: dodgerblue;`}
+ *  ${media.tablet`background: mediumseagreen;`}
+ *  ${media.phone`background: palevioletred;`}
+ * `;
+ *
+ * Cribbed from https://www.styled-components.com/docs/advanced.
+ */
+export const media = (Object.keys(sizes) as Breakpoints[]).reduce(
+  (acc, label) => {
+    acc[label] = (
+      strings: TemplateStringsArray,
+      ...interpolations: SimpleInterpolation[]
+    ) =>
+      css`
+        @media (max-width: ${sizes[label]}px) {
+          ${css(strings, ...interpolations)}
+        }
+      `;
+    return acc;
+  },
+  {} as MediaQueryMap
+);

--- a/client-v2/src/shared/util/mediaQueries.ts
+++ b/client-v2/src/shared/util/mediaQueries.ts
@@ -29,12 +29,12 @@ type MediaQueryMap = {
  * For example --
  *
  * const Content = styled.div`
- *  ${media.desktop`background: dodgerblue;`}
- *  ${media.tablet`background: mediumseagreen;`}
- *  ${media.phone`background: palevioletred;`}
+ *  ${media.desktop`background: red;`}
+ *  ${media.tablet`background: blue;`}
+ *  ${media.phone`background: green;`}
  * `;
  *
- * Cribbed from https://www.styled-components.com/docs/advanced.
+ * Cribbed and typescriptified from https://www.styled-components.com/docs/advanced.
  */
 export const media = (Object.keys(sizes) as Breakpoints[]).reduce(
   (acc, label) => {


### PR DESCRIPTION
## What's changed?

Building on @RichieAHB's work in #739 and some feedback from CP, this PR makes the tool more responsive to the viewport size and the number of fronts currently being displayed -

- Fronts attempt to fill their container up a max width
- Multiple fronts attempt to fit into the viewpoint up to a min width
- Fronts take up more space if their overview or form is open
- The card font size and a few feed features now switch depending on the viewport size

![responsive](https://user-images.githubusercontent.com/7767575/58875469-89ca6c00-86c3-11e9-8ae8-fa58c07850db.gif)

## Implementation notes

@RichieAHB mentioned a layout change that could make handling front minimum widths more flexible, by moving the front header text out of the document flow. This PR doesn't include that change, but it might be worth thinking about in a subsequent PR.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
