### PR TITLE
Fix scrolling in Firefox

### DIFF
--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -36,6 +36,7 @@ import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLab
 import { batchActions } from 'redux-batched-actions';
 
 const FrontContainer = styled('div')`
+  height: 100%;
   display: flex;
 `;
 


### PR DESCRIPTION
## What's changed?

This PR fixes scrolling through the front container list in Firefox, which was broken by #749. 

## Implementation notes

It seems Firefox and Chrome treat heights of flex children with flex properties differently. I'm still working on a proper explanation.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
