### PR TITLE
Fix overview label 

### DIFF
--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -165,6 +165,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
 
   public render() {
     const { front } = this.props;
+    const overviewToggleId = `btn-overview-toggle-${this.props.id}`;
     return (
       <React.Fragment>
         <div
@@ -190,11 +191,11 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                 label={'Collapse all'}
               />
               <OverviewToggleContainer>
-                <OverviewHeading htmlFor="btn-overview-toggle">
+                <OverviewHeading htmlFor={overviewToggleId}>
                   {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
                 </OverviewHeading>
                 <ButtonCircularCaret
-                  id="btn-overview-toggle"
+                  id={overviewToggleId}
                   style={{
                     margin: '0'
                   }}


### PR DESCRIPTION
## What's changed?

The label htmlFor and toggle id for the overview toggle doesn't contain a front id. This means that with multiple fronts, toggling anything but the first overview via the label will toggle the first overview. 🤦‍♀ My mistake!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
