### PR TITLE
Close gap between front header and container

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -50,6 +50,10 @@ const FrontsContainer = styled('div')`
   transform: translate3d(0, 0, 0);
 `;
 
+const FrontSectionContent = styled(SectionContent)`
+  padding-top: 0;
+`;
+
 interface FrontsContainerProps {
   frontId: string;
 }
@@ -121,7 +125,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
             </FrontHeaderMeta>
           </FrontHeader>
         </>
-        <SectionContent direction="column">
+        <FrontSectionContent direction="column">
           {this.props.selectedFront && (
             <Front
               id={this.props.frontId}
@@ -130,7 +134,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
               browsingStage={this.state.collectionSet}
             />
           )}
-        </SectionContent>
+        </FrontSectionContent>
       </FrontsContainer>
     );
   }


### PR DESCRIPTION
## What's changed?

A tiny layout PR to close the gap between the front header and its inner container. Thanks to @akemitakagi for the spot!

Spot the difference (ignoring the dev tools tooltip!) before --

<img width="606" alt="Screenshot 2019-06-04 at 11 26 30" src="https://user-images.githubusercontent.com/7767575/58872307-a1055b80-86bb-11e9-8f3b-ce0cd69bff0f.png">

and after --

<img width="606" alt="Screenshot 2019-06-04 at 11 23 37" src="https://user-images.githubusercontent.com/7767575/58872145-54218500-86bb-11e9-973f-e0219c372632.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
