### PR TITLE
Keep the overview open when the article form closes

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -393,8 +393,8 @@ describe('frontsUIBundle', () => {
       });
     });
     describe('Collection item form display', () => {
-      it('should open and close a collection item form', () => {
-        let state = reducer(
+      it('should open a collection item form', () => {
+        const state = reducer(
           undefined,
           editorSelectArticleFragment('front1', 'exampleArticleFragment')
         );
@@ -402,8 +402,6 @@ describe('frontsUIBundle', () => {
           id: 'exampleArticleFragment',
           isSupporting: false
         });
-        state = reducer(state.editor, editorOpenOverview('front1'));
-        expect(selectEditorArticleFragment(state, 'front1')).toBe(undefined);
       });
     });
     it('should open and close all editing fronts', () => {

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -391,18 +391,6 @@ describe('frontsUIBundle', () => {
         expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(true);
         expect(selectIsFrontOverviewOpen(state, 'front2')).toBe(true);
       });
-      it('should close an overview when a form for that front is opened', () => {
-        let state = reducer(
-          { closedOverviews: [] } as any,
-          editorOpenOverview('front1')
-        );
-        expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(true);
-        state = reducer(
-          state.editor,
-          editorSelectArticleFragment('front1', 'exampleArticleFragment')
-        );
-        expect(selectIsFrontOverviewOpen(state, 'front1')).toBe(false);
-      });
     });
     describe('Collection item form display', () => {
       it('should open and close a collection item form', () => {
@@ -417,7 +405,6 @@ describe('frontsUIBundle', () => {
         state = reducer(state.editor, editorOpenOverview('front1'));
         expect(selectEditorArticleFragment(state, 'front1')).toBe(undefined);
       });
-      it('should close a collection item form when the overview for that front is opened', () => {});
     });
     it('should open and close all editing fronts', () => {
       const state = reducer(

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -491,7 +491,6 @@ const reducer = (state: State = defaultState, action: Action): State => {
     case EDITOR_SELECT_ARTICLE_FRAGMENT: {
       return {
         ...state,
-        closedOverviews: state.closedOverviews.concat(action.payload.frontId),
         selectedArticleFragments: {
           ...state.selectedArticleFragments,
           [action.payload.frontId]: {
@@ -534,13 +533,12 @@ const reducer = (state: State = defaultState, action: Action): State => {
       };
     }
     case EDITOR_OPEN_OVERVIEW: {
-      const newState = {
+      return {
         ...state,
         closedOverviews: state.closedOverviews.filter(
           id => id !== action.payload.frontId
         )
       };
-      return clearArticleFragmentSelection(newState, action.payload.frontId);
     }
     case EDITOR_CLOSE_OVERVIEW: {
       return {

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -73,7 +73,8 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
   min-width: ${formMinWidth}px;
   max-width: 380px;
   margin-left: 10px;
-  height: 100%;
+  margin-top: 10px;
+  height: calc(100% - 10px);
 `;
 
 const FormContent = styled('div')`

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -67,10 +67,10 @@ const SingleFrontContainer = styled('div')<{
    * same width.
    */
   min-width: ${({ isOverviewOpen, isFormOpen }) =>
-    isOverviewOpen
-      ? singleFrontMinWidth + overviewMinWidth + 10
-      : isFormOpen
+    isFormOpen
       ? singleFrontMinWidth + formMinWidth + 10
+      : isOverviewOpen
+      ? singleFrontMinWidth + overviewMinWidth + 10
       : singleFrontMinWidth}px;
   flex: 1 1 auto;
   height: 100%;


### PR DESCRIPTION
## What's changed?

A side effect of #749 (that I added) changed the behaviour of the form toggles -- opening a form would close the overview for the front. This isn't desirable re: feedback from Mariana, so this PR reverts that behaviour: opening a form doesn't interfere with the overview state.
 
## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
