### PR TITLE
Fix tag remove button

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
-import { styled } from 'constants/theme';
+import { styled, theme as globalTheme } from 'constants/theme';
 import { ClearIcon } from 'shared/components/icons/Icons';
 import { SmallRoundButton } from 'util/sharedStyles/buttons';
 
 const SearchTermItem = styled('div')`
+  display: flex;
+  justify-content: space-between;
   color: ${({ theme }) => theme.capiInterface.text};
   font-weight: bold;
   border: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
   font-size: 14px;
+  line-height: 32px;
   background-color: ${({ theme }) => theme.capiInterface.backgroundWhite};
-  padding: 7px 15px 7px 15px;
+  padding: 5px 10px 5px 10px;
   margin-bottom: 10px;
-  :hover {
-    color: ${({ theme }) => theme.capiInterface.textLight};
-  }
+  margin-right: 10px;
 `;
 
 interface FilterItemProps {
@@ -24,8 +25,8 @@ interface FilterItemProps {
 const FilterItem = ({ children, onClear }: FilterItemProps) => (
   <SearchTermItem>
     {children}
-    <SmallRoundButton onClick={() => onClear()} title="Clear search">
-      <ClearIcon size={'l'} />
+    <SmallRoundButton color="" onClick={() => onClear()} title="Clear search">
+      <ClearIcon fill={globalTheme.shared.base.colors.text} size={'l'} />
     </SmallRoundButton>
   </SearchTermItem>
 );

--- a/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FilterItem.tsx
@@ -25,7 +25,7 @@ interface FilterItemProps {
 const FilterItem = ({ children, onClear }: FilterItemProps) => (
   <SearchTermItem>
     {children}
-    <SmallRoundButton color="" onClick={() => onClear()} title="Clear search">
+    <SmallRoundButton onClick={() => onClear()} title="Clear search">
       <ClearIcon fill={globalTheme.shared.base.colors.text} size={'l'} />
     </SmallRoundButton>
   </SearchTermItem>


### PR DESCRIPTION
## What's changed?

This PR makes the tag remove button visible again, and gives tags a modest tucking-in to match what is now a less chonky design. Behold: from

<img width="412" alt="Screenshot 2019-06-05 at 17 05 46" src="https://user-images.githubusercontent.com/7767575/58971848-3126cc00-87b4-11e9-874b-21d241585845.png">

(how do I remove tags?), to

<img width="412" alt="Screenshot 2019-06-05 at 17 00 58" src="https://user-images.githubusercontent.com/7767575/58971803-1e13fc00-87b4-11e9-8575-1cc9bd911fcd.png">

It's no Chips, mind. Thanks to Robert Gardner-Sharpe for the tip (Robert isn't on Github!?)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
