### PR TITLE
Refactor breaking news client

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -29,7 +29,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
     new BreakingNewsClient(
       host = config.notification.host,
       apiKey = config.notification.key,
-      httpProvider = new NotificationHttpProvider(ws)
+      ws
     )
   }
 
@@ -38,8 +38,6 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
     collection: ClientHydratedCollection,
     email: String
   ): Future[Result] = {
-    // TODO MRB:
-    // remove injected HTTP provider
 
     def structuredLog(update: UpdateMessage, level: String = "info", error: Option[String] = None) = {
       structuredLogger.putLog(LogUpdate(update, email), level, error.map(new Exception(_)))

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -15,6 +15,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Result
 import play.api.mvc.Results.{InternalServerError, Ok}
+import util.BreakingNewsClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -27,7 +28,7 @@ class InvalidNotificationContentType(msg: String) extends Throwable(msg) {}
 class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient, val structuredLogger: StructuredLogger) extends Logging {
   lazy val client = {
     logger.info(s"Configuring breaking news client to send notifications to ${config.notification.host}")
-    ApiClient(
+    new BreakingNewsClient(
       host = config.notification.host,
       apiKey = config.notification.key,
       httpProvider = new NotificationHttpProvider(ws)

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -40,7 +40,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
   ): Future[Result] = {
 
     def structuredLog(update: UpdateMessage, level: String = "info", error: Option[BreakingNewsError] = None) = {
-      structuredLogger.putLog(LogUpdate(update, email), level, error.flatMap(BreakingNewsError.getThrowable))
+      structuredLogger.putLog(LogUpdate(update, email), level, error.flatMap(BreakingNewsError.getException))
     }
 
     structuredLog(HandlingBreakingNewsCollection(collectionId))

--- a/app/updates/StructuredLogger.scala
+++ b/app/updates/StructuredLogger.scala
@@ -9,7 +9,7 @@ import services.ConfigAgent
 import scala.collection.JavaConverters._
 
 class StructuredLogger(val config: ApplicationConfiguration, val configAgent: ConfigAgent) extends Logging {
-  def putLog(log: LogUpdate, level: String = "info", error: Option[Exception] = None): Unit = {
+  def putLog(log: LogUpdate, level: String = "info", error: Option[Throwable] = None): Unit = {
     lazy val updatePayload = serializeUpdateMessage(log)
     lazy val shortMessagePayload = serializeShortMessage(log)
     log.fronts(configAgent).foreach { frontId => {

--- a/app/updates/UpdateMessage.scala
+++ b/app/updates/UpdateMessage.scala
@@ -1,6 +1,7 @@
 package updates
 
-import com.gu.facia.client.models.{CollectionJson, CollectionConfigJson, FrontJson, TrailMetaData}
+import com.gu.facia.client.models.{CollectionConfigJson, CollectionJson, FrontJson, TrailMetaData}
+import com.gu.mobile.notifications.client.models.Topic
 import julienrf.json.derived
 import org.joda.time.DateTime
 import play.api.libs.json._
@@ -87,7 +88,15 @@ case class HandlingBreakingNewsCollection(id: String) extends UpdateMessage {
   def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
 }
 
-case class HandlingBreakingNewsTrail(id: String, breakingNewsTrail: ClientHydratedTrail) extends UpdateMessage {
+case class HandlingBreakingNewsTrail(id: String, breakingNewsTrail: ClientHydratedTrail, topic: String) extends UpdateMessage {
+  def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
+}
+
+case class SuppressedBreakingNewsSend(id: String, breakingNewsTrail: ClientHydratedTrail, topic: String) extends UpdateMessage {
+  def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
+}
+
+case class SentBreakingNewsNotification(id: String, breakingNewsTrail: ClientHydratedTrail, topic: String, notificationApiId: String) extends UpdateMessage {
   def affectedFronts(configAgent: ConfigAgent) = configAgent.getConfigsUsingCollectionId(id).toSet[String]
 }
 

--- a/app/util/BreakingNewsClient.scala
+++ b/app/util/BreakingNewsClient.scala
@@ -1,15 +1,14 @@
 package util
 
-import java.util.UUID
-
 import com.gu.mobile.notifications.client._
-import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, NotificationPayload, Topic}
+import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, Topic}
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
+import updates.ClientHydratedTrail
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
 
+case class BreakingNewsRequest(trail: ClientHydratedTrail, topic: Topic, payload: BreakingNewsPayload)
 case class BreakingNewsResponse(id: String)
 
 object BreakingNewsResponse {
@@ -25,17 +24,8 @@ class BreakingNewsClient(
 
   private val url = s"$host/push/topic"
 
-  def send(notificationPayload: BreakingNewsPayload)(implicit ec: ExecutionContext): Future[List[Either[ApiClientError, BreakingNewsResponse]]] = {
-    Future.traverse(notificationPayload.topic) { topic =>
-      // We send a Global notification as multiple notifications to each requested topic
-      // This is because there is a limit of 3 topics at once in mobile-n10n and we currently have 4 global editions
-      val payload = notificationPayload.copy(topic = List(topic), id = UUID.randomUUID())
-      doSend(payload, topic)
-    }
-  }
-
-  private def doSend(payload: BreakingNewsPayload, topic: Topic)(implicit ec: ExecutionContext): Future[Either[ApiClientError, BreakingNewsResponse]] = {
-    val json = Json.stringify(Json.toJson(payload))
+  def send(request: BreakingNewsRequest)(implicit ec: ExecutionContext): Future[Either[ApiClientError, BreakingNewsResponse]] = {
+    val json = Json.stringify(Json.toJson(request.payload))
     postJson(url, json) map {
       case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
       case HttpOk(201, body) => validateFormat[BreakingNewsResponse](body)

--- a/app/util/BreakingNewsClient.scala
+++ b/app/util/BreakingNewsClient.scala
@@ -7,6 +7,8 @@ import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, Notificat
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 case class BreakingNewsResponse(id: String)
 
@@ -23,35 +25,23 @@ class BreakingNewsClient(
 
   private val url = s"$host/push/topic"
 
-  def send(notificationPayload: NotificationPayload)(implicit ec: ExecutionContext): Future[Either[ApiClientError, Unit]] = {
-
-    def doSend(payload: NotificationPayload): Future[Either[ApiClientError, Unit]] = {
-      val json = Json.stringify(Json.toJson(payload))
-      postJson(url, json) map {
-        case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
-        case HttpOk(201, body) => validateFormat[BreakingNewsResponse](body)
-        case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
-      } recover {
-        case e: Exception => Left(HttpProviderError(e))
-      }
+  def send(notificationPayload: BreakingNewsPayload)(implicit ec: ExecutionContext): Future[List[Either[ApiClientError, BreakingNewsResponse]]] = {
+    Future.traverse(notificationPayload.topic) { topic =>
+      // We send a Global notification as multiple notifications to each requested topic
+      // This is because there is a limit of 3 topics at once in mobile-n10n and we currently have 4 global editions
+      val payload = notificationPayload.copy(topic = List(topic), id = UUID.randomUUID())
+      doSend(payload, topic)
     }
+  }
 
-    def doSendOncePerTopic(payload: BreakingNewsPayload): Future[Either[ApiClientError, Unit]] = {
-      val results = payload.topic
-        .map(topic => payload.copy(topic = List(topic), id = UUID.randomUUID()))
-        .map(doSend)
-      Future.sequence(results).map { responses =>
-        responses.collect { case Left(error) => error } match {
-          case Nil => Right(())
-          case onlyOneError :: Nil => Left(onlyOneError)
-          case errors: List[ApiClientError] => Left(UnexpectedApiResponseError(errors.map(_.description).mkString(", ")))
-        }
-      }
-    }
-
-    notificationPayload match {
-      case breakingNews: BreakingNewsPayload if breakingNews.topic.size > 1 => doSendOncePerTopic(breakingNews)
-      case _ => doSend(notificationPayload)
+  private def doSend(payload: BreakingNewsPayload, topic: Topic)(implicit ec: ExecutionContext): Future[Either[ApiClientError, BreakingNewsResponse]] = {
+    val json = Json.stringify(Json.toJson(payload))
+    postJson(url, json) map {
+      case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
+      case HttpOk(201, body) => validateFormat[BreakingNewsResponse](body)
+      case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
+    } recover {
+      case NonFatal(e) => Left(HttpProviderError(e))
     }
   }
 
@@ -64,15 +54,15 @@ class BreakingNewsClient(
     )
   }
 
-  private def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[ApiClientError, Unit] = {
+  private def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[ApiClientError, T] = {
     try {
       Json.parse(jsonBody).validate[T] match {
-        case _: JsSuccess[T] => Right(())
+        case JsSuccess(r, _) => Right(r)
         case _: JsError => Left(UnexpectedApiResponseError(jsonBody))
       }
     }
     catch {
-      case _: Exception => Left(UnexpectedApiResponseError(jsonBody))
+      case NonFatal(_) => Left(UnexpectedApiResponseError(jsonBody))
     }
   }
 }

--- a/app/util/BreakingNewsClient.scala
+++ b/app/util/BreakingNewsClient.scala
@@ -2,7 +2,9 @@ package util
 
 import com.gu.mobile.notifications.client._
 import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, Topic}
+import logging.Logging
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
+import play.api.libs.ws.{WSClient, WSResponse}
 import updates.ClientHydratedTrail
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,32 +18,25 @@ object BreakingNewsResponse {
 }
 
 class BreakingNewsClient(
-  val host: String,
-  val apiKey: String,
-  val httpProvider: HttpProvider,
-  val clientId: String = "nextGen"
-) {
+  host: String,
+  apiKey: String,
+  ws: WSClient
+) extends Logging {
 
   private val url = s"$host/push/topic"
 
   def send(request: BreakingNewsRequest)(implicit ec: ExecutionContext): Future[Either[ApiClientError, BreakingNewsResponse]] = {
     val json = Json.stringify(Json.toJson(request.payload))
-    postJson(url, json) map {
+    val requestBody = json.getBytes("UTF-8")
+    val contentType = ContentType("application/json", "UTF-8")
+
+    post(url, apiKey, contentType, requestBody) map {
       case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
       case HttpOk(201, body) => validateFormat[BreakingNewsResponse](body)
       case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
     } recover {
       case NonFatal(e) => Left(HttpProviderError(e))
     }
-  }
-
-  private def postJson(destUrl: String, json: String) = {
-    httpProvider.post(
-      url = destUrl,
-      apiKey = apiKey,
-      contentType = ContentType("application/json", "UTF-8"),
-      body = json.getBytes("UTF-8")
-    )
   }
 
   private def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[ApiClientError, T] = {
@@ -53,6 +48,23 @@ class BreakingNewsClient(
     }
     catch {
       case NonFatal(_) => Left(UnexpectedApiResponseError(jsonBody))
+    }
+  }
+
+  def post(url: String, apiKey: String, contentType: ContentType, body: Array[Byte])(implicit ec: ExecutionContext): Future[HttpResponse] = {
+    ws.url(url)
+      .withHttpHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}", "Authorization" -> s"Bearer $apiKey")
+      .post(body)
+      .map(extract)
+  }
+
+  private def extract(response: WSResponse): HttpResponse = {
+    if (response.status >= 200 && response.status < 300) {
+      logger.info("Breaking news notification client request sent correctly")
+      HttpOk(response.status, response.body)
+    } else {
+      logger.error(s"Unable to send breaking news client request, status ${response.status}: ${response.statusText}")
+      HttpError(response.status, response.body)
     }
   }
 }

--- a/app/util/BreakingNewsClient.scala
+++ b/app/util/BreakingNewsClient.scala
@@ -1,6 +1,5 @@
 package util
 
-import com.gu.mobile.notifications.client._
 import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, Topic}
 import logging.Logging
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
@@ -11,10 +10,33 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 case class BreakingNewsRequest(trail: ClientHydratedTrail, topic: Topic, payload: BreakingNewsPayload)
+
 case class BreakingNewsResponse(id: String)
 
 object BreakingNewsResponse {
   implicit val jf = Json.format[BreakingNewsResponse]
+}
+
+sealed trait BreakingNewsError
+case class BreakingNewsResponseStatusError(status: Int, body: String) extends BreakingNewsError
+case class BreakingNewsResponseFormatError(error: Either[String, Throwable], body: String) extends BreakingNewsError
+case class BreakingNewsResponseException(err: Throwable) extends BreakingNewsError
+case class BreakingNewsSuppressedError(message: String) extends BreakingNewsError
+
+object BreakingNewsError {
+  def getDescription(error: BreakingNewsError): String = error match {
+    case BreakingNewsResponseStatusError(status, body) => s"Unexpected HTTP status $status: $body"
+    case BreakingNewsResponseFormatError(Left(description), body) => s"Format error in response $description: $body"
+    case BreakingNewsResponseFormatError(Right(err), body) => s"Format error in response: ${err.getMessage}: $body"
+    case BreakingNewsResponseException(err) => s"Unexpected error ${err.getMessage}"
+    case BreakingNewsSuppressedError(message) => message
+  }
+
+  def getThrowable(error: BreakingNewsError): Option[Throwable] = error match {
+    case BreakingNewsResponseFormatError(Right(err), _) => Some(err)
+    case BreakingNewsResponseException(err) => Some(err)
+    case _ => None
+  }
 }
 
 class BreakingNewsClient(
@@ -25,46 +47,45 @@ class BreakingNewsClient(
 
   private val url = s"$host/push/topic"
 
-  def send(request: BreakingNewsRequest)(implicit ec: ExecutionContext): Future[Either[ApiClientError, BreakingNewsResponse]] = {
+  def send(request: BreakingNewsRequest)(implicit ec: ExecutionContext): Future[Either[BreakingNewsError, BreakingNewsResponse]] = {
     val json = Json.stringify(Json.toJson(request.payload))
     val requestBody = json.getBytes("UTF-8")
-    val contentType = ContentType("application/json", "UTF-8")
 
-    post(url, apiKey, contentType, requestBody) map {
-      case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
-      case HttpOk(201, body) => validateFormat[BreakingNewsResponse](body)
-      case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
+    post(url, apiKey, requestBody) map { response =>
+      if(response.status == 201) {
+        validateFormat[BreakingNewsResponse](response.body)
+      } else {
+        Left(BreakingNewsResponseStatusError(response.status, response.body))
+      }
     } recover {
-      case NonFatal(e) => Left(HttpProviderError(e))
+      case NonFatal(e) => Left(BreakingNewsResponseException(e))
     }
   }
 
-  private def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[ApiClientError, T] = {
+  private def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[BreakingNewsError, T] = {
     try {
       Json.parse(jsonBody).validate[T] match {
-        case JsSuccess(r, _) => Right(r)
-        case _: JsError => Left(UnexpectedApiResponseError(jsonBody))
+        case JsSuccess(r, _) =>
+          Right(r)
+
+        case JsError(errors) =>
+          val description = errors.flatMap(_._2.map(_.message)).mkString(", ")
+          Left(BreakingNewsResponseFormatError(Left(description), jsonBody))
       }
     }
     catch {
-      case NonFatal(_) => Left(UnexpectedApiResponseError(jsonBody))
+      case NonFatal(e) =>
+        Left(BreakingNewsResponseFormatError(Right(e), jsonBody))
     }
   }
 
-  def post(url: String, apiKey: String, contentType: ContentType, body: Array[Byte])(implicit ec: ExecutionContext): Future[HttpResponse] = {
+  def post(url: String, apiKey: String, body: Array[Byte])(implicit ec: ExecutionContext): Future[WSResponse] = {
     ws.url(url)
-      .withHttpHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}", "Authorization" -> s"Bearer $apiKey")
+      .withHttpHeaders("Content-Type" -> s"application/json; charset=UTF-8", "Authorization" -> s"Bearer $apiKey")
       .post(body)
-      .map(extract)
-  }
-
-  private def extract(response: WSResponse): HttpResponse = {
-    if (response.status >= 200 && response.status < 300) {
-      logger.info("Breaking news notification client request sent correctly")
-      HttpOk(response.status, response.body)
-    } else {
-      logger.error(s"Unable to send breaking news client request, status ${response.status}: ${response.statusText}")
-      HttpError(response.status, response.body)
-    }
+      .map { response =>
+        logger.info(s"Breaking news client received response ${response.status}: ${response.body}")
+        response
+      }
   }
 }

--- a/app/util/BreakingNewsClient.scala
+++ b/app/util/BreakingNewsClient.scala
@@ -1,0 +1,78 @@
+package util
+
+import java.util.UUID
+
+import com.gu.mobile.notifications.client._
+import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, NotificationPayload, Topic}
+import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class BreakingNewsResponse(id: String)
+
+object BreakingNewsResponse {
+  implicit val jf = Json.format[BreakingNewsResponse]
+}
+
+class BreakingNewsClient(
+  val host: String,
+  val apiKey: String,
+  val httpProvider: HttpProvider,
+  val clientId: String = "nextGen"
+) {
+
+  private val url = s"$host/push/topic"
+
+  def send(notificationPayload: NotificationPayload)(implicit ec: ExecutionContext): Future[Either[ApiClientError, Unit]] = {
+
+    def doSend(payload: NotificationPayload): Future[Either[ApiClientError, Unit]] = {
+      val json = Json.stringify(Json.toJson(payload))
+      postJson(url, json) map {
+        case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
+        case HttpOk(201, body) => validateFormat[BreakingNewsResponse](body)
+        case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
+      } recover {
+        case e: Exception => Left(HttpProviderError(e))
+      }
+    }
+
+    def doSendOncePerTopic(payload: BreakingNewsPayload): Future[Either[ApiClientError, Unit]] = {
+      val results = payload.topic
+        .map(topic => payload.copy(topic = List(topic), id = UUID.randomUUID()))
+        .map(doSend)
+      Future.sequence(results).map { responses =>
+        responses.collect { case Left(error) => error } match {
+          case Nil => Right(())
+          case onlyOneError :: Nil => Left(onlyOneError)
+          case errors: List[ApiClientError] => Left(UnexpectedApiResponseError(errors.map(_.description).mkString(", ")))
+        }
+      }
+    }
+
+    notificationPayload match {
+      case breakingNews: BreakingNewsPayload if breakingNews.topic.size > 1 => doSendOncePerTopic(breakingNews)
+      case _ => doSend(notificationPayload)
+    }
+  }
+
+  private def postJson(destUrl: String, json: String) = {
+    httpProvider.post(
+      url = destUrl,
+      apiKey = apiKey,
+      contentType = ContentType("application/json", "UTF-8"),
+      body = json.getBytes("UTF-8")
+    )
+  }
+
+  private def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[ApiClientError, Unit] = {
+    try {
+      Json.parse(jsonBody).validate[T] match {
+        case _: JsSuccess[T] => Right(())
+        case _: JsError => Left(UnexpectedApiResponseError(jsonBody))
+      }
+    }
+    catch {
+      case _: Exception => Left(UnexpectedApiResponseError(jsonBody))
+    }
+  }
+}

--- a/app/util/BreakingNewsClient.scala
+++ b/app/util/BreakingNewsClient.scala
@@ -19,8 +19,8 @@ object BreakingNewsResponse {
 
 sealed trait BreakingNewsError
 case class BreakingNewsResponseStatusError(status: Int, body: String) extends BreakingNewsError
-case class BreakingNewsResponseFormatError(error: Either[String, Throwable], body: String) extends BreakingNewsError
-case class BreakingNewsResponseException(err: Throwable) extends BreakingNewsError
+case class BreakingNewsResponseFormatError(error: Either[String, Exception], body: String) extends BreakingNewsError
+case class BreakingNewsResponseException(err: Exception) extends BreakingNewsError
 case class BreakingNewsSuppressedError(message: String) extends BreakingNewsError
 
 object BreakingNewsError {
@@ -32,7 +32,7 @@ object BreakingNewsError {
     case BreakingNewsSuppressedError(message) => message
   }
 
-  def getThrowable(error: BreakingNewsError): Option[Throwable] = error match {
+  def getException(error: BreakingNewsError): Option[Exception] = error match {
     case BreakingNewsResponseFormatError(Right(err), _) => Some(err)
     case BreakingNewsResponseException(err) => Some(err)
     case _ => None
@@ -58,7 +58,7 @@ class BreakingNewsClient(
         Left(BreakingNewsResponseStatusError(response.status, response.body))
       }
     } recover {
-      case NonFatal(e) => Left(BreakingNewsResponseException(e))
+      case NonFatal(e: Exception) => Left(BreakingNewsResponseException(e))
     }
   }
 
@@ -74,7 +74,7 @@ class BreakingNewsClient(
       }
     }
     catch {
-      case NonFatal(e) =>
+      case NonFatal(e: Exception) =>
         Left(BreakingNewsResponseFormatError(Right(e), jsonBody))
     }
   }


### PR DESCRIPTION
## What's changed?

https://github.com/guardian/facia-tool/pull/744 unfortunately introduced a bug where Global breaking news notifications would appear to be sent and confirmed in the UI, even though no notifications were actually sent.

We tracked it down to a change in the `mobile-notifications` client from https://github.com/guardian/mobile-n10n/pull/410 which the Fronts tool uses to trigger the notifications. The code that attempted to prioritise the UK breaking news topic first on a Global send ended up filtering out all the topics and sending nothing. Unfortunately, the way the API was defined meant that the Fronts tool itself could not detect this and the failure was entirely swallowed by the library.

In response to this we have decided to continue using the data structures provided by the library but will make the HTTP requests directly from code in the Fronts tool repo. This PR also takes advantage of this to refactor the code that was handling errors, passing up an `Either` type and handling the errors as close as possible to the user. The intention is to clarify and reduce code to make bugs less likely.

## Implementation notes

...

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
