### PR TITLE
Add a test to make sure we can alert on the same story twice

### DIFF
--- a/public/test/spec/breaking-news.spec.js
+++ b/public/test/spec/breaking-news.spec.js
@@ -241,4 +241,94 @@ describe('Breaking News', function () {
         .then(done)
         .catch(done.fail);
     });
+
+    it('Allows the same alert to be sent multiple times', function(done) {
+        const regions = this.testPage.regions;
+
+        regions.latest().trail(1).copy()
+        .then(() => {
+            return this.testPage.actions.edit(() => {
+                return regions.front().collection(1).group(2).pasteOver();
+            })
+            .respondWith({
+                global: {
+                    draft: [{
+                        id: 'internal-code/page/1',
+                        meta: {
+                            imageHide: true,
+                            group: '0'
+                        }
+                    }]
+                }
+            })
+            .done;
+        })
+        .then(() => {
+            return regions.front().collection(1).publish()
+            // Wait for modal to appear
+            .then(() => wait.ms(100));
+        })
+        .then(() => {
+            return this.testPage.actions.publish(() => {
+                return regions.breakingNewsModal().confirm();
+            })
+            .respondWith({
+                global: {
+                    live: [{
+                        id: 'internal-code/page/1',
+                        meta: { group: 0 }
+                    }]
+                }
+            })
+            .done;
+        })
+        .then(() => wait.ms(100))
+        .then(() => {
+            return regions.alert().close();
+        })
+        .then(() => {
+            return this.testPage.actions.edit(() => {
+                return regions.front().collection(1).group(2).trail(1).remove();
+            })
+            .respondWith({
+                global: {
+                    draft: [],
+                    live: [{
+                        id: 'internal-code/page/1'
+                    }],
+                    lastUpdated: (new Date()).toISOString()
+                }
+            })
+            .done;
+        })
+        .then(() => {
+            expect(regions.front().collection(1).publishText()).toBe('Remove');
+            return regions.front().collection(1).publish();
+        })
+        .then(() => {
+            return regions.latest().trail(0).copy();
+        })
+        .then(() => {
+            return this.testPage.actions.edit(() => {
+              return regions.front().collection(1).group(1).pasteOver();
+            })
+            .respondWith({
+                global: {
+                    draft: [{
+                        id: 'internal-code/page/1',
+                        meta: {
+                            imageHide: true,
+                            group: '0'
+                        }
+                    }]
+                }
+            })
+            .done;
+        })
+        .then(() => {
+            expect(regions.front().collection(1).publishText()).toBe('Send alert');
+        })
+        .then(done)
+        .catch(done.fail);
+    });
 });


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

I added a second breaking news test to test that we can alert on a story, remove it and alert on it again as this workflow is a bit complicated and easy to break in any future refactors of the tool.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

I decided to make a separate test for this rather than continue with the very long test to send breaking news that exists in this file. There is some code repetition with this test and the test that already exists but since the test above does a lot of assertions in the middle of the test which I don't want to do sharing the code for the test didn't feel like worth the trouble for this case.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
