### PR TITLE
BUG: Show video option not always showing up on on video stories 

### DIFF
--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -163,6 +163,7 @@ const getParams = (
   'show-elements': 'image',
   'show-tags': 'all',
   'show-fields': getCapiFieldsToShow(isPreview),
+  'show-atoms': 'media',
   ...(isPreview
     ? { 'order-by': 'oldest', 'from-date': getTodayDate() }
     : { 'order-by': 'newest', 'order-date': sortByParam })

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -164,6 +164,7 @@ const getParams = (
   'show-tags': 'all',
   'show-fields': getCapiFieldsToShow(isPreview),
   'show-atoms': 'media',
+  'show-blocks': 'main',
   ...(isPreview
     ? { 'order-by': 'oldest', 'from-date': getTodayDate() }
     : { 'order-by': 'newest', 'order-date': sortByParam })

--- a/client-v2/src/shared/util/derivedArticle.ts
+++ b/client-v2/src/shared/util/derivedArticle.ts
@@ -4,11 +4,13 @@ import { Element } from 'types/Capi';
 
 export const hasMainVideo = (article: DerivedArticle) => {
   return (
-    getMainMediaType(article) === 'video' || hasMainMediaVideoAtom(article)
+    hasMainMediaVideoAtom(article) ||
+    getArticleMainElementType(article) === 'video'
   );
 };
 
-export function getMainMediaType(article: DerivedArticle) {
+// this function probably refers to old-style video pages which have a main element of type video
+export function getArticleMainElementType(article: DerivedArticle) {
   const element = (article.elements || []).find(_ => _.relation === 'main');
   return element ? element.type : undefined;
 }


### PR DESCRIPTION
## What's changed?
A bug was reported: that the 'show video' option was not always appearing on the edit form of video stories.

In more detail:
When you drag a video story in, and then click OPEN to edit, the code fails to recognise it as a video and so the "Show Video" toggle doesn't turn up.

If you refresh the page before trying to open the edit form, it does recognise it as a video, and Show Video successfully appears.

https://trello.com/c/VEuO4h6v/584-bugs-with-show-video-option-not-always-appearing-have-grabbed-one-instance-below-have-noticed-it-coming-and-going-when-vid-atoms

## Implementation notes

The problem was the dragged-in article used the article as present in the CAPI feed. After a refresh it used the article as generated from a slightly different CAPI query as used for collections. 

Critically ie. Blocks and Atoms were not included in the CAPI query for the feed. This PR changes that CAPI query so that Blocks and Atoms are included.  

++ some commenting and renaming in the functions that test for videos, to highlight code that seems out of date. 

![Screenshot 2019-06-07 at 15 41 34](https://user-images.githubusercontent.com/10324129/59112492-0a46d200-893b-11e9-8e4a-8c84d077ea79.png)


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
