### PR TITLE
EDITIONS: hook up manage editions frontend to fake API 

### DIFF
--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -127,13 +127,9 @@ class ManageEdition extends React.Component {
     if (!date) {
       return;
     }
-    fetchIssueByDate(date).then(issue => {
-      if (issue) {
-        this.setState({ currentIssue: issue });
-      } else {
-        this.setState({ currentIssue: null });
-      }
-    });
+    fetchIssueByDate(date).then(issue =>
+      this.setState({ currentIssue: issue || null })
+    );
   };
 
   private handleFocusChange = (isFocussedObj: { focused: boolean | null }) => {

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -6,6 +6,11 @@ import moment, { Moment } from 'moment';
 import { EditionIssue } from 'types/Edition';
 import Issue from './Issue';
 import ButtonDefault from '../../shared/components/input/ButtonDefault';
+import {
+  fetchIssuesForDateRange,
+  fetchIssueByDate,
+  createIssue
+} from 'services/editionsApi';
 
 interface ManageEditionState {
   date: Moment | null;
@@ -29,46 +34,6 @@ const InformationMsg = styled.div<{ status?: 'info' | 'error' }>`
   background-color: ${props => (props.status === 'info' ? 'green' : 'red')};
 `;
 
-const oneIssue = {
-  id: '12348',
-  name: 'Cool new issue just created',
-  publishDate: '2019-06-29 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
-  lastPublished: '2019-05-29 19:11:25',
-  createdOn: '2016-06-22 19:10:25-07',
-  createdBy: 'annaandjon',
-  createdEmail: 'a@g.com'
-};
-
-const allIssues = [
-  {
-    id: '12345',
-    name: 'MondayIssue',
-    publishDate: '2019-05-29 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
-    lastPublished: '2019-05-29 19:11:25',
-    createdOn: '2016-06-22 19:10:25-07',
-    createdBy: 'annaandjon',
-    createdEmail: 'a@g.com'
-  },
-  {
-    id: '12346',
-    name: 'TuesdayIssue',
-    publishDate: '2019-05-30 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
-    lastPublished: '2019-05-29 19:11:25',
-    createdOn: '2016-06-22 19:10:25-07',
-    createdBy: 'annaandjon',
-    createdEmail: 'a@g.com'
-  },
-  {
-    id: '12347',
-    name: 'WednesdayIssue',
-    publishDate: '2019-05-31 19:10:25', // in format TimestampZ, eg 2016-06-22 19:10:25-07
-    lastPublished: '2019-05-29 19:11:25',
-    createdOn: '2016-06-22 19:10:25-07',
-    createdBy: 'annaandjon',
-    createdEmail: 'a@g.com'
-  }
-];
-
 class ManageEdition extends React.Component {
   public state: ManageEditionState = {
     date: null,
@@ -91,7 +56,7 @@ class ManageEdition extends React.Component {
           onNextMonthClick={this.handleMonthClick}
           onPrevMonthClick={this.handleMonthClick}
           id="editions-date"
-          isDayHighlighted={date => !!this.selectIssueForDate(date)}
+          isDayHighlighted={date => !!this.getIssueForDate(date)}
           isOutsideRange={() => false}
         />
         <div>
@@ -141,8 +106,11 @@ class ManageEdition extends React.Component {
       return;
     }
     this.setState({ infoMessage: 'New issue created' });
-    this.createIssue(this.state.date)
-      .then(issue => this.setState({ currentIssue: issue }))
+    createIssue(this.state.date)
+      .then(issue => {
+        console.log('CREATE ISSUE RAN, issue', issue);
+        this.setState({ currentIssue: issue });
+      })
       .catch(err => {
         Raven.captureMessage(
           `Creating an issue for this date ${this.state.date} failed`,
@@ -160,12 +128,13 @@ class ManageEdition extends React.Component {
     if (!date) {
       return;
     }
-    const issue = this.selectIssueForDate(date);
-    if (issue) {
-      this.setState({ currentIssue: issue });
-    } else {
-      this.setState({ currentIssue: null });
-    }
+    fetchIssueByDate(date).then(issue => {
+      if (issue) {
+        this.setState({ currentIssue: issue });
+      } else {
+        this.setState({ currentIssue: null });
+      }
+    });
   };
 
   private handleFocusChange = (isFocussedObj: { focused: boolean | null }) => {
@@ -174,14 +143,14 @@ class ManageEdition extends React.Component {
       const endDate = moment()
         .add(1, 'month')
         .endOf('month');
-      this.fetchIssuesForDateRange(startDate, endDate).then(issues =>
+      fetchIssuesForDateRange(startDate, endDate).then(issues =>
         this.setState({ issues })
       );
     }
     this.setState({ isDatePickerOpen: !!isFocussedObj.focused });
   };
 
-  private selectIssueForDate = (date: Moment) =>
+  private getIssueForDate = (date: Moment) =>
     this.state.issues.find(i =>
       moment(i.publishDate, 'YYYY-MM-DD HH:mm:ss-ZZ').isSame(date, 'day')
     );
@@ -190,7 +159,7 @@ class ManageEdition extends React.Component {
     const startDate = month.clone().startOf('month');
     const endDate = month.clone().endOf('month');
 
-    this.fetchIssuesForDateRange(startDate, endDate)
+    fetchIssuesForDateRange(startDate, endDate)
       .then(issues => this.setState({ issues }))
       .catch(err => {
         Raven.captureMessage(
@@ -202,15 +171,6 @@ class ManageEdition extends React.Component {
         });
       });
   };
-
-  private fetchIssuesForDateRange = async (
-    start: Moment,
-    end: Moment
-  ): Promise<EditionIssue[]> => {
-    return allIssues;
-  };
-
-  private createIssue = async (date: Moment): Promise<EditionIssue> => oneIssue;
 }
 
 export default ManageEdition;

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -56,7 +56,7 @@ class ManageEdition extends React.Component {
           onNextMonthClick={this.handleMonthClick}
           onPrevMonthClick={this.handleMonthClick}
           id="editions-date"
-          isDayHighlighted={date => !!this.getIssueForDate(date)}
+          isDayHighlighted={date => !!this.checkIssuePresentForDate(date)}
           isOutsideRange={() => false}
         />
         <div>
@@ -108,7 +108,6 @@ class ManageEdition extends React.Component {
     this.setState({ infoMessage: 'New issue created' });
     createIssue(this.state.date)
       .then(issue => {
-        console.log('CREATE ISSUE RAN, issue', issue);
         this.setState({ currentIssue: issue });
       })
       .catch(err => {
@@ -150,7 +149,7 @@ class ManageEdition extends React.Component {
     this.setState({ isDatePickerOpen: !!isFocussedObj.focused });
   };
 
-  private getIssueForDate = (date: Moment) =>
+  private checkIssuePresentForDate = (date: Moment) =>
     this.state.issues.find(i =>
       moment(i.publishDate, 'YYYY-MM-DD HH:mm:ss-ZZ').isSame(date, 'day')
     );

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -1,0 +1,54 @@
+import { EditionIssue } from 'types/Edition';
+import { Moment } from 'moment';
+import pandaFetch from './pandaFetch';
+
+const dateFormat = 'YYYY-MM-DD';
+
+export const fetchIssuesForDateRange = async (
+  start: Moment,
+  end: Moment
+): Promise<EditionIssue[]> => {
+  return pandaFetch(
+    `http://localhost:3000/editions-api/issues?start=${start.format(
+      dateFormat
+    )}&end:${end.format(dateFormat)}`,
+    {
+      method: 'get',
+      credentials: 'same-origin'
+    }
+  ).then(response => response.json());
+};
+
+export const fetchIssueByDate = async (date: Moment): Promise<EditionIssue> => {
+  return pandaFetch(
+    `http://localhost:3000/editions-api/issues/${date.format(dateFormat)}`,
+    {
+      method: 'get',
+      credentials: 'same-origin'
+    }
+  )
+    .then(response => {
+      console.log('fetch issue by date', response);
+      if (response) {
+        return response.json();
+      } else {
+        return [];
+      }
+    })
+    .catch(console.log('No issue was found for this date'));
+};
+
+export const createIssue = async (date: Moment): Promise<EditionIssue> => {
+  return pandaFetch(`http://localhost:3000/editions-api/issues`, {
+    method: 'post',
+    // mode: 'no-cors',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    credentials: 'include',
+    body: JSON.stringify({ date: `${date.format(dateFormat)}` })
+  }).then(response => {
+    console.log(response);
+    return response.json();
+  });
+};

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -19,7 +19,9 @@ export const fetchIssuesForDateRange = async (
   ).then(response => response.json());
 };
 
-export const fetchIssueByDate = async (date: Moment): Promise<EditionIssue> => {
+export const fetchIssueByDate = async (
+  date: Moment
+): Promise<EditionIssue | void> => {
   return pandaFetch(
     `http://localhost:3000/editions-api/issues/${date.format(dateFormat)}`,
     {
@@ -30,16 +32,13 @@ export const fetchIssueByDate = async (date: Moment): Promise<EditionIssue> => {
     .then(response => {
       if (response.status === 200) {
         return response.json();
-      } else {
-        return [];
       }
     })
-    .catch(() =>
-      // We want to catch this when no issue is present
-      console.warn(
-        'In FetchIssueByDate function: No issue was found for this date'
-      )
-    );
+    .catch(() => {
+      // We catch here to prevent 404s, which are expected, being uncaught.
+      // Other errors are possible, of course, and it'd be nice to catch them here,
+      // but without a general strategy for handling errors we drop them for now.
+    });
 };
 
 export const createIssue = async (date: Moment): Promise<EditionIssue> => {

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -28,14 +28,18 @@ export const fetchIssueByDate = async (date: Moment): Promise<EditionIssue> => {
     }
   )
     .then(response => {
-      console.log('fetch issue by date', response);
       if (response.status === 200) {
         return response.json();
       } else {
         return [];
       }
     })
-    .catch(console.log('No issue was found for this date'));
+    .catch(() =>
+      // We want to catch this when no issue is present
+      console.warn(
+        'In FetchIssueByDate function: No issue was found for this date'
+      )
+    );
 };
 
 export const createIssue = async (date: Moment): Promise<EditionIssue> => {
@@ -48,7 +52,6 @@ export const createIssue = async (date: Moment): Promise<EditionIssue> => {
     credentials: 'include',
     body: JSON.stringify({ date: `${date.format(dateFormat)}` })
   }).then(response => {
-    console.log(response);
     return response.json();
   });
 };

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -29,7 +29,7 @@ export const fetchIssueByDate = async (date: Moment): Promise<EditionIssue> => {
   )
     .then(response => {
       console.log('fetch issue by date', response);
-      if (response) {
+      if (response.status === 200) {
         return response.json();
       } else {
         return [];
@@ -41,7 +41,7 @@ export const fetchIssueByDate = async (date: Moment): Promise<EditionIssue> => {
 export const createIssue = async (date: Moment): Promise<EditionIssue> => {
   return pandaFetch(`http://localhost:3000/editions-api/issues`, {
     method: 'post',
-    // mode: 'no-cors',
+    mode: 'cors',
     headers: {
       'Content-Type': 'application/json'
     },


### PR DESCRIPTION
## What's changed?
In order to get ready for the backend of editions, we have mocked out an API and connected the frontend up to it. 

Three methods:
* GET: `fetchIssueByDate`
* GET: `fetchIssuesForDateRange`
* POST: `createIssue`

One of these - `fetchIssuesForDateRange` will not be available in the first pass of the API. Some visual features won't work because of this (ie. the highlighting of dates on the calendar), but the basic user journey should still work. 

Journey can be found here: https://fronts.local.dev-gutools.co.uk/v2/manage-editions

## Implementation notes

To mock out the backend we set up an express server with 3 endpoints.

### The Fake API - express server 

<details><summary>Click to view the index.js of the basic express server we used to mock backend</summary>
<p>

```javascript
const express = require("express");
const moment = require("moment");
const cors = require("cors");
const app = express();
const port = 3000;

app.get("/", (req, res) => res.send("Hello World!"));

app.use(cors());
app.use(express.json());
app.use(express.urlencoded({ extended: true }));

const collection1 = {
  id: "collection1",
  name: "Collection 1",
  prefill: "Capi pls",
  isHidden: false,
  updatedOn: "2019-06-29 19:10:25",
  updatedBy: "Jon and Anna!",
  updatedEmail: "jonathon.herbert@guardian.co.uk",
  live: [],
  draft: []
};

const front1 = {
  id: "front1",
  name: "Front 1",
  isHidden: false,
  updatedOn: "2019-06-29 19:10:25",
  updatedBy: "Jon and Anna!",
  updatedEmail: "jonathon.herbert@guardian.co.uk",
  collections: [collection1]
};

const issue1 = {
  id: "issue1",
  name: "Issue 1",
  publishDate: "2019-06-29 19:10:25",
  createdOn: "2019-06-29 19:10:25",
  createdBy: "Jon and Anna!",
  createdEmail: "jonathon.herbert@guardian.co.uk",
  fronts: [front1]
};

const issue2 = {
  id: "issue2",
  name: "Issue 2",
  publishDate: "2019-06-30 19:10:25",
  createdOn: "2019-06-30 19:10:25",
  createdBy: "Jon and Anna!",
  createdEmail: "jonathon.herbert@guardian.co.uk",
  fronts: [front1]
};

const issue3 = {
  id: "issue3",
  name: "Issue 3",
  publishDate: "2019-07-01 19:10:25",
  createdOn: "2019-07-01 19:10:25",
  createdBy: "Jon and Anna!",
  createdEmail: "jonathon.herbert@guardian.co.uk",
  fronts: [front1]
};

const issueTemplate = (date, id) => {
  return {
    id: `issue${id}`,
    name: `Issue ${id}`,
    publishDate: `${date}`,
    createdOn: `${date}`,
    createdBy: "The robots!",
    createdEmail: "jonathon.herbert@guardian.co.uk",
    fronts: [front1]
  };
};

// GET single issue - for date
app.get("/editions-api/issues/:date", (req, res) => {
  res.set("Access-Control-Allow-Origin", "*");
  const date = req.params.date;
  const matchingIssue = [issue1, issue2, issue3].find(i =>
    moment(i.publishDate).isSame(date, "day")
  );
  if (matchingIssue !== undefined) {
    res.status(200);
    res.json(matchingIssue);
  } else {
    res.status(404);
    res.send("No issue found");
  }
});

// GET issues - by date range
app.get("/editions-api/issues", (req, res) => {
  res.set("Access-Control-Allow-Origin", "*");
  res.json([issue1, issue2, issue3]);
});

// POST - create new issue
app.post("/editions-api/issues", (req, res) => {
  res.set("Access-Control-Allow-Origin", "*");
  const date = req.body.date;
  const id = parseInt(Math.random() * 100); //generate fake id
  const issue = issueTemplate(date, id);
  res.json(issue);
});

app.listen(port, () => console.log(`Example app listening on port ${port}!`));

```

</p>
</details>

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
