### PR TITLE
Consistent usage of font-weight

### DIFF
--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -14,15 +14,15 @@ import GHGuardianHeadlineMediumWoff2 from '../fonts/headline/GHGuardianHeadline-
 import GHGuardianHeadlineRegularTtf from '../fonts/headline/GHGuardianHeadline-Regular.ttf';
 import GHGuardianHeadlineRegularWoff from '../fonts/headline/GHGuardianHeadline-Regular.woff';
 import GHGuardianHeadlineRegularWoff2 from '../fonts/headline/GHGuardianHeadline-Regular.woff2';
-import GuardianTextSansTtf from '../fonts/text/GuardianTextSans-Regular.ttf';
-import GuardianTextSansWoff from '../fonts/text/GuardianTextSans-Regular.woff';
-import GuardianTextSansWoff2 from '../fonts/text/GuardianTextSans-Regular.woff2';
+import GuardianTextSansRegularTtf from '../fonts/text/GuardianTextSans-Regular.ttf';
+import GuardianTextSansRegularWoff from '../fonts/text/GuardianTextSans-Regular.woff';
+import GuardianTextSansRegularWoff2 from '../fonts/text/GuardianTextSans-Regular.woff2';
 import GuardianTextSansTtfBold from '../fonts/text/GuardianTextSans-Bold.ttf';
 import GuardianTextSansBoldWoff from '../fonts/text/GuardianTextSans-Bold.woff';
 import GuardianTextSansBoldWoff2 from '../fonts/text/GuardianTextSans-Bold.woff2';
-import GuardianTextSansItalicTtf from '../fonts/text/GuardianTextSans-RegularItalic.ttf';
-import GuardianTextSansItalicWoff from '../fonts/text/GuardianTextSans-RegularItalic.woff';
-import GuardianTextSansItalicWoff2 from '../fonts/text/GuardianTextSans-RegularItalic.woff2';
+import GuardianTextSansRegularItalicTtf from '../fonts/text/GuardianTextSans-RegularItalic.ttf';
+import GuardianTextSansRegularItalicWoff from '../fonts/text/GuardianTextSans-RegularItalic.woff';
+import GuardianTextSansRegularItalicWoff2 from '../fonts/text/GuardianTextSans-RegularItalic.woff2';
 import GuardianTextSansBoldItalicTtf from '../fonts/text/GuardianTextSans-BoldItalic.ttf';
 import GuardianTextSansBoldItalicWoff from '../fonts/text/GuardianTextSans-BoldItalic.woff';
 import GuardianTextSansBoldItalicWoff2 from '../fonts/text/GuardianTextSans-BoldItalic.woff2';
@@ -43,7 +43,7 @@ injectGlobal`
       url(${GHGuardianHeadlineBoldWoff}) format('woff'),
       url(${GHGuardianHeadlineBoldTtf}) format('truetype');
     font-weight: bold;
-    font-weight: 600 800;
+    font-weight: 700;
   }
 
   @font-face {
@@ -52,7 +52,7 @@ injectGlobal`
       url(${GHGuardianHeadlineRegularWoff}) format('woff'),
       url(${GHGuardianHeadlineRegularTtf}) format('truetype');
     font-style: normal;
-    font-weight: 100 400;
+    font-weight: 400;
   }
 
   @font-face {
@@ -65,9 +65,9 @@ injectGlobal`
 
   @font-face {
     font-family: TS3TextSans;
-    src: url(${GuardianTextSansWoff2}) format('woff2'),
-      url(${GuardianTextSansWoff}) format('woff'),
-      url(${GuardianTextSansTtf}) format('truetype');
+    src: url(${GuardianTextSansRegularWoff2}) format('woff2'),
+      url(${GuardianTextSansRegularWoff}) format('woff'),
+      url(${GuardianTextSansRegularTtf}) format('truetype');
     font-style: normal;
     font-weight: 400;
   }
@@ -78,15 +78,16 @@ injectGlobal`
       url(${GuardianTextSansTtfBold}) format('truetype'),
       url(${GuardianTextSansBoldWoff}) format('woff');
     font-weight: bold;
-    font-weight: 500;
+    font-weight: 700;
   }
 
   @font-face {
     font-family: TS3TextSans;
-    src: url(${GuardianTextSansItalicWoff2}) format('woff2'),
-      url(${GuardianTextSansItalicTtf}) format('truetype'),
-      url(${GuardianTextSansItalicWoff}) format('woff');
+    src: url(${GuardianTextSansRegularItalicWoff2}) format('woff2'),
+      url(${GuardianTextSansRegularItalicTtf}) format('truetype'),
+      url(${GuardianTextSansRegularItalicWoff}) format('woff');
     font-style: italic;
+    font-weight: normal;
     font-weight: 400;
   }
 
@@ -96,14 +97,14 @@ injectGlobal`
       url(${GuardianTextSansBoldItalicTtf}) format('truetype'),
       url(${GuardianTextSansBoldItalicWoff}) format('woff');
     font-style: italic;
-    font-weight: 500;
+    font-weight: bold;
+    font-weight: 700;
   }
 
   html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial;
+    font-family: TS3TextSans, 'Helvetica Neue', Helvetica, Arial;
     font-size: 16px;
     font-weight: 100;
-    font-family: TS3TextSans;
     -webkit-font-smoothing: antialiased;
   }
 `;

--- a/client-v2/src/components/ErrorBanner.tsx
+++ b/client-v2/src/components/ErrorBanner.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const ErrorContainer = styled('div')`
   background-color: ${error.primary};
-  font-weight: 50;
+  font-weight: normal;
   padding: 5px;
 `;
 

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -55,7 +55,7 @@ const Title = styled.h1`
   padding-right: 10px;
   vertical-align: top;
   font-family: TS3TextSans;
-  font-weight: 500;
+  font-weight: bold;
   font-size: 20px;
   min-width: 80px;
   ${media.large`
@@ -73,7 +73,7 @@ const RefreshButton = styled.button`
   cursor: pointer;
   font-family: inherit;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: bold;
   outline: none;
 
   &:hover {

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -36,7 +36,7 @@ const Container = styled('div')`
   border-top: ${({ theme }) => `1px solid ${theme.capiInterface.borderLight}`};
   color: ${({ theme }) => theme.capiInterface.feedItemText};
   display: flex;
-  font-weight: 400;
+  font-weight: normal;
   padding-bottom: 20px;
   cursor: pointer;
 
@@ -58,7 +58,7 @@ const Title = styled(`h2`)`
   font-family: TS3TextSans;
   font-size: 15px;
   ${media.large`font-size: 13px;`}
-  font-weight: 400;
+  font-weight: normal;
 `;
 
 const VisitedWrapper = styled.a`

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -23,7 +23,7 @@ const SublinkCollectionItemBody = styled(CollectionItemBody)<{
   flex-direction: ${({ isClipboard }) => (isClipboard ? 'column' : 'row')};
   span {
     font-size: 12px;
-    font-weight: 400;
+    font-weight: normal;
   }
   :hover {
     background-color: #ededed;

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -72,7 +72,7 @@ const TextContainerRight = styled.div`
 
 const Name = styled.span`
   color: ${({ theme }) => theme.shared.base.colors.text};
-  font-weight: 700;
+  font-weight: bold;
   padding-right: 0.25em;
 `;
 

--- a/client-v2/src/components/PressFailAlert.tsx
+++ b/client-v2/src/components/PressFailAlert.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const AlertContainer = styled('div')`
   background-color: ${error.primary};
-  font-weight: 50;
+  font-weight: normal;
   padding: 5px;
 `;
 

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -37,7 +37,7 @@ const NotLiveContainer = styled(CollectionItemMetaHeading)`
 
 const KickerHeading = styled(CollectionItemHeading)`
   font-family: TS3TextSans;
-  font-weight: 500;
+  font-weight: bold;
   padding-right: 3px;
   font-size: ${({ displaySize }) =>
     displaySize === 'small' ? '13px' : '15px'};
@@ -50,7 +50,7 @@ const ArticleHeadingContainerSmall = styled('div')`
 
 const ArticleBodyByline = styled('div')`
   font-family: TS3TextSans;
-  font-weight: 500;
+  font-weight: bold;
   font-size: 15px;
   font-style: italic;
   padding-top: 5px;

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -20,7 +20,7 @@ const PillaredSection = styled('span')<{ pillar?: string; isLive?: boolean }>`
   color: ${({ pillar, isLive }) =>
     getPillarColor(pillar, isLive || true) || 'inherit'};
   font-size: 13px;
-  font-weight: 400;
+  font-weight: normal;
 `;
 
 const HeadlinePolaroidSpan = styled('span')`

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled('span')<{
   showBoostedHeadline?: boolean;
 }>`
   font-family: TS3TextSans;
-  font-weight: 400;
+  font-weight: normal;
   padding-top: 2px;
   font-size: ${({ displaySize, showBoostedHeadline }) => {
     if (displaySize === 'small') {


### PR DESCRIPTION
## What's changed?

We're a bit more consistent in our usage of font-weight across the app. As a result some font rendering problems, unmasked with font-synthesis, should have disappeared. Thanks @paperboyo!

Behold!

E.g. from:

<img width="150" alt="Screenshot 2019-06-13 at 16 24 10" src="https://user-images.githubusercontent.com/7767575/59445509-b2571200-8df7-11e9-89c0-346b8f114af9.png">

To:

<img width="150" alt="Screenshot 2019-06-13 at 16 23 34" src="https://user-images.githubusercontent.com/7767575/59445545-c69b0f00-8df7-11e9-8f82-279f1cce17c2.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
