### PR TITLE
Add tiny cutout people to collection and clipboard items

### DIFF
--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -20,7 +20,7 @@ const ThumbnailCutout = styled('img')<{
   width: 25px;
   bottom: 0;
   ${({ position }) =>
-    position === 'bottomRight' ? 'right: -15px' : 'left: -15px'};
+    position === 'bottomRight' ? 'right: -13px' : 'left: -13px'};
 `;
 
 const ThumbnailEditForm = styled(ThumbnailBase)<{

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -7,9 +7,20 @@ const ThumbnailBase = styled('div')`
 `;
 
 const ThumbnailSmall = styled(ThumbnailBase)`
+  position: relative;
   width: 83px;
   min-width: 83px;
   height: 50px;
+`;
+
+const ThumbnailCutout = styled('img')<{
+  position?: 'bottomLeft' | 'bottomRight';
+}>`
+  position: absolute;
+  width: 25px;
+  bottom: 0;
+  ${({ position }) =>
+    position === 'bottomRight' ? 'right: -15px' : 'left: -15px'};
 `;
 
 const ThumbnailEditForm = styled(ThumbnailBase)<{
@@ -17,13 +28,13 @@ const ThumbnailEditForm = styled(ThumbnailBase)<{
   url: string | undefined | void;
 }>`
   width: 100%;
-  height: 115px;
+  height: 115px
   margin-bottom: 10px;
   opacity: ${({ imageHide }) => (imageHide ? 0.5 : 1)};
   background-image: ${({ url }) => `url('${url}')`};
 `;
 
-export { ThumbnailSmall, ThumbnailEditForm };
+export { ThumbnailSmall, ThumbnailEditForm, ThumbnailCutout };
 
 export default styled(ThumbnailBase)`
   width: 130px;

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -27,6 +27,7 @@ import DraggableArticleImageContainer from './DraggableArticleImageContainer';
 import { media } from 'shared/util/mediaQueries';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
+  flex-shrink: 0;
   width: 83px;
   height: 50px;
 `;

--- a/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyDefault.tsx
@@ -9,7 +9,7 @@ import CollectionItemMetaContainer from '../collectionItem/CollectionItemMetaCon
 import CollectionItemContent from '../collectionItem/CollectionItemContent';
 import { notLiveLabels } from 'constants/fronts';
 import TextPlaceholder from 'shared/components/TextPlaceholder';
-import { ThumbnailSmall } from '../Thumbnail';
+import { ThumbnailSmall, ThumbnailCutout } from '../Thumbnail';
 import CollectionItemMetaHeading from '../collectionItem/CollectionItemMetaHeading';
 import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
 import {
@@ -78,6 +78,7 @@ interface ArticleBodyProps {
   size?: CollectionItemSizes;
   headline?: string;
   thumbnail?: string | void;
+  cutoutThumbnail?: string | void;
   isLive?: boolean;
   urlPath?: string;
   sectionName?: string;
@@ -124,6 +125,7 @@ const articleBodyDefault = React.memo(
     size = 'default',
     headline,
     thumbnail,
+    cutoutThumbnail,
     isLive,
     urlPath,
     displayPlaceholders,
@@ -231,7 +233,11 @@ const articleBodyDefault = React.memo(
                   backgroundImage: `url('${thumbnail}')`,
                   opacity: imageHide ? 0.5 : 1
                 }}
-              />
+              >
+                {cutoutThumbnail ? (
+                  <ThumbnailCutout src={cutoutThumbnail} />
+                ) : null}
+              </ThumbnailSmall>
               <ImageMetadataContainer>
                 {imageSlideshowReplace && 'Slideshow'}
                 {imageReplace && 'Image replaced'}

--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -15,6 +15,7 @@ import {
 import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import ImagePlaceholder from '../ImagePlaceholder';
 import TextPlaceholder from '../TextPlaceholder';
+import { ThumbnailCutout } from '../Thumbnail';
 
 const PillaredSection = styled('span')<{ pillar?: string; isLive?: boolean }>`
   color: ${({ pillar, isLive }) =>
@@ -39,7 +40,7 @@ const ArticlePolaroidComponent = ({
   kicker,
   isLive,
   isUneditable,
-  uuid
+  cutoutThumbnail
 }: ArticleBodyProps) => {
   const articleLabel =
     getArticleLabel(firstPublicationDate, kicker, isLive) || '';
@@ -53,7 +54,11 @@ const ArticlePolaroidComponent = ({
             style={{
               backgroundImage: `url('${thumbnail}')`
             }}
-          />
+          >
+            {cutoutThumbnail ? (
+              <ThumbnailCutout position="bottomRight" src={cutoutThumbnail} />
+            ) : null}
+          </PolaroidThumbnail>
         ))}
       <CollectionItemContent displayType="polaroid" data-testid="headline">
         {displayPlaceholders ? (

--- a/client-v2/src/shared/selectors/collectionItem.ts
+++ b/client-v2/src/shared/selectors/collectionItem.ts
@@ -5,6 +5,7 @@ import {
 } from './shared';
 import { validateId } from 'shared/util/snap';
 import CollectionItemTypes from 'shared/constants/collectionItemTypes';
+import { getContributorImage } from 'util/CAPIUtils';
 
 const createCollectionItemTypeSelector = () =>
   createSelector(
@@ -43,4 +44,16 @@ const createSelectActiveImageUrl = () =>
     }
   );
 
-export { createCollectionItemTypeSelector, createSelectActiveImageUrl };
+const createSelectCutoutUrl = () =>
+  createSelector(
+    externalArticleFromArticleFragmentSelector,
+    externalArticle => {
+      return externalArticle && getContributorImage(externalArticle);
+    }
+  );
+
+export {
+  createCollectionItemTypeSelector,
+  createSelectActiveImageUrl,
+  createSelectCutoutUrl
+};

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -1,6 +1,10 @@
 import omit from 'lodash/omit';
 import { createSelector } from 'reselect';
-import { getThumbnail, getPrimaryTag, getContributorImage } from 'util/CAPIUtils';
+import {
+  getThumbnail,
+  getPrimaryTag,
+  getContributorImage
+} from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import { ExternalArticle } from '../types/ExternalArticle';

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit';
 import { createSelector } from 'reselect';
-import { getThumbnail, getPrimaryTag } from 'util/CAPIUtils';
+import { getThumbnail, getPrimaryTag, getContributorImage } from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import { ExternalArticle } from '../types/ExternalArticle';
@@ -144,6 +144,9 @@ const createArticleFromArticleFragmentSelector = () =>
         pillarId: externalArticle ? externalArticle.pillarId : undefined,
         thumbnail: externalArticle
           ? getThumbnail(externalArticle, articleMeta)
+          : undefined,
+        cutoutThumbnail: externalArticle
+          ? getContributorImage(externalArticle)
           : undefined,
         isLive:
           externalArticle && externalArticle.fields.isLive

--- a/client-v2/src/shared/types/Article.ts
+++ b/client-v2/src/shared/types/Article.ts
@@ -13,6 +13,7 @@ type DerivedArticle = Partial<
   ArticleFragmentRootFields &
   ArticleFragmentMeta & {
     thumbnail?: string | undefined;
+    cutoutThumbnail?: string | undefined;
     kicker?: string;
     isLive: boolean;
   };


### PR DESCRIPTION
## What's changed?

Adds tiny cutout people, a la V1. Bless 'em. Note they're on the right hand side for clipboard -- thanks for the feedback, @akemitakagi !

<img width="754" alt="Screenshot 2019-06-13 at 16 58 59" src="https://user-images.githubusercontent.com/7767575/59448260-ade12800-8dfc-11e9-99ad-5c1fc74bab55.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
