### PR TITLE
Add strategy for fetching collections

### DIFF
--- a/client-v2/integration/fixtures/edition.js
+++ b/client-v2/integration/fixtures/edition.js
@@ -23,7 +23,7 @@ module.exports = {
           // lastUpdated?: number,
           // updatedBy?: string,
           // updatedEmail?: string,
-          articles: []
+          items: []
         },
         {
           id: 'collection-2',
@@ -33,7 +33,7 @@ module.exports = {
           // lastUpdated?: number,
           // updatedBy?: string,
           // updatedEmail?: string,
-          articles: []
+          items: []
         }
       ]
     }

--- a/client-v2/integration/fixtures/edition.js
+++ b/client-v2/integration/fixtures/edition.js
@@ -23,8 +23,7 @@ module.exports = {
           // lastUpdated?: number,
           // updatedBy?: string,
           // updatedEmail?: string,
-          live: [],
-          draft: []
+          articles: []
         },
         {
           id: 'collection-2',
@@ -34,8 +33,7 @@ module.exports = {
           // lastUpdated?: number,
           // updatedBy?: string,
           // updatedEmail?: string,
-          live: [],
-          draft: []
+          articles: []
         }
       ]
     }

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -142,6 +142,25 @@ module.exports = async () =>
       ]);
     });
 
+    app.post('/editions-api/collections*', (req, res) => {
+      return res.json([
+        {
+          id: req.body[0].id,
+          collection: {
+            ...collection,
+            items: collection.draft
+          }
+        },
+        {
+          id: req.body[1].id,
+          collection: {
+            ...collectionTwo,
+            items: collectionTwo.draft
+          }
+        }
+      ]);
+    });
+
     // catch requests to discard collection endpoint
     app.post(
       '/collection/v2Discard/e59785e9-ba82-48d8-b79a-0a80b2f9f808',

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -192,7 +192,8 @@ function getCollections(
     try {
       const collectionResponses = await fetchCollections(
         getState(),
-        collectionIds
+        collectionIds,
+        returnOnlyUpdatedCollections
       );
 
       if (!collectionResponses) {

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -70,6 +70,7 @@ import { frontStages } from 'constants/fronts';
 import { State } from 'types/State';
 import { events } from 'services/GA';
 import { collectionParamsSelector } from 'selectors/collectionSelectors';
+import { fetchCollectionsStrategy } from 'strategies/fetch-collection';
 
 const articlesInCollection = createAllArticlesInCollectionSelector();
 const collectionsInOpenFrontsSelector = createCollectionsInOpenFrontsSelector();
@@ -183,14 +184,10 @@ function getCollections(
   collectionIds: string[],
   returnOnlyUpdatedCollections: boolean = false
 ): ThunkResult<Promise<string[]>> {
-  return async (
-    dispatch: Dispatch,
-    getState: () => State,
-    { fetchCollections }
-  ) => {
+  return async (dispatch: Dispatch, getState: () => State) => {
     dispatch(collectionActions.fetchStart(collectionIds));
     try {
-      const collectionResponses = await fetchCollections(
+      const collectionResponses = await fetchCollectionsStrategy(
         getState(),
         collectionIds,
         returnOnlyUpdatedCollections

--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -5,6 +5,7 @@ import { actions as frontsConfigActions } from 'bundles/frontsConfigBundle';
 import { VisibleArticlesResponse } from 'types/FaciaApi';
 import { Stages } from 'shared/types/Collection';
 import { State } from 'types/State';
+import { fetchFrontsConfigStrategy } from 'strategies/fetch-fronts-config';
 
 function fetchLastPressedSuccess(frontId: string, datePressed: string): Action {
   return {
@@ -75,9 +76,9 @@ export default function getFrontsConfig(): ThunkResult<
     | ReturnType<typeof frontsConfigActions.fetchError>
   >
 > {
-  return (dispatch: Dispatch, getState: () => State, { fetchFrontsConfig }) => {
+  return (dispatch: Dispatch, getState: () => State) => {
     dispatch(frontsConfigActions.fetchStart());
-    const promise = fetchFrontsConfig(getState());
+    const promise = fetchFrontsConfigStrategy(getState());
     if (!promise) {
       return Promise.resolve(
         dispatch(

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -73,10 +73,13 @@ describe('Collection actions', () => {
 
   describe('Get Collections thunk', () => {
     beforeEach(() => fetchMock.reset());
-    const store = configureStore({
-      config,
-      ...stateWithCollection
-    });
+    const store = configureStore(
+      {
+        config,
+        ...stateWithCollection
+      },
+      '/v2/editorial'
+    );
 
     it('should add fetched Collections to the store', async () => {
       const collectionIds = ['testCollection1', 'testCollection2'];

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -7,7 +7,8 @@ import {
   VisibleArticlesResponse,
   FrontConfig,
   CollectionConfigMap,
-  CollectionResponse
+  CollectionResponse,
+  EditionCollectionResponse
 } from 'types/FaciaApi';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import {
@@ -275,10 +276,11 @@ async function getCollection(collectionId: {
   return collection;
 }
 
-async function getCollections( // fetchCollections
+const createGetCollections = <R>(path: string) => async (
+  // fetchCollections
   collections: Array<{ id: string; lastUpdated?: number }>
-): Promise<CollectionResponse[]> {
-  const response = await pandaFetch('/collections', {
+): Promise<R> => {
+  const response = await pandaFetch(path, {
     body: JSON.stringify(collections),
     method: 'POST',
     headers: {
@@ -286,8 +288,15 @@ async function getCollections( // fetchCollections
     },
     credentials: 'same-origin'
   });
-  return await response.json();
-}
+  return response.json();
+};
+
+const getCollections = createGetCollections<CollectionResponse[]>(
+  '/collections'
+);
+const getEditionsCollections = createGetCollections<
+  EditionCollectionResponse[]
+>('/editions-api/collections');
 
 const DEFAULT_PARAMS = {
   'page-size': 50,
@@ -404,6 +413,7 @@ export {
   fetchFrontsConfig,
   fetchEditionsIssueAsConfig,
   getCollections,
+  getEditionsCollections,
   getCollection,
   getContent,
   getTagOrSectionTitle,

--- a/client-v2/src/strategies/fetch-collection.ts
+++ b/client-v2/src/strategies/fetch-collection.ts
@@ -30,7 +30,7 @@ const editionCollectionToCollection = (
 const fetchCollectionsStrategy = (
   state: State,
   collectionIds: string[],
-  returnOnlyUpdatedCollections: boolean = false
+  returnOnlyUpdatedCollections: boolean
 ) =>
   runStrategy<Promise<CollectionResponse[]> | null>(state, {
     front: () =>

--- a/client-v2/src/strategies/fetch-collection.ts
+++ b/client-v2/src/strategies/fetch-collection.ts
@@ -1,0 +1,25 @@
+import { State } from 'types/State';
+import { collectionParamsSelector } from 'selectors/collectionSelectors';
+import { getCollections as fetchCollections } from 'services/faciaApi';
+import { runStrategy } from './run-strategy';
+import { CollectionResponse } from 'types/FaciaApi';
+
+const fetchCollectionsStrategy = async (
+  state: State,
+  collectionIds: string[],
+  returnOnlyUpdatedCollections: boolean = false
+) =>
+  runStrategy<Promise<CollectionResponse[]> | null>(state, {
+    front: () =>
+      fetchCollections(
+        collectionParamsSelector(
+          state,
+          collectionIds,
+          returnOnlyUpdatedCollections
+        )
+      ),
+    edition: () => null,
+    none: () => null
+  });
+
+export { fetchCollectionsStrategy };

--- a/client-v2/src/strategies/fetch-fronts-config.ts
+++ b/client-v2/src/strategies/fetch-fronts-config.ts
@@ -1,0 +1,16 @@
+import {
+  fetchEditionsIssueAsConfig,
+  fetchFrontsConfig
+} from 'services/faciaApi';
+import { State } from 'types/State';
+import { runStrategy } from './run-strategy';
+import { FrontsConfig } from 'types/FaciaApi';
+
+const fetchFrontsConfigStrategy = (state: State) =>
+  runStrategy<Promise<FrontsConfig> | null>(state, {
+    none: () => null,
+    edition: editionId => fetchEditionsIssueAsConfig(editionId),
+    front: () => fetchFrontsConfig()
+  });
+
+export { fetchFrontsConfigStrategy };

--- a/client-v2/src/strategies/run-strategy.ts
+++ b/client-v2/src/strategies/run-strategy.ts
@@ -1,16 +1,18 @@
-import { frontsEdit } from 'constants/routes';
-import { matchPath } from 'react-router';
-import {
-  fetchEditionsIssueAsConfig,
-  fetchFrontsConfig
-} from 'services/faciaApi';
-import { getV2SubPath } from 'selectors/pathSelectors';
 import { State } from 'types/State';
+import { matchPath } from 'react-router';
+import { getV2SubPath } from 'selectors/pathSelectors';
+import { frontsEdit } from 'constants/routes';
+
+interface StrategyMap<R> {
+  edition: (editionId: string) => R;
+  front: (priority: string) => R;
+  none: () => R;
+}
 
 const isValidPathForEdition = (priority: string, id?: string): id is string =>
   !!id && priority === 'edition';
 
-const fetchFrontsConfigStrategy = (state: State) => {
+const runStrategy = <R>(state: State, strategies: StrategyMap<R>) => {
   const editMatch = matchPath<{ priority: string; editionId?: string }>(
     getV2SubPath(state),
     {
@@ -19,7 +21,7 @@ const fetchFrontsConfigStrategy = (state: State) => {
   );
 
   if (!editMatch) {
-    return null;
+    return strategies.none();
   }
 
   const {
@@ -27,10 +29,10 @@ const fetchFrontsConfigStrategy = (state: State) => {
   } = editMatch;
 
   if (isValidPathForEdition(priority, editionId)) {
-    return fetchEditionsIssueAsConfig(editionId);
+    return strategies.edition(editionId);
   }
 
-  return fetchFrontsConfig();
+  return strategies.front(priority);
 };
 
-export { fetchFrontsConfigStrategy };
+export { runStrategy };

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -1,6 +1,9 @@
 import { PriorityName } from './Priority';
 import { $Diff } from 'utility-types';
-import { CollectionFromResponse } from 'shared/types/Collection';
+import {
+  CollectionFromResponse,
+  NestedArticleFragment
+} from 'shared/types/Collection';
 
 interface FrontConfigResponse {
   collections: string[];
@@ -94,6 +97,23 @@ interface CollectionResponse {
   };
 }
 
+interface EditionCollectionFromResponse {
+  items: NestedArticleFragment[];
+  lastUpdated?: number;
+  updatedBy?: string;
+  updatedEmail?: string;
+  platform?: string;
+  displayName: string;
+  groups?: string[];
+  metadata?: Array<{ type: string }>;
+  uneditable?: boolean;
+}
+
+interface EditionCollectionResponse {
+  id: string;
+  collection: EditionCollectionFromResponse;
+}
+
 interface VisibleArticlesResponse {
   desktop: number;
   mobile: number;
@@ -108,6 +128,7 @@ export {
   CollectionConfigMap,
   ArticleDetails,
   CollectionResponse,
+  EditionCollectionResponse,
   VisibleArticlesResponse,
   FrontsToolSettings
 };

--- a/client-v2/src/types/Store.ts
+++ b/client-v2/src/types/Store.ts
@@ -8,7 +8,8 @@ export interface ExtraThunkArgs {
   fetchFrontsConfig: (state: State) => Promise<FrontsConfig> | null;
   fetchCollections: (
     state: State,
-    collectionIds: string[]
+    collectionIds: string[],
+    returnOnlyUpdatedCollections: boolean
   ) => Promise<CollectionResponse[]> | null;
 }
 

--- a/client-v2/src/types/Store.ts
+++ b/client-v2/src/types/Store.ts
@@ -2,18 +2,8 @@ import { Store as ReduxStore, Dispatch } from 'redux';
 import { Action } from './Action';
 import { State } from './State';
 import { ThunkDispatch, ThunkAction } from 'redux-thunk';
-import { FrontsConfig, CollectionResponse } from './FaciaApi';
-
-export interface ExtraThunkArgs {
-  fetchFrontsConfig: (state: State) => Promise<FrontsConfig> | null;
-  fetchCollections: (
-    state: State,
-    collectionIds: string[],
-    returnOnlyUpdatedCollections: boolean
-  ) => Promise<CollectionResponse[]> | null;
-}
 
 export type Store = ReduxStore<State>;
 export type GetState = () => State;
-export type Dispatch = ThunkDispatch<State, ExtraThunkArgs, Action>;
-export type ThunkResult<R> = ThunkAction<R, State, ExtraThunkArgs, Action>;
+export type Dispatch = ThunkDispatch<State, void, Action>;
+export type ThunkResult<R> = ThunkAction<R, State, void, Action>;

--- a/client-v2/src/types/Store.ts
+++ b/client-v2/src/types/Store.ts
@@ -2,10 +2,14 @@ import { Store as ReduxStore, Dispatch } from 'redux';
 import { Action } from './Action';
 import { State } from './State';
 import { ThunkDispatch, ThunkAction } from 'redux-thunk';
-import { FrontsConfig } from './FaciaApi';
+import { FrontsConfig, CollectionResponse } from './FaciaApi';
 
 export interface ExtraThunkArgs {
   fetchFrontsConfig: (state: State) => Promise<FrontsConfig> | null;
+  fetchCollections: (
+    state: State,
+    collectionIds: string[]
+  ) => Promise<CollectionResponse[]> | null;
 }
 
 export type Store = ReduxStore<State>;

--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -15,16 +15,19 @@ import {
 import { State } from 'types/State';
 import { ExtraThunkArgs } from 'types/Store';
 import { fetchFrontsConfigStrategy } from 'strategies/fetch-fronts-config';
+import { fetchCollectionsStrategy } from 'strategies/fetch-collection';
 
 export default function configureStore(initialState?: State) {
   const history = createBrowserHistory();
   const router = routerMiddleware(history);
   const reducer = enableBatching(rootReducer);
+  const extraArgs: ExtraThunkArgs = {
+    fetchFrontsConfig: fetchFrontsConfigStrategy,
+    fetchCollections: fetchCollectionsStrategy
+  };
   const middleware = compose(
     applyMiddleware(
-      thunkMiddleware.withExtraArgument({
-        fetchFrontsConfig: fetchFrontsConfigStrategy
-      } as ExtraThunkArgs),
+      thunkMiddleware.withExtraArgument(extraArgs),
       updateStateFromUrlChange,
       router,
       persistCollectionOnEdit(),

--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -2,7 +2,7 @@ import { applyMiddleware, compose, createStore } from 'redux';
 import { enableBatching } from 'redux-batched-actions';
 import thunkMiddleware from 'redux-thunk';
 import createBrowserHistory from 'history/createBrowserHistory';
-import { routerMiddleware } from 'react-router-redux';
+import { routerMiddleware, push } from 'react-router-redux';
 
 import rootReducer from 'reducers/rootReducer';
 import {
@@ -17,7 +17,10 @@ import { ExtraThunkArgs } from 'types/Store';
 import { fetchFrontsConfigStrategy } from 'strategies/fetch-fronts-config';
 import { fetchCollectionsStrategy } from 'strategies/fetch-collection';
 
-export default function configureStore(initialState?: State) {
+export default function configureStore(
+  initialState?: State,
+  initialPath?: string /* only used for tests */
+) {
   const history = createBrowserHistory();
   const router = routerMiddleware(history);
   const reducer = enableBatching(rootReducer);
@@ -45,6 +48,10 @@ export default function configureStore(initialState?: State) {
     module.hot.accept('reducers/rootReducer.js', () => {
       store.replaceReducer(rootReducer);
     });
+  }
+
+  if (initialPath) {
+    store.dispatch(push(initialPath));
   }
 
   return store;

--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -14,7 +14,7 @@ import {
 } from './storeMiddleware';
 import { State } from 'types/State';
 import { ExtraThunkArgs } from 'types/Store';
-import { fetchFrontsConfigStrategy } from 'strategies';
+import { fetchFrontsConfigStrategy } from 'strategies/fetch-fronts-config';
 
 export default function configureStore(initialState?: State) {
   const history = createBrowserHistory();

--- a/client-v2/src/util/configureStore.ts
+++ b/client-v2/src/util/configureStore.ts
@@ -13,9 +13,6 @@ import {
   persistFavouriteFrontsOnEdit
 } from './storeMiddleware';
 import { State } from 'types/State';
-import { ExtraThunkArgs } from 'types/Store';
-import { fetchFrontsConfigStrategy } from 'strategies/fetch-fronts-config';
-import { fetchCollectionsStrategy } from 'strategies/fetch-collection';
 
 export default function configureStore(
   initialState?: State,
@@ -24,13 +21,9 @@ export default function configureStore(
   const history = createBrowserHistory();
   const router = routerMiddleware(history);
   const reducer = enableBatching(rootReducer);
-  const extraArgs: ExtraThunkArgs = {
-    fetchFrontsConfig: fetchFrontsConfigStrategy,
-    fetchCollections: fetchCollectionsStrategy
-  };
   const middleware = compose(
     applyMiddleware(
-      thunkMiddleware.withExtraArgument(extraArgs),
+      thunkMiddleware,
       updateStateFromUrlChange,
       router,
       persistCollectionOnEdit(),


### PR DESCRIPTION
## What's changed?

Because there will be different ways of fetching collections between editions and fronts tool (and the incoming models will be different). This is a WIP but it'd be good to get the eyes on this from everyone!

## Implementation notes

Start pulling out a strategy for fetching collections.  I've added a new strategy for this and additionally add a helper for picking strategies.

The aim here is to normalise the collection coming in to have a `draft` key and an empty `live` array. We can either assume and empty `live` key precludes the ability to look at the live - or we can define some `Context` that will control whether we can see a `live` toggle button.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
