### PR TITLE
Update collections

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -1,7 +1,6 @@
 import { batchActions } from 'redux-batched-actions';
 import {
   getArticlesBatched,
-  updateCollection as updateCollectionFromApi,
   discardDraftChangesToCollection as discardDraftChangesToCollectionApi,
   fetchVisibleArticles,
   fetchLastPressed as fetchLastPressedApi,
@@ -71,6 +70,7 @@ import { State } from 'types/State';
 import { events } from 'services/GA';
 import { collectionParamsSelector } from 'selectors/collectionSelectors';
 import { fetchCollectionsStrategy } from 'strategies/fetch-collection';
+import { updateCollectionStrategy } from 'strategies/update-collection';
 
 const articlesInCollection = createAllArticlesInCollectionSelector();
 const collectionsInOpenFrontsSelector = createCollectionsInOpenFrontsSelector();
@@ -262,7 +262,11 @@ function updateCollection(collection: Collection): ThunkResult<Promise<void>> {
         getState(),
         collection.id
       );
-      await updateCollectionFromApi(collection.id, denormalisedCollection);
+      await updateCollectionStrategy(
+        getState(),
+        collection.id,
+        denormalisedCollection
+      );
       dispatch(collectionActions.updateSuccess(collection.id));
       const visibleArticles = await getVisibleArticles(
         collection,

--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -39,6 +39,7 @@ const A4 = {
 
 const init = () => {
   const initState = {
+    path: '/v2/editorial',
     shared: {
       collections: {
         loadingIds: [],

--- a/client-v2/src/components/Editions/Issue.tsx
+++ b/client-v2/src/components/Editions/Issue.tsx
@@ -32,11 +32,11 @@ const Issue = (props: IssueProps) => (
         </tr>
         <tr>
           <td>Published:</td>
-          <td>{props.issue.lastPublished ? 'Yes' : 'No'}</td>
+          <td>{props.issue.launchedOn ? 'Yes' : 'No'}</td>
         </tr>
         <tr>
           <td>Last published:</td>
-          <td>{props.issue.lastPublished}</td>
+          <td>{props.issue.launchedOn}</td>
         </tr>
         <tr>
           <td>Creator:</td>

--- a/client-v2/src/services/__tests__/faciaApi.spec.ts
+++ b/client-v2/src/services/__tests__/faciaApi.spec.ts
@@ -63,7 +63,7 @@ describe('faciaApi', () => {
           })
       });
       expect.assertions(1);
-      return expect(updateCollection('exampleId', collection)).resolves.toEqual(
+      return expect(updateCollection('exampleId')(collection)).resolves.toEqual(
         collection
       );
     });
@@ -71,7 +71,7 @@ describe('faciaApi', () => {
       fetchMock.once('/v2Edits', { status: 400 });
       expect.assertions(1);
       try {
-        await updateCollection('exampleId', collection);
+        await updateCollection('exampleId')(collection);
       } catch (e) {
         expect(e.message).toContain('exampleId');
       }

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -20,7 +20,7 @@ import { CapiArticle } from 'types/Capi';
 import chunk from 'lodash/chunk';
 import { CAPISearchQueryResponse, checkIsResults } from './capiQuery';
 import flatMap from 'lodash/flatMap';
-import { EditionsIssue } from 'types/Edition';
+import { EditionsIssue, EditionsCollection } from 'types/Edition';
 
 function fetchEditionsIssueAsConfig(editionId: string): Promise<FrontsConfig> {
   return pandaFetch(`/editions-api/${editionId}`, {
@@ -176,12 +176,12 @@ async function publishCollection(collectionId: string): Promise<void> {
   }
 }
 
-async function updateCollection(
+const createUpdateCollection = <T>(path: string) => async (
   id: string,
-  collection: CollectionWithNestedArticles
-): Promise<CollectionWithNestedArticles> {
+  collection: T
+): Promise<void> => {
   try {
-    const response = await pandaFetch(`/v2Edits`, {
+    const response = await pandaFetch(path, {
       method: 'post',
       headers: {
         'Content-Type': 'application/json'
@@ -197,7 +197,14 @@ async function updateCollection(
       }: ${response.body}`
     );
   }
-}
+};
+
+const updateCollection = createUpdateCollection<CollectionWithNestedArticles>(
+  '/v2Edits'
+);
+const updateEditionsCollection = createUpdateCollection<EditionsCollection>(
+  '/editions-api/collections'
+);
 
 async function saveClipboard(
   clipboardContent: NestedArticleFragment[]
@@ -421,6 +428,7 @@ export {
   fetchLastPressed,
   publishCollection,
   updateCollection,
+  updateEditionsCollection,
   saveClipboard,
   saveOpenFrontIds,
   saveFavouriteFrontIds,

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -176,8 +176,7 @@ async function publishCollection(collectionId: string): Promise<void> {
   }
 }
 
-const createUpdateCollection = <T>(path: string) => async (
-  id: string,
+const createUpdateCollection = <T>(path: string) => (id: string) => async (
   collection: T
 ): Promise<void> => {
   try {
@@ -202,9 +201,10 @@ const createUpdateCollection = <T>(path: string) => async (
 const updateCollection = createUpdateCollection<CollectionWithNestedArticles>(
   '/v2Edits'
 );
-const updateEditionsCollection = createUpdateCollection<EditionsCollection>(
-  '/editions-api/collections'
-);
+const updateEditionsCollection = (collectionId: string) =>
+  createUpdateCollection<EditionsCollection>(
+    `/editions-api/collections/${collectionId}`
+  )(collectionId);
 
 async function saveClipboard(
   clipboardContent: NestedArticleFragment[]

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -547,6 +547,7 @@ const collectionWithSupportingArticles = {
 };
 
 const stateWithCollection: any = {
+  path: '/v2/editorial',
   fronts: {
     frontsConfig: {
       data: {
@@ -651,6 +652,7 @@ const stateWithCollection: any = {
 };
 
 const stateWithCollectionAndSupporting: any = {
+  path: '/v2/editorial',
   shared: {
     collections: {
       data: {
@@ -712,6 +714,7 @@ const stateWithCollectionAndSupporting: any = {
 };
 
 const stateWithSnaplinksAndArticles: any = {
+  path: '/v2/editorial',
   shared: {
     articleFragments: {
       '1269c42e-a341-4464-b206-a5731b92fa46': {

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -96,6 +96,7 @@ interface CollectionFromResponse {
   live: NestedArticleFragment[];
   previously?: NestedArticleFragment[];
   draft?: NestedArticleFragment[];
+  isHidden?: boolean;
   lastUpdated?: number;
   updatedBy?: string;
   updatedEmail?: string;

--- a/client-v2/src/strategies/fetch-collection.ts
+++ b/client-v2/src/strategies/fetch-collection.ts
@@ -15,9 +15,9 @@ const editionCollectionToCollection = (
   return {
     ...restRes,
     collection: {
+      ...restCol,
       draft: items,
-      live: [],
-      ...restCol
+      live: []
     },
     storiesVisibleByStage: {
       // TODO - remove me once we figure out what to do here!

--- a/client-v2/src/strategies/update-collection.ts
+++ b/client-v2/src/strategies/update-collection.ts
@@ -22,9 +22,9 @@ const fetchCollectionsStrategy = (
   collection: CollectionWithNestedArticles
 ) =>
   runStrategy<void>(state, {
-    front: () => updateCollection(id, collection),
+    front: () => updateCollection(id)(collection),
     edition: () =>
-      updateEditionsCollection(id, collectionToEditionCollection(collection)),
+      updateEditionsCollection(id)(collectionToEditionCollection(collection)),
     none: () => null
   });
 

--- a/client-v2/src/strategies/update-collection.ts
+++ b/client-v2/src/strategies/update-collection.ts
@@ -16,7 +16,7 @@ const collectionToEditionCollection = (
   };
 };
 
-const fetchCollectionsStrategy = (
+const updateCollectionStrategy = (
   state: State,
   id: string,
   collection: CollectionWithNestedArticles
@@ -28,4 +28,4 @@ const fetchCollectionsStrategy = (
     none: () => null
   });
 
-export { fetchCollectionsStrategy };
+export { updateCollectionStrategy };

--- a/client-v2/src/strategies/update-collection.ts
+++ b/client-v2/src/strategies/update-collection.ts
@@ -1,0 +1,31 @@
+import { State } from 'types/State';
+import { updateCollection } from 'services/faciaApi';
+import { updateEditionsCollection } from 'services/faciaApi';
+import { runStrategy } from './run-strategy';
+import { CollectionWithNestedArticles } from 'shared/types/Collection';
+import { EditionsCollection } from 'types/Edition';
+
+const collectionToEditionCollection = (
+  col: CollectionWithNestedArticles
+): EditionsCollection => {
+  const { live, draft, isHidden, ...restCol } = col;
+  return {
+    ...restCol,
+    isHidden: isHidden || false,
+    items: draft || []
+  };
+};
+
+const fetchCollectionsStrategy = (
+  state: State,
+  id: string,
+  collection: CollectionWithNestedArticles
+) =>
+  runStrategy<void>(state, {
+    front: () => updateCollection(id, collection),
+    edition: () =>
+      updateEditionsCollection(id, collectionToEditionCollection(collection)),
+    none: () => null
+  });
+
+export { fetchCollectionsStrategy };

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -5,11 +5,10 @@ interface EditionsCollection {
   displayName: string;
   prefill?: string;
   isHidden: boolean;
-  lastUpdated?: string;
+  lastUpdated?: number;
   updatedBy?: string;
   updatedEmail?: string;
-  live: EditionsArticle[];
-  draft: EditionsArticle[];
+  items: EditionsArticle[];
 }
 
 interface EditionsFront {
@@ -25,9 +24,10 @@ interface EditionsFront {
 interface EditionsIssue {
   id: string;
   displayName: string;
-  issueDate: string; // the date for which edition is made for, in format TimestampZ, eg 2016-06-22 19:10:25-07
-  lastPublished: string; // null if not published
-  launchedOn: string;
+  issueDate: number; // midnight on the expect publish date
+  createdOn: number;
+  createdBy: number;
+  launchedOn?: number;
   launchedBy: string;
   launchedEmail: string;
   fronts: EditionsFront[];


### PR DESCRIPTION
## What's changed?

We now have a strategy for updating collections based on where we are in the tool - much like previous PRs.

## Implementation notes

Have tried to reconcile out types in this PR as some of them had got out of sync with the Editions Postgres PR.

After looking at the Postgres PR again I can see that currently the routes aren't quite correct here and I'll need to do a bit of work in a separate PR to ensure we have enough context to fire of fetches with both the `editionName` and `issueId`.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
