### PR TITLE
Add editionName param to manageEditions path

### DIFF
--- a/client-v2/src/routes/routes.ts
+++ b/client-v2/src/routes/routes.ts
@@ -35,7 +35,7 @@ const issuePathProps = {
 const matchIssuePath = (path: string) =>
   matchPath<FrontsEditParams>(path, issuePathProps);
 
-export const manageEditions = `/manage-editions`;
+export const manageEditions = `/manage-editions/:editionName`;
 
 const EditionsRoutes = {
   issuePath: (issueId: string) => editionsApi(`/issues/${issueId}`),


### PR DESCRIPTION
## What's changed?

Add the editionName param back -- I think it was lost a few PRs back.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
