### PR TITLE
Highlight current issues in datepicker

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -39,10 +39,13 @@ class EditionsController(db: EditionsDB, templating: EditionsTemplating, val dep
 
   def listIssues(name: String) = AccessAPIAuthAction { req =>
     Try {
-      val date = req.queryString.get("date").map(_.head).get
-      LocalDate.parse(date)
-    }.map { localDate =>
-      Ok(Json.toJson(db.listIssues(name, localDate)))
+      val dateFrom = req.queryString.get("dateFrom").map(_.head).get
+      val dateTo = req.queryString.get("dateTo").map(_.head).get
+      (LocalDate.parse(dateFrom), LocalDate.parse(dateTo))
+    }.map {
+      case (localDateFrom, localDateTo) => {
+        Ok(Json.toJson(db.listIssues(name, localDateFrom, localDateTo)))
+      }
     }.getOrElse(BadRequest("Invalid or missing date"))
   }
 

--- a/app/services/editions/IssueQueries.scala
+++ b/app/services/editions/IssueQueries.scala
@@ -70,10 +70,11 @@ trait IssueQueries {
     issueId
   }
 
-  def listIssues(editionName: String, date: LocalDate) = DB readOnly { implicit session =>
+  def listIssues(editionName: String, dateFrom: LocalDate, dateTo: LocalDate) = DB readOnly { implicit session =>
     val editionTimeZone = EditionsTemplates.templates(editionName).zoneId
 
-    val zonedIssueDate = date.atStartOfDay(editionTimeZone)
+    val zonedIssueDateFrom = dateFrom.atStartOfDay(editionTimeZone)
+    val zonedIssueDateTo = dateTo.atStartOfDay(editionTimeZone)
 
     sql"""
     SELECT
@@ -88,7 +89,7 @@ trait IssueQueries {
       launched_by,
       launched_email
     FROM edition_issues
-    WHERE issue_date = $zonedIssueDate AND name = $editionName
+    WHERE issue_date BETWEEN $zonedIssueDateFrom AND $zonedIssueDateTo AND name = $editionName
     """.map(EditionsIssue.fromRow(_)).list().apply()
   }
 

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -140,7 +140,8 @@ class ManageEdition extends React.Component<
           this.setState({
             infoMessage: 'New issue created!',
             isError: false,
-            currentIssue: issue
+            currentIssue: issue,
+            isCreatingIssue: false
           });
         }
       ),

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -182,12 +182,12 @@ class ManageEdition extends React.Component<
 
   private isIssuePresentForDate = (date: Moment) =>
     this.state.issues.find(i =>
-      moment(i.issueDate, 'YYYY-MM-DD HH:mm:ss-ZZ').isSame(date, 'day')
+      moment(i.issueDate).isSame(date, 'day')
     );
 
   private handleMonthClick = (month: Moment) => {
     const startDate = month.clone().startOf('month');
-    const endDate = month.clone().endOf('month');
+    const endDate = month.clone().add(1, 'month').endOf('month');
 
     this.fetchDateRange(startDate, endDate);
   };

--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -181,13 +181,14 @@ class ManageEdition extends React.Component<
   };
 
   private isIssuePresentForDate = (date: Moment) =>
-    this.state.issues.find(i =>
-      moment(i.issueDate).isSame(date, 'day')
-    );
+    this.state.issues.find(i => moment(i.issueDate).isSame(date, 'day'));
 
   private handleMonthClick = (month: Moment) => {
     const startDate = month.clone().startOf('month');
-    const endDate = month.clone().add(1, 'month').endOf('month');
+    const endDate = month
+      .clone()
+      .add(1, 'month')
+      .endOf('month');
 
     this.fetchDateRange(startDate, endDate);
   };

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -27,9 +27,7 @@ export const fetchIssueByDate = async (
   return pandaFetch(
     `/editions-api/editions/${editionName}/issues?dateFrom=${date.format(
       dateFormat
-    )}&dateTo=${date.format(
-      dateFormat
-    )}`,
+    )}&dateTo=${date.format(dateFormat)}`,
     {
       method: 'get',
       credentials: 'same-origin'

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -10,9 +10,9 @@ export const fetchIssuesForDateRange = async (
   end: Moment
 ): Promise<EditionsIssue[]> => {
   return pandaFetch(
-    `/editions-api/editions/${editionName}/issues?start=${start.format(
+    `/editions-api/editions/${editionName}/issues?dateFrom=${start.format(
       dateFormat
-    )}&end=${end.format(dateFormat)}`,
+    )}&dateTo=${end.format(dateFormat)}`,
     {
       method: 'get',
       credentials: 'same-origin'
@@ -25,7 +25,9 @@ export const fetchIssueByDate = async (
   date: Moment
 ): Promise<EditionsIssue | void> => {
   return pandaFetch(
-    `/editions-api/editions/${editionName}/issues?date=${date.format(
+    `/editions-api/editions/${editionName}/issues?dateFrom=${date.format(
+      dateFormat
+    )}&dateTo=${date.format(
       dateFormat
     )}`,
     {


### PR DESCRIPTION
~Downstream from #787 -- review this first, gentle reader!~

## What's changed?

Highlight the current issues in the datepicker, so the user can see what's already there. Yay!

<img width="637" alt="Screenshot 2019-06-19 at 16 30 12" src="https://user-images.githubusercontent.com/7767575/59779099-8fbd7100-92af-11e9-8077-79eb746d457c.png">

### Implementation details

This adds a date range to the listIssues query method; the search that looks for an issue on a particular day supplies a range corresponding to its day accordingly, rather than a single day.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
