### PR TITLE
add get collections endpoint

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import logging.Logging
-import model.forms.CreateIssue
+import model.forms._
 import play.api.libs.json.Json
 import services.editions.{EditionsDB, EditionsTemplating}
 import java.time.LocalDate
@@ -44,5 +44,9 @@ class EditionsController(db: EditionsDB, templating: EditionsTemplating, val dep
     }.map { localDate =>
       Ok(Json.toJson(db.listIssues(name, localDate)))
     }.getOrElse(BadRequest("Invalid or missing date"))
+  }
+
+  def getCollections() = AccessAPIAuthAction(parse.json[List[GetCollectionsFilter]]) { req =>
+    Ok(Json.toJson(db.getCollections(req.body)))
   }
 }

--- a/app/model/forms/GetCollectionsFilter.scala
+++ b/app/model/forms/GetCollectionsFilter.scala
@@ -1,0 +1,10 @@
+package model.forms
+
+import play.api.libs.json.Json
+
+case class GetCollectionsFilter(id: String, lastUpdated: Option[Long])
+
+object GetCollectionsFilter {
+  implicit val format = Json.format[GetCollectionsFilter]
+}
+

--- a/app/services/editions/CollectionsQueries.scala
+++ b/app/services/editions/CollectionsQueries.scala
@@ -32,6 +32,7 @@ trait CollectionsQueries {
 
         articles.collection_id AS articles_collection_id,
         articles.page_code     AS articles_page_code,
+        articles.index         AS articles_index,
         articles.added_on      AS articles_added_on,
         articles.added_by      AS articles_added_by,
         articles.added_email   AS articles_added_email

--- a/app/services/editions/CollectionsQueries.scala
+++ b/app/services/editions/CollectionsQueries.scala
@@ -1,0 +1,65 @@
+package services.editions
+
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
+import services.editions.CollectionsHelpers._
+import model.editions._
+import model.forms.GetCollectionsFilter
+import scalikejdbc._
+
+
+trait CollectionsQueries {
+  def getCollections(filters : List[GetCollectionsFilter]) = DB readOnly { implicit session =>
+    case class TypedFilters(id: String, updatedAt: Option[ZonedDateTime])
+    case class GetCollectionsRow(collection: EditionsCollection, article: Option[DbEditionsArticle])
+
+    val sqlFilters = filters.map { f =>
+      TypedFilters(f.id, f.lastUpdated.map(Instant.ofEpochMilli(_).atZone(ZoneId.of("UTC"))))
+    }
+
+    val rows: List[GetCollectionsRow] = sql"""
+      SELECT
+        collections.id
+        collections.front_id
+        collections.index
+        collections.name
+        collections.is_hidden
+        collections.metadata
+        collections.updated_on
+        collections.updated_by
+        collections.updated_email
+        collections.prefill
+
+        articles.collection_id AS articles_collection_id,
+        articles.page_code     AS articles_page_code,
+        articles.added_on      AS articles_added_on,
+        articles.added_by      AS articles_added_by,
+        articles.added_email   AS articles_added_email
+
+      FROM collections
+      LEFT JOIN articles ON (articles.collection_id = collections.id)
+      WHERE EXISTS (
+        SELECT *
+        FROM (VALUES ${sqlFilters.map(f => sqls"(${f.id}, ${f.updatedAt})")}) AS F(id, updated_on)
+        WHERE collection.id = F.id AND (F.updated_on IS NULL OR collection.updated_on > F.updated_on)
+      )
+      """.map { rs =>
+      GetCollectionsRow(
+        EditionsCollection.fromRow(rs),
+        DbEditionsArticle.fromRowOpt(rs, "articles_"))
+    }
+      .list()
+      .apply()
+
+    rows
+      .map(_.collection)
+      .distinctBy(_.id)
+      .map { collection =>
+          val articles = rows
+            .flatMap(_.article)
+            .filter(_.collectionId == collection.id)
+            .map(_.article)
+        collection.copy(items = articles)
+      }
+  }
+}

--- a/app/services/editions/EditionsDB.scala
+++ b/app/services/editions/EditionsDB.scala
@@ -3,7 +3,7 @@ package services.editions
 import scalikejdbc._
 import conf.ApplicationConfiguration
 
-class EditionsDB (config: ApplicationConfiguration) extends IssueQueries {
+class EditionsDB (config: ApplicationConfiguration) extends IssueQueries with CollectionsQueries {
   Class.forName("org.postgresql.Driver")
   ConnectionPool.singleton(config.postgres.url, config.postgres.user, config.postgres.password)
 }

--- a/app/services/editions/package.scala
+++ b/app/services/editions/package.scala
@@ -1,0 +1,57 @@
+package services.editions
+
+import model.editions.{EditionsArticle, EditionsCollection, EditionsFront}
+import scalikejdbc.WrappedResultSet
+
+import scala.collection.IterableLike
+import scala.collection.generic.CanBuildFrom
+
+// Little helpers so we don't contaminate our business model with relational data
+case class DbEditionsFront(front: EditionsFront, issueId: String, index: Int)
+object DbEditionsFront {
+  def fromRowOpt(rs: WrappedResultSet, prefix: String): Option[DbEditionsFront] = {
+    EditionsFront.fromRowOpt(rs, prefix).map { front =>
+      DbEditionsFront(front, rs.string(prefix + "issue_id"), rs.int(prefix + "index"))
+    }
+  }
+}
+
+case class DbEditionsCollection(collection: EditionsCollection, frontId: String, index: Int)
+object DbEditionsCollection {
+  def fromRowOpt(rs: WrappedResultSet, prefix: String): Option[DbEditionsCollection] = {
+    EditionsCollection.fromRowOpt(rs, prefix).map { collection =>
+      DbEditionsCollection(collection, rs.string(prefix + "front_id"), rs.int(prefix + "index"))
+    }
+  }
+}
+
+case class DbEditionsArticle(article: EditionsArticle, collectionId: String, index: Int)
+object DbEditionsArticle {
+  def fromRowOpt(rs: WrappedResultSet, prefix: String): Option[DbEditionsArticle] = {
+    EditionsArticle.fromRowOpt(rs, prefix).map { article =>
+      DbEditionsArticle(
+        article,
+        rs.string(prefix + "collection_id"),
+        rs.int(prefix + "index"))
+    }
+  }
+}
+
+object CollectionsHelpers {
+  implicit class RichCollection[A, Repr](xs: IterableLike[A, Repr]){
+    def distinctBy[B, That](f: A => B)(implicit cbf: CanBuildFrom[Repr, A, That]) = {
+      val builder = cbf(xs.repr)
+      val i = xs.iterator
+      var set = Set[B]()
+      while (i.hasNext) {
+        val o = i.next
+        val b = f(o)
+        if (!set(b)) {
+          set += b
+          builder += o
+        }
+      }
+      builder.result
+    }
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -106,6 +106,7 @@ GET         /editions-api/editions                       controllers.EditionsCon
 GET         /editions-api/editions/:name/issues          controllers.EditionsController.listIssues(name)
 POST        /editions-api/editions/:name/issues          controllers.EditionsController.postIssue(name)
 GET         /editions-api/issues/:id                     controllers.EditionsController.getIssue(id)
+POST        /editions-api/collections                    controllers.EditionsController.getCollections
 
 #PUT         /editions-api/editions/:name/issues/:id/fronts/:frontId/collections/:collectionsId controllers.EditionsController.putCollection
 


### PR DESCRIPTION
Add a get collections endpoint to the editions part of the code base.

Behaves like the existing get collections endpoint where you post an array of `(id, lastUpdated)` objects and we do the filtering per collection