### PR TITLE
Fix id titles

### DIFF
--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -277,8 +277,9 @@ const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
       selectEditorFavouriteFrontIdsByPriority(state, priority),
 
     (frontsForPriority, openFronts, favouriteFronts) => {
-      return frontsForPriority.map(({ id }) => ({
+      return frontsForPriority.map(({ id, displayName }) => ({
         id,
+        displayName,
         isOpen: !!openFronts.find(_ => _.id === id),
         isStarred: !!favouriteFronts.includes(id)
       }));

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -7,7 +7,12 @@ import { MoreIcon, StarIcon } from 'shared/components/icons/Icons';
 import TextHighlighter from './util/TextHighlighter';
 
 interface Props {
-  fronts: Array<{ id: string; isOpen: boolean; isStarred: boolean }>;
+  fronts: Array<{
+    id: string;
+    displayName?: string;
+    isOpen: boolean;
+    isStarred: boolean;
+  }>;
   renderOnlyStarred?: boolean;
   onSelect: (frontId: string) => void;
   onStar: (frontId: string) => void;
@@ -125,7 +130,7 @@ const FrontList = ({
         >
           <ListLabel isActive={!front.isOpen}>
             <TextHighlighter
-              originalString={front.id}
+              originalString={front.displayName || front.id}
               searchString={searchString}
             />
           </ListLabel>

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -128,7 +128,10 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
   public render() {
     const { frontId, isFormOpen, isOverviewOpen } = this.props;
     const title =
-      this.props.selectedFront && startCase(this.props.selectedFront.id);
+      this.props.selectedFront &&
+      startCase(
+        this.props.selectedFront.displayName || this.props.selectedFront.id
+      );
     return (
       <SingleFrontContainer
         key={frontId}

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -7,6 +7,7 @@ import {
 interface FrontConfigResponse {
   collections: string[];
   priority?: string;
+  displayName?: string;
   canonical?: string;
   group?: string;
   isHidden?: boolean;


### PR DESCRIPTION
## What's changed?

This ensures that we don't use the `EditionCollection` `ids` to display titles, but try the `displayName` and otherwise fallback to `id`. 

## Implementation notes

I could have broken this out into a `getFrontTitle` function but thought that might be overkill ... happy to add it if people disagree.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
