### PR TITLE
Editions Prefill

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -192,7 +192,6 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     }
   }
 
-
   object cdn {
     lazy val basePath = getString("assets.basePath").getOrElse("/")
   }
@@ -202,7 +201,9 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
 
     val contentApiLiveHost: String = getMandatoryString("content.api.host")
     def contentApiDraftHost: String = getMandatoryString("content.api.draft.iam-host")
+
     val editionsPrefillHost: String = "https://preview.content.guardianapis.com"
+    lazy val editionsKey: String = "test"
 
     lazy val key: Option[String] = getString("content.api.key")
     lazy val timeout: Int = 2000

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -6,14 +6,13 @@ import java.net.URL
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.rds.auth.{GetIamAuthTokenRequest, RdsIamAuthTokenGenerator}
 import org.apache.commons.io.IOUtils
 import play.api.{Configuration => PlayConfiguration}
 import logging.Logging
 
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
-import com.amazonaws.services.rds.model.{DescribeDBInstancesRequest, Filter => RDSFilter}
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest
 import com.amazonaws.services.rds.AmazonRDSClientBuilder
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest
@@ -202,8 +201,8 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     val contentApiLiveHost: String = getMandatoryString("content.api.host")
     def contentApiDraftHost: String = getMandatoryString("content.api.draft.iam-host")
 
-    val editionsPrefillHost: String = "https://preview.content.guardianapis.com"
-    lazy val editionsKey: String = "test"
+    val editionsPrefillHost: String = getMandatoryString("content.api.editions.prefillHost")
+    lazy val editionsKey: String = getMandatoryString("content.api.editions.apiKey")
 
     lazy val key: Option[String] = getString("content.api.key")
     lazy val timeout: Int = 2000

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -1,7 +1,5 @@
 package model.editions
 
-import java.time.ZonedDateTime
-
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -26,7 +26,7 @@ case object WeekDay extends Enumeration(1) {
 case class FrontPresentation()
 case class CollectionPresentation()
 
-case class CapiPrefillQuery(tag: String) extends AnyVal
+case class CapiPrefillQuery(queryString: String) extends AnyVal
 
 object CapiPrefillQuery {
   implicit def format = Json.format[CapiPrefillQuery]

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -207,7 +207,7 @@ object FrontFilm {
 object FrontFeatures {
   val collectionDepartments = CollectionTemplate(
     name = "G2 Departments",
-    prefill = Some(CapiPrefillQuery("theguardian/g2/features")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/features")),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -70,6 +70,10 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       .fromDate(issueDate.minus(Period.ofDays(3)).toInstant)
       .toDate(issueDate.toInstant)
 
+    params.filter(pair => pair.getName == "section").foreach { sectionPair =>
+      query = query.section(sectionPair.getValue)
+    }
+
     params.filter(pair => pair.getName == "tag").foreach { tagPair =>
       query = query.tag(tagPair.getValue)
     }

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -74,10 +74,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
   def getPreviewHeaders(url: String): Seq[(String,String)] = previewSigner.addIAMHeaders(headers = Map.empty, URI.create(url)).toSeq
 
-  def getPrefillArticlePageCodes(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery) = {
-    // Commenting this out so we can get this merged without prefill working
-    //Future.successful(Nil)
-
+  def getPrefillArticlePageCodes(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[String]] = {
     val query = PrintSentQuery()
       .page(1)
       .pageSize(10)
@@ -91,8 +88,10 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       .tag(capiPrefillQuery.tag)
 
     client.getResponse(query) map { response =>
-      response.results.map {
-        _.id
+      response.results.flatMap {
+        _.fields
+          .flatMap(field => field.internalPageCode)
+          .map(_.toString)
       }.toList
     }
   }

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -2,7 +2,6 @@ package services.editions
 
 import java.time.{LocalDate, LocalTime, ZonedDateTime}
 
-import model.editions.templates.DailyEdition
 import model.editions._
 import services.Capi
 

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -7,6 +7,7 @@ import services.Capi
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.Try
 
 class EditionsTemplating(capi: Capi) {
   def generateEditionTemplate(name: String, localDate: LocalDate): Option[EditionsIssueSkeleton] = {
@@ -29,7 +30,9 @@ class EditionsTemplating(capi: Capi) {
                     EditionsCollectionSkeleton(
                       collection.name,
                       collection.prefill.map { prefill =>
-                        Await.result(capi.getPrefillArticlePageCodes(date, prefill), 10 seconds)
+                        Try {
+                          Await.result(capi.getPrefillArticlePageCodes(date, prefill), 10 seconds)
+                        }.getOrElse(Nil)
                       }.getOrElse(Nil),
                       collection.prefill,
                       collection.presentation,

--- a/app/services/editions/IssueQueries.scala
+++ b/app/services/editions/IssueQueries.scala
@@ -172,7 +172,7 @@ trait IssueQueries {
             .flatMap(row => row.collection.filter(_.frontId == front.id))
             .sortBy(_.index)
             .map(_.collection)
-            .foldLeft(List.empty[EditionsCollection]) {(acc, cur) => if(acc.exists(f => f.id == cur.id)) acc else acc :+ cur}
+            .foldLeft(List.empty[EditionsCollection]) {(acc, cur) => if(acc.exists(c => c.id == cur.id)) acc else acc :+ cur}
             .map { collection =>
               val articles = rows
                 .flatMap(row => row.article.filter(_.collectionId == collection.id))

--- a/app/services/editions/IssueQueries.scala
+++ b/app/services/editions/IssueQueries.scala
@@ -53,7 +53,7 @@ trait IssueQueries {
             updated_on,
             updated_by,
             updated_email
-          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.tag)}, NOW(), ${userName}, ${user.email})
+          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.queryString)}, NOW(), $userName, ${user.email})
           RETURNING id;
           """.map(_.string("id")).single().apply().get
 

--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -70,7 +70,6 @@ CREATE TABLE articles (
 CREATE INDEX article_collection_id_index ON articles(collection_id);
 ALTER TABLE articles ADD CONSTRAINT article_index_must_be_unique UNIQUE (collection_id, index);
 
-
 # --- !Downs
 
 DROP TABLE edition_issues;


### PR DESCRIPTION
Use the CAPI client to get ourselves some editions prefill!

Pretty straight forward! As far as I know the only field we use in the prefill is the tag. I've hardcoded the search to be the last 3 days of content for now - can change that very easily though!

![image](https://user-images.githubusercontent.com/5560113/59843477-8e905080-9350-11e9-8993-9df8d2b9eaa5.png)

