### PR TITLE
Widen priority so we can use issueId

### DIFF
--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -37,7 +37,7 @@ function fetchEditionsIssueAsConfig(issueId: string): Promise<FrontsConfig> {
         fronts[front.id] = {
           ...front,
           collections: front.collections.map(collection => collection.id),
-          priority: 'edition'
+          priority: issueId
         };
         front.collections.forEach(collection => {
           collections[collection.id] = {

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -1,4 +1,3 @@
-import { PriorityName } from './Priority';
 import { $Diff } from 'utility-types';
 import {
   CollectionFromResponse,
@@ -7,7 +6,7 @@ import {
 
 interface FrontConfigResponse {
   collections: string[];
-  priority?: PriorityName;
+  priority?: string;
   canonical?: string;
   group?: string;
   isHidden?: boolean;
@@ -58,12 +57,9 @@ interface FrontsConfigResponse {
   };
 }
 
-type FrontConfig = $Diff<
-  FrontConfigResponse,
-  { priority?: PriorityName | void }
-> & {
+type FrontConfig = $Diff<FrontConfigResponse, { priority?: string | void }> & {
   id: string;
-  priority: PriorityName;
+  priority: string;
 };
 
 type CollectionConfig = CollectionConfigResponse & {

--- a/client-v2/src/types/Priority.ts
+++ b/client-v2/src/types/Priority.ts
@@ -1,10 +1,3 @@
-type PriorityName =
-  | 'editorial'
-  | 'commercial'
-  | 'training'
-  | 'email'
-  | 'edition';
-
 interface Priorities {
   editorial: unknown;
   commercial: unknown;
@@ -13,4 +6,4 @@ interface Priorities {
   edition: unknown;
 }
 
-export { PriorityName, Priorities };
+export { Priorities };


### PR DESCRIPTION
## What's changed?

This widens the `priority` type to `string` so that `issueId` can be used as a `priority`.

## Implementation notes

This sort of sucks because we probably won't be using `issueId` as a `priority` in future. But given how we've changed priority once already _and_ we don't actually use stringified versions of the priorities anywhere, it doesn't seem too calamitous. Again, happy to have other opinions!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
