### PR TITLE
Allow polling to fire on editions page

### DIFF
--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -1,7 +1,7 @@
 import { fetchStaleOpenCollections } from 'actions/Collections';
 import { Dispatch } from 'types/Store';
 import { Store } from 'types/Store';
-import { matchFrontsEditPath } from 'routes/routes';
+import { matchFrontsEditPath, matchIssuePath } from 'routes/routes';
 import { getV2SubPath } from 'selectors/pathSelectors';
 
 /**
@@ -14,7 +14,8 @@ export default (store: Store) =>
     if ((window as any).IS_INTEGRATION) {
       return;
     }
-    const match = matchFrontsEditPath(getV2SubPath(store.getState()));
+    const path = getV2SubPath(store.getState());
+    const match = matchFrontsEditPath(path) || matchIssuePath(path);
     if (!match || !match.params.priority) {
       return;
     }


### PR DESCRIPTION
## What's changed?

This just widens the route matcher to allow editions pages to fire polling.

## Implementation notes

N/A

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
