### PR TITLE
fix fetch collections query and make collection updated fields NOT NULL

### DIFF
--- a/app/services/editions/CollectionsQueries.scala
+++ b/app/services/editions/CollectionsQueries.scala
@@ -19,16 +19,16 @@ trait CollectionsQueries {
 
     val rows: List[GetCollectionsRow] = sql"""
       SELECT
-        collections.id
-        collections.front_id
-        collections.index
-        collections.name
-        collections.is_hidden
-        collections.metadata
-        collections.updated_on
-        collections.updated_by
-        collections.updated_email
-        collections.prefill
+        collections.id,
+        collections.front_id,
+        collections.index,
+        collections.name,
+        collections.is_hidden,
+        collections.metadata,
+        collections.updated_on,
+        collections.updated_by,
+        collections.updated_email,
+        collections.prefill,
 
         articles.collection_id AS articles_collection_id,
         articles.page_code     AS articles_page_code,
@@ -42,7 +42,7 @@ trait CollectionsQueries {
       WHERE EXISTS (
         SELECT *
         FROM (VALUES ${sqlFilters.map(f => sqls"(${f.id}, ${f.updatedAt})")}) AS F(id, updated_on)
-        WHERE collection.id = F.id AND (F.updated_on IS NULL OR collection.updated_on > F.updated_on)
+        WHERE collections.id = F.id AND (F.updated_on IS NULL OR collections.updated_on > F.updated_on::TIMESTAMPTZ)
       )
       """.map { rs =>
       GetCollectionsRow(

--- a/app/services/editions/IssueQueries.scala
+++ b/app/services/editions/IssueQueries.scala
@@ -15,6 +15,8 @@ trait IssueQueries {
                    skeleton: EditionsIssueSkeleton,
                    user: User
   ): String  = DB localTx { implicit session =>
+    val userName = user.firstName + " " + user.lastName
+
     val issueId = sql"""
           INSERT INTO edition_issues (
             name,
@@ -23,7 +25,7 @@ trait IssueQueries {
             created_on,
             created_by,
             created_email
-          ) VALUES ($name, ${skeleton.issueDate}, ${skeleton.zoneId.toString}, now(), ${user.firstName + " " + user.lastName}, ${user.email})
+          ) VALUES ($name, ${skeleton.issueDate}, ${skeleton.zoneId.toString}, now(), ${userName}, ${user.email})
           RETURNING id;
        """.map(_.string("id")).single().apply().get
 
@@ -47,8 +49,11 @@ trait IssueQueries {
             name,
             is_hidden,
             metadata,
-            prefill
-          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.tag)})
+            prefill,
+            updated_on,
+            updated_by,
+            updated_email
+          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.tag)}, NOW(), ${userName}, ${user.email})
           RETURNING id;
           """.execute().apply()
 
@@ -61,7 +66,7 @@ trait IssueQueries {
                     added_on,
                     added_by,
                     added_email
-                    ) VALUES ($collectionId, $pageCode, $tIndex, now(), ${user.firstName + " " + user.lastName}}, ${user.email})
+                    ) VALUES ($collectionId, $pageCode, $tIndex, now(), ${userName}, ${user.email})
                  """.execute().apply()
           }
         }

--- a/conf/evolutions/default/2.sql
+++ b/conf/evolutions/default/2.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+
+ALTER TABLE collections ALTER COLUMN updated_on SET NOT NULL;
+ALTER TABLE collections ALTER COLUMN updated_by SET NOT NULL;
+ALTER TABLE collections ALTER COLUMN updated_email SET NOT NULL;
+
+# --- !Downs
+
+ALTER TABLE collections ALTER COLUMN updated_on DROP NOT NULL;
+ALTER TABLE collections ALTER COLUMN updated_by DROP NOT NULL;
+ALTER TABLE collections ALTER COLUMN updated_email DROP NOT NULL;


### PR DESCRIPTION
Pretty much Ronseal.

I arsed up the previous query by removing the prefixes and forgetting to add the commas back. Nice one m8.

I've also made the `updated_{on,by,email}` fields `NOT NULL` which simplifies the fetch query a little.