### PR TITLE
Shortcircuit fetching collections with no ids

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.Json
 import services.editions.{EditionsDB, EditionsTemplating}
 import java.time.LocalDate
 
-import model.editions.EditionsTemplates
+import model.editions.{EditionsCollection, EditionsTemplates}
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -50,6 +50,12 @@ class EditionsController(db: EditionsDB, templating: EditionsTemplating, val dep
   }
 
   def getCollections() = AccessAPIAuthAction(parse.json[List[GetCollectionsFilter]]) { req =>
-    Ok(Json.toJson(db.getCollections(req.body)))
+    val filters = req.body
+    if (filters.isEmpty) {
+      Ok(Json.toJson(List.empty[EditionsCollection]))
+    } else {
+      Ok(Json.toJson(db.getCollections(filters)))
+    }
+
   }
 }


### PR DESCRIPTION
## What's changed?

If you don't specify a list of collections to fetch then we simply return an empty list. This is a lot simpler than faffing about with the DB query!

## Implementation notes

Very straight forward I hope :)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
