### PR TITLE
Fix the URL escaping in prefills

### DIFF
--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -26,7 +26,14 @@ case object WeekDay extends Enumeration(1) {
 case class FrontPresentation()
 case class CollectionPresentation()
 
-case class CapiPrefillQuery(queryString: String) extends AnyVal
+case class CapiPrefillQuery(queryString: String) extends AnyVal {
+  def escapedQueryString(): String =
+    queryString
+      .replace(",", "%2C")
+      .replace("|", "%7C")
+      .replace("(", "%28")
+      .replace(")", "%29")
+}
 
 object CapiPrefillQuery {
   implicit def format = Json.format[CapiPrefillQuery]

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -1,7 +1,7 @@
 package services
 
 import java.io.IOException
-import java.net.URI
+import java.net.{URI, URLEncoder}
 import java.nio.charset.Charset
 import java.time.{Period, ZoneOffset, ZonedDateTime}
 
@@ -56,7 +56,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
   def geneneratePrefillQuery(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery) = {
     val params = URLEncodedUtils
-      .parse(new URI(capiPrefillQuery.queryString), Charset.forName("UTF-8"))
+      .parse(new URI(capiPrefillQuery.escapedQueryString()), Charset.forName("UTF-8"))
       .asScala
 
     // Horrible hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
@@ -64,7 +64,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
     var query = PrintSentQuery()
       .page(1)
-      .pageSize(20)
+      .pageSize(200)
       .showFields("newspaper-edition-date")
       .showFields("newspaper-page-number")
       .showFields("internal-page-code")


### PR DESCRIPTION
This will be a lot neater when we move to a structured prefill rather than a query string.

We can't simply use a standard URL escaping function because that escapes syntactically relevant parts of the query string (e.g. `?` at the start and the various `&`s)