### PR TITLE
Sort editions fronts by index

### DIFF
--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -8,6 +8,7 @@ import scalikejdbc.WrappedResultSet
 case class EditionsFront(
     id: String,
     displayName: String,
+    index: Int,
     isHidden: Boolean,
     updatedOn: Option[Long],
     updatedBy: Option[String],
@@ -22,6 +23,7 @@ object EditionsFront {
     EditionsFront(
       rs.string(prefix + "id"),
       rs.string(prefix + "name"),
+      rs.int(prefix + "index"),
       rs.boolean(prefix + "is_hidden"),
       rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
       rs.stringOpt(prefix + "updated_by"),
@@ -34,11 +36,13 @@ object EditionsFront {
     for {
       id <- rs.stringOpt(prefix + "id")
       name <- rs.stringOpt(prefix + "name")
+      index <- rs.intOpt(prefix + "index")
       isHidden <- rs.booleanOpt(prefix + "is_hidden")
     } yield
       EditionsFront(
         id,
         name,
+        index,
         isHidden,
         rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
         rs.stringOpt(prefix + "updated_by"),

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -148,6 +148,21 @@ describe('frontsUIBundle', () => {
     });
   });
   describe('createSelectFrontIdWithOpenAndStarredStatesByPriority', () => {
+    const stateWithEditorFronts = {
+      ...initialState,
+      editor: {
+        ...initialState.editor,
+        frontIdsByPriority: {
+          commercial: ['sc-johnson-partner-zone', 'a-shot-of-sustainability']
+        },
+        favouriteFrontIdsByPriority: {
+          commercial: [
+            'sc-johnson-partner-zone',
+            'un-global-compact-partner-zone'
+          ]
+        }
+      }
+    } as any;
     const selectFrontIdWithOpenAndStarredStatesByPriority = createSelectFrontIdWithOpenAndStarredStatesByPriority();
     it('should select all fronts by priority', () => {
       expect(
@@ -158,36 +173,62 @@ describe('frontsUIBundle', () => {
       ).toHaveLength(4);
     });
     it('should add correct Open State meta data', () => {
-      const stateWithEditorFronts = {
-        ...initialState,
-        editor: {
-          ...initialState.editor,
-          frontIdsByPriority: {
-            commercial: ['sc-johnson-partner-zone', 'a-shot-of-sustainability']
-          },
-          favouriteFrontIdsByPriority: {
-            commercial: [
-              'sc-johnson-partner-zone',
-              'un-global-compact-partner-zone'
-            ]
-          }
-        }
-      } as any;
       expect(
         selectFrontIdWithOpenAndStarredStatesByPriority(
           stateWithEditorFronts,
           'commercial'
         )
       ).toEqual([
-        { id: 'a-shot-of-sustainability', isOpen: true, isStarred: false },
-        { id: 'sc-johnson-partner-zone', isOpen: true, isStarred: true },
+        {
+          id: 'a-shot-of-sustainability',
+          displayName: undefined,
+          index: 1,
+          isOpen: true,
+          isStarred: false
+        },
+        {
+          id: 'sc-johnson-partner-zone',
+          displayName: undefined,
+          index: 0,
+          isOpen: true,
+          isStarred: true
+        },
         {
           id: 'sustainable-business/fairtrade-partner-zone',
           isOpen: false,
-          isStarred: false
+          isStarred: false,
+          displayName: undefined,
+          index: 2
         },
-        { id: 'un-global-compact-partner-zone', isOpen: false, isStarred: true }
+        {
+          id: 'un-global-compact-partner-zone',
+          isOpen: false,
+          isStarred: true,
+          displayName: undefined,
+          index: 3
+        }
       ]);
+    });
+    it('should sort fronts by id and name', () => {
+      expect(
+        selectFrontIdWithOpenAndStarredStatesByPriority(
+          stateWithEditorFronts,
+          'commercial',
+          'id'
+        ).map(_ => _.id)
+      ).toEqual([
+        'a-shot-of-sustainability',
+        'sc-johnson-partner-zone',
+        'sustainable-business/fairtrade-partner-zone',
+        'un-global-compact-partner-zone'
+      ]);
+      expect(
+        selectFrontIdWithOpenAndStarredStatesByPriority(
+          stateWithEditorFronts,
+          'commercial',
+          'index'
+        ).map(_ => _.index)
+      ).toEqual([0, 1, 2, 3]);
     });
   });
 

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -1,5 +1,6 @@
 import without from 'lodash/without';
 import compact from 'lodash/compact';
+import sortBy from 'lodash/sortBy';
 import {
   Action,
   EditorOpenCurrentFrontsMenu,
@@ -275,14 +276,18 @@ const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
       selectEditorFrontsByPriority(state, { priority }),
     (state, priority: string) =>
       selectEditorFavouriteFrontIdsByPriority(state, priority),
-
-    (frontsForPriority, openFronts, favouriteFronts) => {
-      return frontsForPriority.map(({ id, displayName }) => ({
+    (_, __, sortByName = true) => sortByName,
+    (frontsForPriority, openFronts, favouriteFronts, shouldSort) => {
+      const fronts = frontsForPriority.map(({ id, displayName }) => ({
         id,
         displayName,
         isOpen: !!openFronts.find(_ => _.id === id),
         isStarred: !!favouriteFronts.includes(id)
       }));
+      if (shouldSort) {
+        return sortBy(fronts, _ => _.id);
+      }
+      return fronts;
     }
   );
 };

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -32,6 +32,7 @@ import {
   REMOVE_GROUP_ARTICLE_FRAGMENT,
   REMOVE_SUPPORTING_ARTICLE_FRAGMENT
 } from 'shared/actions/ArticleFragments';
+import { FrontConfig } from 'types/FaciaApi';
 
 export const EDITOR_OPEN_CURRENT_FRONTS_MENU =
   'EDITOR_OPEN_CURRENT_FRONTS_MENU';
@@ -276,18 +277,16 @@ const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
       selectEditorFrontsByPriority(state, { priority }),
     (state, priority: string) =>
       selectEditorFavouriteFrontIdsByPriority(state, priority),
-    (_, __, sortByName = true) => sortByName,
-    (frontsForPriority, openFronts, favouriteFronts, shouldSort) => {
-      const fronts = frontsForPriority.map(({ id, displayName }) => ({
+    (_, __, sortKey: 'id' | 'index' = 'id') => sortKey,
+    (frontsForPriority, openFronts, favouriteFronts, sortKey) => {
+      const fronts = frontsForPriority.map(({ id, displayName, index }) => ({
         id,
         displayName,
+        index,
         isOpen: !!openFronts.find(_ => _.id === id),
         isStarred: !!favouriteFronts.includes(id)
       }));
-      if (shouldSort) {
-        return sortBy(fronts, _ => _.id);
-      }
-      return fronts;
+      return sortBy(fronts, front => front[sortKey]);
     }
   );
 };

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -32,7 +32,6 @@ import {
   REMOVE_GROUP_ARTICLE_FRAGMENT,
   REMOVE_SUPPORTING_ARTICLE_FRAGMENT
 } from 'shared/actions/ArticleFragments';
-import { FrontConfig } from 'types/FaciaApi';
 
 export const EDITOR_OPEN_CURRENT_FRONTS_MENU =
   'EDITOR_OPEN_CURRENT_FRONTS_MENU';

--- a/client-v2/src/components/FrontsListContainer.ts
+++ b/client-v2/src/components/FrontsListContainer.ts
@@ -16,7 +16,7 @@ const mapStateToProps = () => {
       fronts: selectFrontIdWithOpenAndStarredStates(
         state,
         props.match.params.priority || '',
-        !selectIsEditingEditions(state)
+        selectIsEditingEditions(state) ? 'index' : 'id'
       )
     };
   };

--- a/client-v2/src/components/FrontsListContainer.ts
+++ b/client-v2/src/components/FrontsListContainer.ts
@@ -3,6 +3,7 @@ import { match, withRouter, RouteComponentProps } from 'react-router';
 import { createSelectFrontIdWithOpenAndStarredStatesByPriority } from 'bundles/frontsUIBundle';
 import { State } from '../types/State';
 import FrontList from './FrontList';
+import { selectIsEditingEditions } from 'selectors/pathSelectors';
 
 type Props = {
   match: match<{ priority: string }>;
@@ -14,7 +15,8 @@ const mapStateToProps = () => {
     return {
       fronts: selectFrontIdWithOpenAndStarredStates(
         state,
-        props.match.params.priority || ''
+        props.match.params.priority || '',
+        !selectIsEditingEditions(state)
       )
     };
   };

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -15,7 +15,8 @@ const state = {
             priority: 'commercial',
             canonical: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
             group: 'US professional',
-            id: 'sc-johnson-partner-zone'
+            id: 'sc-johnson-partner-zone',
+            index: 0
           },
           'a-shot-of-sustainability': {
             collections: [
@@ -27,7 +28,8 @@ const state = {
             priority: 'commercial',
             canonical: 'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb',
             group: 'UK consumer',
-            id: 'a-shot-of-sustainability'
+            id: 'a-shot-of-sustainability',
+            index: 1
           },
           'sustainable-business/fairtrade-partner-zone': {
             collections: [
@@ -40,13 +42,15 @@ const state = {
               'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611'
             ],
             priority: 'commercial',
-            id: 'sustainable-business/fairtrade-partner-zone'
+            id: 'sustainable-business/fairtrade-partner-zone',
+            index: 2
           },
           'un-global-compact-partner-zone': {
             collections: ['082d2dc8-f196-4c00-979e-7f541f2772f4'],
             priority: 'commercial',
             canonical: '082d2dc8-f196-4c00-979e-7f541f2772f4',
-            id: 'un-global-compact-partner-zone'
+            id: 'un-global-compact-partner-zone',
+            index: 3
           },
           'gnm-archive': {
             collections: [
@@ -57,7 +61,8 @@ const state = {
               '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56'
             ],
             id: 'gnm-archive',
-            priority: 'editorial'
+            priority: 'editorial',
+            index: 4
           }
         },
         collections: {

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -53,7 +53,6 @@ const getFrontsByPriority = createSelector(
   [getFronts],
   (fronts: FrontConfigMap): FrontsByPriority =>
     Object.keys(fronts)
-      .sort()
       .filter(id => id !== breakingNewsFrontId)
       .reduce((acc: FrontsByPriority, id): FrontsByPriority => {
         const front = fronts[id];

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -1,8 +1,11 @@
 import { State } from 'types/State';
+import { matchIssuePath } from 'routes/routes';
 
 const maybeRemoveV2Prefix = (path: string) => path.replace(/^\/v2/, '');
 
 const getFullPath = (state: State) => state.path;
 const getV2SubPath = (state: State) => maybeRemoveV2Prefix(getFullPath(state));
+const selectIsEditingEditions = (state: State) =>
+  !!matchIssuePath(getV2SubPath(state));
 
-export { getFullPath, getV2SubPath };
+export { getFullPath, getV2SubPath, selectIsEditingEditions };

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -8,6 +8,7 @@ interface FrontConfigResponse {
   collections: string[];
   priority?: string;
   displayName?: string;
+  index?: number;
   canonical?: string;
   group?: string;
   isHidden?: boolean;


### PR DESCRIPTION
## What's changed?

Editions fronts have a specific order and the list is quite small. It's preferable that they keep their order in the fronts menu. This PR preserves this order for editions, but keeps the other sorting behaviour for normal priority fronts.

## Implementation notes

Belatedly I noticed that we weren't pulling the index prop into the client state. We can't rely on the order of object keys in Javascript, so I've added the index prop to our Front model on the client so we can sort by this property explicitly.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
