### PR TITLE
Enable overriding headline

### DIFF
--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import com.gu.editions.{PublishedArticle, PublishedArticleMetadata}
+import com.gu.editions.{PublishedArticle, PublishedFurniture}
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
@@ -13,7 +13,7 @@ object ArticleMetadata {
 case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) {
   def toPublishedArticle: PublishedArticle = PublishedArticle(
     pageCode.toLong,
-    PublishedArticleMetadata(None, None, None) // TODO (sihil): Store in DB and populate here
+    PublishedFurniture(None, metadata.flatMap(_.headline), None) // TODO (sihil): Store in DB and populate here
   )
 }
 

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -4,7 +4,7 @@ import com.gu.editions.{PublishedArticle, PublishedArticleMetadata}
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
-case class ArticleMetadata(headline: String)
+case class ArticleMetadata(headline: Option[String])
 
 object ArticleMetadata {
   implicit val format = Json.format[ArticleMetadata]

--- a/app/model/editions/EditionsFrontendCollection.scala
+++ b/app/model/editions/EditionsFrontendCollection.scala
@@ -4,19 +4,21 @@ import play.api.libs.json.Json
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
 
-case class EditionsFrontendArticle(id: String, frontPublicationDate: Long)
+case class EditionsFrontendArticle(id: String, frontPublicationDate: Long, meta: Option[ArticleMetadata])
 
 object EditionsFrontendArticle {
   def fromArticle(article: EditionsArticle): EditionsFrontendArticle = {
     EditionsFrontendArticle(
       "internal-code/page/" + article.pageCode,
-      article.addedOn
+      article.addedOn,
+      article.metadata
     )
   }
   def toArticle(article: EditionsFrontendArticle): EditionsArticle = {
     EditionsArticle(
       article.id.split("/").last,
-      article.frontPublicationDate
+      article.frontPublicationDate,
+      article.meta
     )
   }
 }

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -1,9 +1,10 @@
 package services.editions.db
 
-import java.time.{Instant, ZoneId, ZonedDateTime}
+import java.time._
 
 import model.editions.EditionsCollection
 import model.forms.GetCollectionsFilter
+import play.api.libs.json.Json
 import scalikejdbc._
 import services.editions.DbEditionsArticle
 import services.editions.CollectionsHelpers._
@@ -14,10 +15,22 @@ trait CollectionsQueries {
     case class GetCollectionsRow(collection: EditionsCollection, article: Option[DbEditionsArticle])
 
     val sqlFilters = filters.map { f =>
-      TypedFilters(f.id, f.lastUpdated.map(Instant.ofEpochMilli(_).atZone(ZoneId.of("UTC"))))
+      // We add a single millisecond here because the precision in the database is higher than what the client
+      // provides (μs in the DB vs ms from the client) so the clients value is effectively truncated.
+      //
+      // Rather than fiddle with timestamp resolution in the query in the database which would affect our
+      // indexing strategy we can just add a single millisecond here.
+      TypedFilters(
+        f.id,
+        f.lastUpdated
+          .map(
+            Instant
+              .ofEpochMilli(_)
+              .atZone(ZoneId.of("UTC"))
+              .plus(Duration.ofMillis(1))))
     }
 
-    val rows: List[GetCollectionsRow] = sql"""
+    val rows = sql"""
       SELECT
         collections.id,
         collections.front_id,
@@ -33,7 +46,8 @@ trait CollectionsQueries {
         articles.collection_id AS articles_collection_id,
         articles.page_code     AS articles_page_code,
         articles.index         AS articles_index,
-        articles.added_on      AS articles_added_on
+        articles.added_on      AS articles_added_on,
+        articles.metadata      AS articles_metadata
 
       FROM collections
       LEFT JOIN articles ON (articles.collection_id = collections.id)
@@ -84,8 +98,9 @@ trait CollectionsQueries {
           collection_id,
           page_code,
           index,
-          added_on
-          ) VALUES (${collection.id}, ${article.pageCode}, $index, now())
+          added_on,
+          metadata
+          ) VALUES (${collection.id}, ${article.pageCode}, $index, now(), ${article.metadata.map(m => Json.toJson(m).toString)}::JSONB)
        """.execute().apply()
     }
 

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -141,7 +141,8 @@ trait IssueQueries {
         articles.collection_id AS articles_collection_id,
         articles.page_code     AS articles_page_code,
         articles.index         AS articles_index,
-        articles.added_on      AS articles_added_on
+        articles.added_on      AS articles_added_on,
+        articles.metadata      AS articles_metadata
 
       FROM edition_issues
       LEFT JOIN fronts ON (fronts.issue_id = edition_issues.id)

--- a/app/services/editions/publishing/PublishedIssueFormatters.scala
+++ b/app/services/editions/publishing/PublishedIssueFormatters.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.Json
 
 object PublishedIssueFormatters {
   implicit val mediaUrlFormat = Json.format[MediaUrl]
-  implicit val publishedArticleMetadataFormat = Json.format[PublishedArticleMetadata]
+  implicit val publishedFurnitureFormat = Json.format[PublishedFurniture]
   implicit val publishedArticleFormat = Json.format[PublishedArticle]
   implicit val publishedCollectionsFormat = Json.format[PublishedCollection]
   implicit val publishedFrontsFormat = Json.format[PublishedFront]

--- a/client-v2/scripts/client-dev.sh
+++ b/client-v2/scripts/client-dev.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-IS_DEBUG=false
+NO_DEBUG=false
 for arg in "$@"
 do
-    if [[ "$arg" == "--debug" ]]; then
-        IS_DEBUG=true
+    if [[ "$arg" == "--no-debug" ]]; then
+        NO_DEBUG=true
         shift
     fi
 done
@@ -18,14 +18,13 @@ cd ..
 printf "\n\rStarting Postgres... \n\r\n\r"
 docker-compose up -d
 
-
 printf "\n\rStarting Play App... \n\r\n\r"
 
 export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G"
 
-if [[ "$IS_DEBUG" = true ]] ; then
-  sbt -jvm-debug 5005 "run"
-else
+if [[ "$NO_DEBUG" = true ]] ; then
   sbt "run"
+else
+  sbt -jvm-debug 5005 "run"
 fi
 

--- a/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
+++ b/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
@@ -6,9 +6,13 @@ import java.time.OffsetDateTime
 
 case class MediaUrl(url: String) extends AnyVal
 
-case class PublishedArticleMetadata(kicker: Option[String], headline: Option[String], imageSrc: Option[MediaUrl])
+case class PublishedFurniture(
+  kickerOverride: Option[String],
+  headlineOverride: Option[String],
+  imageSrcOverride: Option[MediaUrl]
+)
 
-case class PublishedArticle(internalPageCode: Long, meta: PublishedArticleMetadata)
+case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)
 
 case class PublishedCollection(id: String, items: List[PublishedArticle])
 


### PR DESCRIPTION
You can now override headlines!

The frontend still displays the other fields but they're ignored pending a list of what we should remove from David.

