### PR TITLE
Add inline form

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -26,7 +26,7 @@ import {
   selectEditorFavouriteFrontIds,
   selectEditorFavouriteFrontIdsByPriority,
   editorSelectArticleFragment,
-  selectEditorArticleFragment
+  selectOpenArticleFragmentForms
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import { Action } from 'types/Action';
@@ -280,17 +280,17 @@ describe('frontsUIBundle', () => {
       const state = reducer(
         {
           selectedArticleFragments: {
-            frontId: { id: 'articleFragmentId', isSupporting: false }
+            frontId: [{ id: 'articleFragmentId', isSupporting: false }]
           }
         } as any,
         removeGroupArticleFragment('collectionId', 'articleFragmentId')
       );
-      expect(state.editor.selectedArticleFragments.frontId).toBe(undefined);
+      expect(state.editor.selectedArticleFragments.frontId).toEqual([]);
     });
     describe('Clearing article selection in response to persistence events', () => {
       const stateWithSelectedArticleFragments = {
         selectedArticleFragments: {
-          frontId: { id: 'articleFragmentId', isSupporting: false }
+          frontId: [{ id: 'articleFragmentId', isSupporting: false }]
         }
       } as any;
       it("should not clear the article fragment selection when selected article fragments aren't in the front", () => {
@@ -305,7 +305,7 @@ describe('frontsUIBundle', () => {
           stateWithSelectedArticleFragments,
           removeSupportingArticleFragment('collectionId', 'articleFragmentId')
         );
-        expect(state.editor.selectedArticleFragments.frontId).toBe(undefined);
+        expect(state.editor.selectedArticleFragments.frontId).toEqual([]);
       });
       it("should not clear the article fragment selection when selected supporting article fragments aren't in the front", () => {
         const state = reducer(
@@ -322,7 +322,7 @@ describe('frontsUIBundle', () => {
           stateWithSelectedArticleFragments,
           removeClipboardArticleFragment('collectionId', 'articleFragmentId')
         );
-        expect(state.editor.selectedArticleFragments.frontId).toBe(undefined);
+        expect(state.editor.selectedArticleFragments.frontId).toEqual([]);
       });
       it("should not clear the article fragment selection when selected clipboard article fragments aren't in the front", () => {
         const state = reducer(
@@ -398,10 +398,10 @@ describe('frontsUIBundle', () => {
           undefined,
           editorSelectArticleFragment('front1', 'exampleArticleFragment')
         );
-        expect(selectEditorArticleFragment(state, 'front1')).toEqual({
+        expect(selectOpenArticleFragmentForms(state, 'front1')).toEqual([{
           id: 'exampleArticleFragment',
           isSupporting: false
-        });
+        }]);
       });
     });
     it('should open and close all editing fronts', () => {

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -396,12 +396,19 @@ describe('frontsUIBundle', () => {
       it('should open a collection item form', () => {
         const state = reducer(
           undefined,
-          editorSelectArticleFragment('front1', 'exampleArticleFragment')
+          editorSelectArticleFragment(
+            'front1',
+            'exampleArticleFragment',
+            'exampleCollection'
+          )
         );
-        expect(selectOpenArticleFragmentForms(state, 'front1')).toEqual([{
-          id: 'exampleArticleFragment',
-          isSupporting: false
-        }]);
+        expect(selectOpenArticleFragmentForms(state, 'front1')).toEqual([
+          {
+            id: 'exampleArticleFragment',
+            isSupporting: false,
+            collectionId: 'collectionId'
+          }
+        ]);
       });
     });
     it('should open and close all editing fronts', () => {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -314,10 +314,15 @@ const selectHasMultipleFrontsOpen = createSelector(
   }
 );
 
-const selectEditorArticleFragment = <T extends { editor: State }>(
-  state: T,
+const selectOpenArticleFragmentForms = (
+  state: GlobalState,
   frontId: string
 ) => state.editor.selectedArticleFragments[frontId];
+
+const selectIsArticleFragmentFormOpen = (state: GlobalState, articleFragmentId: string, frontId: string) => {
+  return (selectOpenArticleFragmentForms(state, frontId) || []).some(_ => _.id === articleFragmentId)
+}
+
 
 const defaultState = {
   showOpenFrontsMenu: false,
@@ -607,8 +612,9 @@ export {
   selectEditorFavouriteFrontIds,
   selectEditorFrontIdsByPriority,
   selectEditorFavouriteFrontIdsByPriority,
-  selectEditorArticleFragment,
+  selectOpenArticleFragmentForms,
   selectIsCollectionOpen,
+  selectIsArticleFragmentFormOpen,
   editorOpenClipboard,
   editorCloseClipboard,
   editorOpenOverview,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -179,10 +179,10 @@ const editorSelectArticleFragment = (
 });
 
 const editorClearArticleFragmentSelection = (
-  frontId: string
+  articleFragmentId: string
 ): EditorClearArticleFragmentSelection => ({
   type: EDITOR_CLEAR_ARTICLE_FRAGMENT_SELECTION,
-  payload: { frontId }
+  payload: { articleFragmentId }
 });
 
 const editorOpenClipboard = (): EditorOpenClipboard => ({
@@ -215,6 +215,11 @@ const editorCloseAllOverviews = (): EditorCloseAllOverviews => ({
   type: EDITOR_CLOSE_ALL_OVERVIEWS
 });
 
+interface OpenArticleFragmentData {
+  id: string;
+  isSupporting: boolean;
+}
+
 interface State {
   showOpenFrontsMenu: boolean;
   frontIds: string[];
@@ -228,10 +233,7 @@ interface State {
   closedOverviews: string[];
   clipboardOpen: boolean;
   selectedArticleFragments: {
-    [frontId: string]: {
-      id: string;
-      isSupporting: boolean;
-    } | void;
+    [frontId: string]: OpenArticleFragmentData[];
   };
 }
 
@@ -277,9 +279,8 @@ const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
       selectEditorFavouriteFrontIdsByPriority(state, priority),
 
     (frontsForPriority, openFronts, favouriteFronts) => {
-      return frontsForPriority.map(({ id, displayName }) => ({
+      return frontsForPriority.map(({ id }) => ({
         id,
-        displayName,
         isOpen: !!openFronts.find(_ => _.id === id),
         isStarred: !!favouriteFronts.includes(id)
       }));
@@ -329,13 +330,36 @@ const defaultState = {
   selectedArticleFragments: {}
 };
 
-const clearArticleFragmentSelection = (state: State, frontId: string) => ({
-  ...state,
-  selectedArticleFragments: {
-    ...state.selectedArticleFragments,
-    [frontId]: undefined
+const clearArticleFragmentSelection = (
+  state: State,
+  articleFragmentId: string
+): State => {
+  let frontId: string | null = null;
+  for (const entry of Object.entries(state.selectedArticleFragments)) {
+    const [currentFrontId, fragmentDatas] = entry;
+    const currentFragmentDataIndex = fragmentDatas.findIndex(
+      _ => _.id === articleFragmentId
+    );
+    if (currentFragmentDataIndex !== -1) {
+      frontId = currentFrontId;
+      break;
+    }
   }
-});
+
+  if (!frontId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    selectedArticleFragments: {
+      ...state.selectedArticleFragments,
+      [frontId]: state.selectedArticleFragments[frontId].filter(
+        _ => _.id !== articleFragmentId
+      )
+    }
+  };
+};
 
 const getFrontPosition = (
   frontId: string,
@@ -490,36 +514,32 @@ const reducer = (state: State = defaultState, action: Action): State => {
       };
     }
     case EDITOR_SELECT_ARTICLE_FRAGMENT: {
+      const currentlyOpenArticleFragments =
+        state.selectedArticleFragments[action.payload.frontId] || [];
       return {
         ...state,
         selectedArticleFragments: {
           ...state.selectedArticleFragments,
-          [action.payload.frontId]: {
-            id: action.payload.articleFragmentId,
-            isSupporting: action.payload.isSupporting
-          }
+          [action.payload.frontId]: currentlyOpenArticleFragments.concat([
+            {
+              id: action.payload.articleFragmentId,
+              isSupporting: action.payload.isSupporting
+            }
+          ])
         }
       };
     }
     case EDITOR_CLEAR_ARTICLE_FRAGMENT_SELECTION: {
-      return clearArticleFragmentSelection(state, action.payload.frontId);
+      return clearArticleFragmentSelection(
+        state,
+        action.payload.articleFragmentId
+      );
     }
     case REMOVE_SUPPORTING_ARTICLE_FRAGMENT:
     case REMOVE_GROUP_ARTICLE_FRAGMENT:
     case 'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT': {
       const articleFragmentId = action.payload.articleFragmentId;
-      const selectedFrontId = Object.keys(state.selectedArticleFragments).find(
-        frontId => {
-          const selectedArticleFragmentData =
-            state.selectedArticleFragments[frontId];
-          return selectedArticleFragmentData
-            ? selectedArticleFragmentData.id === articleFragmentId
-            : false;
-        }
-      );
-      return selectedFrontId
-        ? clearArticleFragmentSelection(state, selectedFrontId)
-        : state;
+      return clearArticleFragmentSelection(state, articleFragmentId);
     }
     case EDITOR_OPEN_CLIPBOARD: {
       return {

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -11,7 +11,6 @@ import {
 } from 'actions/ArticleFragments';
 import {
   editorSelectArticleFragment,
-  editorClearArticleFragmentSelection,
   selectIsClipboardOpen
 } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
@@ -78,7 +77,6 @@ const FullDivider = styled('hr')`
 
 interface ClipboardProps {
   selectArticleFragment: (id: string, isSupporting?: boolean) => void;
-  clearArticleFragmentSelection: () => void;
   removeCollectionItem: (id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
   isClipboardOpen: boolean;
@@ -256,8 +254,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(
       editorSelectArticleFragment(frontId, articleFragmentId, isSupporting)
     ),
-  clearArticleFragmentSelection: () =>
-    dispatch(editorClearArticleFragmentSelection(clipboardId)),
   removeCollectionItem: (uuid: string) => {
     dispatch(
       removeArticleFragment('clipboard', 'clipboard', uuid, 'clipboard')

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -246,13 +246,14 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  selectArticleFragment: (
-    frontId: string,
-    articleFragmentId: string,
-    isSupporting: boolean
-  ) =>
+  selectArticleFragment: (articleFragmentId: string, isSupporting?: boolean) =>
     dispatch(
-      editorSelectArticleFragment(frontId, articleFragmentId, isSupporting)
+      editorSelectArticleFragment(
+        articleFragmentId,
+        clipboardId,
+        clipboardId,
+        !!isSupporting
+      )
     ),
   removeCollectionItem: (uuid: string) => {
     dispatch(
@@ -284,21 +285,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   dispatch
 });
 
-type TStateProps = ReturnType<typeof mapStateToProps>;
-type TDispatchProps = ReturnType<typeof mapDispatchToProps>;
-
-const mergeProps = (
-  stateProps: TStateProps,
-  dispatchProps: TDispatchProps
-) => ({
-  ...stateProps,
-  ...dispatchProps,
-  selectArticleFragment: (articleId: string, isSupporting = false) =>
-    dispatchProps.selectArticleFragment(clipboardId, articleId, isSupporting)
-});
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
+  mapDispatchToProps
 )(Clipboard);

--- a/client-v2/src/components/ClipboardMeta.tsx
+++ b/client-v2/src/components/ClipboardMeta.tsx
@@ -2,10 +2,7 @@ import { Dispatch } from 'types/Store';
 import React from 'react';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
-import {
-  selectEditorArticleFragment,
-  editorClearArticleFragmentSelection
-} from 'bundles/frontsUIBundle';
+import { editorClearArticleFragmentSelection } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
 import { updateClipboardArticleFragmentMeta } from 'actions/ArticleFragments';
 import { ArticleFragmentMeta } from 'shared/types/Collection';
@@ -42,7 +39,7 @@ const ClipboardMeta = (props: Props) => {
 };
 
 const mapStateToProps = (state: State) => ({
-  selectedArticleFragment: selectEditorArticleFragment(state, clipboardId)
+  selectedArticleFragment: undefined // selectEditorArticleFragment(state, clipboardId)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -20,7 +20,6 @@ import { createSelectFormFieldsForCollectionItem } from 'selectors/formSelectors
 import { ArticleFragmentMeta, ArticleTag } from 'shared/types/Collection';
 import InputText from 'shared/components/input/InputText';
 import InputTextArea from 'shared/components/input/InputTextArea';
-import HorizontalRule from 'shared/components/layout/HorizontalRule';
 import InputCheckboxToggle from 'shared/components/input/InputCheckboxToggle';
 import InputImage from 'shared/components/input/InputImage';
 import InputGroup from 'shared/components/input/InputGroup';
@@ -226,7 +225,13 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     );
 
     return (
-      <FormContainer data-testid="edit-form">
+      <FormContainer
+        data-testid="edit-form"
+        onClick={
+          (e: React.MouseEvent) =>
+            e.stopPropagation() /* Prevent clicks passing through the form */
+        }
+      >
         {!articleExists && (
           <CollectionEditedError>
             {this.state.lastKnownCollectionId &&

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -2,17 +2,14 @@ import React, { SyntheticEvent } from 'react';
 import { connect } from 'react-redux';
 import {
   reduxForm,
-  FieldArray,
   InjectedFormProps,
   formValueSelector,
-  WrappedFieldArrayProps,
   Field
 } from 'redux-form';
 import { styled } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import { ThumbnailEditForm } from 'shared/components/Thumbnail';
 import ContentContainer from 'shared/components/layout/ContentContainer';
-import ContainerHeading from 'shared/components/typography/ContainerHeading';
 import {
   createArticleFromArticleFragmentSelector,
   selectSharedState,
@@ -25,9 +22,7 @@ import InputText from 'shared/components/input/InputText';
 import InputTextArea from 'shared/components/input/InputTextArea';
 import HorizontalRule from 'shared/components/layout/HorizontalRule';
 import InputCheckboxToggle from 'shared/components/input/InputCheckboxToggle';
-import InputImage, {
-  InputImageContainerProps
-} from 'shared/components/input/InputImage';
+import InputImage from 'shared/components/input/InputImage';
 import InputGroup from 'shared/components/input/InputGroup';
 import InputButton from 'shared/components/input/InputButton';
 import Row from '../Row';
@@ -83,11 +78,11 @@ const FormContent = styled('div')`
   overflow-y: scroll;
 `;
 
-const CollectionHeadingPinline = ContainerHeading.extend`
-  display: flex;
-  margin-right: -11px;
-  margin-bottom: 10px;
-`;
+// const CollectionHeadingPinline = ContainerHeading.extend`
+//   display: flex;
+//   margin-right: -11px;
+//   margin-bottom: 10px;
+// `;
 
 const RowContainer = styled('div')`
   overflow: hidden;
@@ -98,15 +93,15 @@ const ButtonContainer = styled('div')`
   line-height: 0;
 `;
 
-const SlideshowRow = styled(Row)`
-  margin-top: 10px;
-  margin-bottom: 5px;
-`;
+// const SlideshowRow = styled(Row)`
+//   margin-top: 10px;
+//   margin-bottom: 5px;
+// `;
 
-const SlideshowLabel = styled('div')`
-  font-size: 12px;
-  color: ${({ theme }) => theme.shared.colors.greyMedium};
-`;
+// const SlideshowLabel = styled('div')`
+//   font-size: 12px;
+//   color: ${({ theme }) => theme.shared.colors.greyMedium};
+// `;
 
 const ImageWrapper = styled('div')`
   transition: opacity 0.15s;
@@ -153,9 +148,9 @@ const FieldContainer = styled(Col)`
   max-width: calc(100% / 3);
 `;
 
-type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
-  frontId: string;
-};
+// type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
+//   frontId: string;
+// };
 
 const KickerSuggestionsContainer = styled.div`
   position: absolute;
@@ -164,21 +159,21 @@ const KickerSuggestionsContainer = styled.div`
   font-size: 12px;
 `;
 
-const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
-  <>
-    {fields.map((name, index) => (
-      <Col key={`${name}-${index}`}>
-        <Field<InputImageContainerProps>
-          name={name}
-          component={InputImage}
-          small
-          criteria={imageCriteria}
-          frontId={frontId}
-        />
-      </Col>
-    ))}
-  </>
-);
+// const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
+//   <>
+//     {fields.map((name, index) => (
+//       <Col key={`${name}-${index}`}>
+//         <Field<InputImageContainerProps>
+//           name={name}
+//           component={InputImage}
+//           small
+//           criteria={imageCriteria}
+//           frontId={frontId}
+//         />
+//       </Col>
+//     ))}
+//   </>
+// );
 
 const getInputId = (articleFragmentId: string, label: string) =>
   `${articleFragmentId}-${label}`;
@@ -203,9 +198,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       articleFragmentId,
       change,
       kickerOptions,
-      imageSlideshowReplace,
+      // imageSlideshowReplace,
       imageHide,
-      imageCutoutReplace,
+      // imageCutoutReplace,
       articleCapiFieldValues,
       pristine,
       showByline,
@@ -331,7 +326,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="isBoosted"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Boost"
                 id={getInputId(articleFragmentId, 'boost')}
                 type="checkbox"
@@ -339,7 +333,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="showBoostedHeadline"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Large headline"
                 id={getInputId(articleFragmentId, 'large-headline')}
                 type="checkbox"
@@ -347,7 +340,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="showQuotedHeadline"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Quote headline"
                 id={getInputId(articleFragmentId, 'quote-headline')}
                 type="checkbox"
@@ -355,7 +347,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="isBreaking"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Breaking News"
                 id={getInputId(articleFragmentId, 'breaking-news')}
                 type="checkbox"
@@ -364,7 +355,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="showByline"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Show Byline"
                 id={getInputId(articleFragmentId, 'show-byline')}
                 type="checkbox"
@@ -372,7 +362,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="showLivePlayable"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Show updates"
                 id={getInputId(articleFragmentId, 'show-updates')}
                 type="checkbox"
@@ -380,7 +369,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="showMainVideo"
                 component={InputCheckboxToggle}
-                container={FieldContainer}
                 label="Show video"
                 id={getInputId(articleFragmentId, 'show-video')}
                 type="checkbox"

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -65,7 +65,6 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;
   flex-direction: column;
   flex: 1;
-  margin-top: 10px;
   height: calc(100% - 10px);
   background-color: ${({ theme }) => theme.base.colors.formBackground};
 `;
@@ -87,6 +86,8 @@ const RowContainer = styled('div')`
 
 const ButtonContainer = styled('div')`
   margin-left: auto;
+  margin-right: -10px;
+  margin-bottom: -10px;
   line-height: 0;
 `;
 
@@ -113,6 +114,7 @@ const CollectionEditedError = styled.div`
 
 const FieldsContainerWrap = styled(Row)`
   flex-wrap: wrap;
+  padding-bottom: 4px;
   border-bottom: 1px solid
     ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
@@ -126,15 +128,8 @@ const CheckboxFieldsContainer: React.SFC<{
   );
   return (
     <FieldsContainerWrap>
-      {childrenToRender.map((child, index) => {
-        // Add a border to the last three children. Is there a cleaner way of doing this?
-        return (
-          <FieldContainer key={child.props.name}>
-            {index > childrenToRender.length - (childrenToRender.length % 3) - 1
-              ? React.cloneElement<any>(child, { addBorder: false })
-              : child}
-          </FieldContainer>
-        );
+      {childrenToRender.map(child => {
+        return <FieldContainer key={child.props.name}>{child}</FieldContainer>;
       })}
     </FieldsContainerWrap>
   );
@@ -143,6 +138,7 @@ const CheckboxFieldsContainer: React.SFC<{
 const FieldContainer = styled(Col)`
   flex-basis: calc(100% / 3);
   max-width: calc(100% / 3);
+  min-width: 125px; /* Prevents labels breaking across lines */
 `;
 
 // type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
@@ -414,7 +410,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   />
                 )}
               </Col>
-              <Col>
+              <Col flex={2}>
                 <InputGroup>
                   <ConditionalField
                     permittedFields={editableFields}
@@ -444,9 +440,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             <ConditionalComponent
               permittedNames={editableFields}
               name={['primaryImage', 'imageHide']}
-            >
-              <HorizontalRule />
-            </ConditionalComponent>
+            />
             {/* <Row>
               <Col>
                 <ImageWrapper faded={!imageCutoutReplace}>

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { SyntheticEvent } from 'react';
 import { connect } from 'react-redux';
 import {
   reduxForm,
@@ -12,7 +12,7 @@ import { styled } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import { ThumbnailEditForm } from 'shared/components/Thumbnail';
 import ContentContainer from 'shared/components/layout/ContentContainer';
-import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
+import ContainerHeading from 'shared/components/typography/ContainerHeading';
 import {
   createArticleFromArticleFragmentSelector,
   selectSharedState,
@@ -71,8 +71,6 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
   flex-direction: column;
   flex: 1;
   min-width: ${formMinWidth}px;
-  max-width: 380px;
-  margin-left: 10px;
   margin-top: 10px;
   height: calc(100% - 10px);
 `;
@@ -82,7 +80,7 @@ const FormContent = styled('div')`
   overflow-y: scroll;
 `;
 
-const CollectionHeadingPinline = ContainerHeadingPinline.extend`
+const CollectionHeadingPinline = ContainerHeading.extend`
   display: flex;
   margin-right: -11px;
   margin-bottom: 10px;
@@ -161,11 +159,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       articleFragmentId,
       change,
       kickerOptions,
-      handleSubmit,
       imageSlideshowReplace,
       imageHide,
       imageCutoutReplace,
-      onCancel,
       articleCapiFieldValues,
       pristine,
       showByline,
@@ -195,16 +191,15 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     };
 
     return (
-      <FormContainer onSubmit={handleSubmit} data-testid="edit-form">
+      <FormContainer data-testid="edit-form">
         <CollectionHeadingPinline>
-          Edit
           <ButtonContainer>
-            <Button onClick={onCancel} type="button" size="l">
+            <Button onClick={this.handleCancel} type="button" size="l">
               Cancel
             </Button>
             <Button
               priority="primary"
-              onClick={handleSubmit}
+              onClick={this.handleSubmit}
               disabled={pristine || !articleExists}
               size="l"
               data-testid="edit-form-save-button"
@@ -495,6 +490,16 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       </FormContainer>
     );
   }
+
+  private handleSubmit = (e: SyntheticEvent<any>) => {
+    e.stopPropagation();
+    this.props.handleSubmit(e);
+  };
+
+  private handleCancel = (e: SyntheticEvent<any>) => {
+    e.stopPropagation();
+    this.props.onCancel();
+  };
 }
 
 const ArticleFragmentForm = reduxForm<

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -61,13 +61,10 @@ type Props = ComponentProps &
     {}
   >;
 
-export const formMinWidth = 300;
-
 const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;
   flex-direction: column;
   flex: 1;
-  min-width: ${formMinWidth}px;
   margin-top: 10px;
   height: calc(100% - 10px);
   background-color: ${({ theme }) => theme.base.colors.formBackground};
@@ -75,7 +72,7 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
 
 const FormContent = styled('div')`
   flex: 1;
-  overflow-y: scroll;
+  overflow: hidden;
 `;
 
 // const CollectionHeadingPinline = ContainerHeading.extend`

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -171,7 +171,7 @@ class CollectionContext extends React.Component<
                       uuid={articleFragment.uuid}
                     >
                       <CollectionItem
-                        frontId={this.props.id}
+                        frontId={this.props.frontId}
                         uuid={articleFragment.uuid}
                         parentId={group.uuid}
                         isUneditable={isUneditable}
@@ -189,7 +189,8 @@ class CollectionContext extends React.Component<
                         >
                           {(supporting, getSupportingProps) => (
                             <CollectionItem
-                              frontId={this.props.id}
+                              isSupporting={true}
+                              frontId={this.props.frontId}
                               uuid={supporting.uuid}
                               parentId={articleFragment.uuid}
                               onSelect={selectArticleFragment(true)}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -24,7 +24,7 @@ import {
   editorOpenCollections,
   editorCloseCollections,
   selectHasMultipleFrontsOpen,
-  selectEditorArticleFragment
+  selectOpenArticleFragmentForms
 } from 'bundles/frontsUIBundle';
 import { getArticlesForCollections } from 'actions/Collections';
 import { collectionItemSets } from 'constants/fronts';
@@ -202,7 +202,7 @@ const createMapStateToProps = () => {
     { browsingStage, id, priority, frontId }: CollectionPropsBeforeState
   ) => {
     const selectIsArticleInCollection = createSelectIsArticleInCollection();
-    const selectedArticleFragmentData = selectEditorArticleFragment(
+    const selectedArticleFragmentData = selectOpenArticleFragmentForms(
       state,
       frontId
     );
@@ -225,11 +225,11 @@ const createMapStateToProps = () => {
       hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
       isEditFormOpen:
         !!selectedArticleFragmentData &&
-        selectIsArticleInCollection(state.shared, {
+        selectedArticleFragmentData.some(_ => selectIsArticleInCollection(state.shared, {
           collectionId: id,
           collectionSet: browsingStage,
-          articleFragmentId: selectedArticleFragmentData.id
-        })
+          articleFragmentId: _.id
+        }))
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -130,8 +130,7 @@ class Collection extends React.Component<CollectionProps> {
         onChangeOpenState={() => onChangeOpenState(id, isOpen)}
         headlineContent={
           hasUnpublishedChanges &&
-          canPublish &&
-          !isEditFormOpen && (
+          canPublish && (
             <React.Fragment>
               <Button
                 size="l"
@@ -139,9 +138,10 @@ class Collection extends React.Component<CollectionProps> {
                 onClick={() => discardDraftChanges(id)}
                 tabIndex={-1}
                 data-testid="collection-discard-button"
+                disabled={isEditFormOpen}
                 title={
                   isEditFormOpen
-                    ? 'You cannot discard changes to this collection whilst the edit form is open.'
+                    ? 'You cannot discard changes to this collection whilst an edit form is open.'
                     : undefined
                 }
               >
@@ -152,9 +152,10 @@ class Collection extends React.Component<CollectionProps> {
                 priority="primary"
                 onClick={() => publish(id, frontId)}
                 tabIndex={-1}
+                disabled={isEditFormOpen}
                 title={
                   isEditFormOpen
-                    ? 'You cannot launch this collection whilst the edit form is open.'
+                    ? 'You cannot launch this collection whilst an edit form is open.'
                     : undefined
                 }
               >
@@ -225,11 +226,13 @@ const createMapStateToProps = () => {
       hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
       isEditFormOpen:
         !!selectedArticleFragmentData &&
-        selectedArticleFragmentData.some(_ => selectIsArticleInCollection(state.shared, {
-          collectionId: id,
-          collectionSet: browsingStage,
-          articleFragmentId: _.id
-        }))
+        selectedArticleFragmentData.some(_ =>
+          selectIsArticleInCollection(state.shared, {
+            collectionId: id,
+            collectionSet: browsingStage,
+            articleFragmentId: _.id
+          })
+        )
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -109,30 +109,32 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       case collectionItemTypes.ARTICLE:
         return (
           <>
-            <Article
-              id={uuid}
-              isUneditable={isUneditable}
-              {...getNodeProps()}
-              onDelete={this.onDelete}
-              onAddToClipboard={onAddToClipboard}
-              onClick={isUneditable ? undefined : () => onSelect(uuid)}
-              fade={selectionExists && !isSelected}
-              size={size}
-              displayType={displayType}
-              imageDropTypes={imageDropTypes}
-              onImageDrop={this.handleImageDrop}
-            >
-              <Sublinks
-                numSupportingArticles={numSupportingArticles}
-                toggleShowArticleSublinks={this.toggleShowArticleSublinks}
-                showArticleSublinks={this.state.showArticleSublinks}
-                parentId={parentId}
-              />
-              {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
-              {numSupportingArticles === 0
-                ? children
-                : this.state.showArticleSublinks && children}
-            </Article>
+            {!isSelected && (
+              <Article
+                id={uuid}
+                isUneditable={isUneditable}
+                {...getNodeProps()}
+                onDelete={this.onDelete}
+                onAddToClipboard={onAddToClipboard}
+                onClick={isUneditable ? undefined : () => onSelect(uuid)}
+                fade={selectionExists && !isSelected}
+                size={size}
+                displayType={displayType}
+                imageDropTypes={imageDropTypes}
+                onImageDrop={this.handleImageDrop}
+              >
+                <Sublinks
+                  numSupportingArticles={numSupportingArticles}
+                  toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+                  showArticleSublinks={this.state.showArticleSublinks}
+                  parentId={parentId}
+                />
+                {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
+                {numSupportingArticles === 0
+                  ? children
+                  : this.state.showArticleSublinks && children}
+              </Article>
+            )}
             {isSelected && (
               <ArticleFragmentForm
                 articleFragmentId={uuid}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -23,8 +23,8 @@ import {
 } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import {
-  selectEditorArticleFragment,
-  editorClearArticleFragmentSelection
+  editorClearArticleFragmentSelection,
+  selectIsArticleFragmentFormOpen
 } from 'bundles/frontsUIBundle';
 import {
   validateImageEvent,
@@ -67,7 +67,6 @@ type ArticleContainerProps = ContainerProps & {
   clearArticleFragmentSelection: () => void;
   type: CollectionItemTypes;
   isSelected: boolean;
-  selectionExists: boolean;
   numSupportingArticles: number;
 };
 
@@ -87,7 +86,6 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
   public render() {
     const {
       uuid,
-      selectionExists,
       isSelected,
       children,
       getNodeProps,
@@ -117,7 +115,6 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 onDelete={this.onDelete}
                 onAddToClipboard={onAddToClipboard}
                 onClick={isUneditable ? undefined : () => onSelect(uuid)}
-                fade={selectionExists && !isSelected}
                 size={size}
                 displayType={displayType}
                 imageDropTypes={imageDropTypes}
@@ -213,10 +210,6 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
 const createMapStateToProps = () => {
   const selectType = createCollectionItemTypeSelector();
   return (state: State, props: ContainerProps) => {
-    const selectedArticleFragmentData = selectEditorArticleFragment(
-      state,
-      props.frontId
-    );
     const maybeArticle = articleFragmentSelector(
       selectSharedState(state),
       props.uuid
@@ -227,10 +220,11 @@ const createMapStateToProps = () => {
     }
     return {
       type: selectType(selectSharedState(state), props.uuid),
-      selectionExists: !!selectedArticleFragmentData,
-      isSelected:
-        !!selectedArticleFragmentData &&
-        selectedArticleFragmentData.id === props.uuid,
+      isSelected: selectIsArticleFragmentFormOpen(
+        state,
+        props.uuid,
+        props.frontId
+      ),
       numSupportingArticles
     };
   };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -64,7 +64,7 @@ type ArticleContainerProps = ContainerProps & {
   copyCollectionItemImageMeta: (from: string, to: string) => void;
   addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   updateArticleFragmentMeta: (meta: ArticleFragmentMeta) => void;
-  clearArticleFragmentSelection: () => void;
+  clearArticleFragmentSelection: (id: string) => void;
   type: CollectionItemTypes;
   isSelected: boolean;
   numSupportingArticles: number;
@@ -141,9 +141,9 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 frontId={frontId}
                 onSave={meta => {
                   updateArticleFragmentMeta(meta);
-                  clearArticleFragmentSelection();
+                  clearArticleFragmentSelection(uuid);
                 }}
-                onCancel={() => clearArticleFragmentSelection()}
+                onCancel={() => clearArticleFragmentSelection(uuid)}
               />
             )}
           </>
@@ -244,8 +244,8 @@ const mapDispatchToProps = (
       dispatch(addImageToArticleFragment(id, response)),
     updateArticleFragmentMeta: (meta: ArticleFragmentMeta) =>
       dispatch(updateArticleFragmentMetaAction(uuid, meta)),
-    clearArticleFragmentSelection: () =>
-      dispatch(editorClearArticleFragmentSelection(frontId))
+    clearArticleFragmentSelection: (id: string) =>
+      dispatch(editorClearArticleFragmentSelection(id))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -17,6 +17,7 @@ import {
   selectSharedState,
   createArticlesInCollectionSelector
 } from 'shared/selectors/shared';
+import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUIBundle';
 
 interface FrontCollectionOverviewContainerProps {
   frontId: string;
@@ -29,6 +30,7 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
   articleCount: number;
   openCollection: (id: string) => void;
   hasUnpublishedChanges: boolean;
+  hasOpenForms: boolean;
 };
 
 const Container = styled.div`
@@ -100,7 +102,8 @@ const CollectionOverview = ({
   articleCount,
   openCollection,
   frontId,
-  hasUnpublishedChanges
+  hasUnpublishedChanges,
+  hasOpenForms
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
@@ -123,9 +126,18 @@ const CollectionOverview = ({
         <ItemCount>({articleCount})</ItemCount>
       </TextContainerLeft>
       <TextContainerRight>
+        {hasOpenForms && (
+          <StatusWarning
+            priority="default"
+            size="s"
+            title="Collection changes have not been launched"
+          >
+            !
+          </StatusWarning>
+        )}
         {collection &&
           collection.lastUpdated &&
-          (!!hasUnpublishedChanges ? (
+          (hasUnpublishedChanges ? (
             <StatusWarning
               priority="primary"
               size="s"
@@ -141,19 +153,29 @@ const CollectionOverview = ({
 const mapStateToProps = () => {
   const collectionSelector = createCollectionSelector();
   const articlesInCollectionSelector = createArticlesInCollectionSelector();
-
-  return (state: State, props: FrontCollectionOverviewContainerProps) => ({
+  const selectCollectionIdsWithOpenForms = createSelectCollectionIdsWithOpenForms();
+  return (
+    state: State,
+    {
+      collectionId,
+      browsingStage,
+      frontId
+    }: FrontCollectionOverviewContainerProps
+  ) => ({
     collection: collectionSelector(selectSharedState(state), {
-      collectionId: props.collectionId
+      collectionId
     }),
     articleCount: articlesInCollectionSelector(selectSharedState(state), {
-      collectionSet: props.browsingStage,
-      collectionId: props.collectionId,
+      collectionSet: browsingStage,
+      collectionId,
       includeSupportingArticles: false
     }).length,
     hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
-      collectionId: props.collectionId
-    })
+      collectionId
+    }),
+    hasOpenForms:
+      selectCollectionIdsWithOpenForms(state, frontId).indexOf(collectionId) !==
+      -1
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -112,6 +112,7 @@ type FrontProps = FrontPropsBeforeState & {
   initialiseFront: () => void;
   formIsOpen: boolean;
   selectArticleFragment: (
+    collectionId: string,
     frontId: string
   ) => (isSupporting?: boolean) => (id: string) => void;
   editorOpenCollections: (ids: string[]) => void;
@@ -233,6 +234,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                     handleInsert={this.handleInsert}
                     handleMove={this.handleMove}
                     selectArticleFragment={this.props.selectArticleFragment(
+                      collectionId,
                       this.props.id
                     )}
                     handleArticleFocus={this.handleArticleFocus}
@@ -280,11 +282,16 @@ const mapDispatchToProps = (
     dispatch,
     initialiseFront: () =>
       dispatch(initialiseCollectionsForFront(props.id, props.browsingStage)),
-    selectArticleFragment: (frontId: string) => (isSupporting?: boolean) => (
-      articleFragmentId: string
-    ) =>
+    selectArticleFragment: (collectionId: string, frontId: string) => (
+      isSupporting?: boolean
+    ) => (articleFragmentId: string) =>
       dispatch(
-        editorSelectArticleFragment(frontId, articleFragmentId, isSupporting)
+        editorSelectArticleFragment(
+          articleFragmentId,
+          collectionId,
+          frontId,
+          isSupporting
+        )
       ),
     editorOpenCollections: (ids: string[]) =>
       dispatch(editorOpenCollections(ids)),

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -13,7 +13,7 @@ import {
   editorOpenOverview,
   editorCloseOverview,
   selectIsFrontOverviewOpen,
-  selectEditorArticleFragment
+  selectOpenArticleFragmentForms
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
@@ -268,7 +268,7 @@ const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
   return {
     front: getFront(state, { frontId: props.id }),
     overviewIsOpen: selectIsFrontOverviewOpen(state, props.id),
-    formIsOpen: !!selectEditorArticleFragment(state, props.id)
+    formIsOpen: !!selectOpenArticleFragmentForms(state, props.id)
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -7,8 +7,7 @@ import { fetchLastPressed } from 'actions/Fronts';
 import { updateCollection } from 'actions/Collections';
 import {
   editorCloseFront,
-  selectIsFrontOverviewOpen,
-  selectOpenArticleFragmentForms
+  selectIsFrontOverviewOpen
 } from 'bundles/frontsUIBundle';
 import Button from 'shared/components/input/ButtonDefault';
 import { frontStages } from 'constants/fronts';
@@ -24,7 +23,6 @@ import { toTitleCase } from 'util/stringUtils';
 import { RadioButton, RadioGroup } from 'components/inputs/RadioButtons';
 import { PreviewEyeIcon, ClearIcon } from 'shared/components/icons/Icons';
 import { createFrontId } from 'util/editUtils';
-import { formMinWidth } from './ArticleFragmentForm';
 import { overviewMinWidth } from './FrontCollectionsOverview';
 
 const FrontHeader = styled(SectionHeader)`
@@ -57,7 +55,6 @@ const singleFrontMinWidth = 380;
 
 const SingleFrontContainer = styled('div')<{
   isOverviewOpen: boolean;
-  isFormOpen: boolean;
 }>`
   /**
    * We parameterise the min-width of the fronts container to handle the
@@ -66,10 +63,8 @@ const SingleFrontContainer = styled('div')<{
    * of the front container proportionally to keep the collection container the
    * same width.
    */
-  min-width: ${({ isOverviewOpen, isFormOpen }) =>
-    isFormOpen
-      ? singleFrontMinWidth + formMinWidth + 10
-      : isOverviewOpen
+  min-width: ${({ isOverviewOpen }) =>
+    isOverviewOpen
       ? singleFrontMinWidth + overviewMinWidth + 10
       : singleFrontMinWidth}px;
   flex: 1 1 auto;
@@ -126,7 +121,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
   };
 
   public render() {
-    const { frontId, isFormOpen, isOverviewOpen } = this.props;
+    const { frontId, isOverviewOpen } = this.props;
     const title =
       this.props.selectedFront &&
       startCase(
@@ -136,7 +131,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
       <SingleFrontContainer
         key={frontId}
         id={createFrontId(frontId)}
-        isFormOpen={isFormOpen}
         isOverviewOpen={isOverviewOpen}
       >
         <FrontContainer>
@@ -193,8 +187,7 @@ const createMapStateToProps = () => {
   return (state: State, props: FrontsContainerProps) => ({
     selectedFront: getFront(state, { frontId: props.frontId }),
     alsoOn: alsoOnSelector(state, { frontId: props.frontId }),
-    isOverviewOpen: selectIsFrontOverviewOpen(state, props.frontId),
-    isFormOpen: !!selectOpenArticleFragmentForms(state, props.frontId)
+    isOverviewOpen: selectIsFrontOverviewOpen(state, props.frontId)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -8,7 +8,7 @@ import { updateCollection } from 'actions/Collections';
 import {
   editorCloseFront,
   selectIsFrontOverviewOpen,
-  selectEditorArticleFragment
+  selectOpenArticleFragmentForms
 } from 'bundles/frontsUIBundle';
 import Button from 'shared/components/input/ButtonDefault';
 import { frontStages } from 'constants/fronts';
@@ -194,7 +194,7 @@ const createMapStateToProps = () => {
     selectedFront: getFront(state, { frontId: props.frontId }),
     alsoOn: alsoOnSelector(state, { frontId: props.frontId }),
     isOverviewOpen: selectIsFrontOverviewOpen(state, props.frontId),
-    isFormOpen: !!selectEditorArticleFragment(state, props.frontId)
+    isFormOpen: !!selectOpenArticleFragmentForms(state, props.frontId)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
@@ -1,18 +1,8 @@
 import React from 'react';
-import ArticleFragmentForm from './ArticleFragmentForm';
 import FrontCollectionsOverview from './FrontCollectionsOverview';
 import { connect } from 'react-redux';
-import {
-  ArticleFragmentMeta,
-  CollectionItemSets
-} from 'shared/types/Collection';
-import { updateArticleFragmentMeta as updateArticleFragmentMetaAction } from 'actions/ArticleFragments';
-import {
-  editorClearArticleFragmentSelection,
-  selectEditorArticleFragment,
-  selectIsFrontOverviewOpen
-} from 'bundles/frontsUIBundle';
-import { Dispatch } from 'types/Store';
+import { CollectionItemSets } from 'shared/types/Collection';
+import { selectIsFrontOverviewOpen } from 'bundles/frontsUIBundle';
 import { State } from 'types/State';
 
 interface ContainerProps {
@@ -21,36 +11,14 @@ interface ContainerProps {
 }
 
 interface ComponentProps extends ContainerProps {
-  selectedArticleFragment: { id: string; isSupporting: boolean } | void;
-  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) => void;
-  clearArticleFragmentSelection: (id: string) => void;
   overviewIsOpen: boolean;
 }
 
 const FrontsDetailView = ({
-  selectedArticleFragment,
   id,
   browsingStage,
-  clearArticleFragmentSelection,
-  updateArticleFragmentMeta,
   overviewIsOpen
 }: ComponentProps) => {
-  if (selectedArticleFragment) {
-    return (
-      <ArticleFragmentForm
-        articleFragmentId={selectedArticleFragment.id}
-        isSupporting={selectedArticleFragment.isSupporting}
-        key={selectedArticleFragment.id}
-        form={selectedArticleFragment.id}
-        frontId={id}
-        onSave={(meta: ArticleFragmentMeta) => {
-          updateArticleFragmentMeta(selectedArticleFragment.id, meta);
-          clearArticleFragmentSelection(id);
-        }}
-        onCancel={() => clearArticleFragmentSelection(id)}
-      />
-    );
-  }
   if (overviewIsOpen) {
     return <FrontCollectionsOverview id={id} browsingStage={browsingStage} />;
   }
@@ -58,18 +26,7 @@ const FrontsDetailView = ({
 };
 
 const mapStateToProps = (state: State, props: ContainerProps) => ({
-  selectedArticleFragment: selectEditorArticleFragment(state, props.id),
   overviewIsOpen: selectIsFrontOverviewOpen(state, props.id)
 });
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) =>
-    dispatch(updateArticleFragmentMetaAction(id, meta)),
-  clearArticleFragmentSelection: (frontId: string) =>
-    dispatch(editorClearArticleFragmentSelection(frontId))
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(FrontsDetailView);
+export default connect(mapStateToProps)(FrontsDetailView);

--- a/client-v2/src/components/inputs/ConditionalField.tsx
+++ b/client-v2/src/components/inputs/ConditionalField.tsx
@@ -5,15 +5,27 @@ import { BaseFieldProps } from 'redux-form';
 
 interface Props extends BaseFieldProps {
   permittedFields?: string[];
+  container?: React.ComponentType;
 }
 
-const ConditionalField = <P extends {}>(props: Props & P) => (
-  <ConditionalComponent
-    name={props.name}
-    permittedNames={props.permittedFields}
-  >
-    <Field<Props & P> {...props} />
-  </ConditionalComponent>
-);
+const ConditionalField = <P extends {}>({
+  container: Container,
+  ...rest
+}: Props & P) => {
+  const FieldComponent = <Field<Props & P> {...rest} />;
+  const Component = Container ? (
+    <Container>{FieldComponent}</Container>
+  ) : (
+    FieldComponent
+  );
+  return (
+    <ConditionalComponent
+      name={rest.name}
+      permittedNames={rest.permittedFields}
+    >
+      {Component}
+    </ConditionalComponent>
+  );
+};
 
 export default ConditionalField;

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -13,7 +13,8 @@ const base = {
     dropZone: '#D6D6D6',
     frontListBorder: '#5E5E5E',
     frontListLabel: shared.colors.greyMediumLight,
-    frontListButton: shared.colors.greyDark
+    frontListButton: shared.colors.greyDark,
+    formBackground: '#dcdcdc'
   }
 };
 

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -2,6 +2,7 @@ import { styled } from 'shared/constants/theme';
 
 const ThumbnailBase = styled('div')`
   background-size: cover;
+  background-position: center;
   background-color: ${({ theme }) =>
     theme.shared.base.colors.backgroundColorFocused};
 `;
@@ -28,7 +29,7 @@ const ThumbnailEditForm = styled(ThumbnailBase)<{
   url: string | undefined | void;
 }>`
   width: 100%;
-  height: 115px
+  height: 90px;
   margin-bottom: 10px;
   opacity: ${({ imageHide }) => (imageHide ? 0.5 : 1)};
   background-image: ${({ url }) => `url('${url}')`};

--- a/client-v2/src/shared/components/input/InputBase.ts
+++ b/client-v2/src/shared/components/input/InputBase.ts
@@ -1,30 +1,22 @@
 import { styled } from 'shared/constants/theme';
+import { theme } from 'constants/theme';
 
-export default styled('input')<{
-  useHeadlineFont?: boolean;
-}>`
+export default styled('input')`
   display: block;
   appearance: none;
-  height: ${props => props.theme.shared.input.height};
-  padding: ${props => props.theme.shared.input.paddingY}
-    ${props => props.theme.shared.input.paddingX};
-  font-size: ${props =>
-    props.useHeadlineFont
-      ? props.theme.shared.input.fontSizeHeadline
-      : props.theme.shared.input.fontSize};
-  color: ${props => props.theme.shared.input.color};
-  background-color: ${props => props.theme.shared.input.backgroundColor};
-  border: 1px solid ${props => props.theme.shared.input.borderColor};
+  height: ${theme.shared.input.height};
+  padding: ${theme.shared.input.paddingY} ${theme.shared.input.paddingX};
+  font-size: ${theme.shared.input.fontSize};
+  color: ${theme.shared.input.color};
+  background-color: ${theme.shared.input.backgroundColor};
+  border: 1px solid ${theme.shared.input.borderColor};
   width: 100%;
   background-clip: padding-box;
-  ${props =>
-    props.useHeadlineFont &&
-    `font-family: GHGuardianHeadline; font-weight: 500`};
   ::placeholder {
-    color: ${props => props.theme.shared.input.placeholderText};
+    color: ${theme.shared.input.placeholderText};
   }
   :focus {
     outline: none;
-    border: solid 1px ${props => props.theme.shared.input.borderColorFocus};
+    border: solid 1px ${theme.shared.input.borderColorFocus};
   }
 `;

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -7,6 +7,7 @@ import InputContainer from './InputContainer';
 
 const CheckboxContainer = styled('div')<{ addBorder: boolean }>`
   display: flex;
+  align-items: center;
   ${({ addBorder }) =>
     addBorder &&
     css`
@@ -17,7 +18,9 @@ const CheckboxContainer = styled('div')<{ addBorder: boolean }>`
 `;
 
 const Label = InputLabel.extend`
+  padding-left: 5px;
   color: ${props => props.theme.shared.input.colorLabel};
+  line-height: 16px;
   flex: 1;
   cursor: pointer;
 `;
@@ -38,7 +41,8 @@ const CheckboxLabel = styled('label')`
   height: 24px;
   padding: 0;
   line-height: 24px;
-  border: ${({ theme }) => `2px solid ${theme.shared.input.checkboxBorderColor}`};
+  border: ${({ theme }) =>
+    `2px solid ${theme.shared.input.checkboxBorderColor}`};
   border-radius: 24px;
   background-color: ${({ theme }) => theme.shared.input.checkboxBorderColor};
   transition: background-color 0.1s ease-in;
@@ -53,7 +57,8 @@ const CheckboxLabel = styled('label')`
     top: 0;
     bottom: 0;
     right: 16px;
-    border: ${({ theme }) => `2px solid ${theme.shared.input.checkboxBorderColor}`};
+    border: ${({ theme }) =>
+      `2px solid ${theme.shared.input.checkboxBorderColor}`};
     border-radius: 24px;
     transition: all 0.1s ease-in 0s;
   }
@@ -88,9 +93,6 @@ export default ({
   <>
     <InputContainer data-testid={dataTestId}>
       <CheckboxContainer addBorder={addBorder}>
-        <Label htmlFor={id} size="sm">
-          {label}
-        </Label>
         <Switch>
           <Checkbox
             type="checkbox"
@@ -101,6 +103,9 @@ export default ({
           />
           <CheckboxLabel htmlFor={id} />
         </Switch>
+        <Label htmlFor={id} size="sm">
+          {label}
+        </Label>
       </CheckboxContainer>
     </InputContainer>
   </>

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -1,33 +1,29 @@
-import { styled, css } from 'shared/constants/theme';
+import { styled } from 'shared/constants/theme';
 import React from 'react';
 import { WrappedFieldProps } from 'redux-form';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
 
-const CheckboxContainer = styled('div')<{ addBorder: boolean }>`
+const checkboxHeight = 15;
+const checkboxWidth = 24;
+
+const CheckboxContainer = styled('div')`
   display: flex;
   align-items: center;
-  ${({ addBorder }) =>
-    addBorder &&
-    css`
-      border-bottom: ${({ theme }) =>
-        `1px solid ${theme.shared.base.colors.borderColor}`};
-      padding-bottom: 6px;
-    `}
 `;
 
 const Label = InputLabel.extend`
   padding-left: 5px;
   color: ${props => props.theme.shared.input.colorLabel};
-  line-height: 16px;
+  line-height: 15px;
   flex: 1;
   cursor: pointer;
 `;
 
 const Switch = styled('div')`
   position: relative;
-  width: 40px;
+  width: ${checkboxWidth}px;
   margin-left: auto;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -38,28 +34,28 @@ const CheckboxLabel = styled('label')`
   display: block;
   overflow: hidden;
   cursor: pointer;
-  height: 24px;
+  height: ${checkboxHeight}px;
   padding: 0;
-  line-height: 24px;
+  line-height: ${checkboxHeight}px;
   border: ${({ theme }) =>
     `2px solid ${theme.shared.input.checkboxBorderColor}`};
-  border-radius: 24px;
+  border-radius: ${checkboxHeight}px;
   background-color: ${({ theme }) => theme.shared.input.checkboxBorderColor};
   transition: background-color 0.1s ease-in;
   :before {
     content: '';
     display: block;
-    width: 24px;
-    height: 24px;
+    width: ${checkboxHeight}px;
+    height: ${checkboxHeight}px;
     margin: 0px;
     background: ${({ theme }) => theme.shared.input.checkboxColorInactive};
     position: absolute;
     top: 0;
     bottom: 0;
-    right: 16px;
+    right: ${checkboxWidth - checkboxHeight}px;
     border: ${({ theme }) =>
       `2px solid ${theme.shared.input.checkboxBorderColor}`};
-    border-radius: 24px;
+    border-radius: ${checkboxHeight}px;
     transition: all 0.1s ease-in 0s;
   }
 `;
@@ -79,20 +75,18 @@ type Props = {
   label?: string;
   id: string;
   dataTestId: string;
-  addBorder?: boolean;
 } & WrappedFieldProps;
 
 export default ({
   label,
   id,
   dataTestId,
-  addBorder = true,
   input: { onChange, ...inputRest },
   ...rest
 }: Props) => (
   <>
     <InputContainer data-testid={dataTestId}>
-      <CheckboxContainer addBorder={addBorder}>
+      <CheckboxContainer>
         <Switch>
           <Checkbox
             type="checkbox"

--- a/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggle.tsx
@@ -1,17 +1,23 @@
-import { styled } from 'shared/constants/theme';
+import { styled, css } from 'shared/constants/theme';
 import React from 'react';
 import { WrappedFieldProps } from 'redux-form';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
-import HorizontalRule from '../layout/HorizontalRule';
 
-const CheckboxContainer = styled('div')`
+const CheckboxContainer = styled('div')<{ addBorder: boolean }>`
   display: flex;
+  ${({ addBorder }) =>
+    addBorder &&
+    css`
+      border-bottom: ${({ theme }) =>
+        `1px solid ${theme.shared.base.colors.borderColor}`};
+      padding-bottom: 6px;
+    `}
 `;
 
 const Label = InputLabel.extend`
-  color: ${props => props.theme.shared.base.colors.textMuted};
+  color: ${props => props.theme.shared.input.colorLabel};
   flex: 1;
   cursor: pointer;
 `;
@@ -32,9 +38,9 @@ const CheckboxLabel = styled('label')`
   height: 24px;
   padding: 0;
   line-height: 24px;
-  border: ${({ theme }) => `2px solid ${theme.shared.input.borderColor}`};
+  border: ${({ theme }) => `2px solid ${theme.shared.input.checkboxBorderColor}`};
   border-radius: 24px;
-  background-color: ${({ theme }) => theme.shared.input.checkboxColorInactive};
+  background-color: ${({ theme }) => theme.shared.input.checkboxBorderColor};
   transition: background-color 0.1s ease-in;
   :before {
     content: '';
@@ -47,7 +53,7 @@ const CheckboxLabel = styled('label')`
     top: 0;
     bottom: 0;
     right: 16px;
-    border: ${({ theme }) => `2px solid ${theme.shared.input.borderColor}`};
+    border: ${({ theme }) => `2px solid ${theme.shared.input.checkboxBorderColor}`};
     border-radius: 24px;
     transition: all 0.1s ease-in 0s;
   }
@@ -68,18 +74,20 @@ type Props = {
   label?: string;
   id: string;
   dataTestId: string;
+  addBorder?: boolean;
 } & WrappedFieldProps;
 
 export default ({
   label,
   id,
   dataTestId,
+  addBorder = true,
   input: { onChange, ...inputRest },
   ...rest
 }: Props) => (
   <>
     <InputContainer data-testid={dataTestId}>
-      <CheckboxContainer>
+      <CheckboxContainer addBorder={addBorder}>
         <Label htmlFor={id} size="sm">
           {label}
         </Label>
@@ -95,6 +103,5 @@ export default ({
         </Switch>
       </CheckboxContainer>
     </InputContainer>
-    <HorizontalRule noMargin />
   </>
 );

--- a/client-v2/src/shared/components/input/InputGroup.ts
+++ b/client-v2/src/shared/components/input/InputGroup.ts
@@ -2,8 +2,8 @@ import { styled } from 'shared/constants/theme';
 import InputContainer from './InputContainer';
 
 export default styled('div')`
-  & > ${InputContainer} {
-    margin: 6px 0;
+  & ${InputContainer} {
+    margin: 4px 0;
   }
   padding-bottom: 4px;
 `;

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -32,7 +32,7 @@ const ImageContainer = styled('div')<{
   position: relative;
   width: 100%;
   ${props => props.small && 'max-width: 100px'};
-  height: ${props => (props.small ? '60px' : '115px')};
+  height: ${props => (props.small ? '60px' : '90px')};
   background-size: cover;
   transition: background-color 0.15s;
   border-left: ${props =>

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -31,7 +31,7 @@ const ImageContainer = styled('div')<{
   flex-direction: column;
   position: relative;
   width: 100%;
-  max-width: ${props => (props.small ? '100px' : '180px')};
+  ${props => props.small && 'max-width: 100px'};
   height: ${props => (props.small ? '60px' : '115px')};
   background-size: cover;
   transition: background-color 0.15s;

--- a/client-v2/src/shared/components/input/InputLabel.ts
+++ b/client-v2/src/shared/components/input/InputLabel.ts
@@ -6,7 +6,7 @@ export default styled('label')<{
   hidden?: boolean;
   for?: string;
 }>`
-  display: ${props => (props.hidden ? 'none' : 'block')};
+  display: ${props => (props.hidden ? 'none' : 'inline-block')};
   font-size: ${props =>
     props.size === 'sm'
       ? props.theme.shared.label.fontSizeSmall
@@ -14,4 +14,5 @@ export default styled('label')<{
   line-height: ${props => props.theme.shared.label.lineHeight};
   font-weight: bold;
   ${props => !props.active && `color:`};
+  cursor: pointer;
 `;

--- a/client-v2/src/shared/components/layout/HideableFormSection.tsx
+++ b/client-v2/src/shared/components/layout/HideableFormSection.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { DownCaretIcon } from '../icons/Icons';
+import { styled, theme } from 'shared/constants/theme';
+import InputLabel from '../input/InputLabel';
+
+interface Props {
+  label: string;
+}
+
+const HideableFormSectionContainer = styled.div`
+  border-bottom: 1px solid ${theme.base.colors.borderColor};
+`;
+
+const FormSectionHeader = styled.div`
+  padding-top: 6px;
+  margin-bottom: 6px;
+  cursor: pointer;
+`;
+
+const CaretContainer = styled.span<{ isOpen: boolean }>`
+  display: inline-block;
+  margin-left: 5px;
+  vertical-align: middle;
+  transition: transform 0.15s;
+  ${({ isOpen }) =>
+    isOpen ? `transform: rotate(90deg)` : `transform: rotate(-90deg)`};
+`;
+
+const HideableFormSection: React.SFC<Props> = ({ children, label }) => {
+  const [isOpen, setOpenState] = useState(false);
+  const id = `HideableFormSection-${label}`;
+  return (
+    <HideableFormSectionContainer>
+      <FormSectionHeader onClick={() => setOpenState(!isOpen)}>
+        <InputLabel htmlFor={id}>{label}</InputLabel>
+        <CaretContainer id={id} isOpen={isOpen}>
+          <DownCaretIcon />
+        </CaretContainer>
+      </FormSectionHeader>
+      {isOpen ? children : null}
+    </HideableFormSectionContainer>
+  );
+};
+
+export default HideableFormSection;

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -63,11 +63,10 @@ const button = {
 };
 
 const input = {
-  height: '34px',
+  height: '30px',
   paddingY: '3px',
   paddingX: '5px',
   fontSize: '14px',
-  fontSizeHeadline: '16px',
   color: base.colors.text,
   colorLabel: colors.greyMediumDarkish,
   backgroundColor: base.colors.backgroundColorLight,

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -5,13 +5,18 @@
  *  with : `import { styled } from 'shared/constants/theme';`
  */
 
-import baseStyled, { ThemedStyledInterface } from 'styled-components';
+import baseStyled, {
+  css as baseCss,
+  ThemedStyledInterface
+} from 'styled-components';
+import { ThemedCssFunction } from 'styled-components';
 
 const colors = {
   blackDark: '#121212', // darkest
   blackLight: '#333',
   greyDark: '#444444',
   greyMediumDark: '#515151',
+  greyMediumDarkish: '#676767',
   greyMedium: '#767676',
   greyMediumLight: '#999999',
   greyLight: '#A9A9A9',
@@ -64,11 +69,12 @@ const input = {
   fontSize: '14px',
   fontSizeHeadline: '16px',
   color: base.colors.text,
+  colorLabel: colors.greyMediumDarkish,
   backgroundColor: base.colors.backgroundColorLight,
   borderColor: base.colors.borderColor,
+  checkboxBorderColor: colors.greyLight,
   borderColorFocus: base.colors.borderColorFocus,
   checkboxColorInactive: base.colors.backgroundColorLight,
-  checkboxBorderColorInactive: base.colors.borderColor,
   checkboxColorActive: base.colors.highlightColor,
   placeholderText: base.colors.placeholderDark
 };
@@ -92,3 +98,4 @@ interface SharedTheme {
   shared: Theme;
 }
 export const styled = baseStyled as ThemedStyledInterface<SharedTheme>;
+export const css = baseCss as ThemedCssFunction<SharedTheme>;

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -108,6 +108,7 @@ interface EditorSelectArticleFragment {
   payload: {
     articleFragmentId: string;
     frontId: string;
+    collectionId: string;
     isSupporting: boolean;
   };
 }

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -115,7 +115,7 @@ interface EditorSelectArticleFragment {
 interface EditorClearArticleFragmentSelection {
   type: typeof EDITOR_CLEAR_ARTICLE_FRAGMENT_SELECTION;
   payload: {
-    frontId: string;
+    articleFragmentId: string;
   };
 }
 

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -219,3 +219,16 @@ export const getArticleFragmentMetaFromFormValues = (
     return value === undefined;
   });
 };
+
+export const shouldRenderField = (
+  name: string | string[],
+  permittedNames?: string[]
+) => {
+  const names = Array.isArray(name) ? name : [name];
+  for (const nameIndex in names) {
+    if (!permittedNames || permittedNames.indexOf(names[nameIndex]) !== -1) {
+      return true;
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
NB: This is a WIP, and is likely to change significantly before it's ready for review.

## What's changed?

Adds an option to open forms inline with the collection. At the moment, this replaces the form on the right hand side, but this is likely to move to a settings-based option where the user can choose one or the other.

![inline](https://user-images.githubusercontent.com/7767575/60585616-07979b00-9d88-11e9-8d67-9d8d5e239b69.gif)

## Implementation notes

TBC

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
