### PR TITLE
Expand all

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -7,7 +7,8 @@ import Button from 'shared/components/input/ButtonDefault';
 import { AlsoOnDetail } from 'types/Collection';
 import {
   publishCollection,
-  discardDraftChangesToCollection
+  discardDraftChangesToCollection,
+  openCollectionsAndFetchTheirArticles
 } from 'actions/Collections';
 import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
 import { isCollectionLockedSelector } from 'selectors/collectionSelectors';
@@ -22,7 +23,6 @@ import {
 } from 'shared/selectors/shared';
 import {
   selectIsCollectionOpen,
-  editorOpenCollections,
   editorCloseCollections,
   selectHasMultipleFrontsOpen,
   selectEditorArticleFragment
@@ -252,8 +252,7 @@ const mapDispatchToProps = (
     if (isOpen) {
       dispatch(editorCloseCollections(id));
     } else {
-      dispatch(getArticlesForCollections([id], browsingStage));
-      dispatch(editorOpenCollections(id));
+      dispatch(openCollectionsAndFetchTheirArticles([id], browsingStage));
     }
   },
   fetchPreviousCollectionArticles: (id: string) => {

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -13,7 +13,8 @@ import {
   editorOpenOverview,
   editorCloseOverview,
   selectIsFrontOverviewOpen,
-  selectEditorArticleFragment
+  selectEditorArticleFragment,
+  editorCloseCollections
 } from 'bundles/frontsUIBundle';
 import {
   CollectionItemSets,
@@ -25,14 +26,16 @@ import { events } from 'services/GA';
 import FrontDetailView from './FrontDetailView';
 import {
   initialiseCollectionsForFront,
-  closeCollections
+  openCollectionsAndFetchTheirArticles
 } from 'actions/Collections';
 import { setFocusState } from 'bundles/focusBundle';
 import Collection from './Collection';
 import { DownCaretIcon } from 'shared/components/icons/Icons';
 import { theme as sharedTheme } from 'shared/constants/theme';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
-import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLabel';
+import ButtonRoundedWithLabel, {
+  ButtonLabel
+} from 'shared/components/input/ButtonRoundedWithLabel';
 
 const FrontContainer = styled('div')`
   height: 100%;
@@ -63,7 +66,6 @@ const OverviewHeading = styled('label')`
 
 const CollapseAllButton = styled(ButtonRoundedWithLabel)`
   & svg {
-    transform: rotate(180deg);
     vertical-align: middle;
   }
   :hover {
@@ -124,6 +126,7 @@ type FrontProps = FrontPropsBeforeState & {
   toggleOverview: (open: boolean) => void;
   overviewIsOpen: boolean;
   closeAllCollections: (collections: string[]) => void;
+  openAllCollections: (collections: string[]) => void;
 };
 
 interface FrontState {
@@ -196,11 +199,24 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
               <CollapseAllButton
                 onClick={e => {
                   e.preventDefault();
+                  this.props.openAllCollections(this.props.collectionIds);
+                }}
+              >
+                <ButtonLabel>{'Expand all '}</ButtonLabel>
+                <DownCaretIcon
+                  fill={sharedTheme.base.colors.text}
+                  direction="down"
+                />
+              </CollapseAllButton>
+              <CollapseAllButton
+                onClick={e => {
+                  e.preventDefault();
                   this.props.closeAllCollections(this.props.collectionIds);
                 }}
-                icon={<DownCaretIcon fill={sharedTheme.base.colors.text} />}
-                label={'Collapse all'}
-              />
+              >
+                <ButtonLabel>{'Collapse all '}</ButtonLabel>
+                <DownCaretIcon fill={sharedTheme.base.colors.text} />
+              </CollapseAllButton>
               <OverviewToggleContainer>
                 <OverviewHeading htmlFor={overviewToggleId}>
                   {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
@@ -264,22 +280,22 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
   };
 }
 
-const mapStateToProps = (state: State, props: FrontPropsBeforeState) => {
+const mapStateToProps = (state: State, { id }: FrontPropsBeforeState) => {
   return {
-    front: getFront(state, { frontId: props.id }),
-    overviewIsOpen: selectIsFrontOverviewOpen(state, props.id),
-    formIsOpen: !!selectEditorArticleFragment(state, props.id)
+    front: getFront(state, { frontId: id }),
+    overviewIsOpen: selectIsFrontOverviewOpen(state, id),
+    formIsOpen: !!selectEditorArticleFragment(state, id)
   };
 };
 
 const mapDispatchToProps = (
   dispatch: Dispatch,
-  props: FrontPropsBeforeState
+  { id, browsingStage }: FrontPropsBeforeState
 ) => {
   return {
     dispatch,
     initialiseFront: () =>
-      dispatch(initialiseCollectionsForFront(props.id, props.browsingStage)),
+      dispatch(initialiseCollectionsForFront(id, browsingStage)),
     selectArticleFragment: (frontId: string) => (isSupporting?: boolean) => (
       articleFragmentId: string
     ) =>
@@ -302,11 +318,11 @@ const mapDispatchToProps = (
         })
       ),
     toggleOverview: (open: boolean) =>
-      dispatch(
-        open ? editorOpenOverview(props.id) : editorCloseOverview(props.id)
-      ),
+      dispatch(open ? editorOpenOverview(id) : editorCloseOverview(id)),
     closeAllCollections: (collections: string[]) =>
-      dispatch(closeCollections(collections))
+      dispatch(editorCloseCollections(collections)),
+    openAllCollections: (collections: string[]) =>
+      dispatch(openCollectionsAndFetchTheirArticles(collections, browsingStage))
   };
 };
 

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -202,7 +202,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                   this.props.openAllCollections(this.props.collectionIds);
                 }}
               >
-                <ButtonLabel>{'Expand all '}</ButtonLabel>
+                <ButtonLabel>Expand all&nbsp;</ButtonLabel>
                 <DownCaretIcon
                   fill={sharedTheme.base.colors.text}
                   direction="down"
@@ -214,7 +214,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                   this.props.closeAllCollections(this.props.collectionIds);
                 }}
               >
-                <ButtonLabel>{'Collapse all '}</ButtonLabel>
+                <ButtonLabel>Collapse all&nbsp;</ButtonLabel>
                 <DownCaretIcon fill={sharedTheme.base.colors.text} />
               </CollapseAllButton>
               <OverviewToggleContainer>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -64,7 +64,7 @@ const OverviewHeading = styled('label')`
   cursor: pointer;
 `;
 
-const CollapseAllButton = styled(ButtonRoundedWithLabel)`
+const OverviewHeadingButton = styled(ButtonRoundedWithLabel)`
   & svg {
     vertical-align: middle;
   }
@@ -196,7 +196,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         <FrontContainer>
           <FrontContentContainer>
             <SectionContentMetaContainer>
-              <CollapseAllButton
+              <OverviewHeadingButton
                 onClick={e => {
                   e.preventDefault();
                   this.props.openAllCollections(this.props.collectionIds);
@@ -207,8 +207,8 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                   fill={sharedTheme.base.colors.text}
                   direction="down"
                 />
-              </CollapseAllButton>
-              <CollapseAllButton
+              </OverviewHeadingButton>
+              <OverviewHeadingButton
                 onClick={e => {
                   e.preventDefault();
                   this.props.closeAllCollections(this.props.collectionIds);
@@ -216,7 +216,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
               >
                 <ButtonLabel>Collapse all&nbsp;</ButtonLabel>
                 <DownCaretIcon fill={sharedTheme.base.colors.text} />
-              </CollapseAllButton>
+              </OverviewHeadingButton>
               <OverviewToggleContainer>
                 <OverviewHeading htmlFor={overviewToggleId}>
                   {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -7,6 +7,10 @@ interface IconProps {
   title?: string | null;
 }
 
+interface Directions {
+  direction?: 'up' | 'down';
+}
+
 type IconSizes = 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'fill';
 const IconSizeMap = {
   xxs: 10,
@@ -20,10 +24,16 @@ const IconSizeMap = {
 };
 const mapSize = (size: IconSizes): number | string => IconSizeMap[size];
 
-const DownCaretIcon = ({ fill, size = 'm', title = null }: IconProps) => (
+const DownCaretIcon = ({
+  fill,
+  size = 'm',
+  title = null,
+  direction = 'up'
+}: IconProps & Directions) => (
   <svg
     width={mapSize(size)}
     height={mapSize(size)}
+    transform={direction === 'down' ? 'none' : 'rotate(180)'}
     viewBox="0 0 30 30"
     xmlns="http://www.w3.org/2000/svg"
     xmlnsXlink="http://www.w3.org/1999/xlink"

--- a/client-v2/src/shared/components/input/ButtonRoundedWithLabel.tsx
+++ b/client-v2/src/shared/components/input/ButtonRoundedWithLabel.tsx
@@ -1,14 +1,6 @@
-import React, { ReactNode } from 'react';
 import { styled } from 'shared/constants/theme';
 
-interface ContainerButtonWithLabelProps {
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  label: string;
-  icon?: ReactNode | null;
-  className?: string;
-}
-
-const ContainerButton = styled('button')`
+export default styled.button`
   cursor: pointer;
   font-family: TS3TextSans;
   font-weight: bold;
@@ -21,19 +13,7 @@ const ContainerButton = styled('button')`
   }
 `;
 
-const Label = styled('div')`
+export const ButtonLabel = styled.div`
   display: inline-block;
-  padding: 3px 5px 3px 0;
+  vertical-align: middle;
 `;
-
-export default ({
-  onClick,
-  label,
-  icon,
-  className
-}: ContainerButtonWithLabelProps) => (
-  <ContainerButton className={className} onClick={onClick}>
-    <Label>{label}</Label>
-    {!!icon ? icon : null}
-  </ContainerButton>
-);


### PR DESCRIPTION
## What's changed?

Add an 'expand all' button to the fronts header. It opens all of the collections for that front.

<img width="609" alt="Screenshot 2019-07-03 at 15 22 32" src="https://user-images.githubusercontent.com/7767575/60599467-69ff9400-9da6-11e9-8ef1-76b9d848287b.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
