### PR TITLE
Initial publishing scaffolding

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -26,7 +26,8 @@ import play.api.db.HikariCPComponents
 import services.editions.db.EditionsDB
 import services.editions.publishing.{EditionsPublishing, PublishedIssuesBucket}
 
-class AppComponents(context: Context, val config: ApplicationConfiguration) extends BaseFaciaControllerComponents(context) with EvolutionsComponents with DBComponents with HikariCPComponents {
+class AppComponents(context: Context, val config: ApplicationConfiguration)
+  extends BaseFaciaControllerComponents(context) with EvolutionsComponents with DBComponents with HikariCPComponents {
 
   applicationEvolutions
 

--- a/app/Components.scala
+++ b/app/Components.scala
@@ -13,7 +13,7 @@ import router.Routes
 import scalikejdbc.DB
 import scalikejdbc.config.DBs
 import services._
-import services.editions.{EditionsDB, EditionsTemplating}
+import services.editions.EditionsTemplating
 import slices.{Containers, FixedContainers}
 import thumbnails.ContainerThumbnails
 import tools.FaciaApiIO
@@ -23,14 +23,16 @@ import scalikejdbc._
 import play.api.db.evolutions.EvolutionsComponents
 import play.api.db.DBComponents
 import play.api.db.HikariCPComponents
+import services.editions.db.EditionsDB
+import services.editions.publishing.{EditionsPublishing, PublishedIssuesBucket}
 
 class AppComponents(context: Context, val config: ApplicationConfiguration) extends BaseFaciaControllerComponents(context) with EvolutionsComponents with DBComponents with HikariCPComponents {
 
   applicationEvolutions
 
+  val isDev: Boolean = context.environment.mode == Mode.Dev
   val isTest: Boolean = context.environment.mode == Mode.Test
   val isProd: Boolean = context.environment.mode == Mode.Prod
-  val isDev: Boolean = context.environment.mode == Mode.Dev
 
   // Services
   val awsEndpoints = new AwsEndpoints(config)
@@ -41,7 +43,10 @@ class AppComponents(context: Context, val config: ApplicationConfiguration) exte
   // Editions services
   val editionsDb = new EditionsDB(config)
   val templating = new EditionsTemplating(capi)
+  val publishingBucket = new PublishedIssuesBucket(config, awsEndpoints)
+  val editionsPublishing = new EditionsPublishing(publishingBucket, editionsDb)
 
+  // Controllers
   val frontsApi = new FrontsApi(config, awsEndpoints)
   val s3FrontsApi = new S3FrontsApi(config, isTest, awsEndpoints)
   val faciaApiIO = new FaciaApiIO(frontsApi, s3FrontsApi)
@@ -64,7 +69,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration) exte
   override lazy val httpErrorHandler = new LoggingHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
 
 //  Controllers
-  val editions = new EditionsController(editionsDb, templating, this)
+  val editions = new EditionsController(editionsDb, templating, editionsPublishing, this)
   val collection = new CollectionController(acl, structuredLogger, updateManager, press, this)
   val defaults = new DefaultsController(acl, isDev, this)
   val faciaCapiProxy = new FaciaContentApiProxy(capi, this)

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -80,6 +80,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     lazy val region = getMandatoryString("aws.region")
     lazy val bucket = getMandatoryString("aws.bucket")
     lazy val frontsBucket = getMandatoryString("aws.frontsBucket")
+    lazy val publishedEditionsIssuesBucket = getMandatoryString("aws.publishedEditionsIssuesBucket")
 
     def cmsFrontsAccountCredentials: AWSCredentialsProvider = credentials.getOrElse(throw new BadConfigurationException("AWS credentials are not configured for CMS Fronts"))
     val credentials: Option[AWSCredentialsProvider] = {

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -75,7 +75,7 @@ class EditionsController(db: EditionsDB,
 
   def getPreviewEdition(id: String) = AccessAPIAuthAction { _ =>
     db.getIssue(id).map { issue =>
-      Ok(Json.toJson(issue.toPublishedIssue()))
+      Ok(Json.toJson(issue.toPublishedIssue))
     }.getOrElse(NotFound(s"Issue $id not found"))
   }
 

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -1,13 +1,13 @@
 package model.editions
 
-import com.gu.editions.PublishedArticle
+import com.gu.editions.{PublishedArticle, PublishedArticleMetadata}
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
 case class EditionsArticle(pageCode: String, addedOn: Long) {
-  def toPublishedArticle(): PublishedArticle = PublishedArticle(
+  def toPublishedArticle: PublishedArticle = PublishedArticle(
     pageCode.toLong,
-    None
+    PublishedArticleMetadata(None, None, None) // TODO (sihil): Store in DB and populate here
   )
 }
 

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -1,9 +1,15 @@
 package model.editions
 
+import com.gu.editions.PublishedArticle
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
-case class EditionsArticle(pageCode: String, addedOn: Long)
+case class EditionsArticle(pageCode: String, addedOn: Long) {
+  def toPublishedArticle(): PublishedArticle = PublishedArticle(
+    pageCode.toLong,
+    None
+  )
+}
 
 object EditionsArticle {
   implicit val writes = Json.format[EditionsArticle]

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -1,8 +1,7 @@
 package model.editions
 
-import java.time.ZonedDateTime
+import com.gu.editions.PublishedCollection
 import play.api.libs.json.Json
-
 import scalikejdbc.WrappedResultSet
 
 case class EditionsCollection(
@@ -14,7 +13,12 @@ case class EditionsCollection(
                                updatedEmail: Option[String],
                                prefill: Option[CapiPrefillQuery],
                                items: List[EditionsArticle],
-)
+) {
+  def toPublishedCollection(): PublishedCollection = PublishedCollection(
+    id,
+    items.map(_.toPublishedArticle)
+  )
+}
 
 object EditionsCollection {
   implicit val format = Json.format[EditionsCollection]

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -14,7 +14,7 @@ case class EditionsCollection(
                                prefill: Option[CapiPrefillQuery],
                                items: List[EditionsArticle],
 ) {
-  def toPublishedCollection(): PublishedCollection = PublishedCollection(
+  def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
     items.map(_.toPublishedArticle)
   )

--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -14,11 +14,16 @@ case class EditionsFront(
     updatedEmail: Option[String],
     collections: List[EditionsCollection]
 ) {
-  def toPublishedFront(): PublishedFront = PublishedFront(
-    id,
-    isHidden,
-    collections.map(_.toPublishedCollection)
-  )
+  def toPublishedFront: Option[PublishedFront] = {
+    if (isHidden)
+      None
+    else
+      Some(PublishedFront(
+        id,
+        displayName,
+        collections.map(_.toPublishedCollection)
+      ))
+  }
 }
 
 object EditionsFront {

--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -1,8 +1,7 @@
 package model.editions
 
-import java.time.ZonedDateTime
+import com.gu.editions.PublishedFront
 import play.api.libs.json.Json
-
 import scalikejdbc.WrappedResultSet
 
 case class EditionsFront(
@@ -14,7 +13,13 @@ case class EditionsFront(
     updatedBy: Option[String],
     updatedEmail: Option[String],
     collections: List[EditionsCollection]
-)
+) {
+  def toPublishedFront(): PublishedFront = PublishedFront(
+    id,
+    isHidden,
+    collections.map(_.toPublishedCollection)
+  )
+}
 
 object EditionsFront {
   implicit val writes = Json.writes[EditionsFront]

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import java.time.{Instant, ZoneId, ZonedDateTime}
+import java.time.{Instant, OffsetDateTime, ZoneId, ZonedDateTime}
 
 import com.gu.editions.PublishedIssue
 import play.api.libs.json.Json
@@ -19,11 +19,11 @@ case class EditionsIssue(
     launchedEmail: Option[String],
     fronts: List[EditionsFront]
 ) {
-  def toPublishedIssue(): PublishedIssue = PublishedIssue(
+  def toPublishedIssue: PublishedIssue = PublishedIssue(
     id,
     displayName,
-    ZonedDateTime.ofInstant(Instant.ofEpochMilli(issueDate), ZoneId.of(timezoneId)),
-    fronts.map(_.toPublishedFront)
+    OffsetDateTime.ofInstant(Instant.ofEpochMilli(issueDate), ZoneId.of(timezoneId)),
+    fronts.flatMap(_.toPublishedFront)
   )
 }
 

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -1,7 +1,8 @@
 package model.editions
 
-import java.time.ZonedDateTime
+import java.time.{Instant, ZoneId, ZonedDateTime}
 
+import com.gu.editions.PublishedIssue
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
@@ -17,7 +18,14 @@ case class EditionsIssue(
     launchedBy: Option[String],
     launchedEmail: Option[String],
     fronts: List[EditionsFront]
-)
+) {
+  def toPublishedIssue(): PublishedIssue = PublishedIssue(
+    id,
+    displayName,
+    ZonedDateTime.ofInstant(Instant.ofEpochMilli(issueDate), ZoneId.of(timezoneId)),
+    fronts.map(_.toPublishedFront)
+  )
+}
 
 object EditionsIssue {
   implicit val writes = Json.writes[EditionsIssue]

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -1,12 +1,12 @@
-package services.editions
+package services.editions.db
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
-import services.editions.CollectionsHelpers._
-import model.editions._
+import model.editions.EditionsCollection
 import model.forms.GetCollectionsFilter
 import scalikejdbc._
-
+import services.editions.DbEditionsArticle
+import services.editions.CollectionsHelpers._
 
 trait CollectionsQueries {
   def getCollections(filters : List[GetCollectionsFilter]) = DB readOnly { implicit session =>

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -1,7 +1,7 @@
-package services.editions
+package services.editions.db
 
-import scalikejdbc._
 import conf.ApplicationConfiguration
+import scalikejdbc._
 
 class EditionsDB (config: ApplicationConfiguration) extends IssueQueries with CollectionsQueries {
   Class.forName("org.postgresql.Driver")

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -1,13 +1,12 @@
-package services.editions
+package services.editions.db
 
 import java.time.LocalDate
 
-import play.api.libs.json.Json
 import com.gu.pandomainauth.model.User
 import model.editions._
 import scalikejdbc._
+import services.editions.{DbEditionsArticle, DbEditionsCollection, DbEditionsFront}
 import services.editions.CollectionsHelpers._
-
 
 trait IssueQueries {
 
@@ -185,5 +184,17 @@ trait IssueQueries {
         }
 
     rows.headOption.map(_.issue.copy(fronts = fronts))
+  }
+
+  def publishIssue(issueId: String, user: User) = DB localTx { implicit session =>
+    val userName = user.firstName + " " + user.lastName
+
+    sql"""
+    UPDATE edition_issues
+    SET launched_on = now(),
+        launched_by = $userName,
+        launched_email = ${user.email}
+    WHERE id = $issueId
+    """.execute().apply()
   }
 }

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -1,0 +1,22 @@
+package services.editions.publishing
+
+import com.gu.pandomainauth.model.User
+import model.editions.EditionsIssue
+import services.editions.db.EditionsDB
+
+class EditionsPublishing(bucket: PublishedIssuesBucket, db: EditionsDB) {
+
+  def publish(issue: EditionsIssue, user: User) = {
+    val publishedIssue = issue.toPublishedIssue()
+
+    // Archive a copy
+    bucket.putIssue(publishedIssue, user)
+
+    // Bump the recently published counters
+    db.publishIssue(issue.id, user)
+
+    // Push new version to API
+    // TODO invoke publish lambda
+  }
+}
+

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -7,7 +7,7 @@ import services.editions.db.EditionsDB
 class EditionsPublishing(bucket: PublishedIssuesBucket, db: EditionsDB) {
 
   def publish(issue: EditionsIssue, user: User) = {
-    val publishedIssue = issue.toPublishedIssue()
+    val publishedIssue = issue.toPublishedIssue
 
     // Archive a copy
     bucket.putIssue(publishedIssue, user)

--- a/app/services/editions/publishing/PublishedIssueFormatters.scala
+++ b/app/services/editions/publishing/PublishedIssueFormatters.scala
@@ -4,6 +4,7 @@ import com.gu.editions._
 import play.api.libs.json.Json
 
 object PublishedIssueFormatters {
+  implicit val mediaUrlFormat = Json.format[MediaUrl]
   implicit val publishedArticleMetadataFormat = Json.format[PublishedArticleMetadata]
   implicit val publishedArticleFormat = Json.format[PublishedArticle]
   implicit val publishedCollectionsFormat = Json.format[PublishedCollection]

--- a/app/services/editions/publishing/PublishedIssueFormatters.scala
+++ b/app/services/editions/publishing/PublishedIssueFormatters.scala
@@ -1,0 +1,12 @@
+package services.editions.publishing
+
+import com.gu.editions._
+import play.api.libs.json.Json
+
+object PublishedIssueFormatters {
+  implicit val publishedArticleMetadataFormat = Json.format[PublishedArticleMetadata]
+  implicit val publishedArticleFormat = Json.format[PublishedArticle]
+  implicit val publishedCollectionsFormat = Json.format[PublishedCollection]
+  implicit val publishedFrontsFormat = Json.format[PublishedFront]
+  implicit val publishedIssueFormat = Json.format[PublishedIssue]
+}

--- a/app/services/editions/publishing/PublishedIssuesBucket.scala
+++ b/app/services/editions/publishing/PublishedIssuesBucket.scala
@@ -1,0 +1,32 @@
+package services.editions.publishing
+
+import java.time.OffsetDateTime
+
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.gu.editions.PublishedIssue
+import conf.ApplicationConfiguration
+import play.api.libs.json.Json
+import services._
+import PublishedIssueFormatters._
+import com.gu.pandomainauth.model.User
+
+class PublishedIssuesBucket(config: ApplicationConfiguration, awsEndpoints: AwsEndpoints) {
+
+  val bucket = config.aws.publishedEditionsIssuesBucket
+
+  val client = AmazonS3ClientBuilder
+    .standard()
+    .withCredentials(config.aws.credentials.get)
+    .withRegion(config.aws.region)
+    .build()
+
+  private def createIssuePath(issue: PublishedIssue, user: User) = {
+    val firstName = user.firstName.replace(" ", "_")
+    val lastName = user.lastName.replace(" ", "_")
+    s"${issue.name}/${issue.issueDate.toLocalDate.toString}/${OffsetDateTime.now().toString}_${firstName}_$lastName.json"
+  }
+
+  def putIssue(issue: PublishedIssue, user: User) = {
+    client.putObject(bucket, createIssuePath(issue, user), Json.stringify(Json.toJson(issue)))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ packageSummary := "Facia tool"
 
 packageDescription := "Guardian front pages editor"
 
-scalaVersion := "2.12.5"
+scalaVersion in ThisBuild := "2.12.5"
 
 import sbt.Resolver
 import sbt.io.Path._
@@ -31,7 +31,7 @@ riffRaffArtifactResources := {
     ) ++ ((jsBundlesDir * "*") pair rebase(jsBundlesDir, "static-facia-tool"))
 }
 
-javacOptions := Seq("-g","-encoding", "utf8")
+javacOptions in ThisBuild := Seq("-g","-encoding", "utf8")
 
 javaOptions in Universal ++= Seq(
     "-Dpidfile.path=/dev/null",
@@ -110,7 +110,17 @@ libraryDependencies ++= Seq(
     "org.scalikejdbc"          %% "scalikejdbc"                  % "3.1.0",
     "org.scalikejdbc"          %% "scalikejdbc-config"           % "3.1.0",
     "org.scalikejdbc"          %% "scalikejdbc-play-initializer" % "2.6.0-scalikejdbc-3.1"
-
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
+val editionsCommon = (project in file("./editions-common"))
+    .settings(
+        name := "editions-common",
+        version := "0.1.0"
+    )
+
+lazy val root = (project in file("."))
+    .dependsOn(editionsCommon)
+    .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
+
+
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,6 +80,7 @@ aws {
     region: "eu-west-1"
     bucket: "aws-frontend-store"
     frontsBucket: "facia-tool-store"
+    publishedEditionsIssuesBucket: "published-editions-CODE"
 }
 
 pandomain {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,8 +80,9 @@ aws {
     region: "eu-west-1"
     bucket: "aws-frontend-store"
     frontsBucket: "facia-tool-store"
-    publishedEditionsIssuesBucket: "published-editions-CODE"
+    publishedEditionsIssuesBucket: "published-editions-code"
 }
+PROD.aws.publishedEditionsIssuesBucket: "published-editions-prod"
 
 pandomain {
   service: "fronts"

--- a/conf/routes
+++ b/conf/routes
@@ -106,6 +106,10 @@ GET         /editions-api/editions                       controllers.EditionsCon
 GET         /editions-api/editions/:name/issues          controllers.EditionsController.listIssues(name)
 POST        /editions-api/editions/:name/issues          controllers.EditionsController.postIssue(name)
 GET         /editions-api/issues/:id                     controllers.EditionsController.getIssue(id)
+POST        /editions-api/issues/:id/publish             controllers.EditionsController.publishIssue(id)
+GET         /editions-api/issues/:id/preview             controllers.EditionsController.getPreviewEdition(id)
 POST        /editions-api/collections                    controllers.EditionsController.getCollections
 PUT         /editions-api/collections/:collectionId      controllers.EditionsController.updateCollection(collectionId)
+
+
 

--- a/editions-common/src/main/scala/com/gu/editions/EditionsEvent.scala
+++ b/editions-common/src/main/scala/com/gu/editions/EditionsEvent.scala
@@ -1,0 +1,8 @@
+package com.gu.editions
+
+import java.time.ZonedDateTime
+
+sealed trait EditionsEvent
+
+case class PublishEvent(edition: String, issueDate: ZonedDateTime, location: String) extends EditionsEvent
+

--- a/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
+++ b/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
@@ -1,0 +1,16 @@
+package com.gu.editions
+
+import java.time.ZonedDateTime
+
+// TODO traitify PublishedItem - when we have more than one type of collection item
+
+case class PublishedArticleMetadata(stuffgoeshere: Int)
+
+case class PublishedArticle(id: Long, meta: Option[PublishedArticleMetadata])
+
+case class PublishedCollection(id: String, items: List[PublishedArticle])
+
+case class PublishedFront(id: String, isHidden: Boolean, collections: List[PublishedCollection])
+
+case class PublishedIssue(id: String, name: String, issueDate: ZonedDateTime, fronts: List[PublishedFront])
+

--- a/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
+++ b/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
@@ -1,16 +1,18 @@
 package com.gu.editions
 
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 
 // TODO traitify PublishedItem - when we have more than one type of collection item
 
-case class PublishedArticleMetadata(stuffgoeshere: Int)
+case class MediaUrl(url: String) extends AnyVal
 
-case class PublishedArticle(id: Long, meta: Option[PublishedArticleMetadata])
+case class PublishedArticleMetadata(kicker: Option[String], headline: Option[String], imageSrc: Option[MediaUrl])
+
+case class PublishedArticle(internalPageCode: Long, meta: PublishedArticleMetadata)
 
 case class PublishedCollection(id: String, items: List[PublishedArticle])
 
-case class PublishedFront(id: String, isHidden: Boolean, collections: List[PublishedCollection])
+case class PublishedFront(id: String, name: String, collections: List[PublishedCollection])
 
-case class PublishedIssue(id: String, name: String, issueDate: ZonedDateTime, fronts: List[PublishedFront])
+case class PublishedIssue(id: String, name: String, issueDate: OffsetDateTime, fronts: List[PublishedFront])
 


### PR DESCRIPTION
This PR adds capabilities to convert a working edition into the publlished edition format and provide endpoints to display the published format as well as to publish it into an S3 bucket.

It adds a new mandatory config for the output bucket.

TODO
------
 - [x] create buckets in the CMS fronts account prior to deploying