### PR TITLE
INPUTS: Automatically resize textareas to fit their content

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -298,7 +298,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               placeholder={articleCapiFieldValues.headline}
               component={InputTextArea}
               useHeadlineFont
-              rows="2"
               originalValue={articleCapiFieldValues.headline}
               data-testid="edit-form-headline-field"
             />

--- a/client-v2/src/shared/components/input/CreateInput.tsx
+++ b/client-v2/src/shared/components/input/CreateInput.tsx
@@ -11,7 +11,15 @@ type Props = {
   label?: string;
   // If provided, the user can revert to this value by clicking the 'rewind' button.
   originalValue?: string;
+  component: React.Component<
+    React.HTMLAttributes<HTMLInputElement> & StyledProps<any>
+  >;
+  type?: string;
 } & WrappedFieldProps;
+
+interface State {
+  inputHeight: number;
+}
 
 const RewindButton = styled.button.attrs({
   type: 'button'
@@ -44,20 +52,59 @@ export default (
     React.HTMLAttributes<HTMLInputElement> & StyledProps<any>
   >,
   type?: string
-) => ({ label, input, originalValue, ...rest }: Props) => (
-  <InputContainer>
-    {label && (
-      <InputLabel htmlFor={label}>
-        {label}
-        {originalValue && input.value !== originalValue && (
-          <RewindButton onClick={() => input.onChange(originalValue)}>
-            <RewindIcon />
-          </RewindButton>
-        )}
-      </InputLabel>
-    )}
-    <InputComponentContainer>
-      <Component id={label} {...input} {...rest} type={type} />
-    </InputComponentContainer>
-  </InputContainer>
-);
+) => {
+  return class extends React.Component<Props, State> {
+    private inputElement: React.RefObject<HTMLInputElement>;
+    constructor(props: Props) {
+      super(props);
+      this.inputElement = React.createRef();
+      this.state = { inputHeight: 36 };
+    }
+
+    public componentDidMount() {
+      this.updateHeight();
+    }
+
+    public componentDidUpdate(prevProps: Props) {
+      if (prevProps !== this.props) {
+        this.updateHeight();
+      }
+    }
+
+    public updateHeight() {
+      this.setState({
+        inputHeight: this.inputElement.current
+          ? this.inputElement.current.scrollHeight
+          : this.state.inputHeight
+      });
+    }
+
+    public render() {
+      const { label, input, originalValue, ...rest } = this.props;
+      return (
+        <InputContainer>
+          {label && (
+            <InputLabel htmlFor={label}>
+              {label}
+              {originalValue && input.value !== originalValue && (
+                <RewindButton onClick={() => input.onChange(originalValue)}>
+                  <RewindIcon />
+                </RewindButton>
+              )}
+            </InputLabel>
+          )}
+          <InputComponentContainer>
+            <Component
+              innerRef={this.inputElement}
+              style={{ height: this.state.inputHeight }}
+              id={label}
+              {...input}
+              {...rest}
+              type={type}
+            />
+          </InputComponentContainer>
+        </InputContainer>
+      );
+    }
+  };
+};

--- a/client-v2/src/shared/components/input/CreateResizeableTextInput.tsx
+++ b/client-v2/src/shared/components/input/CreateResizeableTextInput.tsx
@@ -18,7 +18,7 @@ type Props = {
 } & WrappedFieldProps;
 
 interface State {
-  inputHeight: number;
+  inputHeight: number|string;
 }
 
 const RewindButton = styled.button.attrs({
@@ -47,18 +47,18 @@ const InputComponentContainer = styled.div`
   }
 `;
 
-export default (
+const createResizeableTextInput = (
   Component: new (props: any) => React.Component<
     React.HTMLAttributes<HTMLInputElement> & StyledProps<any>
   >,
   type?: string
 ) => {
-  return class extends React.Component<Props, State> {
+  return class ResizeableTextInput extends React.Component<Props, State> {
     private inputElement: React.RefObject<HTMLInputElement>;
     constructor(props: Props) {
       super(props);
       this.inputElement = React.createRef();
-      this.state = { inputHeight: 36 };
+      this.state = { inputHeight: 'auto' };
     }
 
     public componentDidMount() {
@@ -66,18 +66,16 @@ export default (
     }
 
     public componentDidUpdate(prevProps: Props) {
-      if (prevProps !== this.props) {
+      if (prevProps.input.value !== this.props.input.value) {
         this.updateHeight();
       }
     }
 
     public updateHeight() {
-      this.setState({
-        inputHeight: this.inputElement.current
-          ? this.inputElement.current.scrollHeight
-          : this.state.inputHeight
-      });
+      if(this.inputElement.current) {
+        this.setState({inputHeight: this.inputElement.current.scrollHeight})
     }
+  }
 
     public render() {
       const { label, input, originalValue, ...rest } = this.props;
@@ -108,3 +106,5 @@ export default (
     }
   };
 };
+
+export {createResizeableTextInput}

--- a/client-v2/src/shared/components/input/InputText.ts
+++ b/client-v2/src/shared/components/input/InputText.ts
@@ -1,4 +1,4 @@
 import InputBase from './InputBase';
-import createInput from './CreateInput';
+import {createResizeableTextInput} from './CreateResizeableTextInput';
 
-export default createInput(InputBase, 'text');
+export default createResizeableTextInput(InputBase, 'text');

--- a/client-v2/src/shared/components/input/InputTextArea.ts
+++ b/client-v2/src/shared/components/input/InputTextArea.ts
@@ -1,5 +1,5 @@
 import InputBase from './InputBase';
-import createInput from './CreateInput';
+import {createResizeableTextInput} from './CreateResizeableTextInput';
 
 const InputTextAreaBase = InputBase.withComponent('textarea').extend<{
   minHeight?: number;
@@ -10,4 +10,4 @@ const InputTextAreaBase = InputBase.withComponent('textarea').extend<{
   max-height: ${({ maxHeight = 120 }) => maxHeight}px;
 `;
 
-export default createInput(InputTextAreaBase);
+export default createResizeableTextInput(InputTextAreaBase);

--- a/client-v2/src/shared/components/input/InputTextArea.ts
+++ b/client-v2/src/shared/components/input/InputTextArea.ts
@@ -5,7 +5,6 @@ const InputTextAreaBase = InputBase.withComponent('textarea').extend<{
   minHeight?: number;
   maxHeight?: number;
 }>`
-  height: auto;
   resize: vertical;
   min-height: ${({ minHeight = 40 }) => minHeight}px;
   max-height: ${({ maxHeight = 120 }) => maxHeight}px;


### PR DESCRIPTION
with @jennygrahamjones 

## What's changed?

Users wanted the kicker and headline input fields to show all of the text when the form is opened. Previously it was at a set height which hid some of the words 

BEFORE 
-text is cut off
![Screenshot 2019-07-10 at 17 29 21](https://user-images.githubusercontent.com/10324129/60987041-b57ee880-a338-11e9-8da7-02abd9342d16.png)

AFTER 
-textarea automatically expands to text height
![Screenshot 2019-07-10 at 17 30 21](https://user-images.githubusercontent.com/10324129/60987054-badc3300-a338-11e9-847c-38a6ff84081a.png)

[Trello ticket](https://trello.com/c/m0ZJM8Ce/590-make-trail-length-box-bigger-so-editors-can-see-full-text-in-one-glance)

## Implementation notes

In order to use lifecycle methods - we had to convert this functional component into a class component. 

In order to find the height of the content, we need to access the underlying DOM element behind the React component. Using `ref` allows us to do this. 

However, because we are using a Higher Order Component taking a styled component as an input, we need to use `innerRef` a property already set on a styled component, allowing access to the `ref` on itself. 

This allows the actual node to be passed up to the Higher Order Component.  

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
