### PR TITLE
Highlight overview collection on scroll

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -22,6 +22,7 @@ interface FrontCollectionOverviewContainerProps {
   frontId: string;
   collectionId: string;
   browsingStage: CollectionItemSets;
+  isSelected: boolean;
 }
 
 type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
@@ -31,7 +32,7 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
   hasUnpublishedChanges: boolean;
 };
 
-const Container = styled.div`
+const Container = styled.div<{ isSelected: boolean }>`
   align-items: center;
   appearance: none;
   background-color: ${({ theme }) => theme.shared.base.colors.backgroundColor};
@@ -48,6 +49,10 @@ const Container = styled.div`
   text-align: left;
   text-decoration: none;
   transition: background-color 0.3s;
+
+  ${props =>
+    props.isSelected &&
+    `background-color: ${props.theme.shared.colors.whiteDark}`}
 
   &:hover {
     background-color: ${({ theme }) => theme.shared.colors.whiteDark};
@@ -100,7 +105,8 @@ const CollectionOverview = ({
   articleCount,
   openCollection,
   frontId,
-  hasUnpublishedChanges
+  hasUnpublishedChanges,
+  isSelected
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
@@ -117,6 +123,7 @@ const CollectionOverview = ({
         }
         openCollection(collection.id);
       }}
+      isSelected={isSelected}
     >
       <TextContainerLeft>
         <Name>{collection.displayName}</Name>

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -145,21 +145,21 @@ const isDropFromCAPIFeed = (e: React.DragEvent) =>
   e.dataTransfer.types.includes('capi');
 
 class FrontComponent extends React.Component<FrontProps, FrontState> {
-  private collectionRefs: {
+  private collectionElements: {
     [collectionId: string]: HTMLDivElement | null;
   } = {};
-  private collectionContainerRef: HTMLDivElement | null = null;
+  private collectionContainerElement: HTMLDivElement | null = null;
 
   /**
    * Handle a scroll event. We debounce this as it's called many times by the
    * event handler, and triggers an expensive rerender.
    */
   private handleScroll = debounce(() => {
-    if (!this.collectionContainerRef) {
+    if (!this.collectionContainerElement) {
       return;
     }
-    const scrollTop = this.collectionContainerRef.scrollTop;
-    const currentIdsAndOffsets = Object.entries(this.collectionRefs)
+    const scrollTop = this.collectionContainerElement.scrollTop;
+    const currentIdsAndOffsets = Object.entries(this.collectionElements)
       .filter(
         ([_, element]) =>
           // We filter everything that comes before the collection here, as we
@@ -177,6 +177,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
       currentIdsAndOffsets,
       ([_, offset]) => offset
     );
+
     if (sortedIdsAndOffsets.length) {
       this.setState({
         currentlyScrolledCollectionId: sortedIdsAndOffsets[0][0]
@@ -290,12 +291,14 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
             </SectionContentMetaContainer>
             <FrontCollectionsContainer
               onScroll={this.handleScroll}
-              innerRef={ref => (this.collectionContainerRef = ref)}
+              innerRef={ref => (this.collectionContainerElement = ref)}
             >
               <Root id={this.props.id} data-testid={this.props.id}>
                 {front.collections.map(collectionId => (
                   <CollectionContainer
-                    innerRef={ref => (this.collectionRefs[collectionId] = ref)}
+                    innerRef={ref =>
+                      (this.collectionElements[collectionId] = ref)
+                    }
                   >
                     <Collection
                       key={collectionId}

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -182,7 +182,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
         currentlyScrolledCollectionId: sortedIdsAndOffsets[0][0]
       });
     }
-  }, 50);
+  }, 100);
 
   constructor(props: FrontProps) {
     super(props);

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -12,6 +12,7 @@ import ContentContainer from 'shared/components/layout/ContentContainer';
 interface FrontContainerProps {
   id: string;
   browsingStage: CollectionItemSets;
+  currentCollection: string | undefined;
 }
 
 type FrontCollectionOverviewProps = FrontContainerProps & {
@@ -47,7 +48,8 @@ const ContainerBody = styled.div`
 const FrontCollectionsOverview = ({
   id,
   front,
-  browsingStage
+  browsingStage,
+  currentCollection
 }: FrontCollectionOverviewProps) => (
   <Container setBack isClosed={false}>
     <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
@@ -57,6 +59,7 @@ const FrontCollectionsOverview = ({
           frontId={id}
           key={collectionId}
           collectionId={collectionId}
+          isSelected={currentCollection === collectionId}
           browsingStage={browsingStage}
         />
       ))}

--- a/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontDetailView.tsx
@@ -18,6 +18,7 @@ import { State } from 'types/State';
 interface ContainerProps {
   id: string;
   browsingStage: CollectionItemSets;
+  currentCollection?: string | undefined;
 }
 
 interface ComponentProps extends ContainerProps {
@@ -33,7 +34,8 @@ const FrontsDetailView = ({
   browsingStage,
   clearArticleFragmentSelection,
   updateArticleFragmentMeta,
-  overviewIsOpen
+  overviewIsOpen,
+  currentCollection
 }: ComponentProps) => {
   if (selectedArticleFragment) {
     return (
@@ -52,7 +54,13 @@ const FrontsDetailView = ({
     );
   }
   if (overviewIsOpen) {
-    return <FrontCollectionsOverview id={id} browsingStage={browsingStage} />;
+    return (
+      <FrontCollectionsOverview
+        id={id}
+        browsingStage={browsingStage}
+        currentCollection={currentCollection}
+      />
+    );
   }
   return null;
 };

--- a/client-v2/src/components/layout/LargeSectionHeader.tsx
+++ b/client-v2/src/components/layout/LargeSectionHeader.tsx
@@ -1,11 +1,11 @@
-import { styled } from 'constants/theme';
+import { styled, theme } from 'constants/theme';
 
 export default styled('div')`
   height: 60px;
   padding: 10px;
   font-size: 28px;
-  line-height: 40px;
-  color: ${({ theme }) => theme.shared.base.colors.textLight};
+  line-height: ${theme.layout.sectionHeaderHeight}px;
+  color: ${theme.shared.base.colors.textLight};
   font-family: GHGuardianHeadline;
   font-weight: bold;
 `;

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -32,10 +32,15 @@ const capiInterface = {
   backgroundSelected: shared.colors.orange
 };
 
+const layout = {
+  sectionHeaderHeight: 40
+}
+
 export const theme = {
   shared,
   base,
-  capiInterface
+  capiInterface,
+  layout
 };
 
 export type Theme = typeof theme;


### PR DESCRIPTION
## What's changed?

Highlight the 'current' collection in the overview -- by this interpretation, the one that's closest to the top of the container.

![scroll-behaviour](https://user-images.githubusercontent.com/7767575/60988628-e1e83400-a33b-11e9-946c-ddaba8d43f2b.gif)

## Implementation notes

At the moment, this is less efficient than it should be, because of the way the components are arranged. This is likely to change as a result of #811, so I didn't make that optimisation here, as performance seems adequate.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
