### PR TITLE
Single naming convention for selectors

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -362,10 +362,7 @@ const cloneArticleFragmentToTarget = (
 ): ThunkResult<void> => {
   return (dispatch, getState) => {
     const to = { id: toType, type: toType, index: 0 };
-    const fragment = selectArticleFragment(
-      selectSharedState(getState()),
-      uuid
-    );
+    const fragment = selectArticleFragment(selectSharedState(getState()), uuid);
     const from = null;
     dispatch(moveArticleFragment(to, fragment, from, toType));
   };

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -12,9 +12,9 @@ import {
 import { ArticleFragment } from 'shared/types/Collection';
 import {
   selectSharedState,
-  articleFragmentsSelector,
-  articleFragmentSelector,
-  articleGroupSelector
+  selectArticleFragments,
+  selectArticleFragment,
+  selectArticleGroup
 } from 'shared/selectors/shared';
 import { ThunkResult, Dispatch } from 'types/Store';
 import { addPersistMetaToAction } from 'util/storeMiddleware';
@@ -32,11 +32,11 @@ import {
 import { State } from 'types/State';
 import { startConfirmModal } from './ConfirmModal';
 import { capGroupSiblings } from 'shared/actions/Groups';
-import { collectionCapSelector } from 'selectors/configSelectors';
+import { selectCollectionCap } from 'selectors/configSelectors';
 import { getImageMetaFromValidationResponse } from 'util/form';
 import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { MappableDropType } from 'util/collectionUtils';
-import { willCollectionHitCollectionCapSelector } from 'selectors/collectionSelectors';
+import { selectWillCollectionHitCollectionCap } from 'selectors/collectionSelectors';
 import { batchActions } from 'redux-batched-actions';
 
 type InsertActionCreator = (
@@ -104,9 +104,9 @@ const maybeInsertGroupArticleFragment = (
     // require a modal!
     const state = getState();
 
-    const collectionCap = collectionCapSelector(state);
+    const collectionCap = selectCollectionCap(state);
 
-    const willCollectionHitCollectionCap = willCollectionHitCollectionCapSelector(
+    const willCollectionHitCollectionCap = selectWillCollectionHitCollectionCap(
       state,
       id,
       index,
@@ -273,7 +273,7 @@ const removeArticleFragment = (
       }
       // The article fragment may belong to an orphaned group -
       // we need to find the actual group the article fragment belongs to
-      const idFromState = articleGroupSelector(
+      const idFromState = selectArticleGroup(
         selectSharedState(getState()),
         id,
         articleFragmentId
@@ -333,7 +333,7 @@ const moveArticleFragment = (
       // if from is not null then assume we're copying a moved article fragment
       // into this new position
       const { parent, supporting } = !fromWithRespectToState
-        ? cloneFragment(fragment, articleFragmentsSelector(sharedState))
+        ? cloneFragment(fragment, selectArticleFragments(sharedState))
         : { parent: fragment, supporting: [] };
 
       if (toWithRespectToState) {
@@ -362,7 +362,7 @@ const cloneArticleFragmentToTarget = (
 ): ThunkResult<void> => {
   return (dispatch, getState) => {
     const to = { id: toType, type: toType, index: 0 };
-    const fragment = articleFragmentSelector(
+    const fragment = selectArticleFragment(
       selectSharedState(getState()),
       uuid
     );

--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -422,9 +422,7 @@ function publishCollection(
 
         return new Promise(resolve => setTimeout(resolve, 10000))
           .then(() => {
-            const [params] = selectCollectionParams(getState(), [
-              collectionId
-            ]);
+            const [params] = selectCollectionParams(getState(), [collectionId]);
             return Promise.all([
               getCollectionApi(params),
               fetchLastPressedApi(frontId)

--- a/client-v2/src/actions/ConfirmModal.ts
+++ b/client-v2/src/actions/ConfirmModal.ts
@@ -1,7 +1,7 @@
 import { Action, StartConfirm } from 'types/Action';
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
-import { confirmModalActionsSelector } from 'selectors/confirmModalSelectors';
+import { selectConfirmModalActions } from 'selectors/confirmModalSelectors';
 
 const startConfirmModal = (
   title: string,
@@ -22,7 +22,7 @@ const endConfirmModal = (accept: boolean) => (
   dispatch: Dispatch,
   getState: () => State
 ) => {
-  const actions = confirmModalActionsSelector(getState(), accept) || [];
+  const actions = selectConfirmModalActions(getState(), accept) || [];
   actions.forEach(ac => dispatch(ac));
   dispatch({
     type: 'MODAL/END_CONFIRM'

--- a/client-v2/src/actions/KeyboardNavigation.ts
+++ b/client-v2/src/actions/KeyboardNavigation.ts
@@ -3,10 +3,7 @@ import {
   selectNextIndexAndGroup,
   selectNextClipboardIndexSelector
 } from '../selectors/keyboardNavigationSelectors';
-import {
-  selectSharedState,
-  selectIndexInGroup
-} from 'shared/selectors/shared';
+import { selectSharedState, selectIndexInGroup } from 'shared/selectors/shared';
 import { ArticleFragment } from 'shared/types/Collection';
 import { PosSpec } from 'lib/dnd';
 import { ThunkResult, Dispatch } from 'types/Store';
@@ -65,7 +62,11 @@ const keyboardArticleFragmentMove = (
         );
       }
     } else if (persistTo === 'clipboard') {
-      const clipboardIndeces = selectNextClipboardIndexSelector(state, id, action);
+      const clipboardIndeces = selectNextClipboardIndexSelector(
+        state,
+        id,
+        action
+      );
       if (clipboardIndeces) {
         const { fromIndex, toIndex } = clipboardIndeces;
         const type = 'clipboard';

--- a/client-v2/src/actions/KeyboardNavigation.ts
+++ b/client-v2/src/actions/KeyboardNavigation.ts
@@ -1,11 +1,11 @@
 import { moveArticleFragment } from 'actions/ArticleFragments';
 import {
-  nextIndexAndGroupSelector,
-  nextClipboardIndexSelector
+  selectNextIndexAndGroup,
+  selectNextClipboardIndexSelector
 } from '../selectors/keyboardNavigationSelectors';
 import {
   selectSharedState,
-  indexInGroupSelector
+  selectIndexInGroup
 } from 'shared/selectors/shared';
 import { ArticleFragment } from 'shared/types/Collection';
 import { PosSpec } from 'lib/dnd';
@@ -28,7 +28,7 @@ const keyboardArticleFragmentMove = (
     const state = getState();
     const id = fragment.uuid;
     if (persistTo === 'collection') {
-      const fromIndex = indexInGroupSelector(
+      const fromIndex = selectIndexInGroup(
         selectSharedState(state),
         groupId || '',
         id
@@ -37,7 +37,7 @@ const keyboardArticleFragmentMove = (
 
       const from: PosSpec = { type, index: fromIndex, id: groupId || '' };
 
-      const nextPosition = nextIndexAndGroupSelector(
+      const nextPosition = selectNextIndexAndGroup(
         state,
         groupId || '',
         id,
@@ -65,7 +65,7 @@ const keyboardArticleFragmentMove = (
         );
       }
     } else if (persistTo === 'clipboard') {
-      const clipboardIndeces = nextClipboardIndexSelector(state, id, action);
+      const clipboardIndeces = selectNextClipboardIndexSelector(state, id, action);
       if (clipboardIndeces) {
         const { fromIndex, toIndex } = clipboardIndeces;
         const type = 'clipboard';

--- a/client-v2/src/actions/__tests__/Fronts.spec.ts
+++ b/client-v2/src/actions/__tests__/Fronts.spec.ts
@@ -6,7 +6,7 @@ import { articlesForScJohnsonPartnerZone } from 'fixtures/capiEndpointResponse';
 import { selectIsCollectionOpen } from 'bundles/frontsUIBundle';
 import { selectArticlesInCollections } from 'shared/selectors/collection';
 import {
-  articleFragmentSelector,
+  selectArticleFragment,
   selectSharedState
 } from 'shared/selectors/shared';
 import { initialiseCollectionsForFront } from 'actions/Collections';
@@ -51,7 +51,7 @@ describe('Fronts actions', () => {
         selectArticlesInCollections(sharedState, {
           collectionIds,
           itemSet: 'draft'
-        }).every(_ => !!articleFragmentSelector(sharedState, _))
+        }).every(_ => !!selectArticleFragment(sharedState, _))
       ).toBe(true);
     });
   });

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -26,7 +26,10 @@ import {
 } from 'types/Action';
 import { State as GlobalState } from 'types/State';
 import { events } from 'services/GA';
-import { selectFronts, selectFrontsWithPriority } from 'selectors/frontsSelectors';
+import {
+  selectFronts,
+  selectFrontsWithPriority
+} from 'selectors/frontsSelectors';
 import { createSelector } from 'reselect';
 import {
   REMOVE_GROUP_ARTICLE_FRAGMENT,

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -26,7 +26,7 @@ import {
 } from 'types/Action';
 import { State as GlobalState } from 'types/State';
 import { events } from 'services/GA';
-import { getFronts, getFrontsWithPriority } from 'selectors/frontsSelectors';
+import { selectFronts, selectFrontsWithPriority } from 'selectors/frontsSelectors';
 import { createSelector } from 'reselect';
 import {
   REMOVE_GROUP_ARTICLE_FRAGMENT,
@@ -259,7 +259,7 @@ const selectPriority = (
 
 const createSelectEditorFrontsByPriority = () =>
   createSelector(
-    getFronts,
+    selectFronts,
     selectEditorFrontIds,
     selectPriority,
     (fronts, frontIdsByPriority, priority) => {
@@ -271,7 +271,7 @@ const createSelectEditorFrontsByPriority = () =>
 const createSelectFrontIdWithOpenAndStarredStatesByPriority = () => {
   const selectEditorFrontsByPriority = createSelectEditorFrontsByPriority();
   return createSelector(
-    getFrontsWithPriority,
+    selectFrontsWithPriority,
     (state, priority: string) =>
       selectEditorFrontsByPriority(state, { priority }),
     (state, priority: string) =>

--- a/client-v2/src/components/ConfirmModal.tsx
+++ b/client-v2/src/components/ConfirmModal.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Modal from 'react-modal';
 import { State } from 'types/State';
 import {
-  confirmModalIsOpenSelector,
-  confirmModalTitleSelector,
-  confirmModalDescriptionSelector
+  selectConfirmModalIsOpen,
+  selectConfirmModalTitle,
+  selectConfirmModalDescription
 } from 'selectors/confirmModalSelectors';
 import { Dispatch } from 'types/Store';
 import { endConfirmModal } from 'actions/ConfirmModal';
@@ -77,9 +77,9 @@ const ConfirmModal = ({
 );
 
 const mapStateToProps = (state: State) => ({
-  isOpen: confirmModalIsOpenSelector(state),
-  title: confirmModalTitleSelector(state),
-  description: confirmModalDescriptionSelector(state)
+  isOpen: selectConfirmModalIsOpen(state),
+  title: selectConfirmModalTitle(state),
+  description: selectConfirmModalDescription(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -14,10 +14,10 @@ import Button from 'shared/components/input/ButtonDefault';
 import ContentContainer from 'shared/components/layout/ContentContainer';
 import ContainerHeadingPinline from 'shared/components/typography/ContainerHeadingPinline';
 import {
-  createArticleFromArticleFragmentSelector,
+  createSelectArticleFromArticleFragment,
   selectSharedState,
-  articleTagSelector,
-  externalArticleFromArticleFragmentSelector
+  selectArticleTag,
+  selectExternalArticleFromArticleFragment
 } from 'shared/selectors/shared';
 import { createSelectFormFieldsForCollectionItem } from 'selectors/formSelectors';
 import { ArticleFragmentMeta, ArticleTag } from 'shared/types/Collection';
@@ -543,17 +543,17 @@ const formContainer: React.SFC<ContainerProps & InterfaceProps> = props => (
 );
 
 const createMapStateToProps = () => {
-  const selectArticle = createArticleFromArticleFragmentSelector();
+  const selectArticle = createSelectArticleFromArticleFragment();
   const selectFormFields = createSelectFormFieldsForCollectionItem();
   return (
     state: State,
     { articleFragmentId, isSupporting = false }: InterfaceProps
   ) => {
-    const externalArticle = externalArticleFromArticleFragmentSelector(
+    const externalArticle = selectExternalArticleFromArticleFragment(
       selectSharedState(state),
       articleFragmentId
     );
-    const valueSelector = formValueSelector(articleFragmentId);
+    const selectValue = formValueSelector(articleFragmentId);
     const article = selectArticle(selectSharedState(state), articleFragmentId);
     const parentCollectionId =
       collectionSelectors.selectParentCollectionOfArticleFragment(
@@ -587,15 +587,15 @@ const createMapStateToProps = () => {
       editableFields:
         article && selectFormFields(state, article.uuid, isSupporting),
       kickerOptions: article
-        ? articleTagSelector(selectSharedState(state), articleFragmentId)
+        ? selectArticleTag(selectSharedState(state), articleFragmentId)
         : {},
-      imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
-      imageHide: valueSelector(state, 'imageHide'),
-      imageReplace: valueSelector(state, 'imageReplace'),
-      imageCutoutReplace: valueSelector(state, 'imageCutoutReplace'),
-      showByline: valueSelector(state, 'showByline'),
-      showKickerTag: valueSelector(state, 'showKickerTag'),
-      showKickerSection: valueSelector(state, 'showKickerSection'),
+      imageSlideshowReplace: selectValue(state, 'imageSlideshowReplace'),
+      imageHide: selectValue(state, 'imageHide'),
+      imageReplace: selectValue(state, 'imageReplace'),
+      imageCutoutReplace: selectValue(state, 'imageCutoutReplace'),
+      showByline: selectValue(state, 'showByline'),
+      showKickerTag: selectValue(state, 'showKickerTag'),
+      showKickerSection: selectValue(state, 'showKickerSection'),
       cutoutImage: externalArticle
         ? getContributorImage(externalArticle)
         : undefined

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -16,7 +16,7 @@ import { removeArticleFragment } from 'actions/ArticleFragments';
 import { resetFocusState } from 'bundles/focusBundle';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
-import { createArticleVisibilityDetailsSelector } from 'selectors/frontsSelectors';
+import { createSelectArticleVisibilityDetails } from 'selectors/frontsSelectors';
 import FocusWrapper from 'components/FocusWrapper';
 
 const getArticleNotifications = (
@@ -228,9 +228,9 @@ class CollectionContext extends React.Component<
 }
 
 const createMapStateToProps = () => {
-  const articleVisibilityDetailsSelector = createArticleVisibilityDetailsSelector();
+  const selectArticleVisibilityDetails = createSelectArticleVisibilityDetails();
   return (state: State, props: CollectionContextProps) => {
-    const articleVisibilityDetails = articleVisibilityDetailsSelector(state, {
+    const articleVisibilityDetails = selectArticleVisibilityDetails(state, {
       collectionId: props.id,
       collectionSet: props.browsingStage
     });

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-  createArticleFromArticleFragmentSelector,
+  createSelectArticleFromArticleFragment,
   selectSharedState
 } from 'shared/selectors/shared';
 import { State } from 'types/State';
@@ -43,9 +43,9 @@ export const ArticleDragComponent = ({ headline }: ComponentProps) =>
   ) : null;
 
 const createMapStateToProps = () => {
-  const articleSelector = createArticleFromArticleFragmentSelector();
+  const selectArticle = createSelectArticleFromArticleFragment();
   return (state: State, props: ContainerProps): { headline?: string } => {
-    const article = articleSelector(selectSharedState(state), props.id);
+    const article = selectArticle(selectSharedState(state), props.id);
     return { headline: article && article.headline };
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -16,10 +16,10 @@ import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
 import { selectIsEditingEditions } from 'selectors/pathSelectors';
 import {
-  createCollectionStageGroupsSelector,
-  createCollectionEditWarningSelector,
+  createSelectCollectionStageGroups,
+  createSelectCollectionEditWarning,
   selectSharedState,
-  createPreviouslyLiveArticlesInCollectionSelector
+  createSelectPreviouslyLiveArticlesInCollection
 } from 'shared/selectors/shared';
 import {
   selectIsCollectionOpen,
@@ -199,9 +199,9 @@ class Collection extends React.Component<CollectionProps> {
 }
 
 const createMapStateToProps = () => {
-  const collectionStageGroupsSelector = createCollectionStageGroupsSelector();
-  const editWarningSelector = createCollectionEditWarningSelector();
-  const previouslySelector = createPreviouslyLiveArticlesInCollectionSelector();
+  const selectCollectionStageGroups = createSelectCollectionStageGroups();
+  const selectEditWarning = createSelectCollectionEditWarning();
+  const selectPreviously = createSelectPreviouslyLiveArticlesInCollection();
   return (
     state: State,
     { browsingStage, id, priority, frontId }: CollectionPropsBeforeState
@@ -216,14 +216,14 @@ const createMapStateToProps = () => {
         collectionId: id
       }),
       isCollectionLocked: isCollectionLockedSelector(state, id),
-      groups: collectionStageGroupsSelector(selectSharedState(state), {
+      groups: selectCollectionStageGroups(selectSharedState(state), {
         collectionSet: browsingStage,
         collectionId: id
       }),
-      previousGroups: previouslySelector(selectSharedState(state), {
+      previousGroups: selectPreviously(selectSharedState(state), {
         collectionId: id
       }),
-      displayEditWarning: editWarningSelector(selectSharedState(state), {
+      displayEditWarning: selectEditWarning(selectSharedState(state), {
         collectionId: id
       }),
       isOpen: selectIsCollectionOpen(state, id),

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -10,8 +10,8 @@ import {
   discardDraftChangesToCollection,
   openCollectionsAndFetchTheirArticles
 } from 'actions/Collections';
-import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
-import { isCollectionLockedSelector } from 'selectors/collectionSelectors';
+import { selectHasUnpublishedChanges } from 'selectors/frontsSelectors';
+import { selectIsCollectionLocked } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
 import { selectIsEditingEditions } from 'selectors/pathSelectors';
@@ -212,10 +212,10 @@ const createMapStateToProps = () => {
       frontId
     );
     return {
-      hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
+      hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
         collectionId: id
       }),
-      isCollectionLocked: isCollectionLockedSelector(state, id),
+      isCollectionLocked: selectIsCollectionLocked(state, id),
       groups: selectCollectionStageGroups(selectSharedState(state), {
         collectionSet: browsingStage,
         collectionId: id

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Article from 'shared/components/article/Article';
 import { State } from 'types/State';
-import { createCollectionItemTypeSelector } from 'shared/selectors/collectionItem';
+import { createSelectCollectionItemType } from 'shared/selectors/collectionItem';
 import {
   selectSharedState,
-  articleFragmentSelector
+  selectArticleFragment
 } from 'shared/selectors/shared';
 import collectionItemTypes from 'shared/constants/collectionItemTypes';
 import {
@@ -178,13 +178,13 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
 }
 
 const createMapStateToProps = () => {
-  const selectType = createCollectionItemTypeSelector();
+  const selectType = createSelectCollectionItemType();
   return (state: State, props: ContainerProps) => {
     const selectedArticleFragmentData = selectEditorArticleFragment(
       state,
       props.frontId
     );
-    const maybeArticle = articleFragmentSelector(
+    const maybeArticle = selectArticleFragment(
       selectSharedState(state),
       props.uuid
     );

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -5,7 +5,7 @@ import { events } from 'services/GA';
 
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
-import { hasUnpublishedChangesSelector } from 'selectors/frontsSelectors';
+import { selectHasUnpublishedChanges } from 'selectors/frontsSelectors';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
 import { Collection, CollectionItemSets } from 'shared/types/Collection';
@@ -13,9 +13,9 @@ import { createCollectionId } from 'shared/components/Collection';
 import ButtonDefault from 'shared/components/input/ButtonCircular';
 
 import {
-  createCollectionSelector,
+  createSelectCollection,
   selectSharedState,
-  createArticlesInCollectionSelector
+  createSelectArticlesInCollection
 } from 'shared/selectors/shared';
 
 interface FrontCollectionOverviewContainerProps {
@@ -146,19 +146,19 @@ const CollectionOverview = ({
   ) : null;
 
 const mapStateToProps = () => {
-  const collectionSelector = createCollectionSelector();
-  const articlesInCollectionSelector = createArticlesInCollectionSelector();
+  const selectCollection = createSelectCollection();
+  const selectArticlesInCollection = createSelectArticlesInCollection();
 
   return (state: State, props: FrontCollectionOverviewContainerProps) => ({
-    collection: collectionSelector(selectSharedState(state), {
+    collection: selectCollection(selectSharedState(state), {
       collectionId: props.collectionId
     }),
-    articleCount: articlesInCollectionSelector(selectSharedState(state), {
+    articleCount: selectArticlesInCollection(selectSharedState(state), {
       collectionSet: props.browsingStage,
       collectionId: props.collectionId,
       includeSupportingArticles: false
     }).length,
-    hasUnpublishedChanges: hasUnpublishedChangesSelector(state, {
+    hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
       collectionId: props.collectionId
     })
   });

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -20,7 +20,7 @@ import {
   CollectionItemSets,
   ArticleFragment as TArticleFragment
 } from 'shared/types/Collection';
-import { getFront } from 'selectors/frontsSelectors';
+import { selectFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
 import { events } from 'services/GA';
 import FrontDetailView from './FrontDetailView';
@@ -345,7 +345,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
 
 const mapStateToProps = (state: State, { id }: FrontPropsBeforeState) => {
   return {
-    front: getFront(state, { frontId: id }),
+    front: selectFront(state, { frontId: id }),
     overviewIsOpen: selectIsFrontOverviewOpen(state, id),
     formIsOpen: !!selectEditorArticleFragment(state, id)
   };

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { styled } from 'constants/theme';
 import { State } from 'types/State';
-import { getFront } from 'selectors/frontsSelectors';
+import { selectFront } from 'selectors/frontsSelectors';
 import { FrontConfig } from 'types/FaciaApi';
 import CollectionOverview from './CollectionOverview';
 import { CollectionItemSets } from 'shared/types/Collection';
@@ -68,7 +68,7 @@ const FrontCollectionsOverview = ({
 );
 
 const mapStateToProps = (state: State, props: FrontContainerProps) => ({
-  front: getFront(state, { frontId: props.id })
+  front: selectFront(state, { frontId: props.id })
 });
 
 export default connect(mapStateToProps)(FrontCollectionsOverview);

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -15,7 +15,10 @@ import { frontStages } from 'constants/fronts';
 import { FrontConfig } from 'types/FaciaApi';
 import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
-import { selectFront, createSelectAlsoOnFronts } from 'selectors/frontsSelectors';
+import {
+  selectFront,
+  createSelectAlsoOnFronts
+} from 'selectors/frontsSelectors';
 import Front from './Front';
 import SectionHeader from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -15,7 +15,7 @@ import { frontStages } from 'constants/fronts';
 import { FrontConfig } from 'types/FaciaApi';
 import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
-import { getFront, createAlsoOnSelector } from 'selectors/frontsSelectors';
+import { selectFront, createSelectAlsoOnFronts } from 'selectors/frontsSelectors';
 import Front from './Front';
 import SectionHeader from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';
@@ -196,10 +196,10 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
 }
 
 const createMapStateToProps = () => {
-  const alsoOnSelector = createAlsoOnSelector();
+  const selectAlsoOnFronts = createSelectAlsoOnFronts();
   return (state: State, props: FrontsContainerProps) => ({
-    selectedFront: getFront(state, { frontId: props.frontId }),
-    alsoOn: alsoOnSelector(state, { frontId: props.frontId }),
+    selectedFront: selectFront(state, { frontId: props.frontId }),
+    alsoOn: selectAlsoOnFronts(state, { frontId: props.frontId }),
     isOverviewOpen: selectIsFrontOverviewOpen(state, props.frontId),
     isFormOpen: !!selectEditorArticleFragment(state, props.frontId)
   });

--- a/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
+++ b/client-v2/src/components/clipboard/ArticleFragmentLevel.tsx
@@ -9,7 +9,7 @@ import ArticleDrag, {
   dragOffsetY
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
-import { createSupportingArticlesSelector } from 'shared/selectors/shared';
+import { createSelectSupportingArticles } from 'shared/selectors/shared';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
 
 interface OuterProps {
@@ -77,9 +77,9 @@ const ArticleFragmentLevel = ({
 );
 
 const createMapStateToProps = () => {
-  const supportingArticlesSelector = createSupportingArticlesSelector();
+  const selectSupportingArticles = createSelectSupportingArticles();
   return (state: State, { articleFragmentId }: OuterProps) => ({
-    supporting: supportingArticlesSelector(state, { articleFragmentId })
+    supporting: selectSupportingArticles(state, { articleFragmentId })
   });
 };
 

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Level, LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import { State } from 'types/State';
-import { clipboardArticlesSelector } from 'selectors/clipboardSelectors';
+import { selectClipboardArticles } from 'selectors/clipboardSelectors';
 import { connect } from 'react-redux';
 import { ArticleFragment } from 'shared/types/Collection';
 import ArticleDrag, {
@@ -67,7 +67,7 @@ const ClipboardLevel = ({
 );
 
 const mapStateToProps = (state: State) => ({
-  articleFragments: clipboardArticlesSelector(state)
+  articleFragments: selectClipboardArticles(state)
 });
 
 export default connect(mapStateToProps)(ClipboardLevel);

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -9,7 +9,7 @@ import ArticleDrag, {
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone from 'components/DropZone';
 import { collectionDropTypeBlacklist } from 'constants/fronts';
-import { createArticlesFromIdsSelector } from 'shared/selectors/shared';
+import { createSelectArticlesFromIds } from 'shared/selectors/shared';
 import { styled } from 'constants/theme';
 
 interface OuterProps {
@@ -79,9 +79,9 @@ const GroupLevel = ({
 );
 
 const createMapStateToProps = () => {
-  const articlesFromIdsSelector = createArticlesFromIdsSelector();
+  const selectArticlesFromIds = createSelectArticlesFromIds();
   return (state: State, { articleFragmentIds }: OuterProps) => ({
-    articleFragments: articlesFromIdsSelector(state, {
+    articleFragments: selectArticlesFromIds(state, {
       articleFragmentIds
     })
   });

--- a/client-v2/src/reducers/clipboardReducer.ts
+++ b/client-v2/src/reducers/clipboardReducer.ts
@@ -1,7 +1,7 @@
 import { Action } from 'types/Action';
 import { insertAndDedupeSiblings } from 'shared/util/insertAndDedupeSiblings';
 import { State as SharedState } from '../shared/types/State';
-import { articleFragmentsSelector } from 'shared/selectors/shared';
+import { selectArticleFragments } from 'shared/selectors/shared';
 import {
   INSERT_CLIPBOARD_ARTICLE_FRAGMENT,
   REMOVE_CLIPBOARD_ARTICLE_FRAGMENT,
@@ -28,7 +28,7 @@ const clipboard = (
         state,
         [action.payload.articleFragmentId],
         action.payload.index,
-        articleFragmentsSelector(prevSharedState)
+        selectArticleFragments(prevSharedState)
       );
     }
 

--- a/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/collectionSelectors.spec.ts
@@ -1,13 +1,13 @@
 import {
-  isCollectionLockedSelector,
-  createCollectionsInOpenFrontsSelector
+  selectIsCollectionLocked,
+  createSelectCollectionsInOpenFronts
 } from 'selectors/collectionSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 
 describe('Validating Front Collection configuration metadata', () => {
   it('validates correctly if Collection is uneditable ', () => {
     expect(
-      isCollectionLockedSelector(
+      selectIsCollectionLocked(
         {
           fronts: {
             frontsConfig
@@ -17,7 +17,7 @@ describe('Validating Front Collection configuration metadata', () => {
       )
     ).toEqual(true);
     expect(
-      isCollectionLockedSelector(
+      selectIsCollectionLocked(
         {
           fronts: {
             frontsConfig
@@ -30,10 +30,10 @@ describe('Validating Front Collection configuration metadata', () => {
 });
 
 describe('Selecting collections on all open Fronts', () => {
-  const collectionsInOpenFrontsSelector = createCollectionsInOpenFrontsSelector();
+  const selectCollectionsInOpenFronts = createSelectCollectionsInOpenFronts();
   it('return correct collections for one open Front', () => {
     expect(
-      collectionsInOpenFrontsSelector(
+      selectCollectionsInOpenFronts(
         {
           fronts: {
             frontsConfig
@@ -48,7 +48,7 @@ describe('Selecting collections on all open Fronts', () => {
   });
   it('return correct collections for multiple open Fronts', () => {
     expect(
-      collectionsInOpenFrontsSelector(
+      selectCollectionsInOpenFronts(
         {
           fronts: {
             frontsConfig
@@ -65,7 +65,7 @@ describe('Selecting collections on all open Fronts', () => {
   });
   it('return enpty array for no open Fronts', () => {
     expect(
-      collectionsInOpenFrontsSelector(
+      selectCollectionsInOpenFronts(
         {
           fronts: {
             frontsConfig

--- a/client-v2/src/selectors/__tests__/formSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/formSelectors.spec.ts
@@ -9,28 +9,35 @@ import { state, stateWithVideoArticle } from 'fixtures/form';
 describe('Form utils', () => {
   describe('getFormFieldsForCollectionItem', () => {
     it("should handle articles that don't exist in the state", () => {
-      const selector = createSelectFormFieldsForCollectionItem();
-      expect(selector(state as any, 'who-are-you')).toEqual([]);
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
+      expect(selectFormFields(state as any, 'who-are-you')).toEqual([]);
     });
     it('should give default fields for articles', () => {
-      const selector = createSelectFormFieldsForCollectionItem();
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selector(state as any, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
+        selectFormFields(state as any, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
       ).toEqual(defaultFields);
     });
     it('should give supporting fields for articles in supporting positions', () => {
-      const selector = createSelectFormFieldsForCollectionItem();
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selector(state as any, '95e2bfc0-8999-4e6e-a359-19960967c1e0', true)
+        selectFormFields(
+          state as any,
+          '95e2bfc0-8999-4e6e-a359-19960967c1e0',
+          true
+        )
       ).toEqual(supportingFields);
     });
     it('should add isBoosted for dynamic collection configs', () => {
       const localState = cloneDeep(state);
       localState.fronts.frontsConfig.data.collections.exampleCollection.type =
         'dynamic/example';
-      const selector = createSelectFormFieldsForCollectionItem();
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selector(localState as any, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
+        selectFormFields(
+          localState as any,
+          '95e2bfc0-8999-4e6e-a359-19960967c1e0'
+        )
       ).toEqual([...defaultFields, 'isBoosted']);
     });
     it('should add showLivePlayable for live blogs', () => {
@@ -38,15 +45,18 @@ describe('Form utils', () => {
       localState.shared.externalArticles.data[
         'article/live/0'
       ].fields.liveBloggingNow = 'true';
-      const selector = createSelectFormFieldsForCollectionItem();
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selector(localState as any, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
+        selectFormFields(
+          localState as any,
+          '95e2bfc0-8999-4e6e-a359-19960967c1e0'
+        )
       ).toEqual([...defaultFields, 'showLivePlayable']);
     });
     it('should add showMainVideo for articles with video as the main media', () => {
-      const selector = createSelectFormFieldsForCollectionItem();
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selector(
+        selectFormFields(
           stateWithVideoArticle as any,
           '95e2bfc0-8999-4e6e-a359-19960967c1e0'
         )

--- a/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/frontsSelectors.spec.ts
@@ -1,7 +1,7 @@
 import {
-  getFrontsWithPriority,
-  alsoOnFrontSelector,
-  createArticleVisibilityDetailsSelector
+  selectFrontsWithPriority,
+  selectAlsoOnFront,
+  createSelectArticleVisibilityDetails
 } from 'selectors/frontsSelectors';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { FrontConfig } from 'types/FaciaApi';
@@ -43,7 +43,7 @@ const commercialFronts: FrontConfig[] = [
 describe('Filtering fronts correctly', () => {
   it('return an empty array if config is empty', () => {
     expect(
-      getFrontsWithPriority(
+      selectFrontsWithPriority(
         {
           fronts: {
             frontsConfig: {
@@ -60,7 +60,7 @@ describe('Filtering fronts correctly', () => {
 
   it('filters editorial fronts correctly', () => {
     expect(
-      getFrontsWithPriority(
+      selectFrontsWithPriority(
         {
           fronts: {
             frontsConfig
@@ -73,7 +73,7 @@ describe('Filtering fronts correctly', () => {
 
   it('filters non-editorial fronts correctly', () => {
     expect(
-      getFrontsWithPriority(
+      selectFrontsWithPriority(
         {
           fronts: {
             frontsConfig
@@ -92,7 +92,7 @@ const allFronts = editorialFrontsInConfig
 describe('Selecting which front collection is also on correctly', () => {
   it('fills in also details for all collections on a front', () => {
     expect(
-      alsoOnFrontSelector(
+      selectAlsoOnFront(
         additionalEditorialFronts.find(
           front => front.id === 'editorialSharedWithTraining'
         ),
@@ -108,7 +108,7 @@ describe('Selecting which front collection is also on correctly', () => {
 
   it('returns an empty list of fronts for collection which is not shared', () => {
     expect(
-      alsoOnFrontSelector(
+      selectAlsoOnFront(
         additionalEditorialFronts.find(
           front => front.id === 'editorialNotShared'
         ),
@@ -121,7 +121,7 @@ describe('Selecting which front collection is also on correctly', () => {
 
   it('returns correct list of shared fronts and priorities for shared collections', () => {
     expect(
-      alsoOnFrontSelector(
+      selectAlsoOnFront(
         trainingFronts.find(front => front.id === 'trainingFront'),
         allFronts
       )
@@ -136,7 +136,7 @@ describe('Selecting which front collection is also on correctly', () => {
 
   it('sets merit warning to false if shared collection appears on a commercial front', () => {
     expect(
-      alsoOnFrontSelector(
+      selectAlsoOnFront(
         commercialFronts.find(front => front.id === 'commercialFront'),
         allFronts
       )
@@ -151,7 +151,7 @@ describe('Selecting which front collection is also on correctly', () => {
 
   it('sets merits warnign to true if a commercial collection is shared on another priority', () => {
     expect(
-      alsoOnFrontSelector(
+      selectAlsoOnFront(
         editorialFrontsInConfig.find(front => front.id === 'editorialFront'),
         allFronts
       )
@@ -221,9 +221,9 @@ const visibilityState = {
 
 describe('Article visibility selector', () => {
   it('returns the id of the articleFragment at the last visible position for mobile and desktop, ignoring supporting articleFragments', () => {
-    const articleVisibilityDetailsSelector = createArticleVisibilityDetailsSelector();
+    const selectArticleVisibilityDetails = createSelectArticleVisibilityDetails();
     expect(
-      articleVisibilityDetailsSelector(visibilityState as any, {
+      selectArticleVisibilityDetails(visibilityState as any, {
         collectionSet: 'draft',
         collectionId: 'a'
       })

--- a/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -1,6 +1,6 @@
 import {
-  nextClipboardIndexSelector,
-  nextIndexAndGroupSelector
+  selectNextClipboardIndexSelector,
+  selectNextIndexAndGroup
 } from 'selectors/keyboardNavigationSelectors';
 import state from 'fixtures/initialState';
 
@@ -13,31 +13,31 @@ describe('nextClipboardIndexSelector', () => {
   it('return null when clipboard is empty', () => {
     const stateWithEmptyClipboard = { ...state, clipboard: [] };
     expect(
-      nextClipboardIndexSelector(stateWithEmptyClipboard, 'some-id', 'up')
+      selectNextClipboardIndexSelector(stateWithEmptyClipboard, 'some-id', 'up')
     ).toEqual(null);
   });
 
   it('return null when moving top article up', () => {
     expect(
-      nextClipboardIndexSelector(stateWithClipboard, 'id-1', 'up')
+      selectNextClipboardIndexSelector(stateWithClipboard, 'id-1', 'up')
     ).toEqual(null);
   });
 
   it('return next article when moving top article up', () => {
     expect(
-      nextClipboardIndexSelector(stateWithClipboard, 'id-3', 'up')
+      selectNextClipboardIndexSelector(stateWithClipboard, 'id-3', 'up')
     ).toEqual({ fromIndex: 2, toIndex: 1 });
   });
 
   it('return null when moving bottom article down', () => {
     expect(
-      nextClipboardIndexSelector(stateWithClipboard, 'id-4', 'down')
+      selectNextClipboardIndexSelector(stateWithClipboard, 'id-4', 'down')
     ).toEqual(null);
   });
 
   it('return next article when moving bottom article down', () => {
     expect(
-      nextClipboardIndexSelector(stateWithClipboard, 'id-3', 'down')
+      selectNextClipboardIndexSelector(stateWithClipboard, 'id-3', 'down')
     ).toEqual({ fromIndex: 2, toIndex: 3 });
   });
 });
@@ -172,7 +172,7 @@ describe('nextIndexAndGroupSelector', () => {
       }
     };
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithEmptyGroup,
         'gobbleygook',
         'some-id',
@@ -184,7 +184,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return null when moving top article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group1',
         'fragment-1',
@@ -196,7 +196,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return next group id and index when moving up article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group1',
         'fragment-2',
@@ -208,7 +208,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return null when moving bottom article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group3',
         'fragment-8',
@@ -220,7 +220,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return next group id and index when moving down article in collection', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group1',
         'fragment-2',
@@ -232,7 +232,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return next group id when moving down between groups', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group1',
         'fragment-3',
@@ -244,7 +244,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return next group id when moving up between groups', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group2',
         'fragment-4',
@@ -256,7 +256,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return next group id when moving up between collections', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group3',
         'fragment-7',
@@ -272,7 +272,7 @@ describe('nextIndexAndGroupSelector', () => {
 
   it('return next editable group id when moving down between collections', () => {
     expect(
-      nextIndexAndGroupSelector(
+      selectNextIndexAndGroup(
         stateWithGroups,
         'group2',
         'fragment-6',

--- a/client-v2/src/selectors/__tests__/pathSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/pathSelectors.spec.ts
@@ -10,7 +10,9 @@ describe('pathSelectors', () => {
   });
   describe('getV2SubPath', () => {
     it('gets the path below /v2', () => {
-      expect(selectV2SubPath({ path: '/v2/test/path' } as any)).toBe('/test/path');
+      expect(selectV2SubPath({ path: '/v2/test/path' } as any)).toBe(
+        '/test/path'
+      );
     });
 
     it('returns the full path if not in a /v2 root path', () => {

--- a/client-v2/src/selectors/__tests__/pathSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/pathSelectors.spec.ts
@@ -1,20 +1,20 @@
-import { getFullPath, getV2SubPath } from 'selectors/pathSelectors';
+import { selectFullPath, selectV2SubPath } from 'selectors/pathSelectors';
 
 describe('pathSelectors', () => {
   describe('getFullPath', () => {
     it('gets the full path from state', () => {
-      expect(getFullPath({ path: '/v2/test/path' } as any)).toBe(
+      expect(selectFullPath({ path: '/v2/test/path' } as any)).toBe(
         '/v2/test/path'
       );
     });
   });
   describe('getV2SubPath', () => {
     it('gets the path below /v2', () => {
-      expect(getV2SubPath({ path: '/v2/test/path' } as any)).toBe('/test/path');
+      expect(selectV2SubPath({ path: '/v2/test/path' } as any)).toBe('/test/path');
     });
 
     it('returns the full path if not in a /v2 root path', () => {
-      expect(getV2SubPath({ path: '/v1/v2/test/path' } as any)).toBe(
+      expect(selectV2SubPath({ path: '/v1/v2/test/path' } as any)).toBe(
         '/v1/v2/test/path'
       );
     });

--- a/client-v2/src/selectors/clipboardSelectors.ts
+++ b/client-v2/src/selectors/clipboardSelectors.ts
@@ -1,13 +1,13 @@
 import { State } from 'types/State';
-import { articleFragmentsFromRootStateSelector } from 'shared/selectors/shared';
+import { selectArticleFragmentsFromRootState } from 'shared/selectors/shared';
 import { createShallowEqualResultSelector } from 'shared/util/selectorUtils';
 
-const clipboardContentSelector = (state: State) => state.clipboard || [];
+const selectClipboardContent = (state: State) => state.clipboard || [];
 
-const clipboardArticlesSelector = createShallowEqualResultSelector(
-  clipboardContentSelector,
-  articleFragmentsFromRootStateSelector,
+const selectClipboardArticles = createShallowEqualResultSelector(
+  selectClipboardContent,
+  selectArticleFragmentsFromRootState,
   (clipboard, articleFragments) => clipboard.map(afId => articleFragments[afId])
 );
 
-export { clipboardArticlesSelector, clipboardContentSelector };
+export { selectClipboardArticles, selectClipboardContent };

--- a/client-v2/src/selectors/collectionSelectors.ts
+++ b/client-v2/src/selectors/collectionSelectors.ts
@@ -1,24 +1,24 @@
 import { State } from 'types/State';
-import { getCollectionConfig } from './frontsSelectors';
+import { selectCollectionConfig } from './frontsSelectors';
 import {
   selectSharedState,
-  createCollectionSelector,
+  createSelectCollection,
   groupsArticleCount
 } from 'shared/selectors/shared';
 import flatten from 'lodash/flatten';
 import { createSelectEditorFrontsByPriority } from 'bundles/frontsUIBundle';
 import { getUpdatedSiblingGroupsForInsertion } from 'shared/reducers/groupsReducer';
 
-const selectCollection = createCollectionSelector();
+const selectCollection = createSelectCollection();
 
-const collectionParamsSelector = (
+const selectCollectionParams = (
   state: State,
   collectionIds: string[],
   returnOnlyUpdatedCollections: boolean = false
 ): Array<{ id: string; lastUpdated?: number }> =>
   collectionIds.reduce(
     (collections: Array<{ id: string; lastUpdated?: number }>, id) => {
-      const config = getCollectionConfig(state, id);
+      const config = selectCollectionConfig(state, id);
       if (!config) {
         throw new Error(`Collection ID ${id} does not exist in config`);
       }
@@ -43,7 +43,7 @@ const collectionParamsSelector = (
     []
   );
 
-function createCollectionsInOpenFrontsSelector() {
+function createSelectCollectionsInOpenFronts() {
   const selectEditorFrontsByPriority = createSelectEditorFrontsByPriority();
   return (state: State, priority: string): string[] => {
     const openFrontsForPriority = selectEditorFrontsByPriority(state, {
@@ -53,10 +53,10 @@ function createCollectionsInOpenFrontsSelector() {
   };
 }
 
-const isCollectionLockedSelector = (state: State, id: string): boolean =>
-  !!getCollectionConfig(state, id).uneditable;
+const selectIsCollectionLocked = (state: State, id: string): boolean =>
+  !!selectCollectionConfig(state, id).uneditable;
 
-const willCollectionHitCollectionCapSelector = (
+const selectWillCollectionHitCollectionCap = (
   state: State,
   groupId: string,
   index: number,
@@ -76,8 +76,8 @@ const willCollectionHitCollectionCapSelector = (
 };
 
 export {
-  willCollectionHitCollectionCapSelector,
-  collectionParamsSelector,
-  isCollectionLockedSelector,
-  createCollectionsInOpenFrontsSelector
+  selectWillCollectionHitCollectionCap,
+  selectCollectionParams,
+  selectIsCollectionLocked,
+  createSelectCollectionsInOpenFronts
 };

--- a/client-v2/src/selectors/configSelectors.ts
+++ b/client-v2/src/selectors/configSelectors.ts
@@ -2,49 +2,49 @@ import { createSelector } from 'reselect';
 import { State } from 'types/State';
 import { selectIsEditingEditions } from './pathSelectors';
 
-const configSelector = (state: State) => state.config;
+const selectConfig = (state: State) => state.config;
 
 const selectUserEmail = createSelector(
-  configSelector,
+  selectConfig,
   config => config && config.email
 );
 const selectFirstName = createSelector(
-  configSelector,
+  selectConfig,
   config => config && config.firstName
 );
 const selectLastName = createSelector(
-  configSelector,
+  selectConfig,
   config => config && config.lastName
 );
 
-const capiLiveURLSelector = createSelector(
-  configSelector,
+const selectCapiLiveURL = createSelector(
+  selectConfig,
   config => config && config.capiLiveUrl
 );
 
-const capiPreviewURLSelector = createSelector(
-  configSelector,
+const selectCapiPreviewURL = createSelector(
+  selectConfig,
   config => config && config.capiPreviewUrl
 );
 
-const collectionCapSelector = createSelector(
-  configSelector,
+const selectCollectionCap = createSelector(
+  selectConfig,
   selectIsEditingEditions,
   (config, isEditingEditions) =>
     (!isEditingEditions && config && config.collectionCap) || Infinity
 );
 
-const gridUrlSelector = createSelector(
-  configSelector,
+const selectGridUrl = createSelector(
+  selectConfig,
   config => config && config.mediaBaseUrl
 );
 
 export {
-  capiLiveURLSelector,
-  capiPreviewURLSelector,
+  selectCapiLiveURL,
+  selectCapiPreviewURL,
   selectUserEmail,
   selectFirstName,
   selectLastName,
-  collectionCapSelector,
-  gridUrlSelector
+  selectCollectionCap,
+  selectGridUrl
 };

--- a/client-v2/src/selectors/confirmModalSelectors.ts
+++ b/client-v2/src/selectors/confirmModalSelectors.ts
@@ -1,15 +1,14 @@
 import { State } from 'types/State';
 
-export const confirmModalIsOpenSelector = (state: State) =>
-  !!state.confirmModal;
+export const selectConfirmModalIsOpen = (state: State) => !!state.confirmModal;
 
-export const confirmModalTitleSelector = ({ confirmModal }: State) =>
+export const selectConfirmModalTitle = ({ confirmModal }: State) =>
   confirmModal ? confirmModal.title : '';
 
-export const confirmModalDescriptionSelector = ({ confirmModal }: State) =>
+export const selectConfirmModalDescription = ({ confirmModal }: State) =>
   confirmModal ? confirmModal.description : '';
 
-export const confirmModalActionsSelector = (
+export const selectConfirmModalActions = (
   { confirmModal }: State,
   accept: boolean
 ) =>

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -1,9 +1,9 @@
 import { selectors } from 'shared/bundles/collectionsBundle';
 import {
   selectSharedState,
-  createArticleFromArticleFragmentSelector
+  createSelectArticleFromArticleFragment
 } from 'shared/selectors/shared';
-import { getCollectionConfig } from 'selectors/frontsSelectors';
+import { selectCollectionConfig } from 'selectors/frontsSelectors';
 import { hasMainVideo } from 'shared/util/derivedArticle';
 import { isCollectionConfigDynamic } from '../util/frontsUtils';
 import { createSelector } from 'reselect';
@@ -46,11 +46,11 @@ const selectParentCollectionConfig = (
     selectSharedState(state),
     articleFragmentId
   );
-  return collectionId ? getCollectionConfig(state, collectionId) : undefined;
+  return collectionId ? selectCollectionConfig(state, collectionId) : undefined;
 };
 
 export const createSelectFormFieldsForCollectionItem = () => {
-  const selectDerivedArticle = createArticleFromArticleFragmentSelector();
+  const selectDerivedArticle = createSelectArticleFromArticleFragment();
   const selectDerivedArticleFromRootState = (state: State, id: string) =>
     selectDerivedArticle(selectSharedState(state), id);
   return createSelector(

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -1,20 +1,20 @@
 import {
   selectSharedState,
-  indexInGroupSelector,
-  groupsSelector,
-  groupCollectionSelector,
-  createCollectionSelector
+  selectIndexInGroup,
+  selectGroups,
+  selectGroupCollection,
+  createSelectCollection
 } from '../shared/selectors/shared';
-import { clipboardContentSelector } from 'selectors/clipboardSelectors';
+import { selectClipboardContent } from 'selectors/clipboardSelectors';
 import { State } from 'types/State';
-import { getUnlockedFrontCollections } from './frontsSelectors';
+import { selectUnlockedFrontCollections } from './frontsSelectors';
 
-const nextClipboardIndexSelector = (
+const selectNextClipboardIndex = (
   state: State,
   articleId: string,
   action: string
 ) => {
-  const clipboardContent = clipboardContentSelector(state);
+  const clipboardContent = selectClipboardContent(state);
 
   const fromIndex = clipboardContent.indexOf(articleId);
 
@@ -31,7 +31,7 @@ const nextClipboardIndexSelector = (
   return null;
 };
 
-const nextIndexAndGroupSelector = (
+const selectNextIndexAndGroup = (
   state: State,
   groupId: string,
   articleId: string,
@@ -39,14 +39,14 @@ const nextIndexAndGroupSelector = (
   frontId: string
 ) => {
   const sharedState = selectSharedState(state);
-  const group = groupsSelector(sharedState)[groupId];
+  const group = selectGroups(sharedState)[groupId];
   if (!group) {
     return null;
   }
 
   const groupArticleFragments = group.articleFragments;
 
-  const currentArticleIndex = indexInGroupSelector(
+  const currentArticleIndex = selectIndexInGroup(
     sharedState,
     groupId,
     articleId
@@ -68,7 +68,7 @@ const nextIndexAndGroupSelector = (
   }
 
   // Checking if moving between groups but inside the collection
-  const { collection, collectionItemSet } = groupCollectionSelector(
+  const { collection, collectionItemSet } = selectGroupCollection(
     sharedState,
     groupId
   );
@@ -87,7 +87,7 @@ const nextIndexAndGroupSelector = (
       if (action === 'up') {
         if (groupIndex !== 0) {
           const nextGroupId = collectionGroups[groupIndex - 1];
-          const nextGroupArticles = groupsSelector(sharedState)[nextGroupId]
+          const nextGroupArticles = selectGroups(sharedState)[nextGroupId]
             .articleFragments;
           return { toIndex: nextGroupArticles.length, nextGroupId };
         }
@@ -95,12 +95,12 @@ const nextIndexAndGroupSelector = (
     }
 
     // Checking if moving between collections
-    const frontCollections = getUnlockedFrontCollections(state, frontId);
+    const frontCollections = selectUnlockedFrontCollections(state, frontId);
     const collectionIndex = frontCollections.indexOf(collection.id);
     if (action === 'down') {
       if (collectionIndex < frontCollections.length - 1) {
-        const collectionSelector = createCollectionSelector();
-        const coll = collectionSelector(sharedState, {
+        const selectCollection = createSelectCollection();
+        const coll = selectCollection(sharedState, {
           collectionId: frontCollections[collectionIndex + 1]
         });
         if (!coll || !coll.draft) {
@@ -113,8 +113,8 @@ const nextIndexAndGroupSelector = (
     }
     if (action === 'up') {
       if (collectionIndex !== 0) {
-        const collectionSelector = createCollectionSelector();
-        const coll = collectionSelector(sharedState, {
+        const selectCollection = createSelectCollection();
+        const coll = selectCollection(sharedState, {
           collectionId: frontCollections[collectionIndex - 1]
         });
 
@@ -125,7 +125,7 @@ const nextIndexAndGroupSelector = (
         const nextIndex = coll.draft.length;
         const nextGroupId = coll.draft[nextIndex - 1];
 
-        const nextGroupArticles = groupsSelector(sharedState)[nextGroupId]
+        const nextGroupArticles = selectGroups(sharedState)[nextGroupId]
           .articleFragments;
 
         return {
@@ -142,4 +142,4 @@ const nextIndexAndGroupSelector = (
   return null;
 };
 
-export { nextIndexAndGroupSelector, nextClipboardIndexSelector };
+export { selectNextIndexAndGroup, selectNextClipboardIndex as selectNextClipboardIndexSelector };

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -142,4 +142,7 @@ const selectNextIndexAndGroup = (
   return null;
 };
 
-export { selectNextIndexAndGroup, selectNextClipboardIndex as selectNextClipboardIndexSelector };
+export {
+  selectNextIndexAndGroup,
+  selectNextClipboardIndex as selectNextClipboardIndexSelector
+};

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -3,9 +3,10 @@ import { matchIssuePath } from 'routes/routes';
 
 const maybeRemoveV2Prefix = (path: string) => path.replace(/^\/v2/, '');
 
-const getFullPath = (state: State) => state.path;
-const getV2SubPath = (state: State) => maybeRemoveV2Prefix(getFullPath(state));
+const selectFullPath = (state: State) => state.path;
+const selectV2SubPath = (state: State) =>
+  maybeRemoveV2Prefix(selectFullPath(state));
 const selectIsEditingEditions = (state: State) =>
-  !!matchIssuePath(getV2SubPath(state));
+  !!matchIssuePath(selectV2SubPath(state));
 
-export { getFullPath, getV2SubPath, selectIsEditingEditions };
+export { selectFullPath, selectV2SubPath, selectIsEditingEditions };

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -17,7 +17,7 @@ import { State } from '../../types/State';
 
 import {
   selectSharedState,
-  createArticlesInCollectionSelector
+  createSelectArticlesInCollection
 } from '../selectors/shared';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
@@ -315,7 +315,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 }
 
 const createMapStateToProps = () => {
-  const selectArticlesInCollection = createArticlesInCollectionSelector();
+  const selectArticlesInCollection = createSelectArticlesInCollection();
   return (state: State, props: ContainerProps) => {
     const sharedState = props.selectSharedState
       ? props.selectSharedState(state)

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -4,9 +4,9 @@ import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 
 import {
-  createArticleFromArticleFragmentSelector,
+  createSelectArticleFromArticleFragment,
   selectSharedState,
-  articleFragmentSelector
+  selectArticleFragment
 } from '../../selectors/shared';
 import { selectors } from 'shared/bundles/externalArticlesBundle';
 import { State } from '../../types/State';
@@ -182,7 +182,7 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
 }
 
 const createMapStateToProps = () => {
-  const articleSelector = createArticleFromArticleFragmentSelector();
+  const selectArticle = createSelectArticleFromArticleFragment();
   return (
     state: State,
     props: ContainerProps
@@ -190,8 +190,8 @@ const createMapStateToProps = () => {
     const sharedState = props.selectSharedState
       ? props.selectSharedState(state)
       : selectSharedState(state);
-    const article = articleSelector(sharedState, props.id);
-    const articleFragment = articleFragmentSelector(sharedState, props.id);
+    const article = selectArticle(sharedState, props.id);
+    const articleFragment = selectArticleFragment(sharedState, props.id);
     return {
       article,
       isLoading: selectors.selectIsLoadingInitialDataById(

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -15,7 +15,7 @@ import {
   validateMediaItem,
   validateImageSrc
 } from '../../util/validateImageSrc';
-import { gridUrlSelector } from 'selectors/configSelectors';
+import { selectGridUrl } from 'selectors/configSelectors';
 import { State } from 'types/State';
 import { GridData, Criteria } from 'shared/types/Grid';
 import { RubbishBinIcon, AddImageIcon } from '../icons/Icons';
@@ -350,7 +350,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 
 const mapStateToProps = (state: State) => {
   return {
-    gridUrl: gridUrlSelector(state)
+    gridUrl: selectGridUrl(state)
   };
 };
 

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -13,7 +13,7 @@ import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import { ArticleFragment, CollectionItemSizes } from 'shared/types/Collection';
 import {
   selectSharedState,
-  articleFragmentSelector
+  selectArticleFragment
 } from '../../selectors/shared';
 import { State } from '../../types/State';
 import CollectionItemHeading from '../collectionItem/CollectionItemHeading';
@@ -126,7 +126,7 @@ const mapStateToProps = (
     ? props.selectSharedState(state)
     : selectSharedState(state);
   return {
-    articleFragment: articleFragmentSelector(sharedState, props.id)
+    articleFragment: selectArticleFragment(sharedState, props.id)
   };
 };
 

--- a/client-v2/src/shared/reducers/articleFragmentsReducer.ts
+++ b/client-v2/src/shared/reducers/articleFragmentsReducer.ts
@@ -1,7 +1,7 @@
 import { Action } from '../types/Action';
 import { insertAndDedupeSiblings } from '../util/insertAndDedupeSiblings';
 import { State } from './sharedReducer';
-import { articleFragmentsSelector } from 'shared/selectors/shared';
+import { selectArticleFragments } from 'shared/selectors/shared';
 import {
   UPDATE_ARTICLE_FRAGMENT_META,
   ARTICLE_FRAGMENTS_RECEIVED,
@@ -72,7 +72,7 @@ const articleFragments = (
           ...(insertedArticleFragment.meta.supporting || [])
         ],
         index,
-        articleFragmentsSelector(prevSharedState)
+        selectArticleFragments(prevSharedState)
       );
 
       return {

--- a/client-v2/src/shared/reducers/groupsReducer.ts
+++ b/client-v2/src/shared/reducers/groupsReducer.ts
@@ -2,8 +2,8 @@ import { Action } from '../types/Action';
 import { insertAndDedupeSiblings } from '../util/insertAndDedupeSiblings';
 import { State } from './sharedReducer';
 import {
-  articleFragmentsSelector,
-  groupSiblingsSelector
+  selectArticleFragments,
+  selectGroupSiblings
 } from 'shared/selectors/shared';
 import { capGroupArticleFragments } from 'shared/util/capGroupArticleFragments';
 import keyBy from 'lodash/keyBy';
@@ -15,8 +15,8 @@ const getUpdatedSiblingGroupsForInsertion = (
   insertionIndex: number,
   articleFragmentId: string
 ) => {
-  const articleFragmentsMap = articleFragmentsSelector(sharedState);
-  const groupSiblings = groupSiblingsSelector(sharedState, insertionGroupId);
+  const articleFragmentsMap = selectArticleFragments(sharedState);
+  const groupSiblings = selectGroupSiblings(sharedState, insertionGroupId);
 
   if (!articleFragmentsMap[articleFragmentId]) {
     // this may have happened if we've purged after a poll
@@ -82,7 +82,7 @@ const groups = (
     }
     case 'SHARED/CAP_GROUP_SIBLINGS': {
       const { id, collectionCap } = action.payload;
-      const groupSiblings = groupSiblingsSelector(prevSharedState, id);
+      const groupSiblings = selectGroupSiblings(prevSharedState, id);
       const cappedSiblings = keyBy(
         capGroupArticleFragments(groupSiblings, collectionCap),
         ({ uuid }) => uuid

--- a/client-v2/src/shared/selectors/__tests__/collectionItem.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/collectionItem.spec.ts
@@ -1,22 +1,22 @@
-import { createCollectionItemTypeSelector } from '../collectionItem';
+import { createSelectCollectionItemType } from '../collectionItem';
 import { stateWithSnaplinksAndArticles } from 'shared/fixtures/shared';
 import collectionItemTypes from 'shared/constants/collectionItemTypes';
 
 describe('CollectionItem selectors', () => {
   describe('createCollectionItemTypeSelector', () => {
     it('should identify snap links', () => {
-      const selector = createCollectionItemTypeSelector();
+      const selectCollectionItemType = createSelectCollectionItemType();
       expect(
-        selector(
+        selectCollectionItemType(
           stateWithSnaplinksAndArticles.shared,
           '4c21ff2c-e2c5-4bac-ae14-24beb3f8d8b5'
         )
       ).toEqual(collectionItemTypes.SNAP_LINK);
     });
     it('should identify articles', () => {
-      const selector = createCollectionItemTypeSelector();
+      const selectCollectionItemType = createSelectCollectionItemType();
       expect(
-        selector(
+        selectCollectionItemType(
           stateWithSnaplinksAndArticles.shared,
           '134c9d4f-b05c-43f4-be41-a605b6dccab9'
         )

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -525,9 +525,10 @@ describe('Shared selectors', () => {
 
   describe('groupSiblingsSelector', () => {
     it('selects the sibling groups of a given group id', () => {
-      expect(
-        selectGroupSiblings(state, 'g1').map(({ uuid }) => uuid)
-      ).toEqual(['g1', 'g2']);
+      expect(selectGroupSiblings(state, 'g1').map(({ uuid }) => uuid)).toEqual([
+        'g1',
+        'g2'
+      ]);
     });
   });
 });

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -1,10 +1,10 @@
 import {
-  externalArticleFromArticleFragmentSelector,
-  createArticleFromArticleFragmentSelector,
-  createArticlesInCollectionGroupSelector,
-  createArticlesInCollectionSelector,
-  createCollectionSelector,
-  groupSiblingsSelector
+  selectExternalArticleFromArticleFragment,
+  createSelectArticleFromArticleFragment,
+  createSelectArticlesInCollectionGroup,
+  createSelectArticlesInCollection,
+  createSelectCollection,
+  selectGroupSiblings
 } from '../shared';
 
 const state: any = {
@@ -244,7 +244,7 @@ const state: any = {
 describe('Shared selectors', () => {
   describe('createCollectionSelector', () => {
     it('should select a collection by id', () => {
-      const selector = createCollectionSelector();
+      const selector = createSelectCollection();
       expect(selector(state, { collectionId: 'c1' })).toEqual({
         groups: ['group1', 'group2'],
         live: ['g1', 'g2'],
@@ -255,18 +255,18 @@ describe('Shared selectors', () => {
 
   describe('externalArticleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an external article referenced by the given article fragment', () => {
-      expect(externalArticleFromArticleFragmentSelector(state, 'af1')).toEqual(
+      expect(selectExternalArticleFromArticleFragment(state, 'af1')).toEqual(
         state.externalArticles.data.ea1
       );
       expect(
-        externalArticleFromArticleFragmentSelector(state, 'invalid')
+        selectExternalArticleFromArticleFragment(state, 'invalid')
       ).toEqual(undefined);
     });
   });
 
   describe('createArticleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an article (externalArticle + articleFragment) referenced by the given article fragment', () => {
-      const selector = createArticleFromArticleFragmentSelector();
+      const selector = createSelectArticleFromArticleFragment();
       expect(selector(state, 'af1')).toEqual({
         id: 'ea1',
         pillarName: 'external-pillar',
@@ -301,7 +301,7 @@ describe('Shared selectors', () => {
       expect(selector(state, 'invalid')).toEqual(undefined);
     });
     it('should set isLive property to false if article is not live', () => {
-      const selector = createArticleFromArticleFragmentSelector();
+      const selector = createSelectArticleFromArticleFragment();
       expect(selector(state, 'af2')).toEqual({
         id: 'ea2',
         pillarName: 'external-pillar',
@@ -315,7 +315,7 @@ describe('Shared selectors', () => {
       });
     });
     it('should set isLive to true if property is missing', () => {
-      const selector = createArticleFromArticleFragmentSelector();
+      const selector = createSelectArticleFromArticleFragment();
       expect(selector(state, 'af3')).toEqual({
         id: 'ea3',
         pillarName: 'external-pillar',
@@ -328,7 +328,7 @@ describe('Shared selectors', () => {
       });
     });
     it('should populate default metadata correctly', () => {
-      const selector = createArticleFromArticleFragmentSelector();
+      const selector = createSelectArticleFromArticleFragment();
       expect(selector(state, 'af4')).toEqual({
         id: 'ea4',
         pillarName: 'external-pillar',
@@ -358,7 +358,7 @@ describe('Shared selectors', () => {
 
   describe('createArticlesInCollectionSelector', () => {
     it('should return a list of all the articles in a given collection', () => {
-      const selector = createArticlesInCollectionSelector();
+      const selector = createSelectArticlesInCollection();
       expect(
         selector(state, {
           collectionId: 'c1',
@@ -367,7 +367,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af2', 'af1']);
     });
     it('should return articles in supporting positions', () => {
-      const selector = createArticlesInCollectionSelector();
+      const selector = createSelectArticlesInCollection();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -376,7 +376,7 @@ describe('Shared selectors', () => {
       ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
     it('should not return articles in supporting positions if includeSupportingArticles is false', () => {
-      const selector = createArticlesInCollectionSelector();
+      const selector = createSelectArticlesInCollection();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -389,7 +389,7 @@ describe('Shared selectors', () => {
 
   describe('createArticlesInCollectionGroupSelector', () => {
     it('should return a list of articles held by the given collection for the given display index', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c1',
@@ -413,7 +413,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af3', 'af4']);
     });
     it('should put articles which are in groups that don`t exis in the config in the first group', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       const currentGroups = state.groups;
       const newGroups = {
         ...currentGroups,
@@ -430,7 +430,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af6', 'af2', 'af1']);
     });
     it('should put articles which are in groups that don`t exis in the config in the first group even when none of the groups have names', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       const newGroups = {
         ...{ g1: { uuid: 'g1', articleFragments: ['af4'] } },
         ...{ g2: { uuid: 'g2', id: 'group6', articleFragments: ['af5'] } },
@@ -447,7 +447,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af5', 'af6', 'af4']);
     });
     it('should return articles in supporting positions', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -457,7 +457,7 @@ describe('Shared selectors', () => {
       ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
     it('should not return articles in supporting positions if includeSupportingArticles is false', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -468,7 +468,7 @@ describe('Shared selectors', () => {
       ).toEqual(['afWithSupporting']);
     });
     it('should return an empty array if the collection is not found', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'invalid',
@@ -478,7 +478,7 @@ describe('Shared selectors', () => {
       ).toEqual([]);
     });
     it('should return an empty array if the collectionSet is not found', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c1',
@@ -488,7 +488,7 @@ describe('Shared selectors', () => {
       ).toEqual([]);
     });
     it("should handle articles that don't contain a meta key", () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c4',
@@ -498,7 +498,7 @@ describe('Shared selectors', () => {
       ).toEqual([]);
     });
     it('should assume that articles without a meta key are in the first available group', () => {
-      const selector = createArticlesInCollectionGroupSelector();
+      const selector = createSelectArticlesInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c3',
@@ -508,14 +508,14 @@ describe('Shared selectors', () => {
       ).toEqual(['af5']);
     });
     it('should set the correct kicker when tag kicker is set ', () => {
-      const selector = createArticleFromArticleFragmentSelector();
+      const selector = createSelectArticleFromArticleFragment();
 
       expect(selector(state, 'afWithTagKicker')).toMatchObject({
         kicker: 'tag'
       });
     });
     it('should set the correct kicker when section kicker is set ', () => {
-      const selector = createArticleFromArticleFragmentSelector();
+      const selector = createSelectArticleFromArticleFragment();
 
       expect(selector(state, 'afWithSectionKicker')).toMatchObject({
         kicker: 'section'
@@ -526,7 +526,7 @@ describe('Shared selectors', () => {
   describe('groupSiblingsSelector', () => {
     it('selects the sibling groups of a given group id', () => {
       expect(
-        groupSiblingsSelector(state, 'g1').map(({ uuid }) => uuid)
+        selectGroupSiblings(state, 'g1').map(({ uuid }) => uuid)
       ).toEqual(['g1', 'g2']);
     });
   });

--- a/client-v2/src/shared/selectors/collection.ts
+++ b/client-v2/src/shared/selectors/collection.ts
@@ -1,12 +1,12 @@
 import { State } from 'shared/types/State';
 import { CollectionItemSets } from 'shared/types/Collection';
-import { createArticlesInCollectionSelector } from './shared';
+import { createSelectArticlesInCollection } from './shared';
 import uniq from 'lodash/uniq';
 import flatten from 'lodash/flatten';
 import { createSelector } from 'reselect';
-import { articleFragmentSelector } from '../selectors/shared';
+import { selectArticleFragment } from '../selectors/shared';
 
-const selectArticleIdsInCollection = createArticlesInCollectionSelector();
+const selectArticleIdsInCollection = createSelectArticlesInCollection();
 
 // Does not return UUIDs. Returns interal page codes for fetching articleFragments
 export const selectArticlesInCollections = createSelector(
@@ -22,16 +22,16 @@ export const selectArticlesInCollections = createSelector(
         collectionId: _,
         collectionSet: itemSet
       })
-        .map(articleId => articleFragmentSelector(state, articleId))
+        .map(articleId => selectArticleFragment(state, articleId))
         .map(article => article.id)
     ),
   articleIds => uniq(flatten(articleIds))
 );
 
 export const createSelectIsArticleInCollection = () => {
-  const articlesInCollectionSelector = createArticlesInCollectionSelector();
+  const selectArticlesInCollection = createSelectArticlesInCollection();
   return createSelector(
-    articlesInCollectionSelector,
+    selectArticlesInCollection,
     (
       _: State,
       { articleFragmentId: articleId }: { articleFragmentId: string }

--- a/client-v2/src/shared/selectors/collectionItem.ts
+++ b/client-v2/src/shared/selectors/collectionItem.ts
@@ -1,15 +1,15 @@
 import { createSelector } from 'reselect';
 import {
-  articleFragmentSelector,
-  externalArticleFromArticleFragmentSelector
+  selectArticleFragment,
+  selectExternalArticleFromArticleFragment
 } from './shared';
 import { validateId } from 'shared/util/snap';
 import CollectionItemTypes from 'shared/constants/collectionItemTypes';
 import { getContributorImage } from 'util/CAPIUtils';
 
-const createCollectionItemTypeSelector = () =>
+const createSelectCollectionItemType = () =>
   createSelector(
-    articleFragmentSelector,
+    selectArticleFragment,
     articleFragment => {
       return articleFragment && validateId(articleFragment.id)
         ? CollectionItemTypes.SNAP_LINK
@@ -19,8 +19,8 @@ const createCollectionItemTypeSelector = () =>
 
 const createSelectActiveImageUrl = () =>
   createSelector(
-    articleFragmentSelector,
-    externalArticleFromArticleFragmentSelector,
+    selectArticleFragment,
+    selectExternalArticleFromArticleFragment,
     (articleFragment, externalArticle): string | undefined => {
       if (!articleFragment || !articleFragment.meta) {
         return;
@@ -46,14 +46,14 @@ const createSelectActiveImageUrl = () =>
 
 const createSelectCutoutUrl = () =>
   createSelector(
-    externalArticleFromArticleFragmentSelector,
+    selectExternalArticleFromArticleFragment,
     externalArticle => {
       return externalArticle && getContributorImage(externalArticle);
     }
   );
 
 export {
-  createCollectionItemTypeSelector,
+  createSelectCollectionItemType,
   createSelectActiveImageUrl,
   createSelectCutoutUrl
 };

--- a/client-v2/src/strategies/fetch-collection.ts
+++ b/client-v2/src/strategies/fetch-collection.ts
@@ -1,5 +1,5 @@
 import { State } from 'types/State';
-import { collectionParamsSelector } from 'selectors/collectionSelectors';
+import { selectCollectionParams } from 'selectors/collectionSelectors';
 import { getCollections as fetchCollections } from 'services/faciaApi';
 import { getEditionsCollections as fetchEditionsCollections } from 'services/faciaApi';
 import { runStrategy } from './run-strategy';
@@ -35,7 +35,7 @@ const fetchCollectionsStrategy = (
   runStrategy<Promise<CollectionResponse[]> | null>(state, {
     front: () =>
       fetchCollections(
-        collectionParamsSelector(
+        selectCollectionParams(
           state,
           collectionIds,
           returnOnlyUpdatedCollections
@@ -43,7 +43,7 @@ const fetchCollectionsStrategy = (
       ),
     edition: () =>
       fetchEditionsCollections(
-        collectionParamsSelector(
+        selectCollectionParams(
           state,
           collectionIds,
           returnOnlyUpdatedCollections

--- a/client-v2/src/strategies/run-strategy.ts
+++ b/client-v2/src/strategies/run-strategy.ts
@@ -1,5 +1,5 @@
 import { State } from 'types/State';
-import { getV2SubPath } from 'selectors/pathSelectors';
+import { selectV2SubPath } from 'selectors/pathSelectors';
 import { matchFrontsEditPath, matchIssuePath } from 'routes/routes';
 
 interface StrategyMap<R> {
@@ -9,7 +9,7 @@ interface StrategyMap<R> {
 }
 
 const runStrategy = <R>(state: State, strategies: StrategyMap<R>) => {
-  const path = getV2SubPath(state);
+  const path = selectV2SubPath(state);
 
   const frontsMatch = matchFrontsEditPath(path);
   if (frontsMatch) {

--- a/client-v2/src/util/clipboardUtils.ts
+++ b/client-v2/src/util/clipboardUtils.ts
@@ -2,7 +2,7 @@ import {
   ArticleFragment,
   NestedArticleFragment
 } from 'shared/types/Collection';
-import { clipboardSelector } from 'selectors/frontsSelectors';
+import { selectClipboard } from 'selectors/frontsSelectors';
 import { State } from 'types/State';
 import { normalize, denormalize } from './clipboardSchema';
 import { notLiveLabels } from 'constants/fronts';
@@ -23,7 +23,7 @@ function normaliseClipboard(clipboard: {
 function denormaliseClipboard(
   state: State
 ): { articles: NestedArticleFragment[] } {
-  const clipboard = clipboardSelector(state);
+  const clipboard = selectClipboard(state);
 
   return denormalize(
     { articles: clipboard },

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -9,7 +9,7 @@ import { DerivedArticle } from 'shared/types/Article';
 import { CapiArticle } from 'types/Capi';
 import { State } from 'types/State';
 import {
-  articleFragmentSelector,
+  selectArticleFragment,
   selectSharedState
 } from 'shared/selectors/shared';
 
@@ -189,12 +189,12 @@ export const getArticleFragmentMetaFromFormValues = (
   );
 
   // We only return dirtied values.
-  const isDirtySelector = isDirty(id);
+  const selectIsDirty = isDirty(id);
   const dirtiedFields = pickBy(completeMeta, (_, key) => {
-    return isDirtySelector(state, formToMetaFieldMap[key] || key);
+    return selectIsDirty(state, formToMetaFieldMap[key] || key);
   });
 
-  const existingArticleFragment = articleFragmentSelector(
+  const existingArticleFragment = selectArticleFragment(
     selectSharedState(state),
     id
   );

--- a/client-v2/src/util/moveUtils.ts
+++ b/client-v2/src/util/moveUtils.ts
@@ -1,6 +1,6 @@
 import { PosSpec } from 'lib/dnd';
 import { State } from 'shared/types/State';
-import { groupSiblingsSelector } from 'shared/selectors/shared';
+import { selectGroupSiblings } from 'shared/selectors/shared';
 import { Group } from 'shared/types/Collection';
 import findIndex from 'lodash/findIndex';
 
@@ -85,7 +85,7 @@ function getGroupIndicesWithRespectToState(
   state: State
 ): { articleCount: number; groupSiblings: Group[] } {
   const groupId = position.id;
-  const groupSiblings = groupSiblingsSelector(state, groupId);
+  const groupSiblings = selectGroupSiblings(state, groupId);
   const currentGroupIndex = findIndex(
     groupSiblings,
     group => group.uuid === groupId

--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -2,7 +2,7 @@ import { fetchStaleOpenCollections } from 'actions/Collections';
 import { Dispatch } from 'types/Store';
 import { Store } from 'types/Store';
 import { matchFrontsEditPath, matchIssuePath } from 'routes/routes';
-import { getV2SubPath } from 'selectors/pathSelectors';
+import { selectV2SubPath } from 'selectors/pathSelectors';
 
 /**
  * TODO: do we want to check if there are any collectionUpdates going out here
@@ -14,7 +14,7 @@ export default (store: Store) =>
     if ((window as any).IS_INTEGRATION) {
       return;
     }
-    const path = getV2SubPath(store.getState());
+    const path = selectV2SubPath(store.getState());
     const match = matchFrontsEditPath(path) || matchIssuePath(path);
     if (!match || !match.params.priority) {
       return;

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -12,7 +12,7 @@ import { selectSharedState } from 'shared/selectors/shared';
 import { saveOpenFrontIds, saveFavouriteFrontIds } from 'services/faciaApi';
 import { NestedArticleFragment } from 'shared/types/Collection';
 import { denormaliseClipboard } from 'util/clipboardUtils';
-import { getFront } from 'selectors/frontsSelectors';
+import { selectFront } from 'selectors/frontsSelectors';
 import {
   selectEditorFrontIds,
   selectEditorFavouriteFrontIds
@@ -233,7 +233,7 @@ const persistOpenFrontsOnEdit: (
   // Only persist fronts that exist in the state, clearing out
   // fronts that have been deleted.
   const filteredFrontIdsByPriority = mapValues(frontIdsByPriority, frontIds =>
-    frontIds.filter(frontId => !!getFront(state, { frontId }))
+    frontIds.filter(frontId => !!selectFront(state, { frontId }))
   );
   // Now they're in the state, persist the relevant front ids.
   persistFrontIds(filteredFrontIdsByPriority);


### PR DESCRIPTION
## What's changed?

Rename selectors for consistency -- they now all start with `select`, and factories start with `createSelect`. It makes it easier to see exactly what role the function plays at first glance.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
