### PR TITLE
Correct reversed icons

### DIFF
--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -203,10 +203,7 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                 }}
               >
                 <ButtonLabel>Expand all&nbsp;</ButtonLabel>
-                <DownCaretIcon
-                  fill={sharedTheme.base.colors.text}
-                  direction="down"
-                />
+                <DownCaretIcon fill={sharedTheme.base.colors.text} />
               </OverviewHeadingButton>
               <OverviewHeadingButton
                 onClick={e => {
@@ -215,7 +212,10 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                 }}
               >
                 <ButtonLabel>Collapse all&nbsp;</ButtonLabel>
-                <DownCaretIcon fill={sharedTheme.base.colors.text} />
+                <DownCaretIcon
+                  direction="up"
+                  fill={sharedTheme.base.colors.text}
+                />
               </OverviewHeadingButton>
               <OverviewToggleContainer>
                 <OverviewHeading htmlFor={overviewToggleId}>

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -28,7 +28,7 @@ const DownCaretIcon = ({
   fill,
   size = 'm',
   title = null,
-  direction = 'up'
+  direction = 'down'
 }: IconProps & Directions) => (
   <svg
     width={mapSize(size)}


### PR DESCRIPTION
## What's changed?

Correct icons unintentionally reversed by #812 🙃 

Before:

![Screenshot 2019-07-11 at 12 32 05](https://user-images.githubusercontent.com/7767575/61047783-288b6c00-a3d8-11e9-8436-45e6e7fa7008.png)

After:

![Screenshot 2019-07-11 at 12 31 36](https://user-images.githubusercontent.com/7767575/61047732-11e51500-a3d8-11e9-88ee-df67cf6af88d.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
