### PR TITLE
Remove width limit for fronts

### DIFF
--- a/client-v2/src/components/FrontsEdit/Edit.tsx
+++ b/client-v2/src/components/FrontsEdit/Edit.tsx
@@ -52,6 +52,7 @@ const FrontsContainer = styled(SectionContainer)<{
   makeRoomForExtraHeader: boolean;
 }>`
   display: flex;
+  flex-grow: 1;
   height: 100%;
   overflow-y: hidden;
   overflow-x: scroll;

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -75,7 +75,7 @@ const SingleFrontContainer = styled('div')<{
       : isOverviewOpen
       ? singleFrontMinWidth + overviewMinWidth + 10
       : singleFrontMinWidth}px;
-  flex: 1 1 auto;
+  flex: 1 1;
   height: 100%;
 `;
 

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -61,7 +61,6 @@ interface CollectionState {
 const CollectionContainer = ContentContainer.extend<{
   hasMultipleFrontsOpen?: boolean;
 }>`
-  max-width: 590px;
   &:focus {
     border: 1px solid ${props => props.theme.shared.base.colors.focusColor};
     border-top: none;


### PR DESCRIPTION
## What's changed?

This PR allows fronts to expand to fill the available space.

![responsive-full](https://user-images.githubusercontent.com/7767575/61070586-fd6c4100-a406-11e9-8b68-7ab5947e22e3.gif)

There's no limit on how wide fronts can now get -- after chats with Robert and @akemitakagi we're confident that users will size the tool for their own needs, but we can revisit this assumption if necessary.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
