### PR TITLE
Separate clipboards

### DIFF
--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -28,7 +28,7 @@ case class Defaults(
   navListCap: Int,
   navListType: String,
   collectionMetadata: Iterable[Metadata],
-  clipboardArticles: Option[List[Trail]],
+  clipboardArticles: Map[String, Option[List[Trail]]],
   frontIds: Option[List[String]],
   frontIdsByPriority: Option[Map[String, List[String]]],
   favouriteFrontIdsByPriority: Option[Map[String, List[String]]],
@@ -66,7 +66,7 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
         Metadata.tags.map{
           case (_, meta) => meta
         },
-        None,
+        Map(),
         None,
         None,
         None

--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -16,18 +16,11 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
 
 
   def putClipboardContent() = APIAuthAction { request =>
-    println("-----")
-    println(request.body)
-    println(request.body.asJson)
 
     val clipboardArticleRequest: Option[Map[String, List[Trail]]] = request.body.asJson.flatMap(jsValue => {
-        //TODO we should not fail if the list is missing
-      println("js value is ", jsValue)
       val js = jsValue.as[Map[String, List[Trail]]]
-      println("js is ", js)
       jsValue.asOpt[Map[String, List[Trail]]]
     })
-    println(clipboardArticleRequest)
 
     clipboardArticleRequest match {
       case Some(cliboardArticleLists) => {

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -5,7 +5,7 @@ import com.gu.scanamo.syntax._
 import model.UserData
 
 import scala.concurrent.ExecutionContext
-import com.gu.facia.client.models.Metadata
+import com.gu.facia.client.models.{Metadata, Trail}
 import permissions.Permissions
 import play.api.libs.json.Json
 import switchboard.SwitchManager
@@ -39,6 +39,11 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
     val maybeUserData: Option[UserData] = Scanamo.exec(dynamo.client)(
       userDataTable.get('email -> userEmail)).flatMap(_.right.toOption)
 
+    val clipboardArticles: Map[String, Option[List[Trail]]] = Map(
+      "frontsClipboard" -> maybeUserData.map(_.clipboardArticles.getOrElse(List())),
+      "editionsClipboard" -> maybeUserData.map(_.editionsClipboardArticles.getOrElse(List()))
+    )
+
     val conf = Defaults(
       isDev,
       config.environment.stage,
@@ -58,7 +63,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
       Metadata.tags.map {
         case (_, meta) => meta
       },
-      maybeUserData.map(_.clipboardArticles.getOrElse(List())),
+      clipboardArticles,
       maybeUserData.map(_.frontIds.getOrElse(List())),
       maybeUserData.map(_.frontIdsByPriority.getOrElse(Map())),
       maybeUserData.map(_.favouriteFrontIdsByPriority.getOrElse(Map())),

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -31,6 +31,7 @@ object UserData {
 case class UserData(
   email: String,
   clipboardArticles: Option[List[Trail]],
+  editionsClipboardArticles: Option[List[Trail]],
   frontIds: Option[List[String]],
   frontIdsByPriority: Option[Map[String, List[String]]],
   favouriteFrontIdsByPriority: Option[Map[String, List[String]]]

--- a/client-v2/integration/server/index.html
+++ b/client-v2/integration/server/index.html
@@ -84,8 +84,8 @@
           { type: 'Breaking' },
           { type: 'Branded' }
         ],
-        clipboardArticles: [
-          {
+        clipboardArticles: {
+          frontsClipboard: [{
             id: 'internal-code/page/5224281',
             frontPublicationDate: 1540381197498,
             meta: {
@@ -97,8 +97,9 @@
                 }
               ]
             }
-          }
-        ],
+          }],
+          editionsClipboard: []
+        },
         frontIds: ['test/front'],
         frontIdsByPriority: {
           editorial: ['test/front']

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -57,6 +57,11 @@ type InsertThunkActionCreator = (
   removeAction: Action | null
 ) => ThunkResult<void>;
 
+const getEditingMode = (state: State): ClipboardType => {
+  const isEditionEditions = selectIsEditingEditions(state);
+  return isEditionEditions ? 'editions' : 'fronts';
+};
+
 // Creates a thunk action creator from a plain action creator that also allows
 // passing a persistence location
 // we need to create thunks for these to help TS as we may be dispatching either
@@ -77,8 +82,7 @@ const createInsertArticleFragmentThunk = (action: InsertActionCreator) => (
   if (removeAction) {
     dispatch(removeAction);
   }
-  const isEditionEditions = selectIsEditingEditions(getState());
-  const editingMode = isEditionEditions ? 'editions' : 'fronts';
+  const editingMode = getEditingMode(getState());
   if (persistTo === 'collection') {
     dispatch(
       addPersistMetaToAction(action, {
@@ -309,8 +313,7 @@ const removeArticleFragment = (
     if (!removeActionCreator) {
       return;
     }
-    const isEditionEditions = selectIsEditingEditions(getState());
-    const editingMode = isEditionEditions ? 'editions' : 'fronts';
+    const editingMode = getEditingMode(getState());
     dispatch(
       removeActionCreator(groupIdFromState, articleFragmentId, editingMode)
     );
@@ -363,8 +366,7 @@ const moveArticleFragment = (
         if (!fromWithRespectToState) {
           dispatch(articleFragmentsReceived([parent, ...supporting]));
         }
-        const isEditionEditions = selectIsEditingEditions(getState());
-        const editingMode = isEditionEditions ? 'editions' : 'fronts';
+        const editingMode = getEditingMode(getState());
 
         dispatch(
           insertActionCreator(

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -39,7 +39,7 @@ import { MappableDropType } from 'util/collectionUtils';
 import { willCollectionHitCollectionCapSelector } from 'selectors/collectionSelectors';
 import { batchActions } from 'redux-batched-actions';
 import { selectIsEditingEditions } from 'selectors/pathSelectors';
-import { ClipboardType } from 'shared/types/Clipboard';
+import { ClipboardType } from 'shared/types/clipboard';
 
 type InsertActionCreator = (
   id: string,

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -39,13 +39,13 @@ import { MappableDropType } from 'util/collectionUtils';
 import { willCollectionHitCollectionCapSelector } from 'selectors/collectionSelectors';
 import { batchActions } from 'redux-batched-actions';
 import { selectIsEditingEditions } from 'selectors/pathSelectors';
+import { ClipboardType } from 'shared/types/Clipboard';
 
 type InsertActionCreator = (
   id: string,
   index: number,
   articleFragmentId: string,
-  // TO do change
-  editingMode?: string
+  editingMode?: ClipboardType
 ) => Action;
 
 type InsertThunkActionCreator = (
@@ -79,7 +79,6 @@ const createInsertArticleFragmentThunk = (action: InsertActionCreator) => (
   }
   const isEditionEditions = selectIsEditingEditions(getState());
   const editingMode = isEditionEditions ? 'editions' : 'fronts';
-  // const argumentsToPass = persistToClipboard ? [id, index, articleFragmentId, editingMode] : [id, index, articleFragmentId, editingMode];
   if (persistTo === 'collection') {
     dispatch(
       addPersistMetaToAction(action, {
@@ -198,7 +197,7 @@ const getInsertionActionCreatorFromType = (
 type RemoveActionCreator = (
   id: string,
   articleFragmentId: string,
-  editingMode?: string
+  editingMode?: ClipboardType
 ) => Action;
 
 // this maps a type string such as `group` to a remove action creator and if

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -10,6 +10,7 @@ import {
   InsertClipboardArticleFragment,
   RemoveClipboardArticleFragment
 } from 'types/Action';
+import { ClipboardType } from 'shared/types/Clipboard';
 
 export const REMOVE_CLIPBOARD_ARTICLE_FRAGMENT =
   'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT';
@@ -70,9 +71,9 @@ const insertClipboardArticleFragment = (
   id: string,
   index: number,
   articleFragmentId: string,
-  type?: string
+  type?: ClipboardType
 ): InsertClipboardArticleFragment => {
-  const clipboardType = type || '';
+  const clipboardType = type;
   return {
     type: INSERT_CLIPBOARD_ARTICLE_FRAGMENT,
     payload: {
@@ -87,9 +88,9 @@ const insertClipboardArticleFragment = (
 const removeClipboardArticleFragment = (
   id: string,
   articleFragmentId: string,
-  type?: string
+  type?: ClipboardType
 ): RemoveClipboardArticleFragment => {
-  const clipboardType = type || '';
+  const clipboardType = type;
   return {
     type: REMOVE_CLIPBOARD_ARTICLE_FRAGMENT,
     payload: {

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -60,11 +60,10 @@ function updateClipboard(clipboardContent: {
   frontsClipboard: NestedArticleFragment[];
   editionsClipboard: NestedArticleFragment[];
 }): ThunkResult<Promise<NestedArticleFragment[] | void>> {
-  return () => {
-    return saveClipboard(clipboardContent).catch(() => {
+  return () =>
+    saveClipboard(clipboardContent).catch(() => {
       // @todo: implement once error handling is done
     });
-  };
 }
 
 const insertClipboardArticleFragment = (

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -10,7 +10,7 @@ import {
   InsertClipboardArticleFragment,
   RemoveClipboardArticleFragment
 } from 'types/Action';
-import { ClipboardType } from 'shared/types/Clipboard';
+import { ClipboardType } from 'shared/types/clipboard';
 
 export const REMOVE_CLIPBOARD_ARTICLE_FRAGMENT =
   'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT';

--- a/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
+++ b/client-v2/src/actions/__tests__/ArticleFragments.spec.ts
@@ -104,7 +104,8 @@ const buildStore = (added: ArticleFragmentSpec, collectionCap = Infinity) => {
   };
 };
 
-const getPersistTo = (parentType: string) => parentType === 'clipboard' ? 'clipboard' : 'collection';
+const getPersistTo = (parentType: string) =>
+  parentType === 'clipboard' ? 'clipboard' : 'collection';
 const insert = async (
   insertedArticleFragmentSpec: [string, string],
   index: number,
@@ -170,7 +171,7 @@ const move = (
       type: fromType,
       index: -1 // this doesn't matter
     },
-    getPersistTo(toType),
+    getPersistTo(toType)
   ) as any);
 
   // setting accept to null will enuse the modal is still "open" during the test
@@ -201,7 +202,8 @@ const remove = (
   return getState();
 };
 
-const clipboardSelector = (state: any) => innerClipboardSelector(state).frontsClipboard;
+const clipboardSelector = (state: any) =>
+  innerClipboardSelector(state).frontsClipboard;
 
 const groupArticlesSelectorInner = createGroupArticlesSelector();
 const groupArticlesSelector = (state: any, groupId: string) =>
@@ -220,7 +222,7 @@ describe('ArticleFragments actions', () => {
         clipboardSelector(await insert(['h', '8'], 2, 'clipboard', 'clipboard'))
       ).toEqual(['d', 'e', 'h', 'f']);
 
-       expect(
+      expect(
         groupArticlesSelector(await insert(['h', '8'], 2, 'group', 'a'), 'a')
       ).toEqual(['a', 'b', 'h', 'c']);
 

--- a/client-v2/src/fixtures/clipboard.ts
+++ b/client-v2/src/fixtures/clipboard.ts
@@ -2,7 +2,10 @@ import { initialState as externalArticlesState } from 'shared/bundles/externalAr
 import { initialState as collectionsState } from 'shared/bundles/collectionsBundle';
 
 const stateWithClipboard = {
-  clipboard: ['article', 'article2'],
+  clipboard: {
+    frontsClipboard: ['article', 'article2'],
+    editionsClipboard: ['article3']
+  },
   shared: {
     groups: {},
     externalArticles: externalArticlesState,

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -245,13 +245,16 @@ const state = {
       { type: 'Breaking' },
       { type: 'Branded' }
     ],
-    clipboardArticles: [
-      {
-        id: 'internal-code/page/5592826',
-        frontPublicationDate: 1547204861924,
-        meta: {}
-      }
-    ],
+    clipboardArticles: {
+      frontsClipboard: [
+        {
+          id: 'internal-code/page/5592826',
+          frontPublicationDate: 1547204861924,
+          meta: {}
+        }
+      ],
+      editionsClipboard: []
+    },
     frontIds: [],
     frontIdsByPriority: {},
     favouriteFrontIdsByPriority: {},
@@ -664,7 +667,10 @@ const state = {
     }
   },
   unpublishedChanges: {},
-  clipboard: ['56a3b407-741c-439f-a678-175abea44a9f'],
+  clipboard: {
+    frontsClipboard: ['56a3b407-741c-439f-a678-175abea44a9f'],
+    editionsClipboard: []
+  },
   editor: {
     showOpenFrontsMenu: false,
     frontIds: [],

--- a/client-v2/src/reducers/clipboardReducer.ts
+++ b/client-v2/src/reducers/clipboardReducer.ts
@@ -8,10 +8,13 @@ import {
   UPDATE_CLIPBOARD_CONTENT
 } from 'actions/Clipboard';
 
-type State = string[];
+interface State {
+  frontsClipboard: string[];
+  editionsClipboard: string[];
+}
 
 const clipboard = (
-  state: State = [],
+  state: State = { frontsClipboard: [], editionsClipboard: [] },
   action: Action,
   prevSharedState: SharedState
 ): State => {
@@ -21,15 +24,51 @@ const clipboard = (
       return payload;
     }
     case REMOVE_CLIPBOARD_ARTICLE_FRAGMENT: {
-      return state.filter(id => id !== action.payload.articleFragmentId);
+      if (action.payload.clipboardType === 'fronts') {
+        return {
+          ...state,
+          ...{
+            frontsClipboard: state.frontsClipboard.filter(
+              id => id !== action.payload.articleFragmentId
+            )
+          }
+        };
+      }
+      if (action.payload.clipboardType === 'editions') {
+        return {
+          ...state,
+          ...{
+            editionsClipboard: state.editionsClipboard.filter(
+              id => id !== action.payload.articleFragmentId
+            )
+          }
+        };
+      }
+      return state;
     }
+
     case INSERT_CLIPBOARD_ARTICLE_FRAGMENT: {
-      return insertAndDedupeSiblings(
-        state,
-        [action.payload.articleFragmentId],
-        action.payload.index,
-        articleFragmentsSelector(prevSharedState)
-      );
+      if (action.payload.clipboardType === 'fronts') {
+        const newFrontsClipboard = insertAndDedupeSiblings(
+          state.frontsClipboard,
+          [action.payload.articleFragmentId],
+          action.payload.index,
+          articleFragmentsSelector(prevSharedState)
+        );
+        return { ...state, frontsClipboard: newFrontsClipboard };
+      }
+
+      if (action.payload.clipboardType === 'editions') {
+        const newEditionsClipboard = insertAndDedupeSiblings(
+          state.editionsClipboard,
+          [action.payload.articleFragmentId],
+          action.payload.index,
+          articleFragmentsSelector(prevSharedState)
+        );
+        return { ...state, editionsClipboard: newEditionsClipboard };
+      }
+
+      return state;
     }
 
     default: {

--- a/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -7,11 +7,17 @@ import state from 'fixtures/initialState';
 describe('nextClipboardIndexSelector', () => {
   const stateWithClipboard = {
     ...state,
-    clipboard: ['id-1', 'id-2', 'id-3', 'id-4']
+    clipboard: {
+      frontsClipboard: ['id-1', 'id-2', 'id-3', 'id-4'],
+      editionsClipboard: []
+    }
   };
 
   it('return null when clipboard is empty', () => {
-    const stateWithEmptyClipboard = { ...state, clipboard: [] };
+    const stateWithEmptyClipboard = {
+      ...state,
+      clipboard: { frontsClipboard: [], editionsClipboard: [] }
+    };
     expect(
       nextClipboardIndexSelector(stateWithEmptyClipboard, 'some-id', 'up')
     ).toEqual(null);

--- a/client-v2/src/selectors/clipboardSelectors.ts
+++ b/client-v2/src/selectors/clipboardSelectors.ts
@@ -1,13 +1,20 @@
 import { State } from 'types/State';
 import { articleFragmentsFromRootStateSelector } from 'shared/selectors/shared';
 import { createShallowEqualResultSelector } from 'shared/util/selectorUtils';
+import { selectIsEditingEditions } from 'selectors/pathSelectors';
 
 const clipboardContentSelector = (state: State) => state.clipboard || [];
 
 const clipboardArticlesSelector = createShallowEqualResultSelector(
   clipboardContentSelector,
   articleFragmentsFromRootStateSelector,
-  (clipboard, articleFragments) => clipboard.map(afId => articleFragments[afId])
+  selectIsEditingEditions,
+  (clipboard, articleFragments, isEditingEditions) => {
+    if (isEditingEditions) {
+      return clipboard.editionsClipboard.map(afId => articleFragments[afId]);
+    }
+    return clipboard.frontsClipboard.map(afId => articleFragments[afId]);
+  }
 );
 
 export { clipboardArticlesSelector, clipboardContentSelector };

--- a/client-v2/src/selectors/keyboardNavigationSelectors.ts
+++ b/client-v2/src/selectors/keyboardNavigationSelectors.ts
@@ -8,6 +8,7 @@ import {
 import { clipboardContentSelector } from 'selectors/clipboardSelectors';
 import { State } from 'types/State';
 import { getUnlockedFrontCollections } from './frontsSelectors';
+import { selectIsEditingEditions } from 'selectors/pathSelectors';
 
 const nextClipboardIndexSelector = (
   state: State,
@@ -15,11 +16,18 @@ const nextClipboardIndexSelector = (
   action: string
 ) => {
   const clipboardContent = clipboardContentSelector(state);
+  const isEditingEditions = selectIsEditingEditions(state);
+  let clipboardArticles;
+  if (isEditingEditions) {
+    clipboardArticles = clipboardContent.editionsClipboard;
+  } else {
+    clipboardArticles = clipboardContent.frontsClipboard;
+  }
 
-  const fromIndex = clipboardContent.indexOf(articleId);
+  const fromIndex = clipboardArticles.indexOf(articleId);
 
   if (action === 'down') {
-    if (fromIndex < clipboardContent.length - 1) {
+    if (fromIndex < clipboardArticles.length - 1) {
       return { fromIndex, toIndex: fromIndex + 1 };
     }
   }

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -209,9 +209,10 @@ const updateEditionsCollection = (collectionId: string) =>
     'put'
   )(collectionId);
 
-async function saveClipboard(
-  clipboardContent: NestedArticleFragment[]
-): Promise<NestedArticleFragment[]> {
+async function saveClipboard(clipboardContent: {
+  frontsClipboard: NestedArticleFragment[];
+  editionsClipboard: NestedArticleFragment[];
+}): Promise<NestedArticleFragment[]> {
   // The server does not respond with JSON
   try {
     const response = await pandaFetch(`/userdata/clipboard`, {

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -29,6 +29,11 @@ interface UpdateArticleFragmentMeta {
   };
 }
 
+// The clipboard type here is only needed for when we are inserting
+//  into a clipboard. Ideally clipboard type would only belong to the
+//  clipboard insert action because a lot of the code to handle insertions
+//  in different places in shared is cleaner to have clipboard type here
+//  as optional
 interface InsertArticleFragmentPayload {
   id: string;
   index: number;

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -7,6 +7,7 @@ import {
 } from './Collection';
 import { Actions } from 'lib/createAsyncResourceBundle';
 import { copyArticleFragmentImageMeta } from 'shared/actions/ArticleFragments';
+import { ClipboardType } from 'shared/types/clipboard';
 
 interface ArticleFragmentsReceived {
   type: 'SHARED/ARTICLE_FRAGMENTS_RECEIVED';
@@ -38,7 +39,7 @@ interface InsertArticleFragmentPayload {
   id: string;
   index: number;
   articleFragmentId: string;
-  clipboardType?: string;
+  clipboardType?: ClipboardType;
 }
 
 type InsertGroupArticleFragment = {
@@ -57,7 +58,7 @@ interface RemoveArticleFragmentPayload {
   payload: {
     id: string;
     articleFragmentId: string;
-    clipboardType?: string;
+    clipboardType?: ClipboardType;
   };
 }
 

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -33,6 +33,7 @@ interface InsertArticleFragmentPayload {
   id: string;
   index: number;
   articleFragmentId: string;
+  clipboardType?: string;
 }
 
 type InsertGroupArticleFragment = {
@@ -51,6 +52,7 @@ interface RemoveArticleFragmentPayload {
   payload: {
     id: string;
     articleFragmentId: string;
+    clipboardType?: string;
   };
 }
 

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -234,7 +234,7 @@ interface PublishCollectionSuccess {
 
 interface UpdateClipboardContent {
   type: 'UPDATE_CLIPBOARD_CONTENT';
-  payload: string[];
+  payload: { frontsClipboard: string[]; editionsClipboard: string[] };
 }
 
 interface RecordStaleFronts {

--- a/client-v2/src/types/Config.ts
+++ b/client-v2/src/types/Config.ts
@@ -41,7 +41,10 @@ interface Config {
   favouriteFrontIdsByPriority: {
     [id: string]: string[];
   };
-  clipboardArticles: NestedArticleFragment[];
+  clipboardArticles: {
+    frontsClipboard: NestedArticleFragment[];
+    editionsClipboard: NestedArticleFragment[];
+  };
 }
 
 export { Config };

--- a/client-v2/src/util/__tests__/clipboardUtils.spec.ts
+++ b/client-v2/src/util/__tests__/clipboardUtils.spec.ts
@@ -6,16 +6,21 @@ describe('Clipboard utilities', () => {
   describe('normaliseClipboard', () => {
     it('should normalise a clipboard with articles', () => {
       const result = normaliseClipboard({
-        articles: [liveArticle, articleWithSupporting]
+        frontsClipboard: [liveArticle, articleWithSupporting],
+        editionsClipboard: []
       });
       const { articleFragments } = result;
-      const clipboardArticles = result.clipboard.articles;
-      const supportingArticle = articleFragments[clipboardArticles[1]].meta
-        .supporting![0];
-      expect(clipboardArticles.length).toEqual(2);
+      const frontsClipboardArticles = result.frontsClipboard;
+      const supportingArticle = articleFragments[frontsClipboardArticles[1]]
+        .meta.supporting![0];
+      expect(frontsClipboardArticles.length).toEqual(2);
       expect(Object.keys(articleFragments).length).toEqual(4);
-      expect(articleFragments[clipboardArticles[0]].id).toBe('article/live/0');
-      expect(articleFragments[clipboardArticles[1]].id).toBe('a/long/path/1');
+      expect(articleFragments[frontsClipboardArticles[0]].id).toBe(
+        'article/live/0'
+      );
+      expect(articleFragments[frontsClipboardArticles[1]].id).toBe(
+        'a/long/path/1'
+      );
       expect(articleFragments[supportingArticle].id).toBe('article/draft/2');
     });
   });
@@ -23,11 +28,12 @@ describe('Clipboard utilities', () => {
   describe('denormaliseClipboard', () => {
     it('should denormalise a clipboard from the application state', () => {
       const result = denormaliseClipboard(stateWithClipboard as any);
-      expect(result.articles[0].id).toEqual('article/live/0');
-      expect(result.articles[1].id).toEqual('article/live/1');
-      expect(result.articles[1].meta.supporting![0].id).toEqual(
+      expect(result.frontsClipboard[0].id).toEqual('article/live/0');
+      expect(result.frontsClipboard[1].id).toEqual('article/live/1');
+      expect(result.frontsClipboard[1].meta.supporting![0].id).toEqual(
         'article/live/3'
       );
+      expect(result.editionsClipboard[0].id).toEqual('article/live/3');
     });
   });
 });

--- a/client-v2/src/util/clipboardSchema.ts
+++ b/client-v2/src/util/clipboardSchema.ts
@@ -16,7 +16,10 @@ const articleFragments = createType('articleFragments', {
 });
 
 export const { normalize, denormalize } = build({
-  articles: articleFragments({
+  frontsClipboard: articleFragments({
+    'meta.supporting': supportingArticles()
+  }),
+  editionsClipboard: articleFragments({
     'meta.supporting': supportingArticles()
   })
 });

--- a/client-v2/src/util/clipboardUtils.ts
+++ b/client-v2/src/util/clipboardUtils.ts
@@ -8,27 +8,33 @@ import { normalize, denormalize } from './clipboardSchema';
 import { notLiveLabels } from 'constants/fronts';
 
 function normaliseClipboard(clipboard: {
-  articles: NestedArticleFragment[];
+  frontsClipboard: NestedArticleFragment[];
+  editionsClipboard: NestedArticleFragment[];
 }): {
-  clipboard: { articles: string[] };
+  frontsClipboard: string[];
+  editionsClipboard: string[];
   articleFragments: { [id: string]: ArticleFragment };
 } {
   const normalisedClipboard = normalize(clipboard);
   return {
-    clipboard: normalisedClipboard.result,
+    frontsClipboard: normalisedClipboard.result.frontsClipboard,
+    editionsClipboard: normalisedClipboard.result.editionsClipboard,
     articleFragments: normalisedClipboard.entities.articleFragments || {}
   };
 }
 
 function denormaliseClipboard(
   state: State
-): { articles: NestedArticleFragment[] } {
+): {
+  frontsClipboard: NestedArticleFragment[];
+  editionsClipboard: NestedArticleFragment[];
+} {
   const clipboard = clipboardSelector(state);
 
-  return denormalize(
-    { articles: clipboard },
-    { articleFragments: state.shared.articleFragments }
-  );
+  const denormalised = denormalize(clipboard, {
+    articleFragments: state.shared.articleFragments
+  });
+  return denormalised;
 }
 
 const getArticleLabel = (

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -202,7 +202,8 @@ const persistClipboardOnEdit = (
   const result = next(action);
   const state = store.getState();
   const denormalisedClipboard: {
-    articles: NestedArticleFragment[];
+    frontsClipboard: NestedArticleFragment[];
+    editionsClipboard: NestedArticleFragment[];
   } = denormaliseClipboard(state);
   store.dispatch(updateClipboardAction(denormalisedClipboard));
   return result;


### PR DESCRIPTION
## What's changed?

_Detail the main feature of this PR and optionally a link to the relevant issue / card_

Implements two different clipboards, editions clipboard and fronts clipboard because editing these 
## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

Both clipboards are saved in state in case a user switches between the two editing modes without refreshing.

I have made some compromises to get this feature rolled out in the timely fashion. 
- The two clipboard are stored as separate arrays in dynamo instead of putting them in a neat clipboard object to avoid the need to migrate existing user data
- I have added the clipboard type as an optional field in the shared `InsertArticleFragmentPayload` type - I've added a comment explaining that this is not ideal but because of the code shared between invoking different insert actions passing this in as an optional parameter seemed easier than getting typescript to agree about the types when doing type refinement.  

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
