### PR TITLE
Fixing shrinking text inputs

### DIFF
--- a/client-v2/src/shared/components/input/CreateResizeableTextInput.tsx
+++ b/client-v2/src/shared/components/input/CreateResizeableTextInput.tsx
@@ -72,7 +72,10 @@ const createResizeableTextInput = (
     }
 
     public updateHeight() {
-      if (this.inputElement.current) {
+      if (
+        this.inputElement.current &&
+        this.inputElement.current.type === 'textarea'
+      ) {
         this.setState({ inputHeight: this.inputElement.current.scrollHeight });
       }
     }


### PR DESCRIPTION
## What's changed?

A small bug fix. Introducing the resizable text area component caused 'text' type inputs, e.g. the kicker, to shrink as text was input. 

## Implementation notes

The `updateHeight` function now also checks that the input type is textarea before adjusting to match the scroll height. The kicker field, and other simple text inputs, will not be resized.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
