### PR TITLE
Change styling of the Show more button

### DIFF
--- a/client-v2/src/components/CollectionNotification.tsx
+++ b/client-v2/src/components/CollectionNotification.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { styled } from 'constants/theme';
 
 import { AlsoOnDetail } from 'types/Collection';
-import Button from 'shared/components/input/ButtonDefault';
+import ButtonRoundedWithLabel from 'shared/components/input/ButtonRoundedWithLabel';
 
 interface CollectionNotificationProps {
   alsoOn: AlsoOnDetail;
@@ -18,7 +18,7 @@ const WarningText = styled('span')`
   color: ${({ theme }) => theme.shared.colors.orangeDark};
 `;
 
-const ToggleDetailsButton = Button.extend`
+const ToggleDetailsButton = ButtonRoundedWithLabel.extend`
   position: relative;
   z-index: 5;
 `;
@@ -71,7 +71,6 @@ class CollectionNotification extends React.Component<
           &nbsp;
           <ToggleDetailsButton
             tabIndex={-1}
-            size="s"
             onClick={e => {
               e.stopPropagation();
               return this.setState({


### PR DESCRIPTION
## What's changed?

The 'Show more' button is now styled to match the 'Expand all' and 'Collapse all' buttons, instead of like the 'Discard' button. 

<img width="390" alt="Screenshot 2019-07-12 at 12 04 20" src="https://user-images.githubusercontent.com/12645938/61123807-39ea7c00-a49d-11e9-9589-28a80f9e153b.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
