### PR TITLE
Handle empty storiesVisibleByStage object in collection API responses

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -162,22 +162,32 @@ function getCollectionActions(
     collectionConfig
   );
 
-  return [
+  const actions = [
     collectionActions.fetchSuccess(normalisedCollection),
     articleFragmentsReceived(articleFragments),
     recordUnpublishedChanges(collection.id, hasUnpublishedChanges),
-    groupsReceived(groups),
-    recordVisibleArticles(
-      collection.id,
-      storiesVisibleByStage.live,
-      frontStages.live
-    ),
-    recordVisibleArticles(
-      collection.id,
-      storiesVisibleByStage.draft,
-      frontStages.draft
-    )
+    groupsReceived(groups)
   ];
+
+  if (storiesVisibleByStage.live) {
+    actions.push(
+      recordVisibleArticles(
+        collection.id,
+        storiesVisibleByStage.live,
+        frontStages.live
+      )
+    );
+  }
+  if (storiesVisibleByStage.draft) {
+    actions.push(
+      recordVisibleArticles(
+        collection.id,
+        storiesVisibleByStage.draft,
+        frontStages.draft
+      )
+    );
+  }
+  return actions;
 }
 
 function getCollections(

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -48,7 +48,7 @@ export const scJohnsonPartnerZoneCollection = [
   null
 ];
 
-export const getCollectionsThunkFaciaApiResponse = [
+export const getCollectionsApiResponse = [
   {
     id: 'testCollection1',
     collection: {
@@ -78,5 +78,20 @@ export const getCollectionsThunkFaciaApiResponse = [
       live: { desktop: 4, mobile: 4 },
       draft: { desktop: 4, mobile: 4 }
     }
+  }
+];
+
+export const getCollectionsApiResponseWithoutStoriesVisible = [
+  {
+    id: 'testCollection1',
+    collection: {
+      displayName: 'testCollection1',
+      live: ['abc', 'def'],
+      draft: [],
+      lastUpdated: 1547479667115,
+      previously: undefined,
+      type: 'type'
+    },
+    storiesVisibleByStage: {}
   }
 ];

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -90,8 +90,8 @@ interface CollectionResponse {
   id: string;
   collection: CollectionFromResponse;
   storiesVisibleByStage: {
-    live: VisibleArticlesResponse;
-    draft: VisibleArticlesResponse;
+    live?: VisibleArticlesResponse;
+    draft?: VisibleArticlesResponse;
   };
 }
 


### PR DESCRIPTION
## What's changed?

We now handle empty storiesVisibleByStage objects in our collection responses. This was very unlikely to be empty in website- or app-facing collections, but is very common in e-mail collections, which were failing to parse as a result. As a result, e-mail fronts should now appear as expected.
 
## Implementation notes

This was exposed by correcting the typings and following the code, and makes a strong case for us deriving our API types from the Scala if at all possible!

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
