### PR TITLE
Add spacing to clipboard kicker

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
+++ b/client-v2/src/shared/components/article/ArticleBodyPolaroid.tsx
@@ -68,9 +68,11 @@ const ArticlePolaroidComponent = ({
           </>
         ) : (
           <>
-            <PillaredSection pillar={pillarId} isLive={isLive}>
-              {articleLabel}
-            </PillaredSection>
+            {articleLabel && (
+              <PillaredSection pillar={pillarId} isLive={isLive}>
+                {articleLabel} &nbsp;
+              </PillaredSection>
+            )}
             <HeadlinePolaroidSpan>{headline}</HeadlinePolaroidSpan>
           </>
         )}


### PR DESCRIPTION
## What's changed?

Adds a non-breaking space to kicker text of cards in the clipboard and only displays the kicker component when the kicker contains text.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
