### PR TITLE
Parameterise V2 route

### DIFF
--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -14,6 +14,7 @@ import {
 import { withRouter, RouteComponentProps } from 'react-router';
 import Spinner from 'shared/components/async/Spinner';
 import InformationMsg from 'shared/components/alert/InformationMsg';
+import urls from 'constants/urls';
 
 interface ManageEditionState {
   date: Moment | null;
@@ -107,7 +108,10 @@ class ManageEdition extends React.Component<
         <IssueContainer>
           <Issue issue={this.state.currentIssue!} />
         </IssueContainer>
-        <LinkButton size="l" href={`/v2/issues/${this.state.currentIssue!.id}`}>
+        <LinkButton
+          size="l"
+          href={`/${urls.appRoot}/issues/${this.state.currentIssue!.id}`}
+        >
           Open
         </LinkButton>
       </>

--- a/client-v2/src/constants/urls.ts
+++ b/client-v2/src/constants/urls.ts
@@ -1,4 +1,5 @@
 export default {
   capiLiveUrl: '/api/live/',
-  capiPreviewUrl: '/api/preview/'
+  capiPreviewUrl: '/api/preview/',
+  appRoot: 'v2'
 };

--- a/client-v2/src/routes/routes.ts
+++ b/client-v2/src/routes/routes.ts
@@ -1,7 +1,8 @@
 import { priorities } from '../constants/priorities';
 import { matchPath } from 'react-router';
+import urls from 'constants/urls';
 
-export const base = '/v2';
+export const base = `/${urls.appRoot}`;
 
 const editionsApi = (path: string) => `/editions-api${path}`;
 

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -1,7 +1,9 @@
 import { State } from 'types/State';
 import { matchIssuePath } from 'routes/routes';
+import urls from 'constants/urls';
 
-const maybeRemoveV2Prefix = (path: string) => path.replace(/^\/v2/, '');
+const matchRootPath = new RegExp(`^\/${urls.appRoot}`);
+const maybeRemoveV2Prefix = (path: string) => path.replace(matchRootPath, '');
 
 const selectFullPath = (state: State) => state.path;
 const selectV2SubPath = (state: State) =>


### PR DESCRIPTION
## What's changed?

Parameterise the V2 route. This makes it easy for us to mount the app on different URLs -- e.g. `/v2-prototype`, or perhaps just `/` 😁 

## Implementation notes

We could inject this via webpack configuration if we wanted different routes on a per-build basis, but we couldn't think of a use case, so this is just an application constant for now.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
