### PR TITLE
Editions clipboard

### DIFF
--- a/app/controllers/UserDataController.scala
+++ b/app/controllers/UserDataController.scala
@@ -30,6 +30,21 @@ class UserDataController(frontsApi: FrontsApi, dynamo: Dynamo, val deps: BaseFac
     }
   }
 
+  def putEditionsClipboardContent() = APIAuthAction { request =>
+
+    val clipboardArticles: Option[List[Trail]] = request.body.asJson.flatMap(jsValue =>
+      jsValue.asOpt[List[Trail]])
+
+    clipboardArticles match {
+      case Some(articles) => {
+        val userEmail = request.user.email
+        Scanamo.exec(dynamo.client)(userDataTable.update('email -> request.user.email, set('editionsClipboardArticles -> articles)))
+        Ok
+      }
+      case None => BadRequest
+    }
+  }
+
   def putFrontIds() = APIAuthAction { request =>
     val maybeFrontIds: Option[List[String]] = request.body.asJson.flatMap(
       _.asOpt[List[String]])

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -31,6 +31,7 @@ object UserData {
 case class UserData(
   email: String,
   clipboardArticles: Option[List[Trail]],
+  editionsClipboardArticles: Option[List[Trail]],
   frontIds: Option[List[String]],
   frontIdsByPriority: Option[Map[String, List[String]]],
   favouriteFrontIdsByPriority: Option[Map[String, List[String]]]

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -189,8 +189,10 @@ module.exports = async () =>
           )
     );
 
-    // this catches update requests and pretends they went through ok
+    // this catches post requests and pretends they went through ok
     app.post('*', (_, res) => res.json({ ok: true }));
+    // this catches update requests and pretends they went through ok
+    app.put('*', (_, res) => res.json({ ok: true }));
     const server = app.listen(port, err => {
       if (err) {
         console.log("Intergration server couldn't start");

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -63,16 +63,11 @@ function updateClipboard(clipboardContent: {
       getState(),
       clipboardContent.articles
     );
-    try {
-      if (!saveClipboardResponse) {
-        // @todo: implement once error handling is done
-        return Promise.resolve([]);
-      }
-      return saveClipboardResponse;
-    } catch (error) {
+    if (!saveClipboardResponse) {
       // @todo: implement once error handling is done
-      return [];
+      return Promise.resolve([]);
     }
+    return saveClipboardResponse;
   };
 }
 

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -57,11 +57,23 @@ function storeClipboardContent(clipboardContent: NestedArticleFragment[]) {
 
 function updateClipboard(clipboardContent: {
   articles: NestedArticleFragment[];
-}): ThunkResult<Promise<NestedArticleFragment[] | void>> {
-  return (_, getState: () => State) =>
-    saveClipboardStrategy(getState(), clipboardContent.articles).catch(() => {
+}): ThunkResult<Promise<NestedArticleFragment[]>> {
+  return async (_, getState: () => State) => {
+    const saveClipboardResponse = await saveClipboardStrategy(
+      getState(),
+      clipboardContent.articles
+    );
+    try {
+      if (!saveClipboardResponse) {
+        // @todo: implement once error handling is done
+        return Promise.resolve([]);
+      }
+      return saveClipboardResponse;
+    } catch (error) {
       // @todo: implement once error handling is done
-    });
+      return [];
+    }
+  };
 }
 
 const insertClipboardArticleFragment = (

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -1,5 +1,5 @@
 import { Dispatch, ThunkResult } from 'types/Store';
-import { saveClipboard } from 'services/faciaApi';
+import { saveClipboardStrategy } from 'strategies/save-clipboard';
 import { fetchArticles } from 'actions/Collections';
 import { batchActions } from 'redux-batched-actions';
 import { articleFragmentsReceived } from 'shared/actions/ArticleFragments';
@@ -13,6 +13,7 @@ import {
   InsertClipboardArticleFragment,
   RemoveClipboardArticleFragment
 } from 'types/Action';
+import { State } from 'types/State';
 
 export const REMOVE_CLIPBOARD_ARTICLE_FRAGMENT =
   'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT';
@@ -57,8 +58,8 @@ function storeClipboardContent(clipboardContent: NestedArticleFragment[]) {
 function updateClipboard(clipboardContent: {
   articles: NestedArticleFragment[];
 }): ThunkResult<Promise<NestedArticleFragment[] | void>> {
-  return () =>
-    saveClipboard(clipboardContent.articles).catch(() => {
+  return (_, getState: () => State) =>
+    saveClipboardStrategy(getState(), clipboardContent.articles).catch(() => {
       // @todo: implement once error handling is done
     });
 }

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -209,12 +209,18 @@ const updateEditionsCollection = (collectionId: string) =>
     'put'
   )(collectionId);
 
-async function saveClipboard(
-  clipboardContent: NestedArticleFragment[]
+const saveClipboard = (content: NestedArticleFragment[]) =>
+  createSaveClipboard(content, '/clipboard');
+const saveEditionsClipboard = (content: NestedArticleFragment[]) =>
+  createSaveClipboard(content, '/editionsClipboard');
+
+async function createSaveClipboard(
+  clipboardContent: NestedArticleFragment[],
+  pathSuffix: string
 ): Promise<NestedArticleFragment[]> {
   // The server does not respond with JSON
   try {
-    const response = await pandaFetch(`/userdata/clipboard`, {
+    const response = await pandaFetch(`/userdata${pathSuffix}`, {
       method: 'put',
       credentials: 'same-origin',
       body: JSON.stringify(clipboardContent),
@@ -433,6 +439,7 @@ export {
   updateCollection,
   updateEditionsCollection,
   saveClipboard,
+  saveEditionsClipboard,
   saveOpenFrontIds,
   saveFavouriteFrontIds,
   getCapiUriForContentIds,

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -104,9 +104,7 @@ async function fetchLastPressed(frontId: string): Promise<string> {
     })
     .catch(response => {
       throw new Error(
-        `Tried to fetch last pressed time for front with id ${frontId}, but the server responded with ${
-          response.status
-        }: ${response.body}`
+        `Tried to fetch last pressed time for front with id ${frontId}, but the server responded with ${response.status}: ${response.body}`
       );
     });
 }
@@ -128,9 +126,7 @@ async function fetchVisibleArticles(
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to fetch visible stories for collection type ${collectionType}, but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to fetch visible stories for collection type ${collectionType}, but the server responded with ${response.status}: ${response.body}`
     );
   }
 }
@@ -151,9 +147,7 @@ async function discardDraftChangesToCollection(
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to discard changes to collection with id ${collectionId}, but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to discard changes to collection with id ${collectionId}, but the server responded with ${response.status}: ${response.body}`
     );
   }
 }
@@ -170,9 +164,7 @@ async function publishCollection(collectionId: string): Promise<void> {
     });
   } catch (response) {
     throw new Error(
-      `Tried to publish collection with id ${collectionId}, but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to publish collection with id ${collectionId}, but the server responded with ${response.status}: ${response.body}`
     );
   }
 }
@@ -192,9 +184,7 @@ const createUpdateCollection = <T>(path: string, method: string) => (
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to update collection with id ${id}, but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to update collection with id ${id}, but the server responded with ${response.status}: ${response.body}`
     );
   }
 };
@@ -217,10 +207,10 @@ const saveEditionsClipboard = (content: NestedArticleFragment[]) =>
 async function createSaveClipboard(
   clipboardContent: NestedArticleFragment[],
   pathSuffix: string
-): Promise<NestedArticleFragment[]> {
+): Promise<void> {
   // The server does not respond with JSON
   try {
-    const response = await pandaFetch(`/userdata${pathSuffix}`, {
+    await pandaFetch(`/userdata${pathSuffix}`, {
       method: 'put',
       credentials: 'same-origin',
       body: JSON.stringify(clipboardContent),
@@ -228,12 +218,9 @@ async function createSaveClipboard(
         'Content-Type': 'application/json'
       }
     });
-    return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to update a clipboard but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to update a clipboard but the server responded with ${response.status}: ${response.body}`
     );
   }
 }
@@ -252,9 +239,7 @@ async function saveOpenFrontIds(frontsByPriority?: {
     });
   } catch (response) {
     throw new Error(
-      `Tried to store the open fronts configuration but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to store the open fronts configuration but the server responded with ${response.status}: ${response.body}`
     );
   }
 }
@@ -273,9 +258,7 @@ async function saveFavouriteFrontIds(favouriteFrontsByPriority?: {
     });
   } catch (response) {
     throw new Error(
-      `Tried to store the favourite fronts configuration but the server responded with ${
-        response.status
-      }: ${response.body}`
+      `Tried to store the favourite fronts configuration but the server responded with ${response.status}: ${response.body}`
     );
   }
 }

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -104,7 +104,9 @@ async function fetchLastPressed(frontId: string): Promise<string> {
     })
     .catch(response => {
       throw new Error(
-        `Tried to fetch last pressed time for front with id ${frontId}, but the server responded with ${response.status}: ${response.body}`
+        `Tried to fetch last pressed time for front with id ${frontId}, but the server responded with ${
+          response.status
+        }: ${response.body}`
       );
     });
 }
@@ -126,7 +128,9 @@ async function fetchVisibleArticles(
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to fetch visible stories for collection type ${collectionType}, but the server responded with ${response.status}: ${response.body}`
+      `Tried to fetch visible stories for collection type ${collectionType}, but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 }
@@ -147,7 +151,9 @@ async function discardDraftChangesToCollection(
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to discard changes to collection with id ${collectionId}, but the server responded with ${response.status}: ${response.body}`
+      `Tried to discard changes to collection with id ${collectionId}, but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 }
@@ -164,7 +170,9 @@ async function publishCollection(collectionId: string): Promise<void> {
     });
   } catch (response) {
     throw new Error(
-      `Tried to publish collection with id ${collectionId}, but the server responded with ${response.status}: ${response.body}`
+      `Tried to publish collection with id ${collectionId}, but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 }
@@ -184,7 +192,9 @@ const createUpdateCollection = <T>(path: string, method: string) => (
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to update collection with id ${id}, but the server responded with ${response.status}: ${response.body}`
+      `Tried to update collection with id ${id}, but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 };
@@ -220,7 +230,9 @@ async function createSaveClipboard(
     });
   } catch (response) {
     throw new Error(
-      `Tried to update a clipboard but the server responded with ${response.status}: ${response.body}`
+      `Tried to update a clipboard but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 }
@@ -239,7 +251,9 @@ async function saveOpenFrontIds(frontsByPriority?: {
     });
   } catch (response) {
     throw new Error(
-      `Tried to store the open fronts configuration but the server responded with ${response.status}: ${response.body}`
+      `Tried to store the open fronts configuration but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 }
@@ -258,7 +272,9 @@ async function saveFavouriteFrontIds(favouriteFrontsByPriority?: {
     });
   } catch (response) {
     throw new Error(
-      `Tried to store the favourite fronts configuration but the server responded with ${response.status}: ${response.body}`
+      `Tried to store the favourite fronts configuration but the server responded with ${
+        response.status
+      }: ${response.body}`
     );
   }
 }

--- a/client-v2/src/strategies/save-clipboard.ts
+++ b/client-v2/src/strategies/save-clipboard.ts
@@ -6,8 +6,8 @@ import { NestedArticleFragment } from 'shared/types/Collection';
 const saveClipboardStrategy = (
   state: State,
   content: NestedArticleFragment[]
-) =>
-  runStrategy<void>(state, {
+): Promise<NestedArticleFragment[]> | null =>
+  runStrategy<Promise<NestedArticleFragment[]> | null>(state, {
     front: () => saveClipboard(content),
     edition: () => saveEditionsClipboard(content),
     none: () => null

--- a/client-v2/src/strategies/save-clipboard.ts
+++ b/client-v2/src/strategies/save-clipboard.ts
@@ -6,8 +6,8 @@ import { NestedArticleFragment } from 'shared/types/Collection';
 const saveClipboardStrategy = (
   state: State,
   content: NestedArticleFragment[]
-): Promise<NestedArticleFragment[]> | null =>
-  runStrategy<Promise<NestedArticleFragment[]> | null>(state, {
+): Promise<void> | null =>
+  runStrategy<Promise<void> | null>(state, {
     front: () => saveClipboard(content),
     edition: () => saveEditionsClipboard(content),
     none: () => null

--- a/client-v2/src/strategies/save-clipboard.ts
+++ b/client-v2/src/strategies/save-clipboard.ts
@@ -1,0 +1,16 @@
+import { State } from 'types/State';
+import { saveClipboard, saveEditionsClipboard } from 'services/faciaApi';
+import { runStrategy } from './run-strategy';
+import { NestedArticleFragment } from 'shared/types/Collection';
+
+const saveClipboardStrategy = (
+  state: State,
+  content: NestedArticleFragment[]
+) =>
+  runStrategy<void>(state, {
+    front: () => saveClipboard(content),
+    edition: () => saveEditionsClipboard(content),
+    none: () => null
+  });
+
+export { saveClipboardStrategy };

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -156,8 +156,7 @@ export const getArticleFragmentMetaFromFormValues = (
 ): ArticleFragmentMeta => {
   const primaryImage = values.primaryImage || {};
   const cutoutImage = values.cutoutImage || {};
-  // Lodash doesn't remove undefined in the type settings here, hence the any.
-  const slideshow = compact(values.slideshow as any).map(
+  const slideshow = compact(values.slideshow as ImageData[]).map(
     (image: ImageData) => ({
       ...image,
       width: intToStr(image.width),

--- a/conf/routes
+++ b/conf/routes
@@ -58,6 +58,7 @@ GET         /metadata                                controllers.FaciaToolContro
 POST        /treats/*collectionId                    controllers.FaciaToolController.treatEdits(collectionId)
 
 PUT        /userdata/clipboard                       controllers.UserDataController.putClipboardContent()
+PUT        /userdata/editionsClipboard               controllers.UserDataController.putEditionsClipboardContent()
 PUT        /userdata/frontIds                        controllers.UserDataController.putFrontIds()
 PUT        /userdata/frontIdsByPriority              controllers.UserDataController.putFrontIdsByPriority()
 PUT        /userdata/favouriteFrontIdsByPriority     controllers.UserDataController.putFavouriteFrontIdsByPriority()


### PR DESCRIPTION
## What's changed?

Creates a separate clipboard for editions and for fronts.

## Implementation notes

Only keeps one of the clipboards in the redux state at a time. This is going to cause problems if a user switches between fronts editing and editions editing without refreshing. We are not going to have the same user editing fronts and editions in the first instance so can look into fixing this later.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
