### PR TITLE
Remove the notification client and directly use the models.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.gu" %% "fapi-client-play26" % "3.0.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "mobile-notifications-client" % "1.5",
+    "com.gu" %% "mobile-notifications-api-models" % "1.0.0",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",
 
     "com.gu" %% "scanamo" % "1.0.0-M7",


### PR DESCRIPTION
## What's changed?

This has the side effect of sending only one push notification for a global breaking news, which in turn might make the notification slightly faster. It also means all the editions will be processed at the same time, and should give editorial satisfaction as the UK won't be processed last.

## Implementation notes

It also introduces the parsing of the notification ID, in order to potentially poll the report API and check on the status, although nothing's done with it for now in order to limit my changes to small area.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
