### PR TITLE
Add an extremely temporary v2-prototype path for testing the inline form

### DIFF
--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -16,11 +16,8 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
 
   import model.UserData._
 
-  def index(priority: String = "", frontId: String = "") = getCollectionPermissionFilterByPriority(priority, acl)(ec) { implicit req =>
-
+  def index(priority: String = "", jsFileName: String = "dist/app.bundle.js") = getCollectionPermissionFilterByPriority(priority, acl)(ec) { implicit req =>
     val userDataTable = Table[UserData](config.faciatool.userDataTable)
-
-    val jsFileName = "dist/app.bundle.js"
     val faviconDirectoryName = "favicon/"
 
     val jsLocation: String = routes.V2Assets.at(jsFileName).toString
@@ -73,5 +70,4 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
       Json.toJson(conf).toString()
     ))
   }
-
 }

--- a/client-v2/config/webpack.config.prod-prototype.js
+++ b/client-v2/config/webpack.config.prod-prototype.js
@@ -1,10 +1,16 @@
 import prod from './webpack.config.prod';
 const path = require('path');
+const webpack = require('webpack');
+
+const definePlugin = new webpack.DefinePlugin({
+  'process.env.APP_URL_PREFIX': 'v2-prototype'
+});
 
 export default {
   ...prod,
   output: {
     path: path.resolve(__dirname, '../../public/client-v2/dist-prototype'),
     filename: 'app.bundle.js'
-  }
+  },
+  plugins: [definePlugin]
 };

--- a/client-v2/config/webpack.config.prod-prototype.js
+++ b/client-v2/config/webpack.config.prod-prototype.js
@@ -3,7 +3,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 const definePlugin = new webpack.DefinePlugin({
-  'process.env.APP_URL_PREFIX': 'v2-prototype'
+  'process.env.APP_URL_PREFIX': JSON.stringify('v2-prototype')
 });
 
 export default {

--- a/client-v2/config/webpack.config.prod-prototype.js
+++ b/client-v2/config/webpack.config.prod-prototype.js
@@ -1,0 +1,10 @@
+import prod from './webpack.config.prod';
+const path = require('path');
+
+export default {
+  ...prod,
+  output: {
+    path: path.resolve(__dirname, '../../public/client-v2/dist-prototype'),
+    filename: 'app.bundle.js'
+  }
+};

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -8,7 +8,7 @@
     "compileWithBabel": "node -r @babel/register",
     "bundle": "yarn compileWithBabel $(yarn bin)/webpack",
     "build": "yarn bundle --config config/webpack.config.prod.js",
-    "build-prototype": "git checkout v2-prototype && yarn bundle --config config/webpack.config.prod-prototype.js && git checkout -",
+    "build-prototype": "yarn bundle --config config/webpack.config.prod-prototype.js",
     "watch": "yarn bundle --config config/webpack.config.dev.js --watch",
     "lint": "yarn compileWithBabel $(yarn bin)/eslint './src/**/*.ts?(x)' && $(yarn bin)/tslint './src/**/*.ts?(x)'",
     "lint-fix": "yarn compileWithBabel $(yarn bin)/eslint './src/**/*.ts?(x)' --fix && $(yarn bin)/tslint --fix './src/**/*.ts?(x)'",

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -8,7 +8,7 @@
     "compileWithBabel": "node -r @babel/register",
     "bundle": "yarn compileWithBabel $(yarn bin)/webpack",
     "build": "yarn bundle --config config/webpack.config.prod.js",
-    "build-prototype": "git checkout v2-prototype && yarn bundle --config config/webpack.config.prod-prototype.js && git checkout master",
+    "build-prototype": "git checkout v2-prototype && yarn bundle --config config/webpack.config.prod-prototype.js && git checkout -",
     "watch": "yarn bundle --config config/webpack.config.dev.js --watch",
     "lint": "yarn compileWithBabel $(yarn bin)/eslint './src/**/*.ts?(x)' && $(yarn bin)/tslint './src/**/*.ts?(x)'",
     "lint-fix": "yarn compileWithBabel $(yarn bin)/eslint './src/**/*.ts?(x)' --fix && $(yarn bin)/tslint --fix './src/**/*.ts?(x)'",

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -8,6 +8,7 @@
     "compileWithBabel": "node -r @babel/register",
     "bundle": "yarn compileWithBabel $(yarn bin)/webpack",
     "build": "yarn bundle --config config/webpack.config.prod.js",
+    "build-prototype": "git checkout v2-prototype && yarn bundle --config config/webpack.config.prod-prototype.js && git checkout master",
     "watch": "yarn bundle --config config/webpack.config.dev.js --watch",
     "lint": "yarn compileWithBabel $(yarn bin)/eslint './src/**/*.ts?(x)' && $(yarn bin)/tslint './src/**/*.ts?(x)'",
     "lint-fix": "yarn compileWithBabel $(yarn bin)/eslint './src/**/*.ts?(x)' --fix && $(yarn bin)/tslint --fix './src/**/*.ts?(x)'",

--- a/client-v2/src/constants/urls.ts
+++ b/client-v2/src/constants/urls.ts
@@ -1,5 +1,5 @@
 export default {
   capiLiveUrl: '/api/live/',
   capiPreviewUrl: '/api/preview/',
-  appRoot: 'v2'
+  appRoot: process.env.APP_URL_PREFIX || 'v2'
 };

--- a/conf/routes
+++ b/conf/routes
@@ -95,8 +95,11 @@ GET         /troubleshoot                            controllers.TroubleshootCon
 GET         /troubleshoot/*section                   controllers.TroubleshootController.troubleshoot(section)
 
 # React App
-GET         /v2                                      controllers.V2App.index(path="")
-GET         /v2/*path                                controllers.V2App.index(path)
+GET         /v2                                      controllers.V2App.index(path: String = "", jsFileName: String = "dist/app.bundle.js")
+GET         /v2/*path                                controllers.V2App.index(path: String, jsFileName: String = "dist/app.bundle.js")
+
+GET         /v2-prototype                            controllers.V2App.index(path="", jsFileName="dist-prototype/app.bundle.js")
+GET         /v2-prototype/*path                      controllers.V2App.index(path, jsFileName="dist-prototype/app.bundle.js")
 
 # Grid Usages
 POST        /api/usage                               controllers.GridProxy.addUsage()

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -31,6 +31,7 @@ javascriptV2() {
     yarn lint
     yarn test
     yarn run build
+    yarn run build-prototype
     yarn test-integration-ci
 
     popd

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -33,7 +33,7 @@ javascriptV2() {
     yarn run build
 
     wget https://github.com/guardian/facia-tool/archive/v2-prototype.zip
-    tar -zxvf v2-prototype.zip
+    unzip v2-prototype.zip
     pushd facia-tool-2-prototype/client-v2
     yarn
     yarn run build-prototype

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -31,11 +31,18 @@ javascriptV2() {
     yarn lint
     yarn test
     yarn run build
-    git checkout v2-prototype
-    yarn run build-prototype
-    git checkout -
-    yarn test-integration-ci
 
+    wget https://github.com/guardian/facia-tool/archive/v2-prototype.zip
+    tar -zxvf v2-prototype.zip
+    pushd facia-tool-2-prototype/client-v2
+    yarn
+    yarn run build-prototype
+    popd
+    mv facia-tool-2-prototype/public/client-v2/dist-prototype ../public/client-v2/dist-prototype
+    rm -r facia-tool-2-prototype
+    rm v2-prototype.zip
+
+    yarn test-integration-ci
     popd
 }
 

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -31,7 +31,9 @@ javascriptV2() {
     yarn lint
     yarn test
     yarn run build
+    git checkout v2-prototype
     yarn run build-prototype
+    git checkout -
     yarn test-integration-ci
 
     popd

--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -32,6 +32,7 @@ javascriptV2() {
     yarn test
     yarn run build
 
+    # Temporary steps to inject the client of the v2-prototype branch into the project
     wget https://github.com/guardian/facia-tool/archive/v2-prototype.zip
     unzip v2-prototype.zip
     pushd facia-tool-2-prototype/client-v2
@@ -41,6 +42,7 @@ javascriptV2() {
     mv facia-tool-2-prototype/public/client-v2/dist-prototype ../public/client-v2/dist-prototype
     rm -r facia-tool-2-prototype
     rm v2-prototype.zip
+    # End of temporary steps
 
     yarn test-integration-ci
     popd


### PR DESCRIPTION
## What's changed?

Add an extremely temporary v2-prototype path for testing the inline form.

Ideally, we'd use a feature switch to change the UI, however it's been estimated to be about a weeks worth of effort to implement. We want to get feedback from a few Editors in their daily routine before shipping to 100% of users; CODE isn't a viable option as that would return limited feedback. In the absence of feature switches, this provides a short lived solution.

## Implementation notes

The approach we've taken is to provide a prototype client endpoint, and a prototype client build with its own configuration. We extract the prototype branch manually during CI/CD (there's no way to run git commands with the current teamcity setup), build it, and move it to the appropriate place in the root project. The v2-prototype endpoint then serves it as usual.

This approach has the advantage of being quick, and the disadvantage of being moderately cursed -- we're basically arbitrarily dumping a branch into master. To mitigate concerns here, we should protect the v2-prototype branch in the same way we do master -- e.g. only allow pull requests to be merged.

Finally, this adds around 2 minutes to the build time.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
