### PR TITLE
Persist more fields to DB and make available when published

### DIFF
--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -7,8 +7,10 @@ import scalikejdbc.WrappedResultSet
 case class ArticleMetadata(
   headline: Option[String],
   customKicker: Option[String],
-  showKickerCustom: Option[Boolean],
-  trailText: Option[String]
+  trailText: Option[String],
+  showQuotedHeadline: Option[Boolean],
+  showByline: Option[Boolean],
+  byline: Option[String],
 )
 
 object ArticleMetadata {

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -20,7 +20,15 @@ object ArticleMetadata {
 case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) {
   def toPublishedArticle: PublishedArticle = PublishedArticle(
     pageCode.toLong,
-    PublishedFurniture(metadata.flatMap(_.customKicker), metadata.flatMap(_.headline), None) // TODO (sihil): Store in DB and populate here
+    PublishedFurniture(
+      kicker = metadata.flatMap(_.customKicker),
+      headlineOverride = metadata.flatMap(_.headline),
+      trailTextOverride = metadata.flatMap(_.trailText),
+      bylineOverride = metadata.flatMap(_.byline),
+      showByline = metadata.flatMap(_.showByline).getOrElse(false),
+      showQuotedHeadline = metadata.flatMap(_.showQuotedHeadline).getOrElse(false),
+      imageSrcOverride = None // TODO (sihil): Store in DB and populate here
+    )
   )
 }
 

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -4,7 +4,12 @@ import com.gu.editions.{PublishedArticle, PublishedFurniture}
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
-case class ArticleMetadata(headline: Option[String])
+case class ArticleMetadata(
+  headline: Option[String],
+  customKicker: Option[String],
+  showKickerCustom: Option[Boolean],
+  trailText: Option[String]
+)
 
 object ArticleMetadata {
   implicit val format = Json.format[ArticleMetadata]
@@ -13,7 +18,7 @@ object ArticleMetadata {
 case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) {
   def toPublishedArticle: PublishedArticle = PublishedArticle(
     pageCode.toLong,
-    PublishedFurniture(None, metadata.flatMap(_.headline), None) // TODO (sihil): Store in DB and populate here
+    PublishedFurniture(metadata.flatMap(_.customKicker), metadata.flatMap(_.headline), None) // TODO (sihil): Store in DB and populate here
   )
 }
 

--- a/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
+++ b/editions-common/src/main/scala/com/gu/editions/PublishedIssue.scala
@@ -7,8 +7,12 @@ import java.time.OffsetDateTime
 case class MediaUrl(url: String) extends AnyVal
 
 case class PublishedFurniture(
-  kickerOverride: Option[String],
+  kicker: Option[String],
   headlineOverride: Option[String],
+  trailTextOverride: Option[String],
+  bylineOverride: Option[String],
+  showByline: Boolean,
+  showQuotedHeadline: Boolean,
   imageSrcOverride: Option[MediaUrl]
 )
 
@@ -19,4 +23,3 @@ case class PublishedCollection(id: String, items: List[PublishedArticle])
 case class PublishedFront(id: String, name: String, collections: List[PublishedCollection])
 
 case class PublishedIssue(id: String, name: String, issueDate: OffsetDateTime, fronts: List[PublishedFront])
-

--- a/test/editions/PublishedIssueTest.scala
+++ b/test/editions/PublishedIssueTest.scala
@@ -1,0 +1,51 @@
+package editions
+
+import java.time.{OffsetDateTime, ZoneOffset}
+
+import com.gu.editions.PublishedFurniture
+import model.editions.{ArticleMetadata, EditionsArticle}
+import org.scalatest.{FreeSpec, Matchers}
+
+class PublishedIssueTest extends FreeSpec with Matchers {
+  "PublishedArticles" - {
+    "article fields should be populated correctly" in {
+      val now = OffsetDateTime.of(2019, 9, 30, 10, 23, 0, 0, ZoneOffset.ofHours(1))
+      val article = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
+      val publishedArticle = article.toPublishedArticle
+      publishedArticle.internalPageCode shouldBe 1234456
+      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, None)
+    }
+
+    "furniture defaults should be populated correctly" in {
+      val furniture = ArticleMetadata(None, None, None, None, None, None)
+      val article = EditionsArticle("123456", 0, Some(furniture))
+      val published = article.toPublishedArticle
+
+      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, None)
+    }
+
+    "furniture should be populated when specified" in {
+      val furniture = ArticleMetadata(
+        Some("headline"),
+        Some("kicker"),
+        Some("trail-text"),
+        Some(true),
+        Some(true),
+        Some("byline"),
+      )
+      val article = EditionsArticle("123456", 0, Some(furniture))
+      val published = article.toPublishedArticle
+
+      published.furniture shouldBe PublishedFurniture(
+        Some("kicker"),
+        Some("headline"),
+        Some("trail-text"),
+        Some("byline"),
+        showByline = true,
+        showQuotedHeadline = true,
+        imageSrcOverride = None
+      )
+
+    }
+  }
+}


### PR DESCRIPTION
## What's changed?

Ensure that the following fields are persisted to the DB and available in the published issues:
 - kicker
 - trail text override
 - byline override
 - show byline flag
 - show quoted headline flag

## Implementation notes

Expand the same logic as used in #807.
**Note that this supercedes some commits in #838**

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
