### PR TITLE
Hide unused elements & show edition name/date

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import logging.Logging
 import model.forms._
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 import services.editions.EditionsTemplating
 import java.time.LocalDate
 
@@ -36,6 +36,12 @@ class EditionsController(db: EditionsDB,
   def getIssue(id: String)= AccessAPIAuthAction { _ =>
     db.getIssue(id).map { issue =>
       Ok(Json.toJson(issue))
+    }.getOrElse(NotFound(s"Issue $id not found"))
+  }
+
+  def getIssueSummary(id: String)= AccessAPIAuthAction { _ =>
+    db.getIssueSummary(id).map { issue =>
+      Ok(Json.toJson(issue).as[JsObject] - "fronts")
     }.getOrElse(NotFound(s"Issue $id not found"))
   }
 

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -187,6 +187,27 @@ trait IssueQueries {
     rows.headOption.map(_.issue.copy(fronts = fronts))
   }
 
+  def getIssueSummary(id: String) = DB readOnly { implicit session =>
+    sql"""
+       SELECT
+         edition_issues.id,
+         edition_issues.name,
+         edition_issues.timezone_id,
+         edition_issues.issue_date,
+         edition_issues.created_on,
+         edition_issues.created_by,
+         edition_issues.created_email,
+         edition_issues.launched_on,
+         edition_issues.launched_by,
+         edition_issues.launched_email
+       FROM edition_issues
+       WHERE edition_issues.id = $id
+       """
+      .map(rs => EditionsIssue.fromRow(rs))
+      .single()
+      .apply()
+  }
+
   def publishIssue(issueId: String, user: User) = DB localTx { implicit session =>
     val userName = user.firstName + " " + user.lastName
 

--- a/client-v2/src/actions/Editions.ts
+++ b/client-v2/src/actions/Editions.ts
@@ -1,4 +1,4 @@
-import { getIssue } from 'services/editionsApi';
+import { getIssueSummary } from 'services/editionsApi';
 import { ThunkResult } from 'types/Store';
 import { Dispatch } from 'redux';
 import { actions } from 'bundles/editionsIssueBundle';
@@ -8,7 +8,7 @@ export const getEditionIssue = (
 ): ThunkResult<Promise<void>> => async (dispatch: Dispatch) => {
   try {
     dispatch(actions.fetchStart());
-    const issue = await getIssue(id);
+    const issue = await getIssueSummary(id);
     dispatch(actions.fetchSuccess(issue));
   } catch (error) {
     dispatch(actions.fetchError('Failed to get issue'));

--- a/client-v2/src/actions/Editions.ts
+++ b/client-v2/src/actions/Editions.ts
@@ -1,0 +1,16 @@
+import { getIssue } from 'services/editionsApi';
+import { ThunkResult } from 'types/Store';
+import { Dispatch } from 'redux';
+import { actions } from 'bundles/editionsIssueBundle';
+
+export const getEditionIssue = (
+  id: string
+): ThunkResult<Promise<void>> => async (dispatch: Dispatch) => {
+  try {
+    dispatch(actions.fetchStart());
+    const issue = await getIssue(id);
+    dispatch(actions.fetchSuccess(issue));
+  } catch (error) {
+    dispatch(actions.fetchError('Failed to get issue'));
+  }
+};

--- a/client-v2/src/bundles/editionsIssueBundle.ts
+++ b/client-v2/src/bundles/editionsIssueBundle.ts
@@ -1,0 +1,19 @@
+import createAsyncResourceBundle, {
+  State
+} from 'lib/createAsyncResourceBundle';
+import { EditionsIssue } from 'types/Edition';
+
+export const {
+  actions,
+  actionNames,
+  reducer,
+  selectors,
+  initialState
+} = createAsyncResourceBundle<EditionsIssue>('editionsIssue', {
+  indexById: false,
+  initialData: undefined
+});
+
+export type EditionsIssueState = State<EditionsIssue>;
+
+export default reducer;

--- a/client-v2/src/components/FeedSectionHeader.tsx
+++ b/client-v2/src/components/FeedSectionHeader.tsx
@@ -17,6 +17,7 @@ import { Dispatch } from 'types/Store';
 import FadeTransition from './transitions/FadeTransition';
 import { MoreIcon } from 'shared/components/icons/Icons';
 import { RouteComponentProps } from 'react-router';
+import { selectIsEditingEditions } from 'selectors/pathSelectors';
 
 const FeedbackButton = Button.extend<{
   href: string;
@@ -91,10 +92,28 @@ const CloseButtonInner = styled.div`
   position: relative;
 `;
 
+const EditionIssueInfo = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 12px;
+  line-height: initial;
+`;
+
+const EditionTitle = styled.div`
+  font-size: 20px;
+`;
+
+const EditionDate = styled.div`
+  font-size: 16px;
+`;
+
 type ComponentProps = {
   toggleCurrentFrontsMenu: () => void;
   isCurrentFrontsMenuOpen: boolean;
   frontCount: number;
+  isEditingEditions: boolean;
 } & RouteComponentProps<{ priority: string }>;
 
 type ContainerProps = RouteComponentProps<{ priority: string }>;
@@ -103,7 +122,8 @@ const FeedSectionHeader = ({
   toggleCurrentFrontsMenu,
   isCurrentFrontsMenuOpen,
   frontCount,
-  match
+  match,
+  isEditingEditions
 }: ComponentProps) => (
   <SectionHeaderWithLogo includeBorder={!isCurrentFrontsMenuOpen}>
     <LogoContainer
@@ -130,12 +150,19 @@ const FeedSectionHeader = ({
         <CurrentFrontsList priority={match.params.priority} />
       </FadeTransition>
       <FadeTransition active={!isCurrentFrontsMenuOpen} direction="right">
-        <FeedbackButton
-          href="https://docs.google.com/forms/d/e/1FAIpQLSc4JF0GxrKoxQgsFE9_tQfjAo1RKRU4M5bJWJRKaVlHbR2rpA/viewform?c=0&w=1"
-          target="_blank"
-        >
-          Send us feedback
-        </FeedbackButton>
+        {isEditingEditions ? (
+          <EditionIssueInfo>
+            <EditionTitle>Daily Edition</EditionTitle>
+            <EditionDate>16/09/1992</EditionDate>
+          </EditionIssueInfo>
+        ) : (
+          <FeedbackButton
+            href="https://docs.google.com/forms/d/e/1FAIpQLSc4JF0GxrKoxQgsFE9_tQfjAo1RKRU4M5bJWJRKaVlHbR2rpA/viewform?c=0&w=1"
+            target="_blank"
+          >
+            Send us feedback
+          </FeedbackButton>
+        )}
       </FadeTransition>
     </SectionHeaderContent>
   </SectionHeaderWithLogo>
@@ -147,7 +174,8 @@ const mapStateToProps = () => {
     isCurrentFrontsMenuOpen: selectIsCurrentFrontsMenuOpen(state),
     frontCount: selectEditorFrontsByPriority(state, {
       priority: props.match.params.priority
-    }).length
+    }).length,
+    isEditingEditions: selectIsEditingEditions(state)
   });
 };
 

--- a/client-v2/src/components/FeedSectionHeader.tsx
+++ b/client-v2/src/components/FeedSectionHeader.tsx
@@ -18,10 +18,11 @@ import { Dispatch } from 'types/Store';
 import FadeTransition from './transitions/FadeTransition';
 import { MoreIcon } from 'shared/components/icons/Icons';
 import { RouteComponentProps } from 'react-router';
-import { selectIsEditingEditions } from 'selectors/pathSelectors';
+import { selectEditMode } from 'selectors/pathSelectors';
 import { getEditionIssue } from 'actions/Editions';
 import { EditionsIssue } from 'types/Edition';
 import { selectors as editionsIssueSelectors } from 'bundles/editionsIssueBundle';
+import { EditMode } from 'types/EditMode';
 
 const FeedbackButton = Button.extend<{
   href: string;
@@ -119,7 +120,7 @@ type ComponentProps = {
   frontCount: number;
 
   getEditionsIssue: (id: string) => void;
-  isEditingEditions: boolean;
+  editMode: EditMode;
   editionsIssue?: EditionsIssue;
 } & RouteComponentProps<{ priority: string }>;
 
@@ -127,7 +128,7 @@ type ContainerProps = RouteComponentProps<{ priority: string }>;
 
 class FeedSectionHeader extends Component<ComponentProps> {
   public componentDidMount() {
-    if (this.props.isEditingEditions) {
+    if (this.props.editMode === 'editions') {
       this.props.getEditionsIssue(this.props.match.params.priority);
     }
   }
@@ -138,7 +139,7 @@ class FeedSectionHeader extends Component<ComponentProps> {
       isCurrentFrontsMenuOpen,
       frontCount,
       match,
-      isEditingEditions,
+      editMode,
       editionsIssue
     } = this.props;
     return (
@@ -167,7 +168,7 @@ class FeedSectionHeader extends Component<ComponentProps> {
             <CurrentFrontsList priority={match.params.priority} />
           </FadeTransition>
           <FadeTransition active={!isCurrentFrontsMenuOpen} direction="right">
-            {isEditingEditions ? (
+            {editMode === 'editions' ? (
               editionsIssue ? (
                 <EditionIssueInfo>
                   <EditionTitle>
@@ -200,7 +201,7 @@ const mapStateToProps = () => {
     frontCount: selectEditorFrontsByPriority(state, {
       priority: props.match.params.priority
     }).length,
-    isEditingEditions: selectIsEditingEditions(state),
+    editMode: selectEditMode(state),
     editionsIssue: editionsIssueSelectors.selectAll(state)
   });
 };

--- a/client-v2/src/components/FeedSectionHeader.tsx
+++ b/client-v2/src/components/FeedSectionHeader.tsx
@@ -126,13 +126,13 @@ type ComponentProps = {
 type ContainerProps = RouteComponentProps<{ priority: string }>;
 
 class FeedSectionHeader extends Component<ComponentProps> {
-  componentDidMount() {
+  public componentDidMount() {
     if (this.props.isEditingEditions) {
       this.props.getEditionsIssue(this.props.match.params.priority);
     }
   }
 
-  render() {
+  public render() {
     const {
       toggleCurrentFrontsMenu,
       isCurrentFrontsMenuOpen,

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -232,7 +232,7 @@ const createMapStateToProps = () => {
           collectionId: id,
           collectionSet: browsingStage,
           articleFragmentId: selectedArticleFragmentData.id
-        }),
+        })
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -132,6 +132,7 @@ class Collection extends React.Component<CollectionProps> {
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
         onChangeOpenState={() => onChangeOpenState(id, isOpen)}
         headlineContent={
+          !isEditingEditions &&
           hasUnpublishedChanges &&
           canPublish &&
           !isEditFormOpen && (

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -14,7 +14,6 @@ import { selectHasUnpublishedChanges } from 'selectors/frontsSelectors';
 import { selectIsCollectionLocked } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
 import { CollectionItemSets, Group } from 'shared/types/Collection';
-import { selectIsEditingEditions } from 'selectors/pathSelectors';
 import {
   createSelectCollectionStageGroups,
   createSelectCollectionEditWarning,
@@ -33,6 +32,7 @@ import { createSelectIsArticleInCollection } from 'shared/selectors/collection';
 import CollectionMetaContainer from 'shared/components/collection/CollectionMetaContainer';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 import { styled } from 'constants/theme';
+import EditModeVisibility from 'components/util/EditModeVisibility';
 
 interface CollectionPropsBeforeState {
   id: string;
@@ -63,7 +63,6 @@ type CollectionProps = CollectionPropsBeforeState & {
   hasMultipleFrontsOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
   fetchPreviousCollectionArticles: (id: string) => void;
-  isEditingEditions: boolean;
 };
 
 const PreviouslyCollectionContainer = styled('div')`
@@ -112,8 +111,7 @@ class Collection extends React.Component<CollectionProps> {
       onChangeOpenState,
       hasMultipleFrontsOpen,
       isEditFormOpen,
-      discardDraftChangesToCollection: discardDraftChanges,
-      isEditingEditions
+      discardDraftChangesToCollection: discardDraftChanges
     } = this.props;
 
     const { isPreviouslyOpen } = this.state;
@@ -132,11 +130,10 @@ class Collection extends React.Component<CollectionProps> {
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
         onChangeOpenState={() => onChangeOpenState(id, isOpen)}
         headlineContent={
-          !isEditingEditions &&
           hasUnpublishedChanges &&
           canPublish &&
           !isEditFormOpen && (
-            <React.Fragment>
+            <EditModeVisibility visibleMode="fronts">
               <Button
                 size="l"
                 priority="default"
@@ -164,7 +161,7 @@ class Collection extends React.Component<CollectionProps> {
               >
                 Launch
               </Button>
-            </React.Fragment>
+            </EditModeVisibility>
           )
         }
         metaContent={
@@ -178,7 +175,7 @@ class Collection extends React.Component<CollectionProps> {
       >
         {groups.map(group => children(group, isUneditable, true))}
 
-        {!isEditingEditions && (
+        <EditModeVisibility visibleMode="fronts">
           <PreviouslyCollectionContainer data-testid="previously">
             <PreviouslyCollectionToggle
               onClick={this.togglePreviouslyOpen}
@@ -193,7 +190,7 @@ class Collection extends React.Component<CollectionProps> {
               </PreviouslyGroupsWrapper>
             )}
           </PreviouslyCollectionContainer>
-        )}
+        </EditModeVisibility>
       </CollectionDisplay>
     );
   }
@@ -236,7 +233,6 @@ const createMapStateToProps = () => {
           collectionSet: browsingStage,
           articleFragmentId: selectedArticleFragmentData.id
         }),
-      isEditingEditions: selectIsEditingEditions(state)
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -6,7 +6,6 @@ import { events } from 'services/GA';
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
 import { selectHasUnpublishedChanges } from 'selectors/frontsSelectors';
-import { selectIsEditingEditions } from 'selectors/pathSelectors';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
 import { Collection, CollectionItemSets } from 'shared/types/Collection';
@@ -17,13 +16,13 @@ import {
   selectSharedState,
   createSelectArticlesInCollection
 } from 'shared/selectors/shared';
+import EditModeVisibility from 'components/util/EditModeVisibility';
 
 interface FrontCollectionOverviewContainerProps {
   frontId: string;
   collectionId: string;
   browsingStage: CollectionItemSets;
   isSelected: boolean;
-  isEditingEditions: boolean;
 }
 
 type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
@@ -107,8 +106,7 @@ const CollectionOverview = ({
   openCollection,
   frontId,
   hasUnpublishedChanges,
-  isSelected,
-  isEditingEditions
+  isSelected
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
@@ -132,17 +130,18 @@ const CollectionOverview = ({
         <ItemCount>({articleCount})</ItemCount>
       </TextContainerLeft>
       <TextContainerRight>
-        {!isEditingEditions &&
-          collection &&
+        {collection &&
           collection.lastUpdated &&
           (!!hasUnpublishedChanges ? (
-            <StatusWarning
-              priority="primary"
-              size="s"
-              title="Collection changes have not been launched"
-            >
-              !
-            </StatusWarning>
+            <EditModeVisibility visibleMode="fronts">
+              <StatusWarning
+                priority="primary"
+                size="s"
+                title="Collection changes have not been launched"
+              >
+                !
+              </StatusWarning>
+            </EditModeVisibility>
           ) : null)}
       </TextContainerRight>
     </Container>
@@ -164,7 +163,6 @@ const mapStateToProps = () => {
     hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
       collectionId: props.collectionId
     }),
-    isEditingEditions: selectIsEditingEditions(state)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -6,12 +6,12 @@ import { events } from 'services/GA';
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
 import { selectHasUnpublishedChanges } from 'selectors/frontsSelectors';
+import { selectIsEditingEditions } from 'selectors/pathSelectors';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
 import { Collection, CollectionItemSets } from 'shared/types/Collection';
 import { createCollectionId } from 'shared/components/Collection';
 import ButtonDefault from 'shared/components/input/ButtonCircular';
-
 import {
   createSelectCollection,
   selectSharedState,
@@ -23,6 +23,7 @@ interface FrontCollectionOverviewContainerProps {
   collectionId: string;
   browsingStage: CollectionItemSets;
   isSelected: boolean;
+  isEditingEditions: boolean;
 }
 
 type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
@@ -106,7 +107,8 @@ const CollectionOverview = ({
   openCollection,
   frontId,
   hasUnpublishedChanges,
-  isSelected
+  isSelected,
+  isEditingEditions
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
@@ -130,7 +132,8 @@ const CollectionOverview = ({
         <ItemCount>({articleCount})</ItemCount>
       </TextContainerLeft>
       <TextContainerRight>
-        {collection &&
+        {!isEditingEditions &&
+          collection &&
           collection.lastUpdated &&
           (!!hasUnpublishedChanges ? (
             <StatusWarning
@@ -160,7 +163,8 @@ const mapStateToProps = () => {
     }).length,
     hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
       collectionId: props.collectionId
-    })
+    }),
+    isEditingEditions: selectIsEditingEditions(state)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -162,7 +162,7 @@ const mapStateToProps = () => {
     }).length,
     hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
       collectionId: props.collectionId
-    }),
+    })
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -19,7 +19,6 @@ import {
   selectFront,
   createSelectAlsoOnFronts
 } from 'selectors/frontsSelectors';
-import { selectIsEditingEditions } from 'selectors/pathSelectors';
 import Front from './Front';
 import SectionHeader from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';
@@ -30,6 +29,7 @@ import { PreviewEyeIcon, ClearIcon } from 'shared/components/icons/Icons';
 import { createFrontId } from 'util/editUtils';
 import { formMinWidth } from './ArticleFragmentForm';
 import { overviewMinWidth } from './FrontCollectionsOverview';
+import EditModeVisibility from 'components/util/EditModeVisibility';
 
 const FrontHeader = styled(SectionHeader)`
   display: flex;
@@ -109,7 +109,6 @@ type FrontsComponentProps = FrontsContainerProps & {
   alsoOn: { [id: string]: AlsoOnDetail };
   isOverviewOpen: boolean;
   isFormOpen: boolean;
-  isEditingEditions: boolean;
   frontsActions: {
     fetchLastPressed: (frontId: string) => void;
     editorCloseFront: (frontId: string) => void;
@@ -137,12 +136,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
   };
 
   public render() {
-    const {
-      frontId,
-      isFormOpen,
-      isOverviewOpen,
-      isEditingEditions
-    } = this.props;
+    const { frontId, isFormOpen, isOverviewOpen } = this.props;
     const title =
       this.props.selectedFront &&
       startCase(
@@ -159,11 +153,9 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
           <FrontHeader greyHeader={true}>
             <FrontsHeaderText title={title}>{title}</FrontsHeaderText>
             <FrontHeaderMeta>
-              {!isEditingEditions && (
+              <EditModeVisibility visibleMode="fronts">
                 <a
-                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
-                    this.props.frontId
-                  }`}
+                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${this.props.frontId}`}
                   target="preview"
                 >
                   <FrontHeaderButton size="l">
@@ -171,8 +163,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                     <PreviewButtonText>Preview</PreviewButtonText>
                   </FrontHeaderButton>
                 </a>
-              )}
-              {!isEditingEditions && (
                 <StageSelectButtons>
                   <RadioGroup>
                     {Object.keys(frontStages).map(key => (
@@ -187,7 +177,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                     ))}
                   </RadioGroup>
                 </StageSelectButtons>
-              )}
+              </EditModeVisibility>
               <FrontHeaderButton onClick={this.handleRemoveFront} size="l">
                 <ClearIcon size="xl" />
               </FrontHeaderButton>
@@ -215,8 +205,7 @@ const createMapStateToProps = () => {
     selectedFront: selectFront(state, { frontId: props.frontId }),
     alsoOn: selectAlsoOnFronts(state, { frontId: props.frontId }),
     isOverviewOpen: selectIsFrontOverviewOpen(state, props.frontId),
-    isFormOpen: !!selectEditorArticleFragment(state, props.frontId),
-    isEditingEditions: selectIsEditingEditions(state)
+    isFormOpen: !!selectEditorArticleFragment(state, props.frontId)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -161,7 +161,9 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
             <FrontHeaderMeta>
               {!isEditingEditions && (
                 <a
-                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${this.props.frontId}`}
+                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
+                    this.props.frontId
+                  }`}
                   target="preview"
                 >
                   <FrontHeaderButton size="l">

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -19,6 +19,7 @@ import {
   selectFront,
   createSelectAlsoOnFronts
 } from 'selectors/frontsSelectors';
+import { selectIsEditingEditions } from 'selectors/pathSelectors';
 import Front from './Front';
 import SectionHeader from '../layout/SectionHeader';
 import SectionContent from '../layout/SectionContent';
@@ -108,6 +109,7 @@ type FrontsComponentProps = FrontsContainerProps & {
   alsoOn: { [id: string]: AlsoOnDetail };
   isOverviewOpen: boolean;
   isFormOpen: boolean;
+  isEditingEditions: boolean;
   frontsActions: {
     fetchLastPressed: (frontId: string) => void;
     editorCloseFront: (frontId: string) => void;
@@ -135,7 +137,12 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
   };
 
   public render() {
-    const { frontId, isFormOpen, isOverviewOpen } = this.props;
+    const {
+      frontId,
+      isFormOpen,
+      isOverviewOpen,
+      isEditingEditions
+    } = this.props;
     const title =
       this.props.selectedFront &&
       startCase(
@@ -152,31 +159,33 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
           <FrontHeader greyHeader={true}>
             <FrontsHeaderText title={title}>{title}</FrontsHeaderText>
             <FrontHeaderMeta>
-              <a
-                href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
-                  this.props.frontId
-                }`}
-                target="preview"
-              >
-                <FrontHeaderButton size="l">
-                  <PreviewEyeIcon size="xl" />
-                  <PreviewButtonText>Preview</PreviewButtonText>
-                </FrontHeaderButton>
-              </a>
-              <StageSelectButtons>
-                <RadioGroup>
-                  {Object.keys(frontStages).map(key => (
-                    <RadioButton
-                      inline
-                      key={key}
-                      name={`${this.props.frontId} - frontStages`}
-                      checked={frontStages[key] === this.state.collectionSet}
-                      onChange={() => this.handleCollectionSetSelect(key)}
-                      label={toTitleCase(frontStages[key])}
-                    />
-                  ))}
-                </RadioGroup>
-              </StageSelectButtons>
+              {!isEditingEditions && (
+                <a
+                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${this.props.frontId}`}
+                  target="preview"
+                >
+                  <FrontHeaderButton size="l">
+                    <PreviewEyeIcon size="xl" />
+                    <PreviewButtonText>Preview</PreviewButtonText>
+                  </FrontHeaderButton>
+                </a>
+              )}
+              {!isEditingEditions && (
+                <StageSelectButtons>
+                  <RadioGroup>
+                    {Object.keys(frontStages).map(key => (
+                      <RadioButton
+                        inline
+                        key={key}
+                        name={`${this.props.frontId} - frontStages`}
+                        checked={frontStages[key] === this.state.collectionSet}
+                        onChange={() => this.handleCollectionSetSelect(key)}
+                        label={toTitleCase(frontStages[key])}
+                      />
+                    ))}
+                  </RadioGroup>
+                </StageSelectButtons>
+              )}
               <FrontHeaderButton onClick={this.handleRemoveFront} size="l">
                 <ClearIcon size="xl" />
               </FrontHeaderButton>
@@ -204,7 +213,8 @@ const createMapStateToProps = () => {
     selectedFront: selectFront(state, { frontId: props.frontId }),
     alsoOn: selectAlsoOnFronts(state, { frontId: props.frontId }),
     isOverviewOpen: selectIsFrontOverviewOpen(state, props.frontId),
-    isFormOpen: !!selectEditorArticleFragment(state, props.frontId)
+    isFormOpen: !!selectEditorArticleFragment(state, props.frontId),
+    isEditingEditions: selectIsEditingEditions(state)
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -155,7 +155,9 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
             <FrontHeaderMeta>
               <EditModeVisibility visibleMode="fronts">
                 <a
-                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${this.props.frontId}`}
+                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${
+                    this.props.frontId
+                  }`}
                   target="preview"
                 >
                   <FrontHeaderButton size="l">

--- a/client-v2/src/components/FrontsListContainer.ts
+++ b/client-v2/src/components/FrontsListContainer.ts
@@ -3,7 +3,7 @@ import { match, withRouter, RouteComponentProps } from 'react-router';
 import { createSelectFrontIdWithOpenAndStarredStatesByPriority } from 'bundles/frontsUIBundle';
 import { State } from '../types/State';
 import FrontList from './FrontList';
-import { selectIsEditingEditions } from 'selectors/pathSelectors';
+import { selectEditMode } from 'selectors/pathSelectors';
 
 type Props = {
   match: match<{ priority: string }>;
@@ -16,7 +16,7 @@ const mapStateToProps = () => {
       fronts: selectFrontIdWithOpenAndStarredStates(
         state,
         props.match.params.priority || '',
-        selectIsEditingEditions(state) ? 'index' : 'id'
+        selectEditMode(state) === 'editions' ? 'index' : 'id'
       )
     };
   };

--- a/client-v2/src/components/transitions/FadeTransition.tsx
+++ b/client-v2/src/components/transitions/FadeTransition.tsx
@@ -23,6 +23,7 @@ const applyDirection = ({ direction, length = 15 }: TransitionProps) =>
   directionMap[direction](length);
 
 const TransitionContainer = styled.div<TransitionProps>`
+  display: contents;
   position: relative;
   &.${transitionName}-${({ direction }) => direction}-enter {
     opacity: 0.01;

--- a/client-v2/src/components/util/EditModeVisibility.tsx
+++ b/client-v2/src/components/util/EditModeVisibility.tsx
@@ -1,0 +1,31 @@
+import React, { Fragment, ReactNode } from 'react';
+import { EditMode } from 'types/EditMode';
+import { selectEditMode } from 'selectors/pathSelectors';
+import { State } from 'types/State';
+import { connect } from 'react-redux';
+
+interface EditModeVisibilityProps {
+  currentMode: EditMode;
+  visibleMode: EditMode;
+  children: ReactNode;
+}
+
+const EditModeVisibility = ({
+  currentMode,
+  visibleMode,
+  children
+}: EditModeVisibilityProps) => {
+  if (currentMode === visibleMode) {
+    return <Fragment>{children}</Fragment>;
+  } else {
+    return null;
+  }
+};
+
+const createMapStateToProps = (state: State) => {
+  return {
+    currentMode: selectEditMode(state)
+  };
+};
+
+export default connect(createMapStateToProps)(EditModeVisibility);

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -697,7 +697,17 @@ const state = {
     loadingIds: [],
     updatingIds: []
   },
-  focus: { focusState: undefined }
+  focus: { focusState: undefined },
+  editionsIssue: {
+    data: undefined,
+    pagination: null,
+    lastError: null,
+    error: null,
+    lastFetch: 1547474573363,
+    loading: false,
+    loadingIds: [],
+    updatingIds: []
+  }
 } as State;
 
 export default state;

--- a/client-v2/src/reducers/rootReducer.ts
+++ b/client-v2/src/reducers/rootReducer.ts
@@ -9,6 +9,7 @@ import unpublishedChanges from './unpublishedChangesReducer';
 import clipboard from './clipboardReducer';
 import confirmModal from './confirmModalReducer';
 import editor from '../bundles/frontsUIBundle';
+import editionsIssue from '../bundles/editionsIssueBundle';
 import { capiLiveFeed, capiPreviewFeed } from '../bundles/capiFeedBundle';
 import staleFronts from './staleFrontsReducer';
 
@@ -28,7 +29,8 @@ const rootReducer = (state: any = {}, action: any) => ({
   confirmModal: confirmModal(state.confirmModal, action),
   capiLiveFeed: capiLiveFeed(state.capiLiveFeed, action),
   capiPreviewFeed: capiPreviewFeed(state.capiPreviewFeed, action),
-  focus: focusReducer(state.focus, action)
+  focus: focusReducer(state.focus, action),
+  editionsIssue: editionsIssue(state.editionsIssue, action)
 });
 
 export default rootReducer;

--- a/client-v2/src/selectors/configSelectors.ts
+++ b/client-v2/src/selectors/configSelectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { State } from 'types/State';
-import { selectIsEditingEditions } from './pathSelectors';
+import { selectEditMode } from './pathSelectors';
 
 const selectConfig = (state: State) => state.config;
 
@@ -29,9 +29,9 @@ const selectCapiPreviewURL = createSelector(
 
 const selectCollectionCap = createSelector(
   selectConfig,
-  selectIsEditingEditions,
-  (config, isEditingEditions) =>
-    (!isEditingEditions && config && config.collectionCap) || Infinity
+  selectEditMode,
+  (config, editMode) =>
+    (editMode === 'fronts' && config && config.collectionCap) || Infinity
 );
 
 const selectGridUrl = createSelector(

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -1,6 +1,7 @@
 import { State } from 'types/State';
 import { matchIssuePath } from 'routes/routes';
 import urls from 'constants/urls';
+import { EditMode } from 'types/EditMode';
 
 const matchRootPath = new RegExp(`^\/${urls.appRoot}`);
 const maybeRemoveV2Prefix = (path: string) => path.replace(matchRootPath, '');
@@ -8,7 +9,12 @@ const maybeRemoveV2Prefix = (path: string) => path.replace(matchRootPath, '');
 const selectFullPath = (state: State) => state.path;
 const selectV2SubPath = (state: State) =>
   maybeRemoveV2Prefix(selectFullPath(state));
-const selectIsEditingEditions = (state: State) =>
-  !!matchIssuePath(selectV2SubPath(state));
+const selectEditMode = (state: State): EditMode => {
+  if (!!matchIssuePath(selectV2SubPath(state))) {
+    return 'editions';
+  } else {
+    return 'fronts';
+  }
+};
 
-export { selectFullPath, selectV2SubPath, selectIsEditingEditions };
+export { selectFullPath, selectV2SubPath, selectEditMode };

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -62,3 +62,12 @@ export const createIssue = async (
     return response.json();
   });
 };
+
+export const getIssue = async (id: string): Promise<EditionsIssue> => {
+  return pandaFetch(`/editions-api/issues/${id}`, {
+    method: 'get',
+    credentials: 'same-origin'
+  }).then(response => {
+    return response.json();
+  });
+};

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -63,8 +63,8 @@ export const createIssue = async (
   });
 };
 
-export const getIssue = async (id: string): Promise<EditionsIssue> => {
-  return pandaFetch(`/editions-api/issues/${id}`, {
+export const getIssueSummary = async (id: string): Promise<EditionsIssue> => {
+  return pandaFetch(`/editions-api/issues/${id}/summary`, {
     method: 'get',
     credentials: 'same-origin'
   }).then(response => {

--- a/client-v2/src/types/EditMode.ts
+++ b/client-v2/src/types/EditMode.ts
@@ -1,0 +1,1 @@
+export type EditMode = 'fronts' | 'editions';

--- a/conf/routes
+++ b/conf/routes
@@ -106,6 +106,7 @@ GET         /editions-api/editions                       controllers.EditionsCon
 GET         /editions-api/editions/:name/issues          controllers.EditionsController.listIssues(name)
 POST        /editions-api/editions/:name/issues          controllers.EditionsController.postIssue(name)
 GET         /editions-api/issues/:id                     controllers.EditionsController.getIssue(id)
+GET         /editions-api/issues/:id/summary             controllers.EditionsController.getIssueSummary(id)
 POST        /editions-api/issues/:id/publish             controllers.EditionsController.publishIssue(id)
 GET         /editions-api/issues/:id/preview             controllers.EditionsController.getPreviewEdition(id)
 POST        /editions-api/collections                    controllers.EditionsController.getCollections


### PR DESCRIPTION
## What's changed?
You can now see what edition you're editing!

![image](https://user-images.githubusercontent.com/5560113/61394164-70b7fc00-a8ba-11e9-8b27-8f8e6de146cb.png)

Also hides:
* Launch button on collections
* Warning in collection overview

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
