### PR TITLE
Revert "PRIVATE LINK: replace capi endpoint with private link endpoint"

### DIFF
--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -35,7 +35,7 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
       config.contentApi.contentApiLiveHost
 
     val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
-
+    
     wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(url): _*).get().map { response =>
 
       if (response.status != OK) {
@@ -55,9 +55,6 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
 
     val contentApiHost = config.contentApi.contentApiLiveHost
 
-    // In the CODE and PROD environments, an api key is not required because we are using an AWS private link endpoint to connect to CAPI. 
-    // Private Link endpoints are inside the AWS account and allow other services in the account access to the API. 
-    // In DEV environments - we use a standard external API for which a key is required, and is passed in via the config. 
     val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
     wsClient.url(url).get().map { response =>

--- a/client-v2/src/constants/urls.ts
+++ b/client-v2/src/constants/urls.ts
@@ -1,5 +1,5 @@
 export default {
-  capiLiveUrl: '/api/live',
-  capiPreviewUrl: '/api/preview',
+  capiLiveUrl: '/api/live/',
+  capiPreviewUrl: '/api/preview/',
   appRoot: 'v2'
 };

--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -18,8 +18,7 @@ describe('CAPI', () => {
   describe('search', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';
-      const capiUrl = 'https://capiurl.guardian.com';
-      const capi = capiQuery(capiUrl);
+      const capi = capiQuery();
       capi.search({
         'api-key': apiKey
       });
@@ -34,8 +33,7 @@ describe('CAPI', () => {
     });
     it('changes URL appropriately if the isResource option is passed', () => {
       const apiKey = 'my-api-key';
-      const capiUrl = 'https://capiurl.guardian.com';
-      const capi = capiQuery(capiUrl);
+      const capi = capiQuery();
       const q = 'an/example/url';
       capi.search(
         {
@@ -49,7 +47,7 @@ describe('CAPI', () => {
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
       expect(fetchEndpoint).toBe(
-        'https://capiurl.guardian.com/an/example/url?api-key=my-api-key'
+        'https://content.guardianapis.com/an/example/url?api-key=my-api-key'
       );
     });
   });
@@ -57,21 +55,19 @@ describe('CAPI', () => {
   describe('scheduled', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';
-      const capiUrl = 'https://capiurl.guardian.com';
-      const capi = capiQuery(capiUrl);
+      const capi = capiQuery();
       capi.scheduled({
         'api-key': apiKey
       });
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
       expect(fetchEndpoint).toEqual(
-        'https://capiurl.guardian.com/content/scheduled?api-key=my-api-key'
+        'https://content.guardianapis.com/content/scheduled?api-key=my-api-key'
       );
     });
     it('changes URL appropriately if the isResource option is passed', () => {
       const apiKey = 'my-api-key';
-      const capiUrl = 'https://capiurl.guardian.com';
-      const capi = capiQuery(capiUrl);
+      const capi = capiQuery();
       const q = 'an/example/url';
       capi.scheduled(
         {
@@ -85,7 +81,7 @@ describe('CAPI', () => {
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
       expect(fetchEndpoint).toBe(
-        'https://capiurl.guardian.com/an/example/url?api-key=my-api-key'
+        'https://content.guardianapis.com/an/example/url?api-key=my-api-key'
       );
     });
   });
@@ -93,8 +89,7 @@ describe('CAPI', () => {
   describe('tags', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';
-      const capiUrl = 'https://capiurl.guardian.com';
-      const capi = capiQuery(capiUrl);
+      const capi = capiQuery();
       capi.tags({
         'api-key': apiKey
       });

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -2,6 +2,8 @@ import { qs } from 'util/qs';
 import { CapiArticle, Tag } from 'types/Capi';
 import pandaFetch from 'services/pandaFetch';
 
+const API_BASE = 'https://content.guardianapis.com/';
+
 type Fetch = (path: string) => Promise<Response>;
 
 type CAPIStatus = 'ok' | 'error';
@@ -100,7 +102,7 @@ const fetchCAPIResponse = async <
  *
  * @throws {Error} If fetch throws, CAPI returns an unparsable result, or CAPI returns an error.
  */
-const capiQuery = (baseURL: string) => {
+const capiQuery = (baseURL: string = API_BASE) => {
   const getCAPISearchString = (
     path: string,
     params: any,
@@ -108,8 +110,8 @@ const capiQuery = (baseURL: string) => {
   ) => {
     const { q, ...rest } = params;
     return options && options.isResource
-      ? `${baseURL}/${q}${qs({ ...rest })}`
-      : `${baseURL}/${path}${qs({
+      ? `${baseURL}${q}${qs({ ...rest })}`
+      : `${baseURL}${path}${qs({
           ...params
         })}`;
   };


### PR DESCRIPTION
Reverts guardian/facia-tool#790

Change seems to be causing a problem with tag lookup.