### PR TITLE
Add preview bucket and update contents when collections change

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -81,6 +81,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     lazy val bucket = getMandatoryString("aws.bucket")
     lazy val frontsBucket = getMandatoryString("aws.frontsBucket")
     lazy val publishedEditionsIssuesBucket = getMandatoryString("aws.publishedEditionsIssuesBucket")
+    lazy val previewEditionsIssuesBucket = getMandatoryString("aws.previewEditionsIssuesBucket")
 
     def cmsFrontsAccountCredentials: AWSCredentialsProvider = credentials.getOrElse(throw new BadConfigurationException("AWS credentials are not configured for CMS Fronts"))
     val credentials: Option[AWSCredentialsProvider] = {

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -76,6 +76,13 @@ class EditionsController(db: EditionsDB,
     val form = req.body
     val collectionToUpdate = EditionsFrontendCollectionWrapper.toCollection(form)
     val updatedCollection = db.updateCollection(collectionToUpdate)
+    for {
+      issueId <- db.getIssueIdFromCollectionId(updatedCollection.id)
+      issue <- db.getIssue(issueId)
+    } {
+      logger.info("Updating preview")
+      publishing.updatePreview(issue)
+    }
     Ok(Json.toJson(EditionsFrontendCollectionWrapper.fromCollection(updatedCollection)))
   }
 

--- a/app/controllers/PressController.scala
+++ b/app/controllers/PressController.scala
@@ -20,9 +20,7 @@ case class FrontPressRecord (
  actionTime: String
 )
 
-class PressController (dynamo: Dynamo, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
-  val client = dynamo.client
-
+class PressController (client: AmazonDynamoDB, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
   private lazy val pressedTable = Table[FrontPressRecord](config.faciatool.frontPressUpdateTable)
 
   def getLastModified (path: String) = AccessAPIAuthAction { request =>

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import model.UserData
@@ -10,9 +11,8 @@ import permissions.Permissions
 import play.api.libs.json.Json
 import switchboard.SwitchManager
 import util.{Acl, AclJson}
-import services.Dynamo
 
-class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
+class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
   import model.UserData._
 
@@ -37,7 +37,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamo: Dynamo, val deps: BaseFaciaCon
 
     val userEmail: String = req.user.email
 
-    val maybeUserData: Option[UserData] = Scanamo.exec(dynamo.client)(
+    val maybeUserData: Option[UserData] = Scanamo.exec(dynamoClient)(
       userDataTable.get('email -> userEmail)).flatMap(_.right.toOption)
 
     val clipboardArticles = if (editingEdition)

--- a/app/services/Dynamo.scala
+++ b/app/services/Dynamo.scala
@@ -1,16 +1,14 @@
 package services
 
-import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBClientBuilder, AmazonDynamoDB}
-import conf.ApplicationConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
 
 
-class Dynamo(val awsEndpoints: AwsEndpoints, config: ApplicationConfiguration) {
-  lazy val client: AmazonDynamoDB = {
-    val endpoint = new AwsClientBuilder.EndpointConfiguration(awsEndpoints.dynamoDb, config.aws.region)
+object Dynamo {
+  def client(awsCredentials: AWSCredentialsProvider, region: String): AmazonDynamoDB = {
     val builder: AmazonDynamoDBClientBuilder = AmazonDynamoDBClientBuilder.standard()
-      .withCredentials(config.aws.cmsFrontsAccountCredentials)
-      .withEndpointConfiguration(endpoint)
+      .withCredentials(awsCredentials)
+      .withRegion(region)
     builder.build()
   }
 }

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -97,6 +97,18 @@ trait IssueQueries {
     """.map(EditionsIssue.fromRow(_)).list().apply()
   }
 
+  def getIssueIdFromCollectionId(collectionId: String): Option[String] = DB readOnly { implicit session =>
+    sql"""
+    SELECT edition_issues.id AS id
+    FROM edition_issues
+    INNER JOIN fronts ON (fronts.issue_id = edition_issues.id)
+    INNER JOIN collections ON (collections.front_id = fronts.id)
+    WHERE collections.id = $collectionId
+    """.map { rs =>
+      rs.string("id")
+    }.toOption().apply()
+  }
+
   def getIssue(id: String): Option[EditionsIssue] = DB readOnly { implicit session =>
       case class GetIssueRow(
           issue: EditionsIssue,

--- a/app/services/editions/publishing/EditionsBucket.scala
+++ b/app/services/editions/publishing/EditionsBucket.scala
@@ -1,0 +1,23 @@
+package services.editions.publishing
+
+import com.amazonaws.services.s3.AmazonS3
+import com.gu.editions.PublishedIssue
+import play.api.libs.json.Json
+import PublishedIssueFormatters._
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import com.amazonaws.util.StringInputStream
+
+abstract class EditionsBucket[T](s3Client: AmazonS3, bucketName: String) {
+  def createIssuePrefix(issue: PublishedIssue): String = s"${issue.name}/${issue.issueDate.toLocalDate.toString}"
+
+  def createIssueFilename(issue: PublishedIssue, publicationMetadata: T): String
+
+  def putIssue(issue: PublishedIssue, publicationMetadata: T) = {
+    val issueJson = Json.stringify(Json.toJson(issue))
+    val metadata = new ObjectMetadata()
+    metadata.setContentType("application/json")
+    val key = s"${createIssuePrefix(issue)}/${createIssueFilename(issue, publicationMetadata)}"
+    val request = new PutObjectRequest(bucketName, key, new StringInputStream(issueJson), metadata)
+    s3Client.putObject(request)
+  }
+}

--- a/app/services/editions/publishing/EditionsBucket.scala
+++ b/app/services/editions/publishing/EditionsBucket.scala
@@ -7,16 +7,16 @@ import PublishedIssueFormatters._
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
 import com.amazonaws.util.StringInputStream
 
-abstract class EditionsBucket[T](s3Client: AmazonS3, bucketName: String) {
+abstract class EditionsBucket(s3Client: AmazonS3, bucketName: String) {
   def createIssuePrefix(issue: PublishedIssue): String = s"${issue.name}/${issue.issueDate.toLocalDate.toString}"
 
-  def createIssueFilename(issue: PublishedIssue, publicationMetadata: T): String
+  def createIssueFilename(issue: PublishedIssue): String
 
-  def putIssue(issue: PublishedIssue, publicationMetadata: T) = {
+  def putIssue(issue: PublishedIssue) = {
     val issueJson = Json.stringify(Json.toJson(issue))
     val metadata = new ObjectMetadata()
     metadata.setContentType("application/json")
-    val key = s"${createIssuePrefix(issue)}/${createIssueFilename(issue, publicationMetadata)}"
+    val key = s"${createIssuePrefix(issue)}/${createIssueFilename(issue)}"
     val request = new PutObjectRequest(bucketName, key, new StringInputStream(issueJson), metadata)
     s3Client.putObject(request)
   }

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -8,14 +8,14 @@ class EditionsPublishing(publishedBucket: PublishedIssuesBucket, previewBucket: 
 
   def updatePreview(issue: EditionsIssue) = {
     val previewIssue = issue.toPublishedIssue
-    previewBucket.putIssue(previewIssue, ())
+    previewBucket.putIssue(previewIssue)
   }
 
   def publish(issue: EditionsIssue, user: User) = {
     val publishedIssue = issue.toPublishedIssue
 
     // Archive a copy
-    publishedBucket.putIssue(publishedIssue, user)
+    publishedBucket.putIssue(publishedIssue)
 
     // Bump the recently published counters
     db.publishIssue(issue.id, user)

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -4,13 +4,18 @@ import com.gu.pandomainauth.model.User
 import model.editions.EditionsIssue
 import services.editions.db.EditionsDB
 
-class EditionsPublishing(bucket: PublishedIssuesBucket, db: EditionsDB) {
+class EditionsPublishing(publishedBucket: PublishedIssuesBucket, previewBucket: PreviewIssuesBucket, db: EditionsDB) {
+
+  def updatePreview(issue: EditionsIssue) = {
+    val previewIssue = issue.toPublishedIssue
+    previewBucket.putIssue(previewIssue, ())
+  }
 
   def publish(issue: EditionsIssue, user: User) = {
     val publishedIssue = issue.toPublishedIssue
 
     // Archive a copy
-    bucket.putIssue(publishedIssue, user)
+    publishedBucket.putIssue(publishedIssue, user)
 
     // Bump the recently published counters
     db.publishIssue(issue.id, user)

--- a/app/services/editions/publishing/PreviewIssuesBucket.scala
+++ b/app/services/editions/publishing/PreviewIssuesBucket.scala
@@ -3,6 +3,6 @@ package services.editions.publishing
 import com.amazonaws.services.s3.AmazonS3
 import com.gu.editions.PublishedIssue
 
-class PreviewIssuesBucket(s3Client: AmazonS3, bucketName: String) extends EditionsBucket[Unit](s3Client, bucketName) {
-  override def createIssueFilename(issue: PublishedIssue, publicationMetadata: Unit): String = "preview.json"
+class PreviewIssuesBucket(s3Client: AmazonS3, bucketName: String) extends EditionsBucket(s3Client, bucketName) {
+  override def createIssueFilename(issue: PublishedIssue): String = "preview.json"
 }

--- a/app/services/editions/publishing/PreviewIssuesBucket.scala
+++ b/app/services/editions/publishing/PreviewIssuesBucket.scala
@@ -1,0 +1,8 @@
+package services.editions.publishing
+
+import com.amazonaws.services.s3.AmazonS3
+import com.gu.editions.PublishedIssue
+
+class PreviewIssuesBucket(s3Client: AmazonS3, bucketName: String) extends EditionsBucket[Unit](s3Client, bucketName) {
+  override def createIssueFilename(issue: PublishedIssue, publicationMetadata: Unit): String = "preview.json"
+}

--- a/app/services/editions/publishing/PublishedIssuesBucket.scala
+++ b/app/services/editions/publishing/PublishedIssuesBucket.scala
@@ -4,12 +4,9 @@ import java.time.OffsetDateTime
 
 import com.amazonaws.services.s3.AmazonS3
 import com.gu.editions.PublishedIssue
-import com.gu.pandomainauth.model.User
 
-class PublishedIssuesBucket(s3Client: AmazonS3, bucketName: String) extends EditionsBucket[User](s3Client, bucketName) {
-  override def createIssueFilename(issue: PublishedIssue, publicationMetadata: User): String = {
-    val firstName = publicationMetadata.firstName.replace(" ", "_")
-    val lastName = publicationMetadata.lastName.replace(" ", "_")
-    s"${OffsetDateTime.now().toString}_${firstName}_$lastName.json"
+class PublishedIssuesBucket(s3Client: AmazonS3, bucketName: String) extends EditionsBucket(s3Client, bucketName) {
+  override def createIssueFilename(issue: PublishedIssue): String = {
+    s"${OffsetDateTime.now()}.json"
   }
 }

--- a/app/services/editions/publishing/PublishedIssuesBucket.scala
+++ b/app/services/editions/publishing/PublishedIssuesBucket.scala
@@ -2,31 +2,14 @@ package services.editions.publishing
 
 import java.time.OffsetDateTime
 
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.AmazonS3
 import com.gu.editions.PublishedIssue
-import conf.ApplicationConfiguration
-import play.api.libs.json.Json
-import services._
-import PublishedIssueFormatters._
 import com.gu.pandomainauth.model.User
 
-class PublishedIssuesBucket(config: ApplicationConfiguration, awsEndpoints: AwsEndpoints) {
-
-  val bucket = config.aws.publishedEditionsIssuesBucket
-
-  val client = AmazonS3ClientBuilder
-    .standard()
-    .withCredentials(config.aws.credentials.get)
-    .withRegion(config.aws.region)
-    .build()
-
-  private def createIssuePath(issue: PublishedIssue, user: User) = {
-    val firstName = user.firstName.replace(" ", "_")
-    val lastName = user.lastName.replace(" ", "_")
-    s"${issue.name}/${issue.issueDate.toLocalDate.toString}/${OffsetDateTime.now().toString}_${firstName}_$lastName.json"
-  }
-
-  def putIssue(issue: PublishedIssue, user: User) = {
-    client.putObject(bucket, createIssuePath(issue, user), Json.stringify(Json.toJson(issue)))
+class PublishedIssuesBucket(s3Client: AmazonS3, bucketName: String) extends EditionsBucket[User](s3Client, bucketName) {
+  override def createIssueFilename(issue: PublishedIssue, publicationMetadata: User): String = {
+    val firstName = publicationMetadata.firstName.replace(" ", "_")
+    val lastName = publicationMetadata.lastName.replace(" ", "_")
+    s"${OffsetDateTime.now().toString}_${firstName}_$lastName.json"
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -81,8 +81,10 @@ aws {
     bucket: "aws-frontend-store"
     frontsBucket: "facia-tool-store"
     publishedEditionsIssuesBucket: "published-editions-code"
+    previewEditionsIssuesBucket: "preview-editions-code"
 }
 PROD.aws.publishedEditionsIssuesBucket: "published-editions-prod"
+PROD.aws.previewEditionsIssuesBucket: "preview-editions-prod"
 
 pandomain {
   service: "fronts"

--- a/test/fixtures/DockerPostgresService.scala
+++ b/test/fixtures/DockerPostgresService.scala
@@ -6,8 +6,8 @@ import scala.concurrent.duration._
 trait DockerPostgresService extends DockerKit {
   val externalPort = 44444
   val containerPort = 5432
-  val user = "user"
-  val password = "safepassword"
+  val dbUser = "user"
+  val dbPassword = "safepassword"
   val databaseName = "mydb"
   val dbUrl = s"jdbc:postgresql://localhost:$externalPort/$databaseName?autoReconnect=true&useSSL=false"
   val driver = "org.postgresql.Driver"
@@ -15,9 +15,9 @@ trait DockerPostgresService extends DockerKit {
 
   val postgresContainer = DockerContainer(dockerImage)
     .withPorts((containerPort, Some(externalPort)))
-    .withEnv(s"POSTGRES_USER=$user", s"POSTGRES_PASSWORD=$password", s"POSTGRES_DB=$databaseName")
+    .withEnv(s"POSTGRES_USER=$dbUser", s"POSTGRES_PASSWORD=$dbPassword", s"POSTGRES_DB=$databaseName")
     .withReadyChecker(
-      new PostgresReadyChecker(dbUrl, user, password, driver).looped(30, 1.second)
+      new PostgresReadyChecker(dbUrl, dbUser, dbPassword, driver).looped(30, 1.second)
     )
 
   // adds our container to the DockerKit's list

--- a/test/fixtures/EditionsDBService.scala
+++ b/test/fixtures/EditionsDBService.scala
@@ -17,11 +17,11 @@ trait EditionsDBService extends DockerTestKit with DockerKitDockerJava with Dock
     super.beforeAll()
 
     database = Databases(driver, dbUrl, config = Map(
-      "username" -> user,
-      "password" -> password
+      "username" -> dbUser,
+      "password" -> dbPassword
     ))
 
-    editionsDB = new EditionsDB(dbUrl, user, password)
+    editionsDB = new EditionsDB(dbUrl, dbUser, dbPassword)
   }
 
   def withEvolutions[T]: (=> T) => T = Evolutions.withEvolutions[T](database)


### PR DESCRIPTION
## What's changed?

This provides an initial cut of preview capabilities for editions. Everytime any change is made we write a full copy of the current issue into a new `preview-editions` bucket under `<edition-name>/<issue-date>/preview.json`.

The idea then is that the editions app can use the keys in that bucket as a source of data for populating the preview mode of the app.

## Implementation notes

At present this synchronously queries the DB and writes to the bucket on every single collection update. It would be better to do this asynchronously and debounce it so it is re-published no more frequently than once every couple of seconds.

## Checklist
- [ ] Ensure https://github.com/guardian/editorial-tools-platform/pull/304 is applied and merged

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
