### PR TITLE
PRIVATE LINK: replace capi endpoint with private link endpoint (#2)

### DIFF
--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -55,7 +55,10 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
 
     val contentApiHost = config.contentApi.contentApiLiveHost
 
-    val url = s"$contentApiHost/$path?$queryString"
+    // In the CODE and PROD environments, an api key is not required because we are using an AWS private link endpoint to connect to CAPI. 
+    // Private Link endpoints are inside the AWS account and allow other services in the account access to the API. 
+    // In DEV environments - we use a standard external API for which a key is required, and is passed in via the config. 
+    val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
     wsClient.url(url).get().map { response =>
 

--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -35,7 +35,7 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
       config.contentApi.contentApiLiveHost
 
     val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
-    
+
     wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(url): _*).get().map { response =>
 
       if (response.status != OK) {
@@ -55,7 +55,7 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
 
     val contentApiHost = config.contentApi.contentApiLiveHost
 
-    val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+    val url = s"$contentApiHost/$path?$queryString"
 
     wsClient.url(url).get().map { response =>
 

--- a/client-v2/src/constants/urls.ts
+++ b/client-v2/src/constants/urls.ts
@@ -1,5 +1,5 @@
 export default {
-  capiLiveUrl: '/api/live/',
-  capiPreviewUrl: '/api/preview/',
+  capiLiveUrl: '/api/live',
+  capiPreviewUrl: '/api/preview',
   appRoot: 'v2'
 };

--- a/client-v2/src/services/__tests__/capiQuery.spec.ts
+++ b/client-v2/src/services/__tests__/capiQuery.spec.ts
@@ -18,7 +18,8 @@ describe('CAPI', () => {
   describe('search', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';
-      const capi = capiQuery();
+      const capiUrl = 'https://capiurl.guardian.com';
+      const capi = capiQuery(capiUrl);
       capi.search({
         'api-key': apiKey
       });
@@ -33,7 +34,8 @@ describe('CAPI', () => {
     });
     it('changes URL appropriately if the isResource option is passed', () => {
       const apiKey = 'my-api-key';
-      const capi = capiQuery();
+      const capiUrl = 'https://capiurl.guardian.com';
+      const capi = capiQuery(capiUrl);
       const q = 'an/example/url';
       capi.search(
         {
@@ -47,7 +49,7 @@ describe('CAPI', () => {
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
       expect(fetchEndpoint).toBe(
-        'https://content.guardianapis.com/an/example/url?api-key=my-api-key'
+        'https://capiurl.guardian.com/an/example/url?api-key=my-api-key'
       );
     });
   });
@@ -55,19 +57,21 @@ describe('CAPI', () => {
   describe('scheduled', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';
-      const capi = capiQuery();
+      const capiUrl = 'https://capiurl.guardian.com';
+      const capi = capiQuery(capiUrl);
       capi.scheduled({
         'api-key': apiKey
       });
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
       expect(fetchEndpoint).toEqual(
-        'https://content.guardianapis.com/content/scheduled?api-key=my-api-key'
+        'https://capiurl.guardian.com/content/scheduled?api-key=my-api-key'
       );
     });
     it('changes URL appropriately if the isResource option is passed', () => {
       const apiKey = 'my-api-key';
-      const capi = capiQuery();
+      const capiUrl = 'https://capiurl.guardian.com';
+      const capi = capiQuery(capiUrl);
       const q = 'an/example/url';
       capi.scheduled(
         {
@@ -81,7 +85,7 @@ describe('CAPI', () => {
       expect((global as any).fetch).toBeCalled();
       const fetchEndpoint = (global as any).fetch.mock.calls[0][0];
       expect(fetchEndpoint).toBe(
-        'https://content.guardianapis.com/an/example/url?api-key=my-api-key'
+        'https://capiurl.guardian.com/an/example/url?api-key=my-api-key'
       );
     });
   });
@@ -89,7 +93,8 @@ describe('CAPI', () => {
   describe('tags', () => {
     it('makes a network request on a query', () => {
       const apiKey = 'my-api-key';
-      const capi = capiQuery();
+      const capiUrl = 'https://capiurl.guardian.com';
+      const capi = capiQuery(capiUrl);
       capi.tags({
         'api-key': apiKey
       });

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -133,21 +133,21 @@ const capiQuery = (baseURL: string) => {
     },
     tags: async (params: any): Promise<CAPITagQueryReponse> => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
-        `${baseURL}tags${qs({
+        `${baseURL}/tags${qs({
           ...params
         })}`
       );
     },
     sections: async (params: any): Promise<CAPITagQueryReponse> => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
-        `${baseURL}sections${qs({
+        `${baseURL}/sections${qs({
           ...params
         })}`
       );
     },
     desks: async (params: any): Promise<CAPITagQueryReponse> => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
-        `${baseURL}tags${qs({
+        `${baseURL}/tags${qs({
           type: 'tracking',
           ...params
         })}`

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -108,8 +108,8 @@ const capiQuery = (baseURL: string) => {
   ) => {
     const { q, ...rest } = params;
     return options && options.isResource
-      ? `${q}${qs({ ...rest })}`
-      : `${path}${qs({
+      ? `${baseURL}/${q}${qs({ ...rest })}`
+      : `${baseURL}/${path}${qs({
           ...params
         })}`;
   };

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -2,8 +2,6 @@ import { qs } from 'util/qs';
 import { CapiArticle, Tag } from 'types/Capi';
 import pandaFetch from 'services/pandaFetch';
 
-const API_BASE = 'https://content.guardianapis.com/';
-
 type Fetch = (path: string) => Promise<Response>;
 
 type CAPIStatus = 'ok' | 'error';
@@ -102,7 +100,7 @@ const fetchCAPIResponse = async <
  *
  * @throws {Error} If fetch throws, CAPI returns an unparsable result, or CAPI returns an error.
  */
-const capiQuery = (baseURL: string = API_BASE) => {
+const capiQuery = (baseURL: string) => {
   const getCAPISearchString = (
     path: string,
     params: any,
@@ -110,8 +108,8 @@ const capiQuery = (baseURL: string = API_BASE) => {
   ) => {
     const { q, ...rest } = params;
     return options && options.isResource
-      ? `${baseURL}${q}${qs({ ...rest })}`
-      : `${baseURL}${path}${qs({
+      ? `${q}${qs({ ...rest })}`
+      : `${path}${qs({
           ...params
         })}`;
   };


### PR DESCRIPTION
## What's changed?

This PR revisits #790, which was reverted as it broke tag searches. We've adding the missing trailing slashes to tag/section/desk queries.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
