### PR TITLE
return buildinfo on healthcheck endpoint

### DIFF
--- a/app/controllers/StatusController.scala
+++ b/app/controllers/StatusController.scala
@@ -1,12 +1,14 @@
 package controllers
 
+import facia.BuildInfo
+
 class StatusController(deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
 
   def healthStatus = Action {
     if(deps.permissions.storeIsEmpty) {
       ServiceUnavailable("Permissions store is empty")
     } else {
-      Ok("Ok.")
+      Ok(BuildInfo.toString)
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,6 @@ def env(key: String): Option[String] = Option(System.getenv(key))
 
 riffRaffPackageName := s"cms-fronts::${name.value}"
 riffRaffManifestProjectName := riffRaffPackageName.value
-riffRaffBuildIdentifier := env("BUILD_NUMBER").getOrElse("DEV")
-riffRaffManifestBranch := env("GIT_BRANCH").getOrElse(git.gitCurrentBranch.value)
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources := {

--- a/conf/routes
+++ b/conf/routes
@@ -10,9 +10,6 @@ GET         /oauthCallback                           controllers.PandaAuthContro
 GET         /logout                                  controllers.PandaAuthController.logout
 GET         /login/status                            controllers.PandaAuthController.status
 
-# healthcheck
-GET         /status                                  controllers.StatusController.healthStatus
-
 # static files
 GET         /assets/client-v2/*file                  controllers.V2Assets.at(path="", file)
 GET         /assets/*file                            controllers.UncachedAssets.at(path="", file)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M11")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.19")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1")
 


### PR DESCRIPTION
## What's changed?
This is in preparation for adding prout.

## Implementation notes
Removes the `/status` endpoint as it was the same as `/_healthcheck`. `/_healthcheck` is a more standard name here too.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
