### PR TITLE
Update edition front names and insert 'the fashion' in the running order

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -432,7 +432,7 @@ object FrontLifeFashion {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "Lifestyle",
+    name = "The Fashion",
     collections = List(collectionLifeFashion1, collectionLifeFashion2, collectionLifeFashion3),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -26,6 +26,7 @@ object DailyEdition {
       FrontBooks.front -> WeekDays(List(WeekDay.Sat, WeekDay.Sun)),
       FrontFood.front -> WeekDays(List(WeekDay.Sat)),
       FrontFoodObserver.front -> WeekDays(List(WeekDay.Sun)),
+      FrontLifeFashion.front -> WeekDays(List(WeekDay.Sat)),
       FrontSportGuardian.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
       FrontSportObserver.front -> WeekDays(List(WeekDay.Sun)),
       FrontSpecialSpecial2.front -> Daily(),

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -44,7 +44,7 @@ object FrontSpecialSpecial1 {
   )
 
   val front = FrontTemplate(
-    name = "special/special1",
+    name = "Special 1",
     collections = List(collectionSpecialSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true
@@ -59,7 +59,7 @@ object FrontTopStories {
   )
 
   val front = FrontTemplate(
-    name = "topstories/topstories",
+    name = "Top Stories",
     collections = List(collectionTopStories),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -93,7 +93,7 @@ object FrontNewsUkGuardian {
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
-    name = "news/uknewsguardian",
+    name = "UK News",
     collections = List(collectionNewsFrontPage, collectionNewsSpecial1, collectionNewsUkNewsGuardian, collectionNewsUkFinancial, collectionNewsWeather),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -132,7 +132,7 @@ object FrontNewsUkGuardianSaturday {
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
-    name = "news/uknewsguardian",
+    name = "UK News",
     collections = List(collectionNewsFrontPage, collectionNewsSpecial1, collectionNewsUkNewsGuardian, collectionNewsWeekInReviewGuardian, collectionNewsUkFinancial, collectionNewsWeather),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -157,7 +157,7 @@ object FrontNewsWorldGuardian {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "new/worldnewsguardian",
+    name = "World News",
     collections = List(collectionNewsWorldGuardian, collectionNewsWorldFinancialGuardian, collectionNewsWorldSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -192,7 +192,7 @@ object FrontNewsUkObserver {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "new/uknewsobserver",
+    name = "UK News",
     collections = List(collectionNewsFrontPageObserver, collectionNewsUkNewsObserver, collectionNewsUkBusinessObserver, collectionNewsUkFocusObserver, collectionNewsUkNewsSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -216,7 +216,7 @@ object FrontNewsWorldObserver {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "new/worldnewsobserver",
+    name = "World News",
     collections = List(collectionNewsWorldObserver, collectionNewsWorldBusinessObserver, collectionNewsWorldSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -250,7 +250,7 @@ object FrontJournal {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "opinion/journal",
+    name = "Opinion",
     collections = List(collectionJournalFeatures, collectionJournalComment, collectionJournalLetters, collectionJournalObits, collectionJournalSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -269,7 +269,7 @@ object FrontComment {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "opinion/comment",
+    name = "Opinion",
     collections = List(collectionOpinionComment, collectionOpinionSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -293,7 +293,7 @@ object FrontCulture {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "culture/arts",
+    name = "Culture",
     collections = List(collectionCultureArts, collectionCultureTVandRadio, collectionCultureSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -326,7 +326,7 @@ object FrontCultureFilmMusic {
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
-    name = "culture/filmandmusic",
+    name = "Culture",
     collections = List(collectionCultureFilm, collectionCultureMusic, collectionCultureArts, collectionCultureTVandRadio, collectionCultureSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -354,7 +354,7 @@ object FrontCultureGuide {
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
-    name = "culture/guide",
+    name = "Culture",
     collections = List(collectionCultureFeatures, collectionCulturePreview, collectionCultureTVandRadio, collectionCultureSpecial3),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -388,7 +388,7 @@ object FrontCultureNewReview {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "culture/newreview",
+    name = "Culture",
     collections = List(collectionCultureFeatures, collectionCultureScience, collectionCultureAgenda, collectionCultureCritics, collectionCultureSpecial3),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -407,7 +407,7 @@ object FrontLife {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "life/features",
+    name = "Lifestyle",
     collections = List(collectionLifeFeatures, collectionLifeSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -432,7 +432,7 @@ object FrontLifeFashion {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "life/fashion",
+    name = "Lifestyle",
     collections = List(collectionLifeFashion1, collectionLifeFashion2, collectionLifeFashion3),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true
@@ -483,7 +483,7 @@ object FrontLifeWeekend {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "life/weekend",
+    name = "Lifestyle",
     collections = List(collectionLifeWeekend, collectionLifeFamily, collectionLifeSpace, collectionLifeFashion, collectionLifeBody, collectionLifeTravel, collectionLifeMoney, collectionLifeSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -508,7 +508,7 @@ object FrontLifeMagazineObserver {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "life/magazine",
+    name = "Lifestyle",
     collections = List(collectionLifeMagazineFeatures, collectionLifeLifeStyle, collectionLifeSpecial3),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -527,7 +527,7 @@ object FrontBooks {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "review/books",
+    name = "Books",
     collections = List(collectionBooks, collectionBooksSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -546,7 +546,7 @@ object FrontFood {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "food/food",
+    name = "Food",
     collections = List(collectionFeast, collectionFoodSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -571,7 +571,7 @@ object FrontFoodObserver {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "food/observerfood",
+    name = "Food",
     collections = List(collectionFood, collectionFoodMonthly, collectionFoodSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -590,7 +590,7 @@ object FrontSportGuardian {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "sport/sport",
+    name = "Sport",
     collections = List(collectionSport, collectionSportSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -609,7 +609,7 @@ object FrontSportObserver {
     hidden = true
   )
   val front = FrontTemplate(
-    name = "sport/observersport",
+    name = "Sport",
     collections = List(collectionObsSport, collectionSportSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation
   )
@@ -623,7 +623,7 @@ object FrontSpecialSpecial2 {
   )
 
   val front = FrontTemplate(
-    name = "special/special2",
+    name = "Special 2",
     collections = List(collectionSpecialSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true
@@ -637,7 +637,7 @@ object FrontCrosswords {
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
-    name = "crosswords/crossword",
+    name = "Crosswords",
     collections = List(collectionCrosswords),
     presentation = TemplateDefaults.defaultFrontPresentation
   )


### PR DESCRIPTION
## What's changed?
The names of fronts has been made human readable, and are what actually gets rendered on the app. Note that while some fronts share names (and did previously too), we never show two fronts with the same name on the same day.

In addition, I noticed we defined, but never used the fashion magazine front, so I've added to Saturday, where it will belong when we actually produce it.

## Implementation notes
The fronts names are already used to pick the appropriate swatch to apply by the Editions back end. I've given Rich a snippet that supports both old and new names. A better solution would be for the fronts to pass in presentation properties (that exist in the model) that define which swatch of colours to use when rendering. This would simplify the backend and make everything more easily configurable.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
