### PR TITLE
"Suggested Articles" prefill button

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -75,7 +75,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
   override lazy val httpErrorHandler = new LoggingHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
 
 //  Controllers
-  val editions = new EditionsController(editionsDb, templating, editionsPublishing, this)
+  val editions = new EditionsController(editionsDb, templating, editionsPublishing, capi, this)
   val collection = new CollectionController(acl, structuredLogger, updateManager, press, this)
   val defaults = new DefaultsController(acl, isDev, this)
   val faciaCapiProxy = new FaciaContentApiProxy(capi, this)

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -107,6 +107,7 @@ class EditionsController(db: EditionsDB,
   def getPrefillForCollection(id: String) = AccessAPIAuthAction.async { req =>
     db.getCollectionPrefillQueryString(id).map { prefillUpdate =>
       capi.getPrefillArticles(prefillUpdate.issueDate, prefillUpdate.prefill, prefillUpdate.currentPageCodes).map { body =>
+        // Need to wrap this in a "response" object because the CAPI client and CAPI API return different JSON
         val json = "{\"response\":" + body.asJson.noSpaces + "}"
         val decorated = rewriteBody(json)
         Ok(decorated).as("application/json")

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -7,16 +7,21 @@ import services.editions.EditionsTemplating
 import java.time.{LocalDate, OffsetDateTime}
 
 import model.editions.{EditionsFrontendCollectionWrapper, EditionsTemplates}
+import services.Capi
 import services.editions.db.EditionsDB
-import services.editions.publishing.{EditionsPublishing, PublishedIssuesBucket}
+import services.editions.publishing.EditionsPublishing
 import services.editions.publishing.PublishedIssueFormatters._
+import util.ContentUpgrade.rewriteBody
+import com.gu.contentapi.json.CirceEncoders._
+import io.circe.syntax._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 class EditionsController(db: EditionsDB,
                          templating: EditionsTemplating,
                          publishing: EditionsPublishing,
+                         capi: Capi,
                          val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps)  with Logging {
 
   def postIssue(name: String) = AccessAPIAuthAction(parse.json[CreateIssue]) { req =>
@@ -97,5 +102,15 @@ class EditionsController(db: EditionsDB,
       publishing.publish(issue, req.user, OffsetDateTime.now())
       NoContent
     }.getOrElse(NotFound(s"Issue $id not found"))
+  }
+
+  def getPrefillForCollection(id: String) = AccessAPIAuthAction.async { req =>
+    db.getCollectionPrefillQueryString(id).map { prefillUpdate =>
+      capi.getPrefillArticles(prefillUpdate.issueDate, prefillUpdate.prefill, prefillUpdate.currentPageCodes).map { body =>
+        val json = "{\"response\":" + body.asJson.noSpaces + "}"
+        val decorated = rewriteBody(json)
+        Ok(decorated).as("application/json")
+      }
+    }.getOrElse(Future.successful(NotFound("Collection not found")))
   }
 }

--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -2,9 +2,7 @@ package controllers
 
 import java.net.{URI, URLEncoder}
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
-import com.gu.contentapi.client.{IAMEncoder, IAMSigner}
+import com.gu.contentapi.client.IAMEncoder
 import metrics.FaciaToolMetrics
 import model.Cached
 import play.api.libs.concurrent.Futures

--- a/app/model/editions/internal/PrefillUpdate.scala
+++ b/app/model/editions/internal/PrefillUpdate.scala
@@ -1,0 +1,9 @@
+package model.editions.internal
+
+import java.time.ZonedDateTime
+
+import model.editions.CapiPrefillQuery
+
+// Small class which is returned by the database to allow fetching new prefilled articles
+case class PrefillUpdate(issueDate: ZonedDateTime, prefill: CapiPrefillQuery, currentPageCodes: List[String])
+

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -9,15 +9,17 @@ import org.apache.http.client.utils.URLEncodedUtils
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.contentapi.client.model._
-import com.gu.contentapi.client.{GuardianContentClient, IAMSigner, Parameter}
+import com.gu.contentapi.client.model.v1.SearchResponse
+import com.gu.contentapi.client.{GuardianContentClient, IAMEncoder, IAMSigner, Parameter}
 import conf.ApplicationConfiguration
+import logging.Logging
 import model.editions.CapiPrefillQuery
 import okhttp3.{Call, Callback, Request, Response}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionContext) extends GuardianContentClient(config.contentApi.editionsKey) with Capi  {
+class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionContext) extends GuardianContentClient(config.contentApi.editionsKey) with Capi with Logging {
   override def targetUrl: String = config.contentApi.editionsPrefillHost
 
   override def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
@@ -45,7 +47,6 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       new ProfileCredentialsProvider("capi"),
       new STSAssumeRoleSessionCredentialsProvider.Builder(config.contentApi.previewRole, "capi").build()
     )
-
     new IAMSigner(
       credentialsProvider = capiPreviewCredentials,
       awsRegion = config.aws.region
@@ -54,20 +55,19 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
   def getPreviewHeaders(url: String): Seq[(String,String)] = previewSigner.addIAMHeaders(headers = Map.empty, URI.create(url)).toSeq
 
-  def geneneratePrefillQuery(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery) = {
+  // Prefill
+  def geneneratePrefillQuery(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, fields: List[String]) = {
     val params = URLEncodedUtils
       .parse(new URI(capiPrefillQuery.escapedQueryString()), Charset.forName("UTF-8"))
       .asScala
 
-    // Horrible hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
+    // Hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
     val localDate = issueDate.toLocalDate.atStartOfDay().toInstant(ZoneOffset.UTC)
 
     var query = PrintSentQuery()
       .page(1)
       .pageSize(200)
-      .showFields("newspaper-edition-date")
-      .showFields("newspaper-page-number")
-      .showFields("internal-page-code")
+      .showFields(fields.mkString(","))
       .useDate("newspaper-edition")
       .orderBy("newest")
       .fromDate(localDate)
@@ -88,13 +88,65 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
     query
   }
 
+  // Sadly there's no easy way of converting a CAPI client response into JSON so we'll just proxy - similar to controllers.FaciaContentApiProxy
+  def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = {
+    val fields = List(
+      "newspaperEditionDate",
+      "newspaperPapeNumber",
+      "internalPageCode",
+      "isLive",
+      "firstPublicationDate",
+      "headline",
+      "trailText",
+      "byline",
+      "thumbnail",
+      "secureThumbnail",
+      "liveBloggingNow",
+      "membershipAccess",
+      "shortUrl"
+    )
+
+    val query = geneneratePrefillQuery(issueDate, capiPrefillQuery, fields)
+      .showElements("images")
+      .showTags("all")
+      .showBlocks("main")
+      .showAtoms("media")
+
+    this.getResponse(query).map { response =>
+      val filteredResults = response.results.filter { result =>
+        (for {
+          fields <- result.fields
+          pageCode <- fields.internalPageCode
+        } yield !currentPageCodes.contains(pageCode.toString))
+          .getOrElse(true)
+      }
+
+      response.copy(
+        total = filteredResults.length,
+        results = filteredResults
+      )
+    }
+  }
+
   def getPrefillArticlePageCodes(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[String]] = {
-    this.getResponse(geneneratePrefillQuery(issueDate, capiPrefillQuery)) map { response =>
-      response.results.flatMap {
-        _.fields
-          .flatMap(field => field.internalPageCode)
-          .map(_.toString)
-      }.toList
+    val fields = List(
+      "newspaperEditionDate",
+      "newspaperPageNumber",
+      "internalPageCode"
+    )
+
+    this.getResponse(geneneratePrefillQuery(issueDate, capiPrefillQuery, fields)) map { response =>
+      response.results
+        .flatMap {
+          _.fields
+            .flatMap(fields => (fields.newspaperPageNumber, fields.internalPageCode) match {
+              case (Some(number), Some(code)) => Some((number, code.toString))
+              case _ => None
+            })
+      }
+        .sortBy(_._1)
+        .map(_._2)
+        .toList
     }
   }
 }
@@ -111,4 +163,5 @@ case class PrintSentQuery(parameterHolder: Map[String, Parameter] = Map.empty)
 trait Capi {
   def getPreviewHeaders(url: String): Seq[(String,String)]
   def getPrefillArticlePageCodes(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[String]]
+  def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse]
 }

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -68,7 +68,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       .page(1)
       .pageSize(200)
       .showFields(fields.mkString(","))
-      .useDate("newspaperEditionDate")
+      .useDate("newspaper-edition") // deliberately-kebab-case
       .orderBy("newest")
       .fromDate(localDate)
       .toDate(localDate)

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -68,7 +68,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       .page(1)
       .pageSize(200)
       .showFields(fields.mkString(","))
-      .useDate("newspaper-edition")
+      .useDate("newspaperEditionDate")
       .orderBy("newest")
       .fromDate(localDate)
       .toDate(localDate)

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ val capiModelsVersion = "14.1"
 val capiClientVersion = "14.3"
 val json4sVersion = "3.6.0-M2"
 val enumeratumPlayVersion = "1.5.13"
+val circeVersion = "0.11.1"
 
 resolvers ++= Seq(
     Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
@@ -109,6 +110,11 @@ libraryDependencies ++= Seq(
     "org.scalikejdbc"          %% "scalikejdbc"                  % "3.1.0",
     "org.scalikejdbc"          %% "scalikejdbc-config"           % "3.1.0",
     "org.scalikejdbc"          %% "scalikejdbc-play-initializer" % "2.6.0-scalikejdbc-3.1",
+
+    "io.circe"                 %% "circe-core"                   % circeVersion,
+    "io.circe"                 %% "circe-generic"                % circeVersion,
+    "io.circe"                 %% "circe-parser"                 % circeVersion,
+    
     "com.beachape" %% "enumeratum" % enumeratumPlayVersion,
     "com.beachape" %% "enumeratum-play" % enumeratumPlayVersion,
 

--- a/client-v2/integration/fixtures/capi-prefill.js
+++ b/client-v2/integration/fixtures/capi-prefill.js
@@ -1,0 +1,3375 @@
+module.exports = {
+  response: {
+    status: 'ok',
+    userTier: 'internal',
+    total: 5,
+    startIndex: 1,
+    pageSize: 200,
+    currentPage: 1,
+    pages: 1,
+    orderBy: 'newest',
+    results: [
+      {
+        id:
+          'world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest',
+        type: 'article',
+        sectionId: 'world',
+        sectionName: 'World news',
+        webPublicationDate: '2019-07-19T22:55:30Z',
+        webTitle:
+          'Iran stokes Gulf tensions by seizing two British-linked oil tankers',
+        webUrl:
+          'https://www.theguardian.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest',
+        apiUrl:
+          'https://preview.content.guardianapis.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest',
+        fields: {
+          headline:
+            'Iran stokes Gulf tensions by seizing two British-linked oil tankers',
+          trailText:
+            'UK ships advised to avoid strait of Hormuz as Jeremy Hunt calls Iranian actions ‘unacceptable’ ',
+          byline:
+            'Julian Borger in Washington, Patrick Wintour and Kevin Rawlinson in London',
+          firstPublicationDate: '2019-07-19T17:56:20Z',
+          internalPageCode: 6382255,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv6ym',
+          thumbnail:
+            'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'world/iran',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Iran',
+            webUrl: 'https://www.theguardian.com/world/iran',
+            apiUrl: 'https://preview.content.guardianapis.com/world/iran',
+            references: [],
+            internalName: 'Iran (News)'
+          },
+          {
+            id: 'world/middleeast',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Middle East and North Africa',
+            webUrl: 'https://www.theguardian.com/world/middleeast',
+            apiUrl: 'https://preview.content.guardianapis.com/world/middleeast',
+            references: [],
+            internalName: 'Middle East and North Africa (News) MENA'
+          },
+          {
+            id: 'business/oil',
+            type: 'keyword',
+            sectionId: 'business',
+            sectionName: 'Business',
+            webTitle: 'Oil',
+            webUrl: 'https://www.theguardian.com/business/oil',
+            apiUrl: 'https://preview.content.guardianapis.com/business/oil',
+            references: [],
+            internalName: 'Oil (business)'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'politics/foreignpolicy',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Foreign policy',
+            webUrl: 'https://www.theguardian.com/politics/foreignpolicy',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/foreignpolicy',
+            references: [],
+            internalName: 'Foreign policy'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'profile/julianborger',
+            type: 'contributor',
+            webTitle: 'Julian Borger',
+            webUrl: 'https://www.theguardian.com/profile/julianborger',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/julianborger',
+            references: [],
+            bio:
+              '<p>Julian Borger is the Guardian\'s world affairs editor. He was previously a correspondent in the US, the Middle East, eastern Europe and the Balkans. His book on the pursuit and capture of the Balkan war criminals, <a href="https://bookshop.theguardian.com/catalog/product/view/id/359254/?utm_source=editoriallink&amp;utm_medium=merch&amp;utm_campaign=article">The Butcher\'s Trail</a>, is published by Other Press. Click <a href="https://pgp.theguardian.com/PublicKeys/Julian%20Borger.pub.txt">here</a> for Julian\'s public key</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2016/1/8/1452247825373/Julian-Borger.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/06/Julian-Borger,-R.png',
+            firstName: 'Julian',
+            lastName: 'Borger',
+            rcsId: 'GNL001547',
+            r2ContributorId: '15924',
+            internalName: 'Julian Borger'
+          },
+          {
+            id: 'profile/patrickwintour',
+            type: 'contributor',
+            webTitle: 'Patrick Wintour',
+            webUrl: 'https://www.theguardian.com/profile/patrickwintour',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/patrickwintour',
+            references: [],
+            bio: '<p>Patrick Wintour is diplomatic editor for the Guardian</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/2/4/1423058508175/Patrick-Wintour.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/09/Patrick-Wintour,-R.png',
+            firstName: 'wintour',
+            lastName: '',
+            rcsId: 'GNL004731',
+            r2ContributorId: '16227',
+            internalName: 'Patrick Wintour'
+          },
+          {
+            id: 'profile/kevin-rawlinson',
+            type: 'contributor',
+            webTitle: 'Kevin Rawlinson',
+            webUrl: 'https://www.theguardian.com/profile/kevin-rawlinson',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/kevin-rawlinson',
+            references: [],
+            bio:
+              '<p>Kevin Rawlinson is a night reporter at the Guardian. Twitter <a href="https://twitter.com/kevinjrawlinson?lang=en">@KevinJRawlinson</a></p>',
+            firstName: 'Kevin',
+            lastName: 'Rawlinson',
+            r2ContributorId: '58554',
+            internalName: 'Kevin Rawlinson'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-foreign',
+            type: 'tracking',
+            webTitle: 'UK Foreign',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-foreign',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-foreign',
+            references: [],
+            internalName: 'UK Foreign (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d32060b8f0845f89e310a1f',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="ed66b07abda5301d6316b6f838dbe13a6603216b"> <img src="https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/1000.jpg" alt="The Stena Impero tanker" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">The Stena Impero tanker taken by Iranian Revolutionary Guard forces on Friday evening. </span> <span class="element-image__credit">Photograph: pr</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T18:03:55Z',
+            lastModifiedDate: '2019-07-19T20:19:23Z',
+            contributors: [],
+            createdBy: {
+              email: 'tim.burrows@guardian.co.uk',
+              firstName: 'Tim',
+              lastName: 'Burrows'
+            },
+            lastModifiedBy: {
+              email: 'paul.g.gallagher@guardian.co.uk',
+              firstName: 'Paul',
+              lastName: 'Gallagher (G)'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/2830.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2830, height: 1699 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/master/2830.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 2830,
+                      height: 1699,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'The Stena Impero tanker taken by Iranian Revolutionary Guard forces on Friday evening. ',
+                  displayCredit: true,
+                  credit: 'Photograph: pr',
+                  source: 'pr',
+                  alt: 'The Stena Impero tanker',
+                  mediaId: 'ed66b07abda5301d6316b6f838dbe13a6603216b',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/ed66b07abda5301d6316b6f838dbe13a6603216b',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        atoms: {
+          media: [
+            {
+              id: '20e0358f-6161-45db-9d2d-76cc0737cfc9',
+              atomType: 'media',
+              labels: [],
+              defaultHtml:
+                '<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/L0r-F1lrvQk?showinfo=0&rel=0"></iframe>',
+              data: {
+                media: {
+                  assets: [
+                    {
+                      assetType: 'video',
+                      version: 1,
+                      id: 'L0r-F1lrvQk',
+                      platform: 'youtube'
+                    }
+                  ],
+                  activeVersion: 1,
+                  title:
+                    "Jeremy Hunt warns Iran of 'serious consequences' over tanker seizure - video",
+                  category: 'news',
+                  duration: 62,
+                  source: 'Reuters',
+                  posterUrl:
+                    'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/master/3320.jpg',
+                  description:
+                    '<p>The foreign secretary, Jeremy Hunt, said on Saturday morning that Britain’s response would be ‘considered but robust’ if the British-flagged Stena Impero was not released, although he said the government was not contemplating military action. Iran\'s Revolutionary Guards said they had captured the British-flagged tanker, announcing the move two weeks after the British navy seized an Iranian tanker off Gibraltar, on suspicion of shipping oil to Syria in violation of an EU embargo</p><ul><li><a href="https://www.theguardian.com/world/2019/jul/20/iran-on-dangerous-path-with-seizure-of-stena-impero-says-uk">Iran on \'dangerous path\' with seizure of Stena Impero, says UK</a></li><li><a href="https://www.theguardian.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest">Iran stokes Gulf tensions by seizing two British-linked oil tankers</a></li></ul><p><br></p>',
+                  metadata: {
+                    tags: [
+                      'iranian oil tanker british',
+                      'british seized iranian oil tanker',
+                      'iran',
+                      'stena impero',
+                      'iran news',
+                      'british tanker seized by iran',
+                      'iranian oil tanker seized',
+                      'guardian',
+                      'iran seized british ship',
+                      'uk',
+                      'iran uk',
+                      'jeremy hunt',
+                      'jeremy hunt warns iran',
+                      'jeremy hunt iran',
+                      'politics',
+                      'hunt iran',
+                      'iran hunt',
+                      'iran war',
+                      'war in iran',
+                      'iran 2019',
+                      'uk vs iran',
+                      'oil',
+                      'oil tanker',
+                      'oil tanker seized',
+                      'strait of hormuz',
+                      'gulf',
+                      'middle east',
+                      'news',
+                      'world'
+                    ],
+                    categoryId: '25',
+                    channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
+                    privacyStatus: 'public',
+                    pluto: { commissionId: 'KP-50156', projectId: 'KP-50251' },
+                    youtube: {
+                      title:
+                        "Jeremy Hunt says Iran tanker seizure is unacceptable, warns of 'serious consequences' - video",
+                      description:
+                        "The foreign secretary, Jeremy Hunt, said on Saturday morning that Britain’s response would be ‘considered but robust’ if the British-flagged Stena Impero was not released, although he said the government was not contemplating military action. Iran's Revolutionary Guards said they had captured the British-flagged tanker, announcing the move two weeks after the British navy seized an Iranian tanker off Gibraltar, on suspicion of shipping oil to Syria in violation of an EU embargo\nSubscribe to Guardian News on YouTube ► http://bit.ly/guardianwiressub\n\nIran on 'dangerous path' with seizure of Stena Impero, says UK ► https://www.theguardian.com/world/2019/jul/20/iran-on-dangerous-path-with-seizure-of-stena-impero-says-uk\n\nIran stokes Gulf tensions by seizing two British-linked oil tankers ► https://www.theguardian.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest\n\nSupport the Guardian ► https://support.theguardian.com/contribute\n\nToday in Focus podcast ► https://www.theguardian.com/news/series/todayinfocus\n\nThe Guardian YouTube network:\n\nThe Guardian ► http://www.youtube.com/theguardian\nOwen Jones talks ► http://bit.ly/subsowenjones\nGuardian Football ► http://is.gd/guardianfootball\nGuardian Sport ► http://bit.ly/GDNsport\nGuardian Culture ► http://is.gd/guardianculture"
+                    }
+                  },
+                  posterImage: {
+                    assets: [
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/2000.jpg',
+                        dimensions: { height: 1125, width: 2000 },
+                        size: 77966,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/1000.jpg',
+                        dimensions: { height: 563, width: 1000 },
+                        size: 28122,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/500.jpg',
+                        dimensions: { height: 281, width: 500 },
+                        size: 12404,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/140.jpg',
+                        dimensions: { height: 79, width: 140 },
+                        size: 4995,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/3320.jpg',
+                        dimensions: { height: 1867, width: 3320 },
+                        size: 200219,
+                        aspectRatio: '16:9'
+                      }
+                    ],
+                    master: {
+                      mimeType: 'image/jpeg',
+                      file:
+                        'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/master/3320.jpg',
+                      dimensions: { height: 1867, width: 3320 },
+                      size: 955364,
+                      aspectRatio: '16:9'
+                    },
+                    mediaId:
+                      'https://api.media.gutools.co.uk/images/194a6f901d4f2f82d230ce45ccedfa0687d34612',
+                    source: 'AP'
+                  },
+                  trailText:
+                    '<p>The foreign secretary said on Saturday morning that Britain’s response would be ‘considered but robust’ if the British-flagged Stena Impero was not released</p>',
+                  byline: [],
+                  commissioningDesks: ['tracking/commissioningdesk/uk-video'],
+                  keywords: [
+                    'world/iran',
+                    'politics/jeremy-hunt',
+                    'world/iran-nuclear-deal',
+                    'politics/foreignpolicy',
+                    'tone/news',
+                    'uk/uk'
+                  ],
+                  trailImage: {
+                    assets: [
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/2000.jpg',
+                        dimensions: { height: 1200, width: 2000 },
+                        size: 84360,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/1000.jpg',
+                        dimensions: { height: 600, width: 1000 },
+                        size: 30050,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/500.jpg',
+                        dimensions: { height: 300, width: 500 },
+                        size: 13186,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/140.jpg',
+                        dimensions: { height: 84, width: 140 },
+                        size: 5193,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/3320.jpg',
+                        dimensions: { height: 1992, width: 3320 },
+                        size: 218455,
+                        aspectRatio: '5:3'
+                      }
+                    ],
+                    master: {
+                      mimeType: 'image/jpeg',
+                      file:
+                        'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/master/3320.jpg',
+                      dimensions: { height: 1992, width: 3320 },
+                      size: 1034676,
+                      aspectRatio: '5:3'
+                    },
+                    mediaId:
+                      'https://api.media.gutools.co.uk/images/194a6f901d4f2f82d230ce45ccedfa0687d34612',
+                    source: 'AP'
+                  }
+                }
+              },
+              contentChangeDetails: {
+                lastModified: {
+                  date: 1563781467000,
+                  user: {
+                    email: 'adam.sich@guardian.co.uk',
+                    firstName: 'Adam',
+                    lastName: 'Sich'
+                  }
+                },
+                created: {
+                  date: 1563616131000,
+                  user: {
+                    email: 'maheen.sadiq.casual@guardian.co.uk',
+                    firstName: 'Maheen',
+                    lastName: 'Sadiq (Casual)'
+                  }
+                },
+                published: {
+                  date: 1563781467000,
+                  user: {
+                    email: 'adam.sich@guardian.co.uk',
+                    firstName: 'Adam',
+                    lastName: 'Sich'
+                  }
+                },
+                revision: 25
+              },
+              flags: { blockAds: false },
+              title:
+                "Jeremy Hunt warns Iran of 'serious consequences' over tanker seizure - video",
+              commissioningDesks: []
+            }
+          ]
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News'
+      },
+      {
+        id:
+          'politics/2019/jul/19/brussels-to-offer-boris-johnson-extension-on-no-deal-brexit',
+        type: 'article',
+        sectionId: 'politics',
+        sectionName: 'Politics',
+        webPublicationDate: '2019-07-19T17:21:49Z',
+        webTitle: 'Brussels to offer Boris Johnson extension on no-deal Brexit',
+        webUrl:
+          'https://www.theguardian.com/politics/2019/jul/19/brussels-to-offer-boris-johnson-extension-on-no-deal-brexit',
+        apiUrl:
+          'https://preview.content.guardianapis.com/politics/2019/jul/19/brussels-to-offer-boris-johnson-extension-on-no-deal-brexit',
+        fields: {
+          headline:
+            'Brussels to offer Boris Johnson extension on no-deal Brexit',
+          trailText:
+            'Exclusive: extra time could be used for renegotiation but will be billed as chance for no-deal planning',
+          byline: 'Daniel Boffey in Brussels',
+          firstPublicationDate: '2019-07-19T17:21:49Z',
+          internalPageCode: 6380761,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv4kd',
+          thumbnail:
+            'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'politics/eu-referendum',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Brexit',
+            webUrl: 'https://www.theguardian.com/politics/eu-referendum',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/eu-referendum',
+            references: [],
+            internalName: 'Brexit'
+          },
+          {
+            id: 'politics/boris-johnson',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Boris Johnson',
+            webUrl: 'https://www.theguardian.com/politics/boris-johnson',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/boris-johnson',
+            references: [],
+            internalName: 'Boris Johnson'
+          },
+          {
+            id: 'politics/conservatives',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Conservatives',
+            webUrl: 'https://www.theguardian.com/politics/conservatives',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/conservatives',
+            references: [],
+            internalName: 'Conservatives tories tory party'
+          },
+          {
+            id: 'politics/foreignpolicy',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Foreign policy',
+            webUrl: 'https://www.theguardian.com/politics/foreignpolicy',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/foreignpolicy',
+            references: [],
+            internalName: 'Foreign policy'
+          },
+          {
+            id: 'world/eu',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'European Union',
+            webUrl: 'https://www.theguardian.com/world/eu',
+            apiUrl: 'https://preview.content.guardianapis.com/world/eu',
+            references: [],
+            internalName: 'EU European Union (News)'
+          },
+          {
+            id: 'world/europe-news',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Europe',
+            webUrl: 'https://www.theguardian.com/world/europe-news',
+            apiUrl:
+              'https://preview.content.guardianapis.com/world/europe-news',
+            references: [],
+            internalName: 'Europe (News)'
+          },
+          {
+            id: 'politics/politics',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Politics',
+            webUrl: 'https://www.theguardian.com/politics/politics',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/politics',
+            references: [],
+            internalName: 'Politics'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'profile/daniel-boffey',
+            type: 'contributor',
+            webTitle: 'Daniel Boffey',
+            webUrl: 'https://www.theguardian.com/profile/daniel-boffey',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/daniel-boffey',
+            references: [],
+            bio: "<p>Daniel Boffey is the Guardian's Brussels bureau chief</p>",
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2016/1/28/1453983010155/Daniel-Boffey.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/06/Daniel-Boffey,-L.png',
+            firstName: 'boffey',
+            lastName: 'daniel',
+            r2ContributorId: '43351',
+            internalName: 'Daniel Boffey'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-home-news',
+            type: 'tracking',
+            webTitle: 'UK Home News',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-home-news',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-home-news',
+            references: [],
+            internalName: 'UK Home News (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d31fa6e8f0845f89e3109a6',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="b46016835812f21a4f16494e75ec320e72700ec1"> <img src="https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/1000.jpg" alt="Boris Johnson" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Boris Johnson meeting supporters at a hustings last weekend. He is expected to be named Tory leader and PM next Tuesday.</span> <span class="element-image__credit">Photograph: Chris Radburn/AFP/Getty Images</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T17:14:22Z',
+            lastModifiedDate: '2019-07-19T17:20:56Z',
+            contributors: [],
+            createdBy: {
+              email: 'john.ives@guardian.co.uk',
+              firstName: 'John',
+              lastName: 'Ives'
+            },
+            lastModifiedBy: {
+              email: 'john.ives@guardian.co.uk',
+              firstName: 'John',
+              lastName: 'Ives'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/3246.jpg',
+                    typeData: { aspectRatio: '5:3', width: 3246, height: 1947 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/master/3246.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 3246,
+                      height: 1947,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'Boris Johnson meeting supporters at a hustings last weekend. He is expected to be named Tory leader and PM next Tuesday.',
+                  copyright: 'AFP or licensors',
+                  displayCredit: true,
+                  credit: 'Photograph: Chris Radburn/AFP/Getty Images',
+                  source: 'AFP/Getty Images',
+                  photographer: 'Chris Radburn',
+                  alt: 'Boris Johnson',
+                  mediaId: 'b46016835812f21a4f16494e75ec320e72700ec1',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/b46016835812f21a4f16494e75ec320e72700ec1',
+                  suppliersReference: 'AFP_1IP2GA',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News'
+      },
+      {
+        id:
+          'world/2019/jul/19/gulf-crisis-questions-over-detention-iranian-tanker',
+        type: 'article',
+        sectionId: 'world',
+        sectionName: 'World news',
+        webPublicationDate: '2019-07-19T22:29:06Z',
+        webTitle:
+          "'Too few ships': UK ministers under fire over defence in Gulf",
+        webUrl:
+          'https://www.theguardian.com/world/2019/jul/19/gulf-crisis-questions-over-detention-iranian-tanker',
+        apiUrl:
+          'https://preview.content.guardianapis.com/world/2019/jul/19/gulf-crisis-questions-over-detention-iranian-tanker',
+        fields: {
+          headline:
+            "'Too few ships': UK ministers under fire over defence in Gulf",
+          trailText:
+            'Former navy chief attacks decision to allow tankers through strait without escort<br>',
+          byline: 'Patrick Wintour',
+          firstPublicationDate: '2019-07-19T22:29:06Z',
+          internalPageCode: 6383087,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv7ph',
+          thumbnail:
+            'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'world/iran',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Iran',
+            webUrl: 'https://www.theguardian.com/world/iran',
+            apiUrl: 'https://preview.content.guardianapis.com/world/iran',
+            references: [],
+            internalName: 'Iran (News)'
+          },
+          {
+            id: 'business/oil',
+            type: 'keyword',
+            sectionId: 'business',
+            sectionName: 'Business',
+            webTitle: 'Oil',
+            webUrl: 'https://www.theguardian.com/business/oil',
+            apiUrl: 'https://preview.content.guardianapis.com/business/oil',
+            references: [],
+            internalName: 'Oil (business)'
+          },
+          {
+            id: 'world/middleeast',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Middle East and North Africa',
+            webUrl: 'https://www.theguardian.com/world/middleeast',
+            apiUrl: 'https://preview.content.guardianapis.com/world/middleeast',
+            references: [],
+            internalName: 'Middle East and North Africa (News) MENA'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'profile/patrickwintour',
+            type: 'contributor',
+            webTitle: 'Patrick Wintour',
+            webUrl: 'https://www.theguardian.com/profile/patrickwintour',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/patrickwintour',
+            references: [],
+            bio: '<p>Patrick Wintour is diplomatic editor for the Guardian</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/2/4/1423058508175/Patrick-Wintour.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/09/Patrick-Wintour,-R.png',
+            firstName: 'wintour',
+            lastName: '',
+            rcsId: 'GNL004731',
+            r2ContributorId: '16227',
+            internalName: 'Patrick Wintour'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-home-news',
+            type: 'tracking',
+            webTitle: 'UK Home News',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-home-news',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-home-news',
+            references: [],
+            internalName: 'UK Home News (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d3242e98f08d0b6ca53430a',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="8033184e1dfa06d12076cb59f47d6b639b628e93"> <img src="https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/1000.jpg" alt="Grace 1 oil tanker" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">The Iranian-owned Grace 1 supertanker is still being held in Gibraltar after its seizure two weeks ago.</span> <span class="element-image__credit">Photograph: A Carrasco Ragel/EPA</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T22:23:37Z',
+            lastModifiedDate: '2019-07-19T22:24:21Z',
+            contributors: [],
+            createdBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            lastModifiedBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/4429.jpg',
+                    typeData: { aspectRatio: '5:3', width: 4429, height: 2658 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/master/4429.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 4429,
+                      height: 2658,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'The Iranian-owned Grace 1 supertanker is still being held in Gibraltar after its seizure two weeks ago.',
+                  displayCredit: true,
+                  credit: 'Photograph: A Carrasco Ragel/EPA',
+                  source: 'EPA',
+                  photographer: 'A Carrasco Ragel',
+                  alt: 'Grace 1 oil tanker',
+                  mediaId: '8033184e1dfa06d12076cb59f47d6b639b628e93',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/8033184e1dfa06d12076cb59f47d6b639b628e93',
+                  suppliersReference: 'GRAFAND9425',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News'
+      },
+      {
+        id:
+          'society/ng-interactive/2019/jul/19/share-an-instagram-star-at-a-crossroads-video',
+        type: 'interactive',
+        sectionId: 'society',
+        sectionName: 'Society',
+        webPublicationDate: '2019-07-19T11:00:11Z',
+        webTitle: 'Share - An Instagram star at a crossroads - video',
+        webUrl:
+          'https://www.theguardian.com/society/ng-interactive/2019/jul/19/share-an-instagram-star-at-a-crossroads-video',
+        apiUrl:
+          'https://preview.content.guardianapis.com/society/ng-interactive/2019/jul/19/share-an-instagram-star-at-a-crossroads-video',
+        fields: {
+          headline: 'Share - An Instagram star at a crossroads - video',
+          trailText:
+            'Tim has more than 4m followers on Instagram. But his online persona is different to his one in real life. When a big decision needs to be made, will he be able to reconcile his two identities? ',
+          byline:
+            'Ellie Wen, Barna Szasz, Charlie Phillips and Jacqueline Edenbrow',
+          firstPublicationDate: '2019-07-19T11:00:11Z',
+          internalPageCode: 6334989,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/bzmq6',
+          thumbnail:
+            'https://media.guim.co.uk/7174802a470d809d115c43e6710586da121822cb/36_0_1800_1080/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'society/youngpeople',
+            type: 'keyword',
+            sectionId: 'society',
+            sectionName: 'Society',
+            webTitle: 'Young people',
+            webUrl: 'https://www.theguardian.com/society/youngpeople',
+            apiUrl:
+              'https://preview.content.guardianapis.com/society/youngpeople',
+            references: [],
+            internalName: 'Young people, teenagers, teens (Society)'
+          },
+          {
+            id: 'society/mental-health',
+            type: 'keyword',
+            sectionId: 'society',
+            sectionName: 'Society',
+            webTitle: 'Mental health',
+            webUrl: 'https://www.theguardian.com/society/mental-health',
+            apiUrl:
+              'https://preview.content.guardianapis.com/society/mental-health',
+            references: [],
+            internalName: 'Mental health (Society)'
+          },
+          {
+            id: 'technology/instagram',
+            type: 'keyword',
+            sectionId: 'technology',
+            sectionName: 'Technology',
+            webTitle: 'Instagram',
+            webUrl: 'https://www.theguardian.com/technology/instagram',
+            apiUrl:
+              'https://preview.content.guardianapis.com/technology/instagram',
+            references: [],
+            internalName: 'Instagram'
+          },
+          {
+            id: 'world/lgbt-rights',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'LGBT rights',
+            webUrl: 'https://www.theguardian.com/world/lgbt-rights',
+            apiUrl:
+              'https://preview.content.guardianapis.com/world/lgbt-rights',
+            references: [],
+            internalName: 'Gay and LGBT rights'
+          },
+          {
+            id: 'news/series/the-guardian-documentary',
+            type: 'series',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'The Guardian documentary',
+            webUrl:
+              'https://www.theguardian.com/news/series/the-guardian-documentary',
+            apiUrl:
+              'https://preview.content.guardianapis.com/news/series/the-guardian-documentary',
+            references: [],
+            description:
+              'Our weekly slot for new short international documentary stories, produced by the best independent filmmakers',
+            internalName: 'The Guardian documentary (series)'
+          },
+          {
+            id: 'technology/technology',
+            type: 'keyword',
+            sectionId: 'technology',
+            sectionName: 'Technology',
+            webTitle: 'Technology',
+            webUrl: 'https://www.theguardian.com/technology/technology',
+            apiUrl:
+              'https://preview.content.guardianapis.com/technology/technology',
+            references: [],
+            internalName: 'Technology'
+          },
+          {
+            id: 'type/interactive',
+            type: 'type',
+            webTitle: 'Interactive',
+            webUrl: 'https://www.theguardian.com/interactive',
+            apiUrl: 'https://preview.content.guardianapis.com/type/interactive',
+            references: [],
+            internalName: 'Interactive (Content type)'
+          },
+          {
+            id: 'tone/documentaries',
+            type: 'tone',
+            webTitle: 'Documentaries',
+            webUrl: 'https://www.theguardian.com/tone/documentaries',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tone/documentaries',
+            references: [],
+            internalName: 'Documentaries'
+          },
+          {
+            id: 'profile/charlie-phillips',
+            type: 'contributor',
+            webTitle: 'Charlie Phillips',
+            webUrl: 'https://www.theguardian.com/profile/charlie-phillips',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/charlie-phillips',
+            references: [],
+            bio:
+              '<p>Charlie Phillips is head of documentaries at the Guardian.&nbsp;Click <a href="https://pgp.theguardian.com/PublicKeys/Charlie%20Phillips.pub.txt">here</a> for Charlie Phillip\'s public key</p>',
+            bylineImageUrl:
+              'https://uploads.guim.co.uk/2018/08/22/Charlie-Phillips.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2018/08/22/Charlie_Phillips,_L.png',
+            firstName: 'Charlie ',
+            lastName: 'Phillips',
+            r2ContributorId: '67839',
+            internalName: 'Charlie Phillips'
+          },
+          {
+            id: 'profile/jacqueline-edenbrow',
+            type: 'contributor',
+            webTitle: 'Jacqueline Edenbrow',
+            webUrl: 'https://www.theguardian.com/profile/jacqueline-edenbrow',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/jacqueline-edenbrow',
+            references: [],
+            bio:
+              '<p>Jacqueline Edenbrow is an executive producer for documentaries at the Guardian</p>',
+            firstName: 'Jacqueline',
+            lastName: ' Edenbrow',
+            r2ContributorId: '84257',
+            internalName: 'Jacqueline Edenbrow'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-video',
+            type: 'tracking',
+            webTitle: 'UK Video',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-video',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-video',
+            references: [],
+            internalName: 'UK Video (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News'
+      },
+      {
+        id: 'world/2019/jul/20/gulf-crisis-tanker-retaliation-iran-hormuz',
+        type: 'article',
+        sectionId: 'world',
+        sectionName: 'World news',
+        webPublicationDate: '2019-07-19T23:26:33Z',
+        webTitle:
+          "Gulf crisis: story began with UK's seizure of Iranian-flagged ship in Gibraltar",
+        webUrl:
+          'https://www.theguardian.com/world/2019/jul/20/gulf-crisis-tanker-retaliation-iran-hormuz',
+        apiUrl:
+          'https://preview.content.guardianapis.com/world/2019/jul/20/gulf-crisis-tanker-retaliation-iran-hormuz',
+        fields: {
+          headline:
+            "Gulf crisis: story began with UK's seizure of Iranian-flagged ship in Gibraltar",
+          trailText:
+            'Grace 1 was impounded over claim it was bound for Syria – but diplomats knew there might be consequences',
+          byline: 'Patrick Wintour Diplomatic editor',
+          firstPublicationDate: '2019-07-19T23:26:33Z',
+          internalPageCode: 6382603,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv77j',
+          thumbnail:
+            'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'world/iran',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Iran',
+            webUrl: 'https://www.theguardian.com/world/iran',
+            apiUrl: 'https://preview.content.guardianapis.com/world/iran',
+            references: [],
+            internalName: 'Iran (News)'
+          },
+          {
+            id: 'business/oil',
+            type: 'keyword',
+            sectionId: 'business',
+            sectionName: 'Business',
+            webTitle: 'Oil',
+            webUrl: 'https://www.theguardian.com/business/oil',
+            apiUrl: 'https://preview.content.guardianapis.com/business/oil',
+            references: [],
+            internalName: 'Oil (business)'
+          },
+          {
+            id: 'uk/military',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'Military',
+            webUrl: 'https://www.theguardian.com/uk/military',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/military',
+            references: [],
+            internalName: 'Military UK'
+          },
+          {
+            id: 'world/middleeast',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Middle East and North Africa',
+            webUrl: 'https://www.theguardian.com/world/middleeast',
+            apiUrl: 'https://preview.content.guardianapis.com/world/middleeast',
+            references: [],
+            internalName: 'Middle East and North Africa (News) MENA'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'tone/analysis',
+            type: 'tone',
+            webTitle: 'Analysis',
+            webUrl: 'https://www.theguardian.com/tone/analysis',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/analysis',
+            references: [],
+            internalName: 'Analysis (Tone)'
+          },
+          {
+            id: 'profile/patrickwintour',
+            type: 'contributor',
+            webTitle: 'Patrick Wintour',
+            webUrl: 'https://www.theguardian.com/profile/patrickwintour',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/patrickwintour',
+            references: [],
+            bio: '<p>Patrick Wintour is diplomatic editor for the Guardian</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/2/4/1423058508175/Patrick-Wintour.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/09/Patrick-Wintour,-R.png',
+            firstName: 'wintour',
+            lastName: '',
+            rcsId: 'GNL004731',
+            r2ContributorId: '16227',
+            internalName: 'Patrick Wintour'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-foreign',
+            type: 'tracking',
+            webTitle: 'UK Foreign',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-foreign',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-foreign',
+            references: [],
+            internalName: 'UK Foreign (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d3226ca8f08cf92bb7735ff',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="d76e18187349bdb988201b0d9877544b4180aaca"> <img src="https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/1000.jpg" alt="Stena Impero tanker" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">The Stena Impero and its crew of more than 20 are now in the hands of the Iranian Revolutionary Guards.</span> <span class="element-image__credit">Photograph: Stena Bulk/AP</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T20:23:38Z',
+            lastModifiedDate: '2019-07-19T20:24:37Z',
+            contributors: [],
+            createdBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            lastModifiedBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/3000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 3000, height: 1800 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/master/3000.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 3000,
+                      height: 1800,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'The Stena Impero and its crew of more than 20 are now in the hands of the Iranian Revolutionary Guards.',
+                  displayCredit: true,
+                  credit: 'Photograph: Stena Bulk/AP',
+                  source: 'AP',
+                  photographer: 'Stena Bulk',
+                  alt: 'Stena Impero tanker',
+                  mediaId: 'd76e18187349bdb988201b0d9877544b4180aaca',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/d76e18187349bdb988201b0d9877544b4180aaca',
+                  suppliersReference: 'LON804',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News'
+      }
+    ],
+    results: [
+      {
+        id:
+          'world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest',
+        type: 'article',
+        sectionId: 'world',
+        sectionName: 'World news',
+        webPublicationDate: '2019-07-19T22:55:30Z',
+        webTitle:
+          'Iran stokes Gulf tensions by seizing two British-linked oil tankers',
+        webUrl:
+          'https://www.theguardian.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest',
+        apiUrl:
+          'https://preview.content.guardianapis.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest',
+        fields: {
+          headline:
+            'Iran stokes Gulf tensions by seizing two British-linked oil tankers',
+          trailText:
+            'UK ships advised to avoid strait of Hormuz as Jeremy Hunt calls Iranian actions ‘unacceptable’ ',
+          byline:
+            'Julian Borger in Washington, Patrick Wintour and Kevin Rawlinson in London',
+          firstPublicationDate: '2019-07-19T17:56:20Z',
+          internalPageCode: 6382255,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv6ym',
+          thumbnail:
+            'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'world/iran',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Iran',
+            webUrl: 'https://www.theguardian.com/world/iran',
+            apiUrl: 'https://preview.content.guardianapis.com/world/iran',
+            references: [],
+            internalName: 'Iran (News)'
+          },
+          {
+            id: 'world/middleeast',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Middle East and North Africa',
+            webUrl: 'https://www.theguardian.com/world/middleeast',
+            apiUrl: 'https://preview.content.guardianapis.com/world/middleeast',
+            references: [],
+            internalName: 'Middle East and North Africa (News) MENA'
+          },
+          {
+            id: 'business/oil',
+            type: 'keyword',
+            sectionId: 'business',
+            sectionName: 'Business',
+            webTitle: 'Oil',
+            webUrl: 'https://www.theguardian.com/business/oil',
+            apiUrl: 'https://preview.content.guardianapis.com/business/oil',
+            references: [],
+            internalName: 'Oil (business)'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'politics/foreignpolicy',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Foreign policy',
+            webUrl: 'https://www.theguardian.com/politics/foreignpolicy',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/foreignpolicy',
+            references: [],
+            internalName: 'Foreign policy'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'profile/julianborger',
+            type: 'contributor',
+            webTitle: 'Julian Borger',
+            webUrl: 'https://www.theguardian.com/profile/julianborger',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/julianborger',
+            references: [],
+            bio:
+              '<p>Julian Borger is the Guardian\'s world affairs editor. He was previously a correspondent in the US, the Middle East, eastern Europe and the Balkans. His book on the pursuit and capture of the Balkan war criminals, <a href="https://bookshop.theguardian.com/catalog/product/view/id/359254/?utm_source=editoriallink&amp;utm_medium=merch&amp;utm_campaign=article">The Butcher\'s Trail</a>, is published by Other Press. Click <a href="https://pgp.theguardian.com/PublicKeys/Julian%20Borger.pub.txt">here</a> for Julian\'s public key</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2016/1/8/1452247825373/Julian-Borger.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/06/Julian-Borger,-R.png',
+            firstName: 'Julian',
+            lastName: 'Borger',
+            rcsId: 'GNL001547',
+            r2ContributorId: '15924',
+            internalName: 'Julian Borger'
+          },
+          {
+            id: 'profile/patrickwintour',
+            type: 'contributor',
+            webTitle: 'Patrick Wintour',
+            webUrl: 'https://www.theguardian.com/profile/patrickwintour',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/patrickwintour',
+            references: [],
+            bio: '<p>Patrick Wintour is diplomatic editor for the Guardian</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/2/4/1423058508175/Patrick-Wintour.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/09/Patrick-Wintour,-R.png',
+            firstName: 'wintour',
+            lastName: '',
+            rcsId: 'GNL004731',
+            r2ContributorId: '16227',
+            internalName: 'Patrick Wintour'
+          },
+          {
+            id: 'profile/kevin-rawlinson',
+            type: 'contributor',
+            webTitle: 'Kevin Rawlinson',
+            webUrl: 'https://www.theguardian.com/profile/kevin-rawlinson',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/kevin-rawlinson',
+            references: [],
+            bio:
+              '<p>Kevin Rawlinson is a night reporter at the Guardian. Twitter <a href="https://twitter.com/kevinjrawlinson?lang=en">@KevinJRawlinson</a></p>',
+            firstName: 'Kevin',
+            lastName: 'Rawlinson',
+            r2ContributorId: '58554',
+            internalName: 'Kevin Rawlinson'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-foreign',
+            type: 'tracking',
+            webTitle: 'UK Foreign',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-foreign',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-foreign',
+            references: [],
+            internalName: 'UK Foreign (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d32060b8f0845f89e310a1f',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="ed66b07abda5301d6316b6f838dbe13a6603216b"> <img src="https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/1000.jpg" alt="The Stena Impero tanker" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">The Stena Impero tanker taken by Iranian Revolutionary Guard forces on Friday evening. </span> <span class="element-image__credit">Photograph: pr</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T18:03:55Z',
+            lastModifiedDate: '2019-07-19T20:19:23Z',
+            contributors: [],
+            createdBy: {
+              email: 'tim.burrows@guardian.co.uk',
+              firstName: 'Tim',
+              lastName: 'Burrows'
+            },
+            lastModifiedBy: {
+              email: 'paul.g.gallagher@guardian.co.uk',
+              firstName: 'Paul',
+              lastName: 'Gallagher (G)'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/2830.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2830, height: 1699 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/ed66b07abda5301d6316b6f838dbe13a6603216b/0_0_2830_1699/master/2830.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 2830,
+                      height: 1699,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'The Stena Impero tanker taken by Iranian Revolutionary Guard forces on Friday evening. ',
+                  displayCredit: true,
+                  credit: 'Photograph: pr',
+                  source: 'pr',
+                  alt: 'The Stena Impero tanker',
+                  mediaId: 'ed66b07abda5301d6316b6f838dbe13a6603216b',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/ed66b07abda5301d6316b6f838dbe13a6603216b',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        atoms: {
+          media: [
+            {
+              id: '20e0358f-6161-45db-9d2d-76cc0737cfc9',
+              atomType: 'media',
+              labels: [],
+              defaultHtml:
+                '<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/L0r-F1lrvQk?showinfo=0&rel=0"></iframe>',
+              data: {
+                media: {
+                  assets: [
+                    {
+                      assetType: 'video',
+                      version: 1,
+                      id: 'L0r-F1lrvQk',
+                      platform: 'youtube'
+                    }
+                  ],
+                  activeVersion: 1,
+                  title:
+                    "Jeremy Hunt warns Iran of 'serious consequences' over tanker seizure - video",
+                  category: 'news',
+                  duration: 62,
+                  source: 'Reuters',
+                  posterUrl:
+                    'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/master/3320.jpg',
+                  description:
+                    '<p>The foreign secretary, Jeremy Hunt, said on Saturday morning that Britain’s response would be ‘considered but robust’ if the British-flagged Stena Impero was not released, although he said the government was not contemplating military action. Iran\'s Revolutionary Guards said they had captured the British-flagged tanker, announcing the move two weeks after the British navy seized an Iranian tanker off Gibraltar, on suspicion of shipping oil to Syria in violation of an EU embargo</p><ul><li><a href="https://www.theguardian.com/world/2019/jul/20/iran-on-dangerous-path-with-seizure-of-stena-impero-says-uk">Iran on \'dangerous path\' with seizure of Stena Impero, says UK</a></li><li><a href="https://www.theguardian.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest">Iran stokes Gulf tensions by seizing two British-linked oil tankers</a></li></ul><p><br></p>',
+                  metadata: {
+                    tags: [
+                      'iranian oil tanker british',
+                      'british seized iranian oil tanker',
+                      'iran',
+                      'stena impero',
+                      'iran news',
+                      'british tanker seized by iran',
+                      'iranian oil tanker seized',
+                      'guardian',
+                      'iran seized british ship',
+                      'uk',
+                      'iran uk',
+                      'jeremy hunt',
+                      'jeremy hunt warns iran',
+                      'jeremy hunt iran',
+                      'politics',
+                      'hunt iran',
+                      'iran hunt',
+                      'iran war',
+                      'war in iran',
+                      'iran 2019',
+                      'uk vs iran',
+                      'oil',
+                      'oil tanker',
+                      'oil tanker seized',
+                      'strait of hormuz',
+                      'gulf',
+                      'middle east',
+                      'news',
+                      'world'
+                    ],
+                    categoryId: '25',
+                    channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
+                    privacyStatus: 'public',
+                    pluto: { commissionId: 'KP-50156', projectId: 'KP-50251' },
+                    youtube: {
+                      title:
+                        "Jeremy Hunt says Iran tanker seizure is unacceptable, warns of 'serious consequences' - video",
+                      description:
+                        "The foreign secretary, Jeremy Hunt, said on Saturday morning that Britain’s response would be ‘considered but robust’ if the British-flagged Stena Impero was not released, although he said the government was not contemplating military action. Iran's Revolutionary Guards said they had captured the British-flagged tanker, announcing the move two weeks after the British navy seized an Iranian tanker off Gibraltar, on suspicion of shipping oil to Syria in violation of an EU embargo\nSubscribe to Guardian News on YouTube ► http://bit.ly/guardianwiressub\n\nIran on 'dangerous path' with seizure of Stena Impero, says UK ► https://www.theguardian.com/world/2019/jul/20/iran-on-dangerous-path-with-seizure-of-stena-impero-says-uk\n\nIran stokes Gulf tensions by seizing two British-linked oil tankers ► https://www.theguardian.com/world/2019/jul/19/british-tanker-iran-capture-fears-stena-impero-uk-ship-latest\n\nSupport the Guardian ► https://support.theguardian.com/contribute\n\nToday in Focus podcast ► https://www.theguardian.com/news/series/todayinfocus\n\nThe Guardian YouTube network:\n\nThe Guardian ► http://www.youtube.com/theguardian\nOwen Jones talks ► http://bit.ly/subsowenjones\nGuardian Football ► http://is.gd/guardianfootball\nGuardian Sport ► http://bit.ly/GDNsport\nGuardian Culture ► http://is.gd/guardianculture"
+                    }
+                  },
+                  posterImage: {
+                    assets: [
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/2000.jpg',
+                        dimensions: { height: 1125, width: 2000 },
+                        size: 77966,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/1000.jpg',
+                        dimensions: { height: 563, width: 1000 },
+                        size: 28122,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/500.jpg',
+                        dimensions: { height: 281, width: 500 },
+                        size: 12404,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/140.jpg',
+                        dimensions: { height: 79, width: 140 },
+                        size: 4995,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/3320.jpg',
+                        dimensions: { height: 1867, width: 3320 },
+                        size: 200219,
+                        aspectRatio: '16:9'
+                      }
+                    ],
+                    master: {
+                      mimeType: 'image/jpeg',
+                      file:
+                        'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_25_3320_1867/master/3320.jpg',
+                      dimensions: { height: 1867, width: 3320 },
+                      size: 955364,
+                      aspectRatio: '16:9'
+                    },
+                    mediaId:
+                      'https://api.media.gutools.co.uk/images/194a6f901d4f2f82d230ce45ccedfa0687d34612',
+                    source: 'AP'
+                  },
+                  trailText:
+                    '<p>The foreign secretary said on Saturday morning that Britain’s response would be ‘considered but robust’ if the British-flagged Stena Impero was not released</p>',
+                  byline: [],
+                  commissioningDesks: ['tracking/commissioningdesk/uk-video'],
+                  keywords: [
+                    'world/iran',
+                    'politics/jeremy-hunt',
+                    'world/iran-nuclear-deal',
+                    'politics/foreignpolicy',
+                    'tone/news',
+                    'uk/uk'
+                  ],
+                  trailImage: {
+                    assets: [
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/2000.jpg',
+                        dimensions: { height: 1200, width: 2000 },
+                        size: 84360,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/1000.jpg',
+                        dimensions: { height: 600, width: 1000 },
+                        size: 30050,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/500.jpg',
+                        dimensions: { height: 300, width: 500 },
+                        size: 13186,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/140.jpg',
+                        dimensions: { height: 84, width: 140 },
+                        size: 5193,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/3320.jpg',
+                        dimensions: { height: 1992, width: 3320 },
+                        size: 218455,
+                        aspectRatio: '5:3'
+                      }
+                    ],
+                    master: {
+                      mimeType: 'image/jpeg',
+                      file:
+                        'https://media.guim.co.uk/194a6f901d4f2f82d230ce45ccedfa0687d34612/0_33_3320_1992/master/3320.jpg',
+                      dimensions: { height: 1992, width: 3320 },
+                      size: 1034676,
+                      aspectRatio: '5:3'
+                    },
+                    mediaId:
+                      'https://api.media.gutools.co.uk/images/194a6f901d4f2f82d230ce45ccedfa0687d34612',
+                    source: 'AP'
+                  }
+                }
+              },
+              contentChangeDetails: {
+                lastModified: {
+                  date: 1563781467000,
+                  user: {
+                    email: 'adam.sich@guardian.co.uk',
+                    firstName: 'Adam',
+                    lastName: 'Sich'
+                  }
+                },
+                created: {
+                  date: 1563616131000,
+                  user: {
+                    email: 'maheen.sadiq.casual@guardian.co.uk',
+                    firstName: 'Maheen',
+                    lastName: 'Sadiq (Casual)'
+                  }
+                },
+                published: {
+                  date: 1563781467000,
+                  user: {
+                    email: 'adam.sich@guardian.co.uk',
+                    firstName: 'Adam',
+                    lastName: 'Sich'
+                  }
+                },
+                revision: 25
+              },
+              flags: { blockAds: false },
+              title:
+                "Jeremy Hunt warns Iran of 'serious consequences' over tanker seizure - video",
+              commissioningDesks: []
+            }
+          ]
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News',
+        frontsMeta: {
+          defaults: {
+            isBreaking: false,
+            isBoosted: false,
+            showMainVideo: false,
+            imageHide: false,
+            showKickerCustom: false,
+            showByline: false,
+            showQuotedHeadline: false,
+            imageSlideshowReplace: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            imageReplace: false,
+            imageCutoutReplace: false,
+            showKickerSection: false,
+            showBoostedHeadline: false
+          },
+          tone: 'news'
+        }
+      },
+      {
+        id:
+          'politics/2019/jul/19/brussels-to-offer-boris-johnson-extension-on-no-deal-brexit',
+        type: 'article',
+        sectionId: 'politics',
+        sectionName: 'Politics',
+        webPublicationDate: '2019-07-19T17:21:49Z',
+        webTitle: 'Brussels to offer Boris Johnson extension on no-deal Brexit',
+        webUrl:
+          'https://www.theguardian.com/politics/2019/jul/19/brussels-to-offer-boris-johnson-extension-on-no-deal-brexit',
+        apiUrl:
+          'https://preview.content.guardianapis.com/politics/2019/jul/19/brussels-to-offer-boris-johnson-extension-on-no-deal-brexit',
+        fields: {
+          headline:
+            'Brussels to offer Boris Johnson extension on no-deal Brexit',
+          trailText:
+            'Exclusive: extra time could be used for renegotiation but will be billed as chance for no-deal planning',
+          byline: 'Daniel Boffey in Brussels',
+          firstPublicationDate: '2019-07-19T17:21:49Z',
+          internalPageCode: 6380761,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv4kd',
+          thumbnail:
+            'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'politics/eu-referendum',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Brexit',
+            webUrl: 'https://www.theguardian.com/politics/eu-referendum',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/eu-referendum',
+            references: [],
+            internalName: 'Brexit'
+          },
+          {
+            id: 'politics/boris-johnson',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Boris Johnson',
+            webUrl: 'https://www.theguardian.com/politics/boris-johnson',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/boris-johnson',
+            references: [],
+            internalName: 'Boris Johnson'
+          },
+          {
+            id: 'politics/conservatives',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Conservatives',
+            webUrl: 'https://www.theguardian.com/politics/conservatives',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/conservatives',
+            references: [],
+            internalName: 'Conservatives tories tory party'
+          },
+          {
+            id: 'politics/foreignpolicy',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Foreign policy',
+            webUrl: 'https://www.theguardian.com/politics/foreignpolicy',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/foreignpolicy',
+            references: [],
+            internalName: 'Foreign policy'
+          },
+          {
+            id: 'world/eu',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'European Union',
+            webUrl: 'https://www.theguardian.com/world/eu',
+            apiUrl: 'https://preview.content.guardianapis.com/world/eu',
+            references: [],
+            internalName: 'EU European Union (News)'
+          },
+          {
+            id: 'world/europe-news',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Europe',
+            webUrl: 'https://www.theguardian.com/world/europe-news',
+            apiUrl:
+              'https://preview.content.guardianapis.com/world/europe-news',
+            references: [],
+            internalName: 'Europe (News)'
+          },
+          {
+            id: 'politics/politics',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Politics',
+            webUrl: 'https://www.theguardian.com/politics/politics',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/politics',
+            references: [],
+            internalName: 'Politics'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'profile/daniel-boffey',
+            type: 'contributor',
+            webTitle: 'Daniel Boffey',
+            webUrl: 'https://www.theguardian.com/profile/daniel-boffey',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/daniel-boffey',
+            references: [],
+            bio: "<p>Daniel Boffey is the Guardian's Brussels bureau chief</p>",
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2016/1/28/1453983010155/Daniel-Boffey.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/06/Daniel-Boffey,-L.png',
+            firstName: 'boffey',
+            lastName: 'daniel',
+            r2ContributorId: '43351',
+            internalName: 'Daniel Boffey'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-home-news',
+            type: 'tracking',
+            webTitle: 'UK Home News',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-home-news',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-home-news',
+            references: [],
+            internalName: 'UK Home News (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d31fa6e8f0845f89e3109a6',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="b46016835812f21a4f16494e75ec320e72700ec1"> <img src="https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/1000.jpg" alt="Boris Johnson" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Boris Johnson meeting supporters at a hustings last weekend. He is expected to be named Tory leader and PM next Tuesday.</span> <span class="element-image__credit">Photograph: Chris Radburn/AFP/Getty Images</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T17:14:22Z',
+            lastModifiedDate: '2019-07-19T17:20:56Z',
+            contributors: [],
+            createdBy: {
+              email: 'john.ives@guardian.co.uk',
+              firstName: 'John',
+              lastName: 'Ives'
+            },
+            lastModifiedBy: {
+              email: 'john.ives@guardian.co.uk',
+              firstName: 'John',
+              lastName: 'Ives'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/3246.jpg',
+                    typeData: { aspectRatio: '5:3', width: 3246, height: 1947 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/b46016835812f21a4f16494e75ec320e72700ec1/149_54_3246_1947/master/3246.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 3246,
+                      height: 1947,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'Boris Johnson meeting supporters at a hustings last weekend. He is expected to be named Tory leader and PM next Tuesday.',
+                  copyright: 'AFP or licensors',
+                  displayCredit: true,
+                  credit: 'Photograph: Chris Radburn/AFP/Getty Images',
+                  source: 'AFP/Getty Images',
+                  photographer: 'Chris Radburn',
+                  alt: 'Boris Johnson',
+                  mediaId: 'b46016835812f21a4f16494e75ec320e72700ec1',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/b46016835812f21a4f16494e75ec320e72700ec1',
+                  suppliersReference: 'AFP_1IP2GA',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News',
+        frontsMeta: {
+          defaults: {
+            isBreaking: false,
+            isBoosted: false,
+            showMainVideo: false,
+            imageHide: false,
+            showKickerCustom: false,
+            showByline: false,
+            showQuotedHeadline: false,
+            imageSlideshowReplace: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            imageReplace: false,
+            imageCutoutReplace: false,
+            showKickerSection: false,
+            showBoostedHeadline: false
+          },
+          tone: 'news'
+        }
+      },
+      {
+        id:
+          'world/2019/jul/19/gulf-crisis-questions-over-detention-iranian-tanker',
+        type: 'article',
+        sectionId: 'world',
+        sectionName: 'World news',
+        webPublicationDate: '2019-07-19T22:29:06Z',
+        webTitle:
+          "'Too few ships': UK ministers under fire over defence in Gulf",
+        webUrl:
+          'https://www.theguardian.com/world/2019/jul/19/gulf-crisis-questions-over-detention-iranian-tanker',
+        apiUrl:
+          'https://preview.content.guardianapis.com/world/2019/jul/19/gulf-crisis-questions-over-detention-iranian-tanker',
+        fields: {
+          headline:
+            "'Too few ships': UK ministers under fire over defence in Gulf",
+          trailText:
+            'Former navy chief attacks decision to allow tankers through strait without escort<br>',
+          byline: 'Patrick Wintour',
+          firstPublicationDate: '2019-07-19T22:29:06Z',
+          internalPageCode: 6383087,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv7ph',
+          thumbnail:
+            'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'world/iran',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Iran',
+            webUrl: 'https://www.theguardian.com/world/iran',
+            apiUrl: 'https://preview.content.guardianapis.com/world/iran',
+            references: [],
+            internalName: 'Iran (News)'
+          },
+          {
+            id: 'business/oil',
+            type: 'keyword',
+            sectionId: 'business',
+            sectionName: 'Business',
+            webTitle: 'Oil',
+            webUrl: 'https://www.theguardian.com/business/oil',
+            apiUrl: 'https://preview.content.guardianapis.com/business/oil',
+            references: [],
+            internalName: 'Oil (business)'
+          },
+          {
+            id: 'world/middleeast',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Middle East and North Africa',
+            webUrl: 'https://www.theguardian.com/world/middleeast',
+            apiUrl: 'https://preview.content.guardianapis.com/world/middleeast',
+            references: [],
+            internalName: 'Middle East and North Africa (News) MENA'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'profile/patrickwintour',
+            type: 'contributor',
+            webTitle: 'Patrick Wintour',
+            webUrl: 'https://www.theguardian.com/profile/patrickwintour',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/patrickwintour',
+            references: [],
+            bio: '<p>Patrick Wintour is diplomatic editor for the Guardian</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/2/4/1423058508175/Patrick-Wintour.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/09/Patrick-Wintour,-R.png',
+            firstName: 'wintour',
+            lastName: '',
+            rcsId: 'GNL004731',
+            r2ContributorId: '16227',
+            internalName: 'Patrick Wintour'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-home-news',
+            type: 'tracking',
+            webTitle: 'UK Home News',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-home-news',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-home-news',
+            references: [],
+            internalName: 'UK Home News (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d3242e98f08d0b6ca53430a',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="8033184e1dfa06d12076cb59f47d6b639b628e93"> <img src="https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/1000.jpg" alt="Grace 1 oil tanker" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">The Iranian-owned Grace 1 supertanker is still being held in Gibraltar after its seizure two weeks ago.</span> <span class="element-image__credit">Photograph: A Carrasco Ragel/EPA</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T22:23:37Z',
+            lastModifiedDate: '2019-07-19T22:24:21Z',
+            contributors: [],
+            createdBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            lastModifiedBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/4429.jpg',
+                    typeData: { aspectRatio: '5:3', width: 4429, height: 2658 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/8033184e1dfa06d12076cb59f47d6b639b628e93/0_214_4429_2658/master/4429.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 4429,
+                      height: 2658,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'The Iranian-owned Grace 1 supertanker is still being held in Gibraltar after its seizure two weeks ago.',
+                  displayCredit: true,
+                  credit: 'Photograph: A Carrasco Ragel/EPA',
+                  source: 'EPA',
+                  photographer: 'A Carrasco Ragel',
+                  alt: 'Grace 1 oil tanker',
+                  mediaId: '8033184e1dfa06d12076cb59f47d6b639b628e93',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/8033184e1dfa06d12076cb59f47d6b639b628e93',
+                  suppliersReference: 'GRAFAND9425',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News',
+        frontsMeta: {
+          defaults: {
+            isBreaking: false,
+            isBoosted: false,
+            showMainVideo: false,
+            imageHide: false,
+            showKickerCustom: false,
+            showByline: false,
+            showQuotedHeadline: false,
+            imageSlideshowReplace: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            imageReplace: false,
+            imageCutoutReplace: false,
+            showKickerSection: false,
+            showBoostedHeadline: false
+          },
+          tone: 'news'
+        }
+      },
+      {
+        id:
+          'society/ng-interactive/2019/jul/19/share-an-instagram-star-at-a-crossroads-video',
+        type: 'interactive',
+        sectionId: 'society',
+        sectionName: 'Society',
+        webPublicationDate: '2019-07-19T11:00:11Z',
+        webTitle: 'Share - An Instagram star at a crossroads - video',
+        webUrl:
+          'https://www.theguardian.com/society/ng-interactive/2019/jul/19/share-an-instagram-star-at-a-crossroads-video',
+        apiUrl:
+          'https://preview.content.guardianapis.com/society/ng-interactive/2019/jul/19/share-an-instagram-star-at-a-crossroads-video',
+        fields: {
+          headline: 'Share - An Instagram star at a crossroads - video',
+          trailText:
+            'Tim has more than 4m followers on Instagram. But his online persona is different to his one in real life. When a big decision needs to be made, will he be able to reconcile his two identities? ',
+          byline:
+            'Ellie Wen, Barna Szasz, Charlie Phillips and Jacqueline Edenbrow',
+          firstPublicationDate: '2019-07-19T11:00:11Z',
+          internalPageCode: 6334989,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/bzmq6',
+          thumbnail:
+            'https://media.guim.co.uk/7174802a470d809d115c43e6710586da121822cb/36_0_1800_1080/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'society/youngpeople',
+            type: 'keyword',
+            sectionId: 'society',
+            sectionName: 'Society',
+            webTitle: 'Young people',
+            webUrl: 'https://www.theguardian.com/society/youngpeople',
+            apiUrl:
+              'https://preview.content.guardianapis.com/society/youngpeople',
+            references: [],
+            internalName: 'Young people, teenagers, teens (Society)'
+          },
+          {
+            id: 'society/mental-health',
+            type: 'keyword',
+            sectionId: 'society',
+            sectionName: 'Society',
+            webTitle: 'Mental health',
+            webUrl: 'https://www.theguardian.com/society/mental-health',
+            apiUrl:
+              'https://preview.content.guardianapis.com/society/mental-health',
+            references: [],
+            internalName: 'Mental health (Society)'
+          },
+          {
+            id: 'technology/instagram',
+            type: 'keyword',
+            sectionId: 'technology',
+            sectionName: 'Technology',
+            webTitle: 'Instagram',
+            webUrl: 'https://www.theguardian.com/technology/instagram',
+            apiUrl:
+              'https://preview.content.guardianapis.com/technology/instagram',
+            references: [],
+            internalName: 'Instagram'
+          },
+          {
+            id: 'world/lgbt-rights',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'LGBT rights',
+            webUrl: 'https://www.theguardian.com/world/lgbt-rights',
+            apiUrl:
+              'https://preview.content.guardianapis.com/world/lgbt-rights',
+            references: [],
+            internalName: 'Gay and LGBT rights'
+          },
+          {
+            id: 'news/series/the-guardian-documentary',
+            type: 'series',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'The Guardian documentary',
+            webUrl:
+              'https://www.theguardian.com/news/series/the-guardian-documentary',
+            apiUrl:
+              'https://preview.content.guardianapis.com/news/series/the-guardian-documentary',
+            references: [],
+            description:
+              'Our weekly slot for new short international documentary stories, produced by the best independent filmmakers',
+            internalName: 'The Guardian documentary (series)'
+          },
+          {
+            id: 'technology/technology',
+            type: 'keyword',
+            sectionId: 'technology',
+            sectionName: 'Technology',
+            webTitle: 'Technology',
+            webUrl: 'https://www.theguardian.com/technology/technology',
+            apiUrl:
+              'https://preview.content.guardianapis.com/technology/technology',
+            references: [],
+            internalName: 'Technology'
+          },
+          {
+            id: 'type/interactive',
+            type: 'type',
+            webTitle: 'Interactive',
+            webUrl: 'https://www.theguardian.com/interactive',
+            apiUrl: 'https://preview.content.guardianapis.com/type/interactive',
+            references: [],
+            internalName: 'Interactive (Content type)'
+          },
+          {
+            id: 'tone/documentaries',
+            type: 'tone',
+            webTitle: 'Documentaries',
+            webUrl: 'https://www.theguardian.com/tone/documentaries',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tone/documentaries',
+            references: [],
+            internalName: 'Documentaries'
+          },
+          {
+            id: 'profile/charlie-phillips',
+            type: 'contributor',
+            webTitle: 'Charlie Phillips',
+            webUrl: 'https://www.theguardian.com/profile/charlie-phillips',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/charlie-phillips',
+            references: [],
+            bio:
+              '<p>Charlie Phillips is head of documentaries at the Guardian.&nbsp;Click <a href="https://pgp.theguardian.com/PublicKeys/Charlie%20Phillips.pub.txt">here</a> for Charlie Phillip\'s public key</p>',
+            bylineImageUrl:
+              'https://uploads.guim.co.uk/2018/08/22/Charlie-Phillips.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2018/08/22/Charlie_Phillips,_L.png',
+            firstName: 'Charlie ',
+            lastName: 'Phillips',
+            r2ContributorId: '67839',
+            internalName: 'Charlie Phillips'
+          },
+          {
+            id: 'profile/jacqueline-edenbrow',
+            type: 'contributor',
+            webTitle: 'Jacqueline Edenbrow',
+            webUrl: 'https://www.theguardian.com/profile/jacqueline-edenbrow',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/jacqueline-edenbrow',
+            references: [],
+            bio:
+              '<p>Jacqueline Edenbrow is an executive producer for documentaries at the Guardian</p>',
+            firstName: 'Jacqueline',
+            lastName: ' Edenbrow',
+            r2ContributorId: '84257',
+            internalName: 'Jacqueline Edenbrow'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-video',
+            type: 'tracking',
+            webTitle: 'UK Video',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-video',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-video',
+            references: [],
+            internalName: 'UK Video (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News',
+        frontsMeta: {
+          defaults: {
+            isBreaking: false,
+            isBoosted: false,
+            showMainVideo: false,
+            imageHide: false,
+            showKickerCustom: false,
+            showByline: false,
+            showQuotedHeadline: false,
+            imageSlideshowReplace: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            imageReplace: false,
+            imageCutoutReplace: false,
+            showKickerSection: false,
+            showBoostedHeadline: false
+          },
+          tone: 'news'
+        }
+      },
+      {
+        id: 'world/2019/jul/20/gulf-crisis-tanker-retaliation-iran-hormuz',
+        type: 'article',
+        sectionId: 'world',
+        sectionName: 'World news',
+        webPublicationDate: '2019-07-19T23:26:33Z',
+        webTitle:
+          "Gulf crisis: story began with UK's seizure of Iranian-flagged ship in Gibraltar",
+        webUrl:
+          'https://www.theguardian.com/world/2019/jul/20/gulf-crisis-tanker-retaliation-iran-hormuz',
+        apiUrl:
+          'https://preview.content.guardianapis.com/world/2019/jul/20/gulf-crisis-tanker-retaliation-iran-hormuz',
+        fields: {
+          headline:
+            "Gulf crisis: story began with UK's seizure of Iranian-flagged ship in Gibraltar",
+          trailText:
+            'Grace 1 was impounded over claim it was bound for Syria – but diplomats knew there might be consequences',
+          byline: 'Patrick Wintour Diplomatic editor',
+          firstPublicationDate: '2019-07-19T23:26:33Z',
+          internalPageCode: 6382603,
+          newspaperEditionDate: '2019-07-20T00:00:00Z',
+          shortUrl: 'https://gu.com/p/cv77j',
+          thumbnail:
+            'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/500.jpg',
+          isLive: true
+        },
+        tags: [
+          {
+            id: 'world/iran',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Iran',
+            webUrl: 'https://www.theguardian.com/world/iran',
+            apiUrl: 'https://preview.content.guardianapis.com/world/iran',
+            references: [],
+            internalName: 'Iran (News)'
+          },
+          {
+            id: 'business/oil',
+            type: 'keyword',
+            sectionId: 'business',
+            sectionName: 'Business',
+            webTitle: 'Oil',
+            webUrl: 'https://www.theguardian.com/business/oil',
+            apiUrl: 'https://preview.content.guardianapis.com/business/oil',
+            references: [],
+            internalName: 'Oil (business)'
+          },
+          {
+            id: 'uk/military',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'Military',
+            webUrl: 'https://www.theguardian.com/uk/military',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/military',
+            references: [],
+            internalName: 'Military UK'
+          },
+          {
+            id: 'world/middleeast',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'Middle East and North Africa',
+            webUrl: 'https://www.theguardian.com/world/middleeast',
+            apiUrl: 'https://preview.content.guardianapis.com/world/middleeast',
+            references: [],
+            internalName: 'Middle East and North Africa (News) MENA'
+          },
+          {
+            id: 'uk/uk',
+            type: 'keyword',
+            sectionId: 'uk-news',
+            sectionName: 'UK news',
+            webTitle: 'UK news',
+            webUrl: 'https://www.theguardian.com/uk/uk',
+            apiUrl: 'https://preview.content.guardianapis.com/uk/uk',
+            references: [],
+            internalName: 'UK news'
+          },
+          {
+            id: 'world/world',
+            type: 'keyword',
+            sectionId: 'world',
+            sectionName: 'World news',
+            webTitle: 'World news',
+            webUrl: 'https://www.theguardian.com/world/world',
+            apiUrl: 'https://preview.content.guardianapis.com/world/world',
+            references: [],
+            internalName: 'World news'
+          },
+          {
+            id: 'type/article',
+            type: 'type',
+            webTitle: 'Article',
+            webUrl: 'https://www.theguardian.com/articles',
+            apiUrl: 'https://preview.content.guardianapis.com/type/article',
+            references: [],
+            internalName: 'Article (Content type)'
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: [],
+            internalName: 'News (Tone)'
+          },
+          {
+            id: 'tone/analysis',
+            type: 'tone',
+            webTitle: 'Analysis',
+            webUrl: 'https://www.theguardian.com/tone/analysis',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/analysis',
+            references: [],
+            internalName: 'Analysis (Tone)'
+          },
+          {
+            id: 'profile/patrickwintour',
+            type: 'contributor',
+            webTitle: 'Patrick Wintour',
+            webUrl: 'https://www.theguardian.com/profile/patrickwintour',
+            apiUrl:
+              'https://preview.content.guardianapis.com/profile/patrickwintour',
+            references: [],
+            bio: '<p>Patrick Wintour is diplomatic editor for the Guardian</p>',
+            bylineImageUrl:
+              'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/2/4/1423058508175/Patrick-Wintour.jpg',
+            bylineLargeImageUrl:
+              'https://uploads.guim.co.uk/2017/10/09/Patrick-Wintour,-R.png',
+            firstName: 'wintour',
+            lastName: '',
+            rcsId: 'GNL004731',
+            r2ContributorId: '16227',
+            internalName: 'Patrick Wintour'
+          },
+          {
+            id: 'publication/theguardian',
+            type: 'publication',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'The Guardian',
+            webUrl: 'https://www.theguardian.com/theguardian/all',
+            apiUrl:
+              'https://preview.content.guardianapis.com/publication/theguardian',
+            references: [],
+            description:
+              "All the latest from the world's leading liberal voice.",
+            internalName: 'The Guardian publication'
+          },
+          {
+            id: 'theguardian/mainsection',
+            type: 'newspaper-book',
+            sectionId: 'news',
+            sectionName: 'News',
+            webTitle: 'Main section',
+            webUrl: 'https://www.theguardian.com/theguardian/mainsection',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection',
+            references: [],
+            internalName: 'Gdn: Main section G1 (nb)'
+          },
+          {
+            id: 'theguardian/mainsection/topstories',
+            type: 'newspaper-book-section',
+            sectionId: 'theguardian',
+            sectionName: 'From the Guardian',
+            webTitle: 'Top stories',
+            webUrl:
+              'https://www.theguardian.com/theguardian/mainsection/topstories',
+            apiUrl:
+              'https://preview.content.guardianapis.com/theguardian/mainsection/topstories',
+            references: [],
+            internalName: 'Gdn: Top stories (nbs)'
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-foreign',
+            type: 'tracking',
+            webTitle: 'UK Foreign',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-foreign',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-foreign',
+            references: [],
+            internalName: 'UK Foreign (commissioning)'
+          }
+        ],
+        elements: [],
+        references: [],
+        blocks: {
+          main: {
+            id: '5d3226ca8f08cf92bb7735ff',
+            bodyHtml:
+              '<figure class="element element-image" data-media-id="d76e18187349bdb988201b0d9877544b4180aaca"> <img src="https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/1000.jpg" alt="Stena Impero tanker" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">The Stena Impero and its crew of more than 20 are now in the hands of the Iranian Revolutionary Guards.</span> <span class="element-image__credit">Photograph: Stena Bulk/AP</span> </figcaption> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-07-19T20:23:38Z',
+            lastModifiedDate: '2019-07-19T20:24:37Z',
+            contributors: [],
+            createdBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            lastModifiedBy: {
+              email: 'andy.bodle@guardian.co.uk',
+              firstName: 'Andy',
+              lastName: 'Bodle'
+            },
+            elements: [
+              {
+                type: 'image',
+                assets: [
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/2000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 2000, height: 1200 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/1000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 1000, height: 600 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/500.jpg',
+                    typeData: { aspectRatio: '5:3', width: 500, height: 300 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/140.jpg',
+                    typeData: { aspectRatio: '5:3', width: 140, height: 84 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/3000.jpg',
+                    typeData: { aspectRatio: '5:3', width: 3000, height: 1800 }
+                  },
+                  {
+                    type: 'image',
+                    mimeType: 'image/jpeg',
+                    file:
+                      'https://media.guim.co.uk/d76e18187349bdb988201b0d9877544b4180aaca/0_9_3000_1800/master/3000.jpg',
+                    typeData: {
+                      aspectRatio: '5:3',
+                      width: 3000,
+                      height: 1800,
+                      isMaster: true
+                    }
+                  }
+                ],
+                imageTypeData: {
+                  caption:
+                    'The Stena Impero and its crew of more than 20 are now in the hands of the Iranian Revolutionary Guards.',
+                  displayCredit: true,
+                  credit: 'Photograph: Stena Bulk/AP',
+                  source: 'AP',
+                  photographer: 'Stena Bulk',
+                  alt: 'Stena Impero tanker',
+                  mediaId: 'd76e18187349bdb988201b0d9877544b4180aaca',
+                  mediaApiUri:
+                    'https://api.media.gutools.co.uk/images/d76e18187349bdb988201b0d9877544b4180aaca',
+                  suppliersReference: 'LON804',
+                  imageType: 'Photograph'
+                }
+              }
+            ]
+          }
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News',
+        frontsMeta: {
+          defaults: {
+            isBreaking: false,
+            isBoosted: false,
+            showMainVideo: false,
+            imageHide: false,
+            showKickerCustom: false,
+            showByline: false,
+            showQuotedHeadline: false,
+            imageSlideshowReplace: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            imageReplace: false,
+            imageCutoutReplace: false,
+            showKickerSection: false,
+            showBoostedHeadline: false
+          },
+          tone: 'analysis'
+        }
+      }
+    ]
+  }
+};

--- a/client-v2/integration/fixtures/edition.js
+++ b/client-v2/integration/fixtures/edition.js
@@ -1,9 +1,9 @@
 module.exports = {
   id: 'issue-1',
   displayName: 'Daily Edition',
-  publishDate: '2016-06-22 19:10:25-07', // the date for which edition is made for, in format TimestampZ, eg 2016-06-22 19:10:25-07
+  issueDate: 1563987694281, // the date for which edition is made for, in format TimestampZ, eg 2016-06-22 19:10:25-07
   lastPublished: null, // null if not published
-  launchedOn: '2016-06-21 19:10:25-07',
+  launchedOn: 1563577200000,
   launchedBy: 'Richard Beddington',
   launchedEmail: 'r.b@gu.com',
   fronts: [
@@ -23,7 +23,10 @@ module.exports = {
           // lastUpdated?: number,
           // updatedBy?: string,
           // updatedEmail?: string,
-          items: []
+          items: [],
+          prefill: {
+            queryString: 'this-doesnt-matter'
+          }
         },
         {
           id: 'collection-2',

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -20,6 +20,10 @@ const EDIT_FORM_HEADLINE_FIELD = 'edit-form-headline-field';
 const EDIT_FORM_SAVE_BUTTON = 'edit-form-save-button';
 const EDIT_FORM_BREAKING_NEWS_TOGGLE = 'edit-form-breaking-news-toggle';
 
+const FRONTS_MENU_BUTTON = 'fronts-menu-button';
+const FRONTS_MENU_ITEM = 'fronts-menu-item';
+const PREFILL_BUTTON = 'prefill-button';
+
 // Html Mocks //
 const GUARDIAN_TAG_ANCHOR = 'guardian-tag';
 const EXTERNAL_LINK_ANCHOR = 'external-link';
@@ -123,6 +127,13 @@ export const frontDropZone = maybeGetNth(
 export const frontItemAddToClipboardHoverButton = maybeGetNth(
   select(FRONT_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
 );
+
+// Front Menu //
+export const frontsMenuButton = () => select(FRONTS_MENU_BUTTON);
+export const frontsMenuItem = maybeGetNth(select(FRONTS_MENU_ITEM));
+
+// Prefill Button //
+export const prefillButton = maybeGetNth(select(PREFILL_BUTTON));
 
 // Snaps //
 export const guardianSnapLink = maybeGetNth(select(GUARDIAN_TAG_ANCHOR));

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -10,6 +10,7 @@ const collectionTwo = require('../fixtures/collection2');
 const collectionThree = require('../fixtures/collection3');
 const capiCollection = require('../fixtures/capi-collection');
 const capiSearch = require('../fixtures/capi-search');
+const prefill = require('../fixtures/capi-prefill');
 const snapTag = require('../fixtures/snap-tag');
 const snapTagPage = require('../fixtures/snap-tag-page');
 const snapExternalPage = require('../../src/shared/fixtures/bbcSectionPage');
@@ -118,9 +119,6 @@ module.exports = async () =>
 
     app.get('/config', (_, res) => res.json(config));
 
-    // edition endpoint
-    app.get('/editions-api/*', (_, res) => res.json(edition));
-
     app.post('/collections*', (req, res) => {
       return res.json([
         {
@@ -142,7 +140,14 @@ module.exports = async () =>
       ]);
     });
 
-    app.post('/editions-api/collections*', (req, res) => {
+    app.get('/editions-api/issues/:id', (_, res) => res.json(edition));
+    app.get('/editions-api/issues/:id/summary', (_, res) =>
+      res.json({ ...edition, fronts: undefined })
+    );
+    app.get('/editions-api/collections/:id/prefill', (req, res) => {
+      return res.json(prefill);
+    });
+    app.post('/editions-api/collections', (req, res) => {
       return res.json([
         {
           id: req.body[0].id,

--- a/client-v2/integration/tests/editions.spec.js
+++ b/client-v2/integration/tests/editions.spec.js
@@ -1,0 +1,31 @@
+import setup from '../server/setup';
+import teardown from '../server/teardown';
+import {
+  frontsMenuButton,
+  frontsMenuItem,
+  prefillButton,
+  feedItemHeadline
+} from '../selectors';
+
+fixture`Fronts edit`
+  .page`http://localhost:3456/v2/issues/fake-edition-isssue-id`
+  .before(setup)
+  .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
+  .after(teardown);
+
+test('Only show prefill button when prefill query is defined', async t => {
+  await t
+    .click(frontsMenuButton())
+    .click(frontsMenuItem(0))
+    .expect(prefillButton().count)
+    .eql(1);
+});
+
+test('Check prefill button renders searches properly.', async t => {
+  await t
+    .click(frontsMenuButton())
+    .click(frontsMenuItem(0))
+    .click(prefillButton(0))
+    .expect(feedItemHeadline(0).textContent)
+    .eql('Iran stokes Gulf tensions by seizing two British-linked oil tankers');
+});

--- a/client-v2/src/actions/__tests__/Persistence.spec.ts
+++ b/client-v2/src/actions/__tests__/Persistence.spec.ts
@@ -79,7 +79,8 @@ const init = () => {
         a3: A3,
         a4: A4
       }
-    }
+    },
+    feed: {}
   };
   const reducer = enableBatching(rootReducer);
   const middleware = compose(

--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -3,6 +3,9 @@ import { CapiArticle } from 'types/Capi';
 import { ThunkResult } from 'types/Store';
 import { previewCapi, liveCapi } from 'services/frontsCapi';
 import { checkIsContent } from 'services/capiQuery';
+import { getPrefills } from 'services/editionsApi';
+import { Dispatch } from 'redux';
+import { PrefillModeOn, PrefillModeOff } from 'types/Action';
 
 type FeedState = CapiArticle[];
 
@@ -12,7 +15,7 @@ const {
   selectors: liveSelectors
 } = createAsyncResourceBundle<FeedState>('capiLiveFeed', {
   indexById: false,
-  selectLocalState: state => state.capiLiveFeed,
+  selectLocalState: state => state.capi.capiLiveFeed,
   initialData: []
 });
 
@@ -38,7 +41,7 @@ const {
   selectors: previewSelectors
 } = createAsyncResourceBundle<FeedState>('capiPreviewFeed', {
   indexById: false,
-  selectLocalState: state => state.capiPreviewFeed,
+  selectLocalState: state => state.capi.capiPreviewFeed,
   initialData: []
 });
 
@@ -113,11 +116,58 @@ export const fetchPreview = (
   }
 };
 
+const {
+  actions: prefillActions,
+  reducer: prefillFeed,
+  selectors: prefillSelectors
+} = createAsyncResourceBundle<FeedState>('prefillFeed', {
+  indexById: false,
+  selectLocalState: state => state.capi.prefillFeed,
+  initialData: []
+});
+
+export const fetchPrefill = (
+  id: string
+): ThunkResult<void> => async dispatch => {
+  dispatch({
+    type: 'FEED_STATE_IS_PREFILL_MODE',
+    payload: { isPrefillMode: true }
+  });
+  dispatch(prefillActions.fetchStart('prefill'));
+
+  try {
+    const { response } = await getPrefills(id);
+    if (!checkIsContent(response)) {
+      dispatch(
+        prefillActions.fetchSuccess(
+          response.results.filter(isNonCommercialArticle, {
+            totalPages: response.pages,
+            currentPage: response.currentPage,
+            pageSize: response.pageSize
+          })
+        )
+      );
+    }
+  } catch (e) {
+    dispatch(prefillActions.fetchError(e.message));
+  }
+};
+
+export const hidePrefills = () => (dispatch: Dispatch) => {
+  dispatch({
+    type: 'FEED_STATE_IS_PREFILL_MODE',
+    payload: { isPrefillMode: false }
+  });
+};
+
 export {
   liveActions,
   previewActions,
+  prefillActions,
   capiLiveFeed,
   capiPreviewFeed,
+  prefillFeed,
   liveSelectors,
-  previewSelectors
+  previewSelectors,
+  prefillSelectors
 };

--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -5,7 +5,6 @@ import { previewCapi, liveCapi } from 'services/frontsCapi';
 import { checkIsContent } from 'services/capiQuery';
 import { getPrefills } from 'services/editionsApi';
 import { Dispatch } from 'redux';
-import { PrefillModeOn, PrefillModeOff } from 'types/Action';
 
 type FeedState = CapiArticle[];
 
@@ -15,7 +14,7 @@ const {
   selectors: liveSelectors
 } = createAsyncResourceBundle<FeedState>('capiLiveFeed', {
   indexById: false,
-  selectLocalState: state => state.capi.capiLiveFeed,
+  selectLocalState: state => state.feed.capiLiveFeed,
   initialData: []
 });
 
@@ -41,7 +40,7 @@ const {
   selectors: previewSelectors
 } = createAsyncResourceBundle<FeedState>('capiPreviewFeed', {
   indexById: false,
-  selectLocalState: state => state.capi.capiPreviewFeed,
+  selectLocalState: state => state.feed.capiPreviewFeed,
   initialData: []
 });
 
@@ -122,7 +121,7 @@ const {
   selectors: prefillSelectors
 } = createAsyncResourceBundle<FeedState>('prefillFeed', {
   indexById: false,
-  selectLocalState: state => state.capi.prefillFeed,
+  selectLocalState: state => state.feed.prefillFeed,
   initialData: []
 });
 

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -272,7 +272,7 @@ class FeedsContainer extends React.Component<
     return this.state.capiFeedIndex === 0;
   }
 
-  renderPrefillFixedContent = () => {
+  public renderPrefillFixedContent = () => {
     return (
       <PrefillNoticeContainer>
         <PrefillNotice>

--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -475,7 +475,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(fetchLive(params, isResource)),
   fetchPreview: (params: object, isResource: boolean) =>
     dispatch(fetchPreview(params, isResource)),
-  hidePrefills: (id: string) => dispatch(hidePrefills())
+  hidePrefills: () => dispatch(hidePrefills())
 });
 
 export default connect(

--- a/client-v2/src/components/FrontList.tsx
+++ b/client-v2/src/components/FrontList.tsx
@@ -121,6 +121,7 @@ const FrontList = ({
     <ListContainer>
       {frontsToRender.map(front => (
         <ListItem
+          data-testid="fronts-menu-item"
           isActive={!front.isOpen}
           isStarred={!!front.isStarred}
           key={front.id}

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -127,11 +127,11 @@ const isLive = (article: CapiArticle) =>
 
 const getArticleLabel = (article: CapiArticle) => {
   const {
-    fields: { firstPublicationDate, newspaperEditionDate },
+    fields: { firstPublicationDate },
     sectionName,
     frontsMeta: { tone }
   } = article;
-  if (!isLive(article) && !newspaperEditionDate) {
+  if (!isLive(article)) {
     if (firstPublicationDate) {
       return notLiveLabels.takenDown;
     }
@@ -175,7 +175,7 @@ class FeedItem extends React.Component<FeedItemProps> {
                 color:
                   getPillarColor(
                     article.pillarId,
-                    isLive(article) || !!article.fields.newspaperEditionDate,
+                    isLive(article),
                     article.frontsMeta.tone === liveBlogTones.dead
                   ) || styleTheme.capiInterface.textLight
               }}

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -127,11 +127,11 @@ const isLive = (article: CapiArticle) =>
 
 const getArticleLabel = (article: CapiArticle) => {
   const {
-    fields: { firstPublicationDate },
+    fields: { firstPublicationDate, newspaperEditionDate },
     sectionName,
     frontsMeta: { tone }
   } = article;
-  if (!isLive(article)) {
+  if (!isLive(article) && !newspaperEditionDate) {
     if (firstPublicationDate) {
       return notLiveLabels.takenDown;
     }
@@ -175,7 +175,7 @@ class FeedItem extends React.Component<FeedItemProps> {
                 color:
                   getPillarColor(
                     article.pillarId,
-                    isLive(article),
+                    isLive(article) || !!article.fields.newspaperEditionDate,
                     article.frontsMeta.tone === liveBlogTones.dead
                   ) || styleTheme.capiInterface.textLight
               }}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -35,7 +35,6 @@ import CollectionMetaContainer from 'shared/components/collection/CollectionMeta
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
 import { styled } from 'constants/theme';
 import EditModeVisibility from 'components/util/EditModeVisibility';
-import { getPrefills } from 'services/editionsApi';
 import { fetchPrefill } from 'bundles/capiFeedBundle';
 
 interface CollectionPropsBeforeState {
@@ -118,8 +117,7 @@ class Collection extends React.Component<CollectionProps> {
       hasMultipleFrontsOpen,
       isEditFormOpen,
       discardDraftChangesToCollection: discardDraftChanges,
-      hasPrefill,
-      fetchPrefill
+      hasPrefill
     } = this.props;
 
     const { isPreviouslyOpen } = this.state;
@@ -147,7 +145,7 @@ class Collection extends React.Component<CollectionProps> {
                   <Button
                     size="l"
                     priority="default"
-                    onClick={() => fetchPrefill(id)}
+                    onClick={() => this.props.fetchPrefill(id)}
                     title="Get suggested articles for this collection"
                   >
                     Suggest Articles

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -143,6 +143,7 @@ class Collection extends React.Component<CollectionProps> {
               {hasPrefill && (
                 <EditModeVisibility visibleMode="editions">
                   <Button
+                    data-testid="prefill-button"
                     size="l"
                     priority="default"
                     onClick={() => this.props.fetchPrefill(id)}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -233,7 +233,7 @@ const createMapStateToProps = () => {
   ) => {
     const selectDoesCollectionHaveOpenForms = createSelectDoesCollectionHaveOpenForms();
     return {
-      hasPrefill: selectCollectionHasPrefill(state, id),
+      hasPrefill: selectCollectionHasPrefill(state, collectionId),
       hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
         collectionId
       }),

--- a/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontsMenu.tsx
@@ -142,6 +142,7 @@ class FrontsMenu extends React.Component<Props, State> {
         <FrontsMenuContainer isOpen={this.state.isOpen}>
           <ButtonOverlayContainer>
             <ButtonOverlay
+              data-testid="fronts-menu-button"
               onClick={this.toggleFrontsMenu}
               active={this.state.isOpen}
             >

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -1,672 +1,687 @@
 import { State } from 'types/State';
 
-const state = {
-  confirmModal: null,
-  fronts: {
-    frontsConfig: {
-      data: {
-        fronts: {
-          'sc-johnson-partner-zone': {
-            collections: [
-              'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
-              '4ab657ff-c105-4292-af23-cda00457b6b7',
-              'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99'
-            ],
-            priority: 'commercial',
-            canonical: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
-            group: 'US professional',
-            id: 'sc-johnson-partner-zone',
-            index: 0
-          },
-          'a-shot-of-sustainability': {
-            collections: [
-              'bf2267c3-93a3-405c-8381-672fcb0e0b86',
-              '7902d549-b02a-49b7-828b-c959d4b6f5db',
-              'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb',
-              'e307d948-c6d5-4a2e-b0f4-3fdef9d8655c'
-            ],
-            priority: 'commercial',
-            canonical: 'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb',
-            group: 'UK consumer',
-            id: 'a-shot-of-sustainability',
-            index: 1
-          },
-          'sustainable-business/fairtrade-partner-zone': {
-            collections: [
-              '341974f3-aff8-42bf-b2d2-fb789b450d57',
-              '44b4cefc-cca4-4019-8aa2-df424d0307ab',
-              '5dfd1f1a-4442-436a-a5aa-83486d78f905',
-              '8df68e59-e7ef-40e5-bcf3-4ea3eb30950c',
-              'ab21e2b6-93cb-4140-ac09-97c382dcaeb2',
-              '6851252b-5b53-4089-886d-47e2e32a8a2d',
-              'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611'
-            ],
-            priority: 'commercial',
-            id: 'sustainable-business/fairtrade-partner-zone',
-            index: 2
-          },
-          'un-global-compact-partner-zone': {
-            collections: ['082d2dc8-f196-4c00-979e-7f541f2772f4'],
-            priority: 'commercial',
-            canonical: '082d2dc8-f196-4c00-979e-7f541f2772f4',
-            id: 'un-global-compact-partner-zone',
-            index: 3
-          },
-          'gnm-archive': {
-            collections: [
-              'dc14dd30-da03-4d42-8e96-0a7243a4274e',
-              '28d44c92-0666-48d3-8f3b-ed3806455af6',
-              '51e1da7b-84b1-4274-84e1-4aa368bf893a',
-              'effe55e6-1a11-4c39-be17-d245f776ba4c',
-              '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56'
-            ],
-            id: 'gnm-archive',
-            priority: 'editorial',
-            index: 4
-          }
-        },
-        collections: {
-          '28d44c92-0666-48d3-8f3b-ed3806455af6': {
-            displayName: 'pictures and video',
-            backfill: {
-              type: 'capi',
-              query: 'search?tag=gnm-archive/gnm-archive,type/gallery'
-            },
-            type: 'fixed/medium/slow-VI',
-            href: 'gnm-archive/gnm-archive+type/gallery',
-            id: '28d44c92-0666-48d3-8f3b-ed3806455af6'
-          },
-          '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56': {
-            displayName: 'other Guardian sites',
-            type: 'nav/list',
-            id: '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56'
-          },
-          '5dfd1f1a-4442-436a-a5aa-83486d78f905': {
-            displayName: 'interactive',
-            type: 'fixed/small/slow-III',
-            id: '5dfd1f1a-4442-436a-a5aa-83486d78f905'
-          },
-          'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
-            displayName: 'sc johnson partner zone',
-            metadata: [{ type: 'Branded' }],
-            type: 'fixed/large/slow-XIV',
-            id: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808'
-          },
-          'effe55e6-1a11-4c39-be17-d245f776ba4c': {
-            displayName: 'the collections',
-            type: 'fixed/small/slow-IV',
-            id: 'effe55e6-1a11-4c39-be17-d245f776ba4c'
-          },
-          'e307d948-c6d5-4a2e-b0f4-3fdef9d8655c': {
-            displayName: 'discover Nespresso',
-            backfill: { type: 'capi', query: 'discover-nespresso' },
-            type: 'fixed/small/slow-IV',
-            href: 'discover-nespresso',
-            id: 'e307d948-c6d5-4a2e-b0f4-3fdef9d8655c'
-          },
-          '082d2dc8-f196-4c00-979e-7f541f2772f4': {
-            displayName: 'UN Global Compact partner zone',
-            type: 'fixed/small/slow-III',
-            id: '082d2dc8-f196-4c00-979e-7f541f2772f4'
-          },
-          '7902d549-b02a-49b7-828b-c959d4b6f5db': {
-            displayName: 'interactive.',
-            type: 'fixed/small/slow-I',
-            id: '7902d549-b02a-49b7-828b-c959d4b6f5db'
-          },
-          '341974f3-aff8-42bf-b2d2-fb789b450d57': {
-            displayName: 'fairtrade foundation partner zone',
-            type: 'fixed/medium/fast-XI',
-            id: '341974f3-aff8-42bf-b2d2-fb789b450d57'
-          },
-          'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb': {
-            displayName: 'a shot of sustainability',
-            backfill: {
-              type: 'capi',
-              query: 'search?section=a-shot-of-sustainability'
-            },
-            type: 'fixed/medium/slow-VII',
-            href: 'a-shot-of-sustainability',
-            id: 'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb'
-          },
-          '8df68e59-e7ef-40e5-bcf3-4ea3eb30950c': {
-            displayName: 'commodities',
-            type: 'fixed/medium/slow-VII',
-            id: '8df68e59-e7ef-40e5-bcf3-4ea3eb30950c'
-          },
-          '51e1da7b-84b1-4274-84e1-4aa368bf893a': {
-            displayName: 'the big picture',
-            type: 'fixed/small/slow-I',
-            id: '51e1da7b-84b1-4274-84e1-4aa368bf893a'
-          },
-          '4ab657ff-c105-4292-af23-cda00457b6b7': {
-            displayName: 'popular in sustainable business',
-            backfill: {
-              type: 'capi',
-              query:
-                'sustainable-business/sustainable-business?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true'
-            },
-            type: 'news/most-popular',
-            href: 'sustainable-business/sustainable-business',
-            id: '4ab657ff-c105-4292-af23-cda00457b6b7'
-          },
-          '6851252b-5b53-4089-886d-47e2e32a8a2d': {
-            displayName: 'get involved',
-            type: 'fixed/small/slow-III',
-            id: '6851252b-5b53-4089-886d-47e2e32a8a2d'
-          },
-          'dc14dd30-da03-4d42-8e96-0a7243a4274e': {
-            displayName: 'the archive',
-            type: 'fixed/large/slow-XIV',
-            id: 'dc14dd30-da03-4d42-8e96-0a7243a4274e'
-          },
-          'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99': {
-            displayName: 'values-led business hub',
-            backfill: {
-              type: 'capi',
-              query:
-                'search?tag=sustainable-business/series/values-business&use-date=published'
-            },
-            metadata: [{ type: 'Branded' }],
-            type: 'fixed/small/slow-IV',
-            href: 'sustainable-business/series/values-business',
-            description:
-              'Exploring how values – and their influence over everyday decisions – affect business sustainability and success',
-            id: 'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99'
-          },
-          'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611': {
-            displayName: 'more from fairtrade foundation',
-            type: 'fixed/small/slow-IV',
-            id: 'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611'
-          },
-          'bf2267c3-93a3-405c-8381-672fcb0e0b86': {
-            displayName: 'Important news 2',
-            type: 'fixed/medium/slow-VI',
-            id: 'bf2267c3-93a3-405c-8381-672fcb0e0b86'
-          },
-          'ab21e2b6-93cb-4140-ac09-97c382dcaeb2': {
-            displayName: 'business supply chains',
-            type: 'fixed/medium/fast-XI',
-            id: 'ab21e2b6-93cb-4140-ac09-97c382dcaeb2'
-          },
-          '44b4cefc-cca4-4019-8aa2-df424d0307ab': {
-            displayName: 'smallholder farmers',
-            type: 'fixed/medium/slow-XII-mpu',
-            id: '44b4cefc-cca4-4019-8aa2-df424d0307ab'
-          }
-        }
-      },
-      pagination: null,
-      lastError: null,
-      error: null,
-      lastFetch: 1547474511048,
-      loading: false,
-      loadingIds: [],
-      updatingIds: []
-    },
-    lastPressed: {},
-    collectionVisibility: { draft: {}, live: {} }
-  },
-  config: {
-    dev: true,
-    stage: 'CODE',
-    env: 'code',
-    editions: ['uk', 'us', 'au'],
-    email: 'jonathon.herbert@guardian.co.uk',
-    avatarUrl:
-      'https://lh4.googleusercontent.com/-XsUf7pwnZ_k/AAAAAAAAAAI/AAAAAAAAAAA/AKxrwcbJGKNqozZjexFlptsFL7TmT02Byw/mo/photo.jpg',
-    firstName: 'Jonathon',
-    lastName: 'Herbert',
-    sentryPublicDSN:
-      'https://4527e03d554a4962ae99a7481e9278ff@app.getsentry.com/35467',
-    mediaBaseUrl: 'https://media.gutools.co.uk',
-    apiBaseUrl: 'https://api.media.test.dev-gutools.co.uk',
-    switches: {
-      'facia-tool-allow-breaking-news-for-all': false,
-      'facia-tool-permissions-access': true,
-      'facia-tool-allow-edit-editorial-fronts-for-all': false,
-      'facia-tool-allow-config-for-all': false,
-      'facia-tool-allow-launch-editorial-fronts-for-all': false,
-      'facia-tool-allow-launch-commercial-fronts-for-all': false,
-      'facia-tool-sparklines': true,
-      'facia-tool-draft-content': true,
-      'facia-tool-disable': false
-    },
-    acl: {
-      fronts: { 'breaking-news': true },
-      permissions: { 'configure-config': true }
-    },
-    collectionCap: 20,
-    navListCap: 40,
-    navListType: 'nav/list',
-    collectionMetadata: [
-      { type: 'Canonical' },
-      { type: 'Special' },
-      { type: 'Breaking' },
-      { type: 'Branded' }
-    ],
-    userData: {
-      clipboardArticles: [
-        {
-          id: 'internal-code/page/5592826',
-          frontPublicationDate: 1547204861924,
-          meta: {}
-        }
-      ],
-      frontIds: [],
-      frontIdsByPriority: {},
-      favouriteFrontIdsByPriority: {},
-      featureSwitches: []
-    },
-    capiLiveUrl: 'https://fronts.local.dev-gutools.co.uk/api/live/',
-    capiPreviewUrl: 'https://fronts.local.dev-gutools.co.uk/api/preview/'
-  },
-  error: '',
-  path: '/v2/editorial',
-  shared: {
-    featureSwitches: {},
-    articleFragments: {
-      '56a3b407-741c-439f-a678-175abea44a9f': {
-        id: 'internal-code/page/5592826',
-        frontPublicationDate: 1547204861924,
-        meta: { supporting: [] },
-        uuid: '56a3b407-741c-439f-a678-175abea44a9f'
-      },
-      exampleId: {
-        id: 'internal-code/page/5592826',
-        frontPublicationDate: 1547204861924,
-        meta: { headline: 'Bill Shorten', supporting: [] },
-        uuid: 'exampleId'
-      }
-    },
-    groups: {
-      group123: {
-        id: 'gobbleygook',
-        name: 'groupname',
-        uuid: 'group123',
-        articleFragments: ['56a3b407-741c-439f-a678-175abea44a9f']
-      }
-    },
-    collections: {
-      data: {
-        'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
-          live: ['group123'],
-          lastUpdated: 1547202598354,
-          updatedBy: 'Name Surname',
-          updatedEmail: 'email@email.co.uk',
-          displayName: 'headlines',
-          id: '5a32abdf-2d1c-4f9e-a116-617e4d055ab9',
-          type: 'fixed/small/slow-IV'
-        }
-      },
-      pagination: null,
-      lastError: null,
-      error: null,
-      lastFetch: null,
-      loading: false,
-      loadingIds: [],
-      updatingIds: []
-    },
-    externalArticles: {
-      data: {
-        'internal-code/page/5592826': {
-          id: 'internal-code/page/5592826',
-          type: 'video',
-          sectionId: 'media',
-          sectionName: 'Media',
-          webPublicationDate: '2019-01-11T11:06:58Z',
-          webTitle: 'Fiona Bruce makes debut as Question Time host – video',
-          webUrl:
-            'https://www.theguardian.com/media/video/2019/jan/11/fiona-bruce-makes-debut-as-question-time-host-video',
-          apiUrl:
-            'https://preview.content.guardianapis.com/media/video/2019/jan/11/fiona-bruce-makes-debut-as-question-time-host-video',
-          fields: {
-            headline: 'Fiona Bruce makes debut as Question Time host – video',
-            trailText:
-              "<p>The presenter made her first appearance as the host of the BBC show.&nbsp; It is the first time in the programme's history that a woman has held the position</p>",
-            byline: '',
-            firstPublicationDate: '2019-01-11T11:06:58Z',
-            internalPageCode: '5592826',
-            shortUrl: 'https://gu.com/p/ae3zj',
-            thumbnail:
-              'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/500.jpg',
-            isLive: 'true'
-          },
-          tags: [
-            {
-              id: 'media/fiona-bruce',
-              type: 'keyword',
-              sectionId: 'media',
-              sectionName: 'Media',
-              webTitle: 'Fiona Bruce',
-              webUrl: 'https://www.theguardian.com/media/fiona-bruce',
-              apiUrl:
-                'https://preview.content.guardianapis.com/media/fiona-bruce',
-              references: []
-            },
-            {
-              id: 'media/bbc',
-              type: 'keyword',
-              sectionId: 'media',
-              sectionName: 'Media',
-              webTitle: 'BBC',
-              webUrl: 'https://www.theguardian.com/media/bbc',
-              apiUrl: 'https://preview.content.guardianapis.com/media/bbc',
-              references: []
-            },
-            {
-              id: 'tone/news',
-              type: 'tone',
-              webTitle: 'News',
-              webUrl: 'https://www.theguardian.com/tone/news',
-              apiUrl: 'https://preview.content.guardianapis.com/tone/news',
-              references: []
-            },
-            {
-              id: 'media/media',
-              type: 'keyword',
-              sectionId: 'media',
-              sectionName: 'Media',
-              webTitle: 'Media',
-              webUrl: 'https://www.theguardian.com/media/media',
-              apiUrl: 'https://preview.content.guardianapis.com/media/media',
-              references: []
-            },
-            {
-              id: 'tv-and-radio/question-time',
-              type: 'keyword',
-              sectionId: 'tv-and-radio',
-              sectionName: 'Television & radio',
-              webTitle: 'Question Time',
-              webUrl: 'https://www.theguardian.com/tv-and-radio/question-time',
-              apiUrl:
-                'https://preview.content.guardianapis.com/tv-and-radio/question-time',
-              references: []
-            },
-            {
-              id: 'politics/politics',
-              type: 'keyword',
-              sectionId: 'politics',
-              sectionName: 'Politics',
-              webTitle: 'Politics',
-              webUrl: 'https://www.theguardian.com/politics/politics',
-              apiUrl:
-                'https://preview.content.guardianapis.com/politics/politics',
-              references: []
-            },
-            {
-              id: 'culture/culture',
-              type: 'keyword',
-              sectionId: 'culture',
-              sectionName: 'Culture',
-              webTitle: 'Culture',
-              webUrl: 'https://www.theguardian.com/culture/culture',
-              apiUrl:
-                'https://preview.content.guardianapis.com/culture/culture',
-              references: []
-            },
-            {
-              id: 'type/video',
-              type: 'type',
-              webTitle: 'Video',
-              webUrl: 'https://www.theguardian.com/video',
-              apiUrl: 'https://preview.content.guardianapis.com/type/video',
-              references: []
-            },
-            {
-              id: 'tracking/commissioningdesk/uk-video',
-              type: 'tracking',
-              webTitle: 'UK Video',
-              webUrl:
-                'https://www.theguardian.com/tracking/commissioningdesk/uk-video',
-              apiUrl:
-                'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-video',
-              references: []
-            }
+const fronts = {
+  frontsConfig: {
+    data: {
+      fronts: {
+        'sc-johnson-partner-zone': {
+          collections: [
+            'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
+            '4ab657ff-c105-4292-af23-cda00457b6b7',
+            'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99'
           ],
-          elements: [],
-          blocks: {
-            main: {
-              id: '5c38752ee4b0cebe761842fa',
-              bodyHtml:
-                '<figure class="element element-atom"> <gu-atom data-atom-id="4b651e39-3d5d-46c3-b10b-05bd77f89673"         data-atom-type="media"    > </gu-atom> </figure>',
-              bodyTextSummary: '',
-              attributes: {},
-              published: false,
-              createdDate: '2019-01-11T10:51:26Z',
-              lastModifiedDate: '2019-01-11T11:11:07Z',
-              contributors: [],
-              createdBy: {
-                email: 'tola.onanuga.casual@guardian.co.uk',
-                firstName: 'Tola',
-                lastName: 'Onanuga'
-              },
-              lastModifiedBy: {
-                email: 'gary.marshall.casual@guardian.co.uk',
-                firstName: 'Gary',
-                lastName: 'Marshall'
-              },
-              elements: [
-                {
-                  type: 'contentatom',
-                  assets: [],
-                  contentAtomTypeData: {
-                    atomId: '4b651e39-3d5d-46c3-b10b-05bd77f89673',
-                    atomType: 'media'
-                  }
-                }
-              ]
-            }
-          },
-          atoms: {
-            media: [
-              {
-                id: '4b651e39-3d5d-46c3-b10b-05bd77f89673',
-                atomType: 'media',
-                labels: [],
-                defaultHtml:
-                  '<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/bGnEcyxZIOM?showinfo=0&rel=0"></iframe>',
-                data: {
-                  media: {
-                    assets: [
-                      {
-                        assetType: 'video',
-                        version: 1,
-                        id: 'bGnEcyxZIOM',
-                        platform: 'youtube'
-                      }
-                    ],
-                    activeVersion: 1,
-                    title:
-                      'Fiona Bruce makes debut as Question Time host – video',
-                    category: 'news',
-                    duration: 69,
-                    source: 'BBC',
-                    posterUrl:
-                      'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/master/851.jpg',
-                    description:
-                      '<p>The presenter made her first appearance as host of <a href="https://www.bbc.co.uk/iplayer/episode/b0by97hj/question-time-2019-10012019">the BBC show</a> on Thursday. It is the first time in the programme\'s history that a woman has held the position. Bruce received generally positive reviews for the Brexit-dominated episode</p><ul><li><a href="https://www.theguardian.com/tv-and-radio/2019/jan/11/question-time-fiona-bruce-is-fresh-face-in-a-tired-format">Question Time: Fiona Bruce is fresh face in a tired format</a></li></ul>',
-                    metadata: {
-                      tags: [
-                        'question time',
-                        'bbc',
-                        'bbc question time',
-                        'fiona bruce',
-                        'fiona bruce question time',
-                        'emily thornberry',
-                        'James Cleverly',
-                        'James Cleverly question time',
-                        'emily thornberry question time',
-                        'politics',
-                        'culture'
-                      ],
-                      categoryId: '25',
-                      channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
-                      pluto: { commissionId: 'KP-46751', projectId: 'KP-46881' }
-                    },
-                    posterImage: {
-                      assets: [
-                        {
-                          mimeType: 'image/jpeg',
-                          file:
-                            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/500.jpg',
-                          dimensions: { height: 281, width: 500 },
-                          size: 23272,
-                          aspectRatio: '16:9'
-                        },
-                        {
-                          mimeType: 'image/jpeg',
-                          file:
-                            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/140.jpg',
-                          dimensions: { height: 79, width: 140 },
-                          size: 6256,
-                          aspectRatio: '16:9'
-                        },
-                        {
-                          mimeType: 'image/jpeg',
-                          file:
-                            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/851.jpg',
-                          dimensions: { height: 479, width: 851 },
-                          size: 50542,
-                          aspectRatio: '16:9'
-                        }
-                      ],
-                      master: {
-                        mimeType: 'image/jpeg',
-                        file:
-                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/master/851.jpg',
-                        dimensions: { height: 479, width: 851 },
-                        size: 170842,
-                        aspectRatio: '16:9'
-                      },
-                      mediaId:
-                        'https://api.media.gutools.co.uk/images/d38bca368b0fa22d1a47923ac05fb4c6d20005a1',
-                      source: 'BBC'
-                    },
-                    trailText:
-                      "<p>The presenter made her first appearance as the host of the BBC show.&nbsp; It is the first time in the programme's history that a woman has held the position</p>",
-                    byline: [],
-                    commissioningDesks: ['tracking/commissioningdesk/uk-video'],
-                    keywords: [
-                      'media/fiona-bruce',
-                      'media/bbc',
-                      'tone/news',
-                      'media/media',
-                      'tv-and-radio/question-time',
-                      'politics/politics',
-                      'culture/culture'
-                    ],
-                    trailImage: {
-                      assets: [
-                        {
-                          mimeType: 'image/jpeg',
-                          file:
-                            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/500.jpg',
-                          dimensions: { height: 300, width: 500 },
-                          size: 24328,
-                          aspectRatio: '5:3'
-                        },
-                        {
-                          mimeType: 'image/jpeg',
-                          file:
-                            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/140.jpg',
-                          dimensions: { height: 84, width: 140 },
-                          size: 6675,
-                          aspectRatio: '5:3'
-                        },
-                        {
-                          mimeType: 'image/jpeg',
-                          file:
-                            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/814.jpg',
-                          dimensions: { height: 488, width: 814 },
-                          size: 47050,
-                          aspectRatio: '5:3'
-                        }
-                      ],
-                      master: {
-                        mimeType: 'image/jpeg',
-                        file:
-                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/master/814.jpg',
-                        dimensions: { height: 488, width: 814 },
-                        size: 154564,
-                        aspectRatio: '5:3'
-                      },
-                      mediaId:
-                        'https://api.media.gutools.co.uk/images/d38bca368b0fa22d1a47923ac05fb4c6d20005a1',
-                      source: 'BBC'
-                    },
-                    optimisedForWeb: true
-                  }
-                },
-                contentChangeDetails: {
-                  lastModified: {
-                    date: 1547207897000,
-                    user: {
-                      email: 'andrew.halley@guardian.co.uk',
-                      firstName: 'Andrew',
-                      lastName: 'Halley'
-                    }
-                  },
-                  created: {
-                    date: 1547199831000,
-                    user: {
-                      email: 'gary.marshall.casual@guardian.co.uk',
-                      firstName: 'Gary',
-                      lastName: 'Marshall'
-                    }
-                  },
-                  published: {
-                    date: 1547205070000,
-                    user: {
-                      email: 'gary.marshall.casual@guardian.co.uk',
-                      firstName: 'Gary',
-                      lastName: 'Marshall'
-                    }
-                  },
-                  revision: 30
-                },
-                flags: { blockAds: true },
-                title: 'Fiona Bruce makes debut as Question Time host – video',
-                commissioningDesks: []
-              }
-            ]
-          },
-          isGone: false,
-          isHosted: false,
-          pillarId: 'pillar/news',
-          pillarName: 'News',
-          frontsMeta: {
-            defaults: {
-              isBreaking: false,
-              isBoosted: false,
-              showMainVideo: true,
-              imageHide: false,
-              showKickerCustom: false,
-              showByline: false,
-              showQuotedHeadline: false,
-              imageSlideshowReplace: false,
-              showKickerTag: false,
-              showLivePlayable: false,
-              imageReplace: false,
-              imageCutoutReplace: false,
-              showKickerSection: false,
-              showBoostedHeadline: false
-            },
-            tone: 'media'
-          },
-          urlPath:
-            'media/video/2019/jan/11/fiona-bruce-makes-debut-as-question-time-host-video'
+          priority: 'commercial',
+          canonical: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
+          group: 'US professional',
+          id: 'sc-johnson-partner-zone',
+          index: 0
+        },
+        'a-shot-of-sustainability': {
+          collections: [
+            'bf2267c3-93a3-405c-8381-672fcb0e0b86',
+            '7902d549-b02a-49b7-828b-c959d4b6f5db',
+            'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb',
+            'e307d948-c6d5-4a2e-b0f4-3fdef9d8655c'
+          ],
+          priority: 'commercial',
+          canonical: 'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb',
+          group: 'UK consumer',
+          id: 'a-shot-of-sustainability',
+          index: 1
+        },
+        'sustainable-business/fairtrade-partner-zone': {
+          collections: [
+            '341974f3-aff8-42bf-b2d2-fb789b450d57',
+            '44b4cefc-cca4-4019-8aa2-df424d0307ab',
+            '5dfd1f1a-4442-436a-a5aa-83486d78f905',
+            '8df68e59-e7ef-40e5-bcf3-4ea3eb30950c',
+            'ab21e2b6-93cb-4140-ac09-97c382dcaeb2',
+            '6851252b-5b53-4089-886d-47e2e32a8a2d',
+            'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611'
+          ],
+          priority: 'commercial',
+          id: 'sustainable-business/fairtrade-partner-zone',
+          index: 2
+        },
+        'un-global-compact-partner-zone': {
+          collections: ['082d2dc8-f196-4c00-979e-7f541f2772f4'],
+          priority: 'commercial',
+          canonical: '082d2dc8-f196-4c00-979e-7f541f2772f4',
+          id: 'un-global-compact-partner-zone',
+          index: 3
+        },
+        'gnm-archive': {
+          collections: [
+            'dc14dd30-da03-4d42-8e96-0a7243a4274e',
+            '28d44c92-0666-48d3-8f3b-ed3806455af6',
+            '51e1da7b-84b1-4274-84e1-4aa368bf893a',
+            'effe55e6-1a11-4c39-be17-d245f776ba4c',
+            '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56'
+          ],
+          id: 'gnm-archive',
+          priority: 'editorial',
+          index: 4
         }
       },
-      pagination: null,
-      lastError: null,
-      error: null,
-      lastFetch: 1547474510279,
-      loading: false,
-      loadingIds: [],
-      updatingIds: []
+      collections: {
+        '28d44c92-0666-48d3-8f3b-ed3806455af6': {
+          displayName: 'pictures and video',
+          backfill: {
+            type: 'capi',
+            query: 'search?tag=gnm-archive/gnm-archive,type/gallery'
+          },
+          type: 'fixed/medium/slow-VI',
+          href: 'gnm-archive/gnm-archive+type/gallery',
+          id: '28d44c92-0666-48d3-8f3b-ed3806455af6'
+        },
+        '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56': {
+          displayName: 'other Guardian sites',
+          type: 'nav/list',
+          id: '7a35f3e8-3fab-4b2a-bc2f-7649f8342b56'
+        },
+        '5dfd1f1a-4442-436a-a5aa-83486d78f905': {
+          displayName: 'interactive',
+          type: 'fixed/small/slow-III',
+          id: '5dfd1f1a-4442-436a-a5aa-83486d78f905'
+        },
+        'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
+          displayName: 'sc johnson partner zone',
+          metadata: [{ type: 'Branded' }],
+          type: 'fixed/large/slow-XIV',
+          id: 'e59785e9-ba82-48d8-b79a-0a80b2f9f808'
+        },
+        'effe55e6-1a11-4c39-be17-d245f776ba4c': {
+          displayName: 'the collections',
+          type: 'fixed/small/slow-IV',
+          id: 'effe55e6-1a11-4c39-be17-d245f776ba4c'
+        },
+        'e307d948-c6d5-4a2e-b0f4-3fdef9d8655c': {
+          displayName: 'discover Nespresso',
+          backfill: { type: 'capi', query: 'discover-nespresso' },
+          type: 'fixed/small/slow-IV',
+          href: 'discover-nespresso',
+          id: 'e307d948-c6d5-4a2e-b0f4-3fdef9d8655c'
+        },
+        '082d2dc8-f196-4c00-979e-7f541f2772f4': {
+          displayName: 'UN Global Compact partner zone',
+          type: 'fixed/small/slow-III',
+          id: '082d2dc8-f196-4c00-979e-7f541f2772f4'
+        },
+        '7902d549-b02a-49b7-828b-c959d4b6f5db': {
+          displayName: 'interactive.',
+          type: 'fixed/small/slow-I',
+          id: '7902d549-b02a-49b7-828b-c959d4b6f5db'
+        },
+        '341974f3-aff8-42bf-b2d2-fb789b450d57': {
+          displayName: 'fairtrade foundation partner zone',
+          type: 'fixed/medium/fast-XI',
+          id: '341974f3-aff8-42bf-b2d2-fb789b450d57'
+        },
+        'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb': {
+          displayName: 'a shot of sustainability',
+          backfill: {
+            type: 'capi',
+            query: 'search?section=a-shot-of-sustainability'
+          },
+          type: 'fixed/medium/slow-VII',
+          href: 'a-shot-of-sustainability',
+          id: 'e4e9d1f0-542b-4df2-bbc4-6ac0532396bb'
+        },
+        '8df68e59-e7ef-40e5-bcf3-4ea3eb30950c': {
+          displayName: 'commodities',
+          type: 'fixed/medium/slow-VII',
+          id: '8df68e59-e7ef-40e5-bcf3-4ea3eb30950c'
+        },
+        '51e1da7b-84b1-4274-84e1-4aa368bf893a': {
+          displayName: 'the big picture',
+          type: 'fixed/small/slow-I',
+          id: '51e1da7b-84b1-4274-84e1-4aa368bf893a'
+        },
+        '4ab657ff-c105-4292-af23-cda00457b6b7': {
+          displayName: 'popular in sustainable business',
+          backfill: {
+            type: 'capi',
+            query:
+              'sustainable-business/sustainable-business?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true'
+          },
+          type: 'news/most-popular',
+          href: 'sustainable-business/sustainable-business',
+          id: '4ab657ff-c105-4292-af23-cda00457b6b7'
+        },
+        '6851252b-5b53-4089-886d-47e2e32a8a2d': {
+          displayName: 'get involved',
+          type: 'fixed/small/slow-III',
+          id: '6851252b-5b53-4089-886d-47e2e32a8a2d'
+        },
+        'dc14dd30-da03-4d42-8e96-0a7243a4274e': {
+          displayName: 'the archive',
+          type: 'fixed/large/slow-XIV',
+          id: 'dc14dd30-da03-4d42-8e96-0a7243a4274e'
+        },
+        'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99': {
+          displayName: 'values-led business hub',
+          backfill: {
+            type: 'capi',
+            query:
+              'search?tag=sustainable-business/series/values-business&use-date=published'
+          },
+          metadata: [{ type: 'Branded' }],
+          type: 'fixed/small/slow-IV',
+          href: 'sustainable-business/series/values-business',
+          description:
+            'Exploring how values – and their influence over everyday decisions – affect business sustainability and success',
+          id: 'c7f48719-6cbc-4024-ae92-1b5f9f6c0c99'
+        },
+        'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611': {
+          displayName: 'more from fairtrade foundation',
+          type: 'fixed/small/slow-IV',
+          id: 'd5a943c6-ce77-4ffa-a9ab-3c9e736cc611'
+        },
+        'bf2267c3-93a3-405c-8381-672fcb0e0b86': {
+          displayName: 'Important news 2',
+          type: 'fixed/medium/slow-VI',
+          id: 'bf2267c3-93a3-405c-8381-672fcb0e0b86'
+        },
+        'ab21e2b6-93cb-4140-ac09-97c382dcaeb2': {
+          displayName: 'business supply chains',
+          type: 'fixed/medium/fast-XI',
+          id: 'ab21e2b6-93cb-4140-ac09-97c382dcaeb2'
+        },
+        '44b4cefc-cca4-4019-8aa2-df424d0307ab': {
+          displayName: 'smallholder farmers',
+          type: 'fixed/medium/slow-XII-mpu',
+          id: '44b4cefc-cca4-4019-8aa2-df424d0307ab'
+        }
+      }
+    },
+    pagination: null,
+    lastError: null,
+    error: null,
+    lastFetch: 1547474511048,
+    loading: false,
+    loadingIds: [],
+    updatingIds: []
+  },
+  lastPressed: {},
+  collectionVisibility: { draft: {}, live: {} }
+};
+const config = {
+  dev: true,
+  stage: 'CODE',
+  env: 'code',
+  editions: ['uk', 'us', 'au'],
+  email: 'jonathon.herbert@guardian.co.uk',
+  avatarUrl:
+    'https://lh4.googleusercontent.com/-XsUf7pwnZ_k/AAAAAAAAAAI/AAAAAAAAAAA/AKxrwcbJGKNqozZjexFlptsFL7TmT02Byw/mo/photo.jpg',
+  firstName: 'Jonathon',
+  lastName: 'Herbert',
+  sentryPublicDSN:
+    'https://4527e03d554a4962ae99a7481e9278ff@app.getsentry.com/35467',
+  mediaBaseUrl: 'https://media.gutools.co.uk',
+  apiBaseUrl: 'https://api.media.test.dev-gutools.co.uk',
+  switches: {
+    'facia-tool-allow-breaking-news-for-all': false,
+    'facia-tool-permissions-access': true,
+    'facia-tool-allow-edit-editorial-fronts-for-all': false,
+    'facia-tool-allow-config-for-all': false,
+    'facia-tool-allow-launch-editorial-fronts-for-all': false,
+    'facia-tool-allow-launch-commercial-fronts-for-all': false,
+    'facia-tool-sparklines': true,
+    'facia-tool-draft-content': true,
+    'facia-tool-disable': false
+  },
+  acl: {
+    fronts: { 'breaking-news': true },
+    permissions: { 'configure-config': true }
+  },
+  collectionCap: 20,
+  navListCap: 40,
+  navListType: 'nav/list',
+  collectionMetadata: [
+    { type: 'Canonical' },
+    { type: 'Special' },
+    { type: 'Breaking' },
+    { type: 'Branded' }
+  ],
+  userData: {
+    clipboardArticles: [
+      {
+        id: 'internal-code/page/5592826',
+        frontPublicationDate: 1547204861924,
+        meta: {}
+      }
+    ],
+    frontIds: [],
+    frontIdsByPriority: {},
+    favouriteFrontIdsByPriority: {},
+    featureSwitches: []
+  },
+  capiLiveUrl: 'https://fronts.local.dev-gutools.co.uk/api/live/',
+  capiPreviewUrl: 'https://fronts.local.dev-gutools.co.uk/api/preview/'
+};
+
+const shared = {
+  featureSwitches: {},
+  articleFragments: {
+    '56a3b407-741c-439f-a678-175abea44a9f': {
+      id: 'internal-code/page/5592826',
+      frontPublicationDate: 1547204861924,
+      meta: { supporting: [] },
+      uuid: '56a3b407-741c-439f-a678-175abea44a9f'
+    },
+    exampleId: {
+      id: 'internal-code/page/5592826',
+      frontPublicationDate: 1547204861924,
+      meta: { headline: 'Bill Shorten', supporting: [] },
+      uuid: 'exampleId'
     }
   },
+  groups: {
+    group123: {
+      id: 'gobbleygook',
+      name: 'groupname',
+      uuid: 'group123',
+      articleFragments: ['56a3b407-741c-439f-a678-175abea44a9f']
+    }
+  },
+  collections: {
+    data: {
+      'e59785e9-ba82-48d8-b79a-0a80b2f9f808': {
+        live: ['group123'],
+        lastUpdated: 1547202598354,
+        updatedBy: 'Name Surname',
+        updatedEmail: 'email@email.co.uk',
+        displayName: 'headlines',
+        id: '5a32abdf-2d1c-4f9e-a116-617e4d055ab9',
+        type: 'fixed/small/slow-IV'
+      }
+    },
+    pagination: null,
+    lastError: null,
+    error: null,
+    lastFetch: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: []
+  },
+  externalArticles: {
+    data: {
+      'internal-code/page/5592826': {
+        id: 'internal-code/page/5592826',
+        type: 'video',
+        sectionId: 'media',
+        sectionName: 'Media',
+        webPublicationDate: '2019-01-11T11:06:58Z',
+        webTitle: 'Fiona Bruce makes debut as Question Time host – video',
+        webUrl:
+          'https://www.theguardian.com/media/video/2019/jan/11/fiona-bruce-makes-debut-as-question-time-host-video',
+        apiUrl:
+          'https://preview.content.guardianapis.com/media/video/2019/jan/11/fiona-bruce-makes-debut-as-question-time-host-video',
+        fields: {
+          headline: 'Fiona Bruce makes debut as Question Time host – video',
+          trailText:
+            "<p>The presenter made her first appearance as the host of the BBC show.&nbsp; It is the first time in the programme's history that a woman has held the position</p>",
+          byline: '',
+          firstPublicationDate: '2019-01-11T11:06:58Z',
+          internalPageCode: '5592826',
+          shortUrl: 'https://gu.com/p/ae3zj',
+          thumbnail:
+            'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/500.jpg',
+          isLive: 'true'
+        },
+        tags: [
+          {
+            id: 'media/fiona-bruce',
+            type: 'keyword',
+            sectionId: 'media',
+            sectionName: 'Media',
+            webTitle: 'Fiona Bruce',
+            webUrl: 'https://www.theguardian.com/media/fiona-bruce',
+            apiUrl:
+              'https://preview.content.guardianapis.com/media/fiona-bruce',
+            references: []
+          },
+          {
+            id: 'media/bbc',
+            type: 'keyword',
+            sectionId: 'media',
+            sectionName: 'Media',
+            webTitle: 'BBC',
+            webUrl: 'https://www.theguardian.com/media/bbc',
+            apiUrl: 'https://preview.content.guardianapis.com/media/bbc',
+            references: []
+          },
+          {
+            id: 'tone/news',
+            type: 'tone',
+            webTitle: 'News',
+            webUrl: 'https://www.theguardian.com/tone/news',
+            apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+            references: []
+          },
+          {
+            id: 'media/media',
+            type: 'keyword',
+            sectionId: 'media',
+            sectionName: 'Media',
+            webTitle: 'Media',
+            webUrl: 'https://www.theguardian.com/media/media',
+            apiUrl: 'https://preview.content.guardianapis.com/media/media',
+            references: []
+          },
+          {
+            id: 'tv-and-radio/question-time',
+            type: 'keyword',
+            sectionId: 'tv-and-radio',
+            sectionName: 'Television & radio',
+            webTitle: 'Question Time',
+            webUrl: 'https://www.theguardian.com/tv-and-radio/question-time',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tv-and-radio/question-time',
+            references: []
+          },
+          {
+            id: 'politics/politics',
+            type: 'keyword',
+            sectionId: 'politics',
+            sectionName: 'Politics',
+            webTitle: 'Politics',
+            webUrl: 'https://www.theguardian.com/politics/politics',
+            apiUrl:
+              'https://preview.content.guardianapis.com/politics/politics',
+            references: []
+          },
+          {
+            id: 'culture/culture',
+            type: 'keyword',
+            sectionId: 'culture',
+            sectionName: 'Culture',
+            webTitle: 'Culture',
+            webUrl: 'https://www.theguardian.com/culture/culture',
+            apiUrl: 'https://preview.content.guardianapis.com/culture/culture',
+            references: []
+          },
+          {
+            id: 'type/video',
+            type: 'type',
+            webTitle: 'Video',
+            webUrl: 'https://www.theguardian.com/video',
+            apiUrl: 'https://preview.content.guardianapis.com/type/video',
+            references: []
+          },
+          {
+            id: 'tracking/commissioningdesk/uk-video',
+            type: 'tracking',
+            webTitle: 'UK Video',
+            webUrl:
+              'https://www.theguardian.com/tracking/commissioningdesk/uk-video',
+            apiUrl:
+              'https://preview.content.guardianapis.com/tracking/commissioningdesk/uk-video',
+            references: []
+          }
+        ],
+        elements: [],
+        blocks: {
+          main: {
+            id: '5c38752ee4b0cebe761842fa',
+            bodyHtml:
+              '<figure class="element element-atom"> <gu-atom data-atom-id="4b651e39-3d5d-46c3-b10b-05bd77f89673"         data-atom-type="media"    > </gu-atom> </figure>',
+            bodyTextSummary: '',
+            attributes: {},
+            published: false,
+            createdDate: '2019-01-11T10:51:26Z',
+            lastModifiedDate: '2019-01-11T11:11:07Z',
+            contributors: [],
+            createdBy: {
+              email: 'tola.onanuga.casual@guardian.co.uk',
+              firstName: 'Tola',
+              lastName: 'Onanuga'
+            },
+            lastModifiedBy: {
+              email: 'gary.marshall.casual@guardian.co.uk',
+              firstName: 'Gary',
+              lastName: 'Marshall'
+            },
+            elements: [
+              {
+                type: 'contentatom',
+                assets: [],
+                contentAtomTypeData: {
+                  atomId: '4b651e39-3d5d-46c3-b10b-05bd77f89673',
+                  atomType: 'media'
+                }
+              }
+            ]
+          }
+        },
+        atoms: {
+          media: [
+            {
+              id: '4b651e39-3d5d-46c3-b10b-05bd77f89673',
+              atomType: 'media',
+              labels: [],
+              defaultHtml:
+                '<iframe frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/bGnEcyxZIOM?showinfo=0&rel=0"></iframe>',
+              data: {
+                media: {
+                  assets: [
+                    {
+                      assetType: 'video',
+                      version: 1,
+                      id: 'bGnEcyxZIOM',
+                      platform: 'youtube'
+                    }
+                  ],
+                  activeVersion: 1,
+                  title:
+                    'Fiona Bruce makes debut as Question Time host – video',
+                  category: 'news',
+                  duration: 69,
+                  source: 'BBC',
+                  posterUrl:
+                    'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/master/851.jpg',
+                  description:
+                    '<p>The presenter made her first appearance as host of <a href="https://www.bbc.co.uk/iplayer/episode/b0by97hj/question-time-2019-10012019">the BBC show</a> on Thursday. It is the first time in the programme\'s history that a woman has held the position. Bruce received generally positive reviews for the Brexit-dominated episode</p><ul><li><a href="https://www.theguardian.com/tv-and-radio/2019/jan/11/question-time-fiona-bruce-is-fresh-face-in-a-tired-format">Question Time: Fiona Bruce is fresh face in a tired format</a></li></ul>',
+                  metadata: {
+                    tags: [
+                      'question time',
+                      'bbc',
+                      'bbc question time',
+                      'fiona bruce',
+                      'fiona bruce question time',
+                      'emily thornberry',
+                      'James Cleverly',
+                      'James Cleverly question time',
+                      'emily thornberry question time',
+                      'politics',
+                      'culture'
+                    ],
+                    categoryId: '25',
+                    channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
+                    pluto: { commissionId: 'KP-46751', projectId: 'KP-46881' }
+                  },
+                  posterImage: {
+                    assets: [
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/500.jpg',
+                        dimensions: { height: 281, width: 500 },
+                        size: 23272,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/140.jpg',
+                        dimensions: { height: 79, width: 140 },
+                        size: 6256,
+                        aspectRatio: '16:9'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/851.jpg',
+                        dimensions: { height: 479, width: 851 },
+                        size: 50542,
+                        aspectRatio: '16:9'
+                      }
+                    ],
+                    master: {
+                      mimeType: 'image/jpeg',
+                      file:
+                        'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/125_60_851_479/master/851.jpg',
+                      dimensions: { height: 479, width: 851 },
+                      size: 170842,
+                      aspectRatio: '16:9'
+                    },
+                    mediaId:
+                      'https://api.media.gutools.co.uk/images/d38bca368b0fa22d1a47923ac05fb4c6d20005a1',
+                    source: 'BBC'
+                  },
+                  trailText:
+                    "<p>The presenter made her first appearance as the host of the BBC show.&nbsp; It is the first time in the programme's history that a woman has held the position</p>",
+                  byline: [],
+                  commissioningDesks: ['tracking/commissioningdesk/uk-video'],
+                  keywords: [
+                    'media/fiona-bruce',
+                    'media/bbc',
+                    'tone/news',
+                    'media/media',
+                    'tv-and-radio/question-time',
+                    'politics/politics',
+                    'culture/culture'
+                  ],
+                  trailImage: {
+                    assets: [
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/500.jpg',
+                        dimensions: { height: 300, width: 500 },
+                        size: 24328,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/140.jpg',
+                        dimensions: { height: 84, width: 140 },
+                        size: 6675,
+                        aspectRatio: '5:3'
+                      },
+                      {
+                        mimeType: 'image/jpeg',
+                        file:
+                          'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/814.jpg',
+                        dimensions: { height: 488, width: 814 },
+                        size: 47050,
+                        aspectRatio: '5:3'
+                      }
+                    ],
+                    master: {
+                      mimeType: 'image/jpeg',
+                      file:
+                        'https://media.guim.co.uk/d38bca368b0fa22d1a47923ac05fb4c6d20005a1/109_80_814_488/master/814.jpg',
+                      dimensions: { height: 488, width: 814 },
+                      size: 154564,
+                      aspectRatio: '5:3'
+                    },
+                    mediaId:
+                      'https://api.media.gutools.co.uk/images/d38bca368b0fa22d1a47923ac05fb4c6d20005a1',
+                    source: 'BBC'
+                  },
+                  optimisedForWeb: true
+                }
+              },
+              contentChangeDetails: {
+                lastModified: {
+                  date: 1547207897000,
+                  user: {
+                    email: 'andrew.halley@guardian.co.uk',
+                    firstName: 'Andrew',
+                    lastName: 'Halley'
+                  }
+                },
+                created: {
+                  date: 1547199831000,
+                  user: {
+                    email: 'gary.marshall.casual@guardian.co.uk',
+                    firstName: 'Gary',
+                    lastName: 'Marshall'
+                  }
+                },
+                published: {
+                  date: 1547205070000,
+                  user: {
+                    email: 'gary.marshall.casual@guardian.co.uk',
+                    firstName: 'Gary',
+                    lastName: 'Marshall'
+                  }
+                },
+                revision: 30
+              },
+              flags: { blockAds: true },
+              title: 'Fiona Bruce makes debut as Question Time host – video',
+              commissioningDesks: []
+            }
+          ]
+        },
+        isGone: false,
+        isHosted: false,
+        pillarId: 'pillar/news',
+        pillarName: 'News',
+        frontsMeta: {
+          defaults: {
+            isBreaking: false,
+            isBoosted: false,
+            showMainVideo: true,
+            imageHide: false,
+            showKickerCustom: false,
+            showByline: false,
+            showQuotedHeadline: false,
+            imageSlideshowReplace: false,
+            showKickerTag: false,
+            showLivePlayable: false,
+            imageReplace: false,
+            imageCutoutReplace: false,
+            showKickerSection: false,
+            showBoostedHeadline: false
+          },
+          tone: 'media'
+        },
+        urlPath:
+          'media/video/2019/jan/11/fiona-bruce-makes-debut-as-question-time-host-video'
+      }
+    },
+    pagination: null,
+    lastError: null,
+    error: null,
+    lastFetch: 1547474510279,
+    loading: false,
+    loadingIds: [],
+    updatingIds: []
+  }
+};
+
+const emptyFeedBundle = {
+  data: [],
+  pagination: null,
+  lastError: null,
+  error: null,
+  lastFetch: 1547474573228,
+  loading: false,
+  loadingIds: [],
+  updatingIds: []
+};
+
+const state = {
+  confirmModal: null,
+  fronts,
+  config,
+  error: '',
+  path: '/v2/editorial',
+  shared,
   unpublishedChanges: {},
   clipboard: ['56a3b407-741c-439f-a678-175abea44a9f'],
   editor: {
@@ -681,25 +696,13 @@ const state = {
   },
   staleFronts: {},
   form: {},
-  capiLiveFeed: {
-    data: [],
-    pagination: null,
-    lastError: null,
-    error: null,
-    lastFetch: 1547474573228,
-    loading: false,
-    loadingIds: [],
-    updatingIds: []
-  },
-  capiPreviewFeed: {
-    data: [],
-    pagination: null,
-    lastError: null,
-    error: null,
-    lastFetch: 1547474573363,
-    loading: false,
-    loadingIds: [],
-    updatingIds: []
+  feed: {
+    feedState: {
+      isPrefillMode: false
+    },
+    capiLiveFeed: emptyFeedBundle,
+    capiPreviewFeed: emptyFeedBundle,
+    prefillFeed: emptyFeedBundle
   },
   focus: { focusState: undefined },
   editionsIssue: {

--- a/client-v2/src/reducers/feedStateReducer.ts
+++ b/client-v2/src/reducers/feedStateReducer.ts
@@ -1,0 +1,25 @@
+import { Action } from 'types/Action';
+
+interface State {
+  isPrefillMode: boolean;
+}
+
+const feedState = (
+  state: State = {
+    isPrefillMode: false
+  },
+  action: Action
+) => {
+  switch (action.type) {
+    case 'FEED_STATE_IS_PREFILL_MODE': {
+      return {
+        isPrefillMode: action.payload.isPrefillMode
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default feedState;

--- a/client-v2/src/reducers/rootReducer.ts
+++ b/client-v2/src/reducers/rootReducer.ts
@@ -10,13 +10,18 @@ import clipboard from './clipboardReducer';
 import confirmModal from './confirmModalReducer';
 import editor from '../bundles/frontsUIBundle';
 import editionsIssue from '../bundles/editionsIssueBundle';
-import { capiLiveFeed, capiPreviewFeed } from '../bundles/capiFeedBundle';
+import {
+  capiLiveFeed,
+  capiPreviewFeed,
+  prefillFeed
+} from '../bundles/capiFeedBundle';
 import staleFronts from './staleFrontsReducer';
+import feedState from './feedStateReducer';
 
 import { reducer as focusReducer } from '../bundles/focusBundle';
 import { reducer as featureSwitchesReducer } from 'redux/modules/featureSwitches';
 
-const rootReducer = (state: any = {}, action: any) => ({
+const rootReducer = (state: any = { capi: {} }, action: any) => ({
   fronts: fronts(state.fronts, action),
   config: config(state.config, action),
   error: error(state.error, action),
@@ -28,8 +33,12 @@ const rootReducer = (state: any = {}, action: any) => ({
   staleFronts: staleFronts(state.staleFronts, action),
   form: form(state.form, action),
   confirmModal: confirmModal(state.confirmModal, action),
-  capiLiveFeed: capiLiveFeed(state.capiLiveFeed, action),
-  capiPreviewFeed: capiPreviewFeed(state.capiPreviewFeed, action),
+  capi: {
+    feedState: feedState(state.capi.feedState, action),
+    capiLiveFeed: capiLiveFeed(state.capi.capiLiveFeed, action),
+    capiPreviewFeed: capiPreviewFeed(state.capi.capiPreviewFeed, action),
+    prefillFeed: prefillFeed(state.capi.prefillFeed, action)
+  },
   focus: focusReducer(state.focus, action),
   editionsIssue: editionsIssue(state.editionsIssue, action),
   featureSwitches: featureSwitchesReducer(state.featureSwitches, action)

--- a/client-v2/src/reducers/rootReducer.ts
+++ b/client-v2/src/reducers/rootReducer.ts
@@ -21,7 +21,7 @@ import feedState from './feedStateReducer';
 import { reducer as focusReducer } from '../bundles/focusBundle';
 import { reducer as featureSwitchesReducer } from 'redux/modules/featureSwitches';
 
-const rootReducer = (state: any = { capi: {} }, action: any) => ({
+const rootReducer = (state: any = { feed: {} }, action: any) => ({
   fronts: fronts(state.fronts, action),
   config: config(state.config, action),
   error: error(state.error, action),
@@ -33,11 +33,11 @@ const rootReducer = (state: any = { capi: {} }, action: any) => ({
   staleFronts: staleFronts(state.staleFronts, action),
   form: form(state.form, action),
   confirmModal: confirmModal(state.confirmModal, action),
-  capi: {
-    feedState: feedState(state.capi.feedState, action),
-    capiLiveFeed: capiLiveFeed(state.capi.capiLiveFeed, action),
-    capiPreviewFeed: capiPreviewFeed(state.capi.capiPreviewFeed, action),
-    prefillFeed: prefillFeed(state.capi.prefillFeed, action)
+  feed: {
+    feedState: feedState(state.feed.feedState, action),
+    capiLiveFeed: capiLiveFeed(state.feed.capiLiveFeed, action),
+    capiPreviewFeed: capiPreviewFeed(state.feed.capiPreviewFeed, action),
+    prefillFeed: prefillFeed(state.feed.prefillFeed, action)
   },
   focus: focusReducer(state.focus, action),
   editionsIssue: editionsIssue(state.editionsIssue, action),

--- a/client-v2/src/selectors/feedStateSelectors.ts
+++ b/client-v2/src/selectors/feedStateSelectors.ts
@@ -1,4 +1,4 @@
 import { State } from 'types/State';
 
 export const selectIsPrefillMode = (state: State) =>
-  state.capi.feedState.isPrefillMode;
+  state.feed.feedState.isPrefillMode;

--- a/client-v2/src/selectors/feedStateSelectors.ts
+++ b/client-v2/src/selectors/feedStateSelectors.ts
@@ -1,0 +1,4 @@
+import { State } from 'types/State';
+
+export const selectIsPrefillMode = (state: State) =>
+  state.capi.feedState.isPrefillMode;

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -121,10 +121,8 @@ const selectFrontsWithPriority = (
 const getCollections = (state: State): CollectionConfigMap =>
   frontsConfigSelectors.selectAll(state).collections || {};
 
-const selectCollectionConfig = (
-  state: State,
-  id: string
-): CollectionConfig | null => getCollections(state)[id] || null;
+const selectCollectionConfig = (state: State, id: string): CollectionConfig =>
+  getCollections(state)[id];
 
 const selectCollectionHasPrefill = (state: State, id: string): boolean =>
   !!(selectCollectionConfig(state, id) || { prefill: undefined }).prefill;

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -121,8 +121,13 @@ const selectFrontsWithPriority = (
 const getCollections = (state: State): CollectionConfigMap =>
   frontsConfigSelectors.selectAll(state).collections || {};
 
-const selectCollectionConfig = (state: State, id: string): CollectionConfig =>
-  getCollections(state)[id] || null;
+const selectCollectionConfig = (
+  state: State,
+  id: string
+): CollectionConfig | null => getCollections(state)[id] || null;
+
+const selectCollectionHasPrefill = (state: State, id: string): boolean =>
+  !!(selectCollectionConfig(state, id) || { prefill: undefined }).prefill;
 
 const selectFrontsIds = createSelector(
   [selectFronts],
@@ -340,6 +345,7 @@ export {
   selectFront,
   selectFronts,
   selectCollectionConfig,
+  selectCollectionHasPrefill,
   selectFrontsConfig,
   selectCollectionConfigs,
   selectFrontsIds,

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -83,7 +83,7 @@ export const publishIssue = async (id: string): Promise<EditionsIssue> => {
 };
 
 export const getPrefills = async (
-  id: String
+  id: string
 ): Promise<CAPISearchQueryResponse> => {
   return pandaFetch(`/editions-api/collections/${id}/prefill`, {
     method: 'get',

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -1,6 +1,7 @@
 import { EditionsIssue } from 'types/Edition';
 import { Moment } from 'moment';
 import pandaFetch from './pandaFetch';
+import { CAPISearchQueryResponse } from './capiQuery';
 
 const dateFormat = 'YYYY-MM-DD';
 
@@ -79,4 +80,13 @@ export const publishIssue = async (id: string): Promise<EditionsIssue> => {
     // TODO publish endpoint returns a 204 No Content, we probably want something...
     return response.json();
   });
+};
+
+export const getPrefills = async (
+  id: String
+): Promise<CAPISearchQueryResponse> => {
+  return pandaFetch(`/editions-api/collections/${id}/prefill`, {
+    method: 'get',
+    credentials: 'same-origin'
+  }).then(response => response.json());
 };

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -125,7 +125,6 @@ const renderColouredQuotes = (
 
 const articleBodyDefault = React.memo(
   ({
-    newspaperEditionDate,
     firstPublicationDate,
     frontPublicationDate,
     scheduledPublicationDate,
@@ -174,7 +173,7 @@ const articleBodyDefault = React.memo(
                 {size === 'default' && <TextPlaceholder width={25} />}
               </>
             )}
-            {size === 'default' && (isLive || newspaperEditionDate) && (
+            {size === 'default' && isLive && (
               <CollectionItemMetaHeading>
                 {startCase(sectionName)}
               </CollectionItemMetaHeading>
@@ -182,7 +181,7 @@ const articleBodyDefault = React.memo(
             {type === 'liveblog' && (
               <CollectionItemMetaContent>Liveblog</CollectionItemMetaContent>
             )}
-            {!isLive && !newspaperEditionDate && !displayPlaceholders && (
+            {!isLive && !displayPlaceholders && (
               <NotLiveContainer>
                 {firstPublicationDate
                   ? notLiveLabels.takenDown

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -74,6 +74,7 @@ const ImageMetadataContainer = styled('div')`
 `;
 
 interface ArticleBodyProps {
+  newspaperEditionDate?: string;
   firstPublicationDate?: string;
   frontPublicationDate?: number;
   scheduledPublicationDate?: string;
@@ -124,6 +125,7 @@ const renderColouredQuotes = (
 
 const articleBodyDefault = React.memo(
   ({
+    newspaperEditionDate,
     firstPublicationDate,
     frontPublicationDate,
     scheduledPublicationDate,
@@ -172,7 +174,7 @@ const articleBodyDefault = React.memo(
                 {size === 'default' && <TextPlaceholder width={25} />}
               </>
             )}
-            {size === 'default' && isLive && (
+            {size === 'default' && (isLive || newspaperEditionDate) && (
               <CollectionItemMetaHeading>
                 {startCase(sectionName)}
               </CollectionItemMetaHeading>
@@ -180,7 +182,7 @@ const articleBodyDefault = React.memo(
             {type === 'liveblog' && (
               <CollectionItemMetaContent>Liveblog</CollectionItemMetaContent>
             )}
-            {!isLive && !displayPlaceholders && (
+            {!isLive && !newspaperEditionDate && !displayPlaceholders && (
               <NotLiveContainer>
                 {firstPublicationDate
                   ? notLiveLabels.takenDown

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -650,7 +650,8 @@ const stateWithCollection: any = {
         uuid: '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d'
       }
     }
-  }
+  },
+  feed: {}
 };
 
 const stateWithCollectionAndSupporting: any = {

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -272,6 +272,13 @@ interface EndConfirm {
   type: 'MODAL/END_CONFIRM';
 }
 
+interface IsPrefillMode {
+  type: 'FEED_STATE_IS_PREFILL_MODE';
+  payload: {
+    isPrefillMode: boolean;
+  };
+}
+
 type SetFocusState = ReturnType<typeof setFocusState>;
 type ResetFocusState = ReturnType<typeof resetFocusState>;
 
@@ -322,7 +329,8 @@ type Action =
   | EditorCloseCollection
   | SetFocusState
   | ResetFocusState
-  | ActionSetFeatureValue;
+  | ActionSetFeatureValue
+  | IsPrefillMode;
 
 export {
   ActionError,
@@ -369,5 +377,6 @@ export {
   EditorCloseAllOverviews,
   RecordStaleFronts,
   StartConfirm,
-  EndConfirm
+  EndConfirm,
+  IsPrefillMode
 };

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -98,6 +98,7 @@ interface CapiArticleFields {
   liveBloggingNow?: CapiBool;
   shortUrl?: string;
   membershipUrl?: string;
+  newspaperEditionDate?: string;
 }
 
 // See https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift#L1431

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -98,7 +98,6 @@ interface CapiArticleFields {
   liveBloggingNow?: CapiBool;
   shortUrl?: string;
   membershipUrl?: string;
-  newspaperEditionDate?: string;
 }
 
 // See https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift#L1431

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -1,9 +1,13 @@
 type EditionsArticle = any;
 
+interface EditionsPrefill {
+  queryString: string;
+}
+
 interface EditionsCollection {
   id: string;
   displayName: string;
-  prefill?: string;
+  prefill?: EditionsPrefill;
   isHidden: boolean;
   lastUpdated?: number;
   updatedBy?: string;
@@ -34,4 +38,10 @@ interface EditionsIssue {
   fronts: EditionsFront[];
 }
 
-export { EditionsIssue, EditionsFront, EditionsCollection, EditionsArticle };
+export {
+  EditionsIssue,
+  EditionsFront,
+  EditionsCollection,
+  EditionsArticle,
+  EditionsPrefill
+};

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -29,6 +29,10 @@ interface FrontsToolSettings {
   displayEditWarning?: boolean;
 }
 
+interface EditionsPrefill {
+  queryString: string;
+}
+
 interface CollectionConfigResponse {
   displayName: string;
   type: string;
@@ -48,6 +52,7 @@ interface CollectionConfigResponse {
   hideShowMore?: boolean;
   platform?: Platform;
   frontsToolSettings?: FrontsToolSettings;
+  prefill?: EditionsPrefill;
 }
 
 interface FrontsConfigResponse {

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -3,6 +3,7 @@ import {
   CollectionFromResponse,
   NestedArticleFragment
 } from 'shared/types/Collection';
+import { EditionsPrefill } from './Edition';
 
 interface FrontConfigResponse {
   collections: string[];
@@ -27,10 +28,6 @@ type Platform = 'Web' | 'Platform';
 
 interface FrontsToolSettings {
   displayEditWarning?: boolean;
-}
-
-interface EditionsPrefill {
-  queryString: string;
 }
 
 interface CollectionConfigResponse {

--- a/conf/routes
+++ b/conf/routes
@@ -101,12 +101,13 @@ GET         /v2/*path                                controllers.V2App.index(pat
 POST        /api/usage                               controllers.GridProxy.addUsage()
 
 # Editions
-GET         /editions-api/editions                       controllers.EditionsController.getAvailableEditions
-GET         /editions-api/editions/:name/issues          controllers.EditionsController.listIssues(name)
-POST        /editions-api/editions/:name/issues          controllers.EditionsController.postIssue(name)
-GET         /editions-api/issues/:id                     controllers.EditionsController.getIssue(id)
-GET         /editions-api/issues/:id/summary             controllers.EditionsController.getIssueSummary(id)
-POST        /editions-api/issues/:id/publish             controllers.EditionsController.publishIssue(id)
-GET         /editions-api/issues/:id/preview             controllers.EditionsController.getPreviewEdition(id)
-POST        /editions-api/collections                    controllers.EditionsController.getCollections
-PUT         /editions-api/collections/:collectionId      controllers.EditionsController.updateCollection(collectionId)
+GET         /editions-api/editions                               controllers.EditionsController.getAvailableEditions
+GET         /editions-api/editions/:name/issues                  controllers.EditionsController.listIssues(name)
+POST        /editions-api/editions/:name/issues                  controllers.EditionsController.postIssue(name)
+GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
+GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)
+POST        /editions-api/issues/:id/publish                     controllers.EditionsController.publishIssue(id)
+GET         /editions-api/issues/:id/preview                     controllers.EditionsController.getPreviewEdition(id)
+POST        /editions-api/collections                            controllers.EditionsController.getCollections
+PUT         /editions-api/collections/:collectionId              controllers.EditionsController.updateCollection(collectionId)
+GET         /editions-api/collections/:collectionId/prefill      controllers.EditionsController.getPrefillForCollection(collectionId)

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -2,6 +2,7 @@ package services
 
 import java.time.{LocalDate, ZonedDateTime}
 
+import com.gu.contentapi.client.model.v1.SearchResponse
 import org.scalatest.{FreeSpec, Matchers}
 import model.editions._
 import services.editions.EditionsTemplating
@@ -13,7 +14,7 @@ class editionTemplateTest extends FreeSpec with Matchers {
   // Currently not testing prefills!
   object TestCapi extends Capi {
     override def getPreviewHeaders(url: String): Seq[(String, String)] = Seq.empty[(String, String)]
-
+    override def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
     override def getPrefillArticlePageCodes(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[String]] = Future.successful(Nil)
   }
   val templating = new EditionsTemplating(TestCapi)


### PR DESCRIPTION
## What's changed?

Add the ability to fetch suggested articles from CAPI. This required quite a bit of reworking the feed component in the frontend so is a little large.

## How does this work?

When you're viewing a collection which has a prefill available you'll see a `Suggested Articles` button. Click it and the feed will be replaced with a list of articles which match the prefill query and aren't currently in the collection.

From here you can click/drag them in as before!

![image](https://user-images.githubusercontent.com/5560113/61814461-0fef6d00-ae40-11e9-9d46-c352b87057e7.png)

## Implementation notes

Some things I'm not mega happy with which would be good to discuss:
* Use of `newspaperEditionDate` as an alternative to `isLive` isn't very semantically clear.
* Rather clowny adding of `"{\"response\":" + json + "}" to work around the fact the CAPI client is slightly different to the actual HTTP response from CAPI.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
