### PR TITLE
Correct snap link rendering

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -151,7 +151,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 {...getNodeProps()}
                 onDelete={this.onDelete}
                 onClick={isUneditable ? undefined : () => onSelect(uuid)}
-                fade={!isSelected}
+                fade={isFaded}
                 size={size}
                 textSize={textSize}
                 showMeta={showMeta}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -153,6 +153,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 onClick={isUneditable ? undefined : () => onSelect(uuid)}
                 fade={!isSelected}
                 size={size}
+                textSize={textSize}
+                showMeta={showMeta}
               />
               <Sublinks
                 numSupportingArticles={numSupportingArticles}


### PR DESCRIPTION
## What's changed?

There were a few properties for snaplinks missed in #860, and snaps look a bit funny as a result. This PR adds them back.

Before:

<img width="219" alt="Screenshot 2019-07-25 at 14 38 25" src="https://user-images.githubusercontent.com/7767575/61878999-03bfea00-aeea-11e9-803d-79f903f4a077.png">

After:

<img width="218" alt="Screenshot 2019-07-25 at 14 39 23" src="https://user-images.githubusercontent.com/7767575/61879000-06224400-aeea-11e9-948b-62e7d4f866d2.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
