### PR TITLE
Disable image drag in clipboard

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -155,6 +155,7 @@ class Clipboard extends React.Component<ClipboardProps> {
                             frontId={clipboardId}
                             getNodeProps={getAfProps}
                             showMeta={false}
+                            canDragImage={false}
                             textSize="small"
                             onSelect={this.props.selectArticleFragment}
                             onDelete={() =>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -61,6 +61,7 @@ interface ContainerProps {
   isUneditable?: boolean;
   showMeta?: boolean;
   isSupporting?: boolean;
+  canDragImage?: boolean;
 }
 
 type ArticleContainerProps = ContainerProps & {
@@ -109,7 +110,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       clearArticleFragmentSelection,
       parentId,
       showMeta,
-      frontId
+      frontId,
+      canDragImage
     } = this.props;
 
     const getCard = () => {
@@ -129,6 +131,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
               showMeta={showMeta}
               imageDropTypes={imageDropTypes}
               onImageDrop={this.handleImageDrop}
+              canDragImage={canDragImage}
             >
               <Sublinks
                 numSupportingArticles={numSupportingArticles}

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -57,6 +57,7 @@ interface ArticleComponentProps {
   onAddToClipboard?: () => void;
   isUneditable?: boolean;
   showMeta?: boolean;
+  canDragImage?: boolean;
 }
 
 interface ContainerProps extends ArticleComponentProps {
@@ -109,7 +110,8 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
       isUneditable,
       imageDropTypes = [],
       onImageDrop,
-      showMeta
+      showMeta,
+      canDragImage
     } = this.props;
 
     const dragEventHasImageData = (e: React.DragEvent) =>
@@ -172,6 +174,7 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
                 onAddToClipboard={onAddToClipboard}
                 displayPlaceholders={isLoading}
                 showMeta={showMeta}
+                canDragImage={canDragImage}
               />
               <ImageDragIntentIndicator />
             </ArticleBodyContainer>

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -103,6 +103,7 @@ interface ArticleBodyProps {
   type?: string;
   showBoostedHeadline?: boolean;
   showMeta?: boolean;
+  canDragImage?: boolean;
 }
 
 const renderColouredQuotes = (
@@ -150,7 +151,8 @@ const articleBodyDefault = React.memo(
     type,
     uuid,
     showBoostedHeadline,
-    showMeta = true
+    showMeta = true,
+    canDragImage = true
   }: ArticleBodyProps) => {
     const ArticleHeadingContainer =
       size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
@@ -237,7 +239,7 @@ const articleBodyDefault = React.memo(
           (displayPlaceholders ? (
             <ThumbnailPlaceholder />
           ) : (
-            <DraggableArticleImageContainer id={uuid}>
+            <DraggableArticleImageContainer id={uuid} canDrag={canDragImage}>
               <ThumbnailSmall
                 style={{
                   backgroundImage: `url('${thumbnail}')`,

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -15,6 +15,7 @@ import { createSelectActiveImageUrl } from 'shared/selectors/collectionItem';
 
 interface ContainerProps {
   id: string;
+  canDrag?: boolean;
 }
 
 interface ComponentProps extends ContainerProps {
@@ -76,11 +77,11 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
 
 const mapStateToProps = () => {
   const selectActiveImageUrl = createSelectActiveImageUrl();
-  return (state: State, { id }: ContainerProps) => {
+  return (state: State, { id, canDrag = true }: ContainerProps) => {
     const activeImageUrl = selectActiveImageUrl(selectSharedState(state), id);
     return {
       activeImageUrl,
-      canDrag: !!activeImageUrl,
+      canDrag: !!activeImageUrl && canDrag,
       hasImageOverrides: selectCollectionItemHasMediaOverrides(
         selectSharedState(state),
         id


### PR DESCRIPTION
## What's changed?

Does what it says on the tin! Users are making mistakes dragging the image part of a card into a collection, and then replacing an image by accident instead of dragging the article body itself. Better image drag messaging may improve this behaviour, but until then we are disabling image dragging on the clip, as re: discussions with Mariana this is an unusual interaction anyway.


## Implementation details

Because only the rendering context understands whether the card is being rendering in a collection or clipboard context, we have to thread these props through a few components. I can't think of a better way to do this, but I'm definitely open to suggestions!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
