### PR TITLE
DRAG AND DROP: Make image dragging more obvious 

### DIFF
--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -1,38 +1,33 @@
-import { styled } from 'shared/constants/theme';
-import { theme as theme2 } from 'constants/theme';
+import { theme, styled } from 'constants/theme';
 
 const ThumbnailBase = styled('div')`
   background-size: cover;
-  background-color: ${({ theme }) =>
-    theme.shared.base.colors.backgroundColorFocused};
+  background-color: ${theme.shared.base.colors.backgroundColorFocused};
 `;
 
 const ThumbnailSmall = styled(ThumbnailBase)<{
-  url?: string;
+  url?: string | void;
   isDraggingImageOver?: boolean;
   imageHide?: boolean;
 }>`
   position: relative;
-  width: 83px;
-  min-width: ${theme2.shared.thumbnailImage.width};
-  height: ${theme2.shared.thumbnailImage.height};
+  width: ${theme.shared.thumbnailImage.width};
+  min-width: ${theme.shared.thumbnailImage.width};
+  height: ${theme.shared.thumbnailImage.height};
   color: white;
   font-size: 10px;
   font-weight: bold;
-  opacity: ${({imageHide}) => imageHide && imageHide ? '0.5' : '1'};
-  ${({ isDraggingImageOver, url }) =>
-    isDraggingImageOver 
-    ?
-      `background: ${theme2.base.colors.dropZoneActiveStory};
+  opacity: ${({ imageHide }) => (imageHide && imageHide ? '0.5' : '1')};
+  background-image: ${({ url }) => `url('${url}')`};
+  ${({ isDraggingImageOver }) =>
+    isDraggingImageOver &&
+    `background: ${theme.base.colors.dropZoneActiveStory};
       :before {
         content: 'Replace image';
         position: absolute;
         top: 18px;
         left: 9px;
-      }`
-    :
-      `background-image: url('${url}');`
-  };
+      }`};
 `;
 
 const ThumbnailCutout = styled('img')<{

--- a/client-v2/src/shared/components/Thumbnail.tsx
+++ b/client-v2/src/shared/components/Thumbnail.tsx
@@ -1,4 +1,5 @@
 import { styled } from 'shared/constants/theme';
+import { theme as theme2 } from 'constants/theme';
 
 const ThumbnailBase = styled('div')`
   background-size: cover;
@@ -6,11 +7,32 @@ const ThumbnailBase = styled('div')`
     theme.shared.base.colors.backgroundColorFocused};
 `;
 
-const ThumbnailSmall = styled(ThumbnailBase)`
+const ThumbnailSmall = styled(ThumbnailBase)<{
+  url?: string;
+  isDraggingImageOver?: boolean;
+  imageHide?: boolean;
+}>`
   position: relative;
   width: 83px;
-  min-width: 83px;
-  height: 50px;
+  min-width: ${theme2.shared.thumbnailImage.width};
+  height: ${theme2.shared.thumbnailImage.height};
+  color: white;
+  font-size: 10px;
+  font-weight: bold;
+  opacity: ${({imageHide}) => imageHide && imageHide ? '0.5' : '1'};
+  ${({ isDraggingImageOver, url }) =>
+    isDraggingImageOver 
+    ?
+      `background: ${theme2.base.colors.dropZoneActiveStory};
+      :before {
+        content: 'Replace image';
+        position: absolute;
+        top: 18px;
+        left: 9px;
+      }`
+    :
+      `background-image: url('${url}');`
+  };
 `;
 
 const ThumbnailCutout = styled('img')<{

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -18,7 +18,6 @@ import ArticleBody from './ArticleBody';
 import { CollectionItemSizes } from 'shared/types/Collection';
 import { getPillarColor } from 'shared/util/getPillarColor';
 import DragIntentContainer from '../DragIntentContainer';
-import ImageDragIntentIndicator from '../ImageDragIntentIndicator';
 
 const ArticleBodyContainer = styled(CollectionItemBody)<{
   pillarId: string | undefined;
@@ -36,10 +35,6 @@ const ArticleBodyContainer = styled(CollectionItemBody)<{
     ${CollectionItemMetaHeading} {
       color: ${({ theme }) => theme.shared.base.colors.textMuted};
     }
-  }
-  ${ImageDragIntentIndicator} {
-    display: none;
-    ${({ isDraggingImageOver }) => isDraggingImageOver && `display: block;`}
   }
   height: 100%;
 `;
@@ -175,8 +170,8 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
                 displayPlaceholders={isLoading}
                 showMeta={showMeta}
                 canDragImage={canDragImage}
+                isDraggingImageOver={this.state.isDraggingImageOver}
               />
-              <ImageDragIntentIndicator />
             </ArticleBodyContainer>
           </DragIntentContainer>
           {children}

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -103,11 +103,8 @@ interface ArticleBodyProps {
   type?: string;
   showBoostedHeadline?: boolean;
   showMeta?: boolean;
-<<<<<<< HEAD
   canDragImage?: boolean;
-=======
   isDraggingImageOver: boolean;
->>>>>>> Amend image dragging
 }
 
 const renderColouredQuotes = (
@@ -156,11 +153,8 @@ const articleBodyDefault = React.memo(
     uuid,
     showBoostedHeadline,
     showMeta = true,
-<<<<<<< HEAD
-    canDragImage = true
-=======
+    canDragImage = true,
     isDraggingImageOver
->>>>>>> Amend image dragging
   }: ArticleBodyProps) => {
     const ArticleHeadingContainer =
       size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -103,7 +103,11 @@ interface ArticleBodyProps {
   type?: string;
   showBoostedHeadline?: boolean;
   showMeta?: boolean;
+<<<<<<< HEAD
   canDragImage?: boolean;
+=======
+  isDraggingImageOver: boolean;
+>>>>>>> Amend image dragging
 }
 
 const renderColouredQuotes = (
@@ -152,7 +156,11 @@ const articleBodyDefault = React.memo(
     uuid,
     showBoostedHeadline,
     showMeta = true,
+<<<<<<< HEAD
     canDragImage = true
+=======
+    isDraggingImageOver
+>>>>>>> Amend image dragging
   }: ArticleBodyProps) => {
     const ArticleHeadingContainer =
       size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
@@ -241,10 +249,9 @@ const articleBodyDefault = React.memo(
           ) : (
             <DraggableArticleImageContainer id={uuid} canDrag={canDragImage}>
               <ThumbnailSmall
-                style={{
-                  backgroundImage: `url('${thumbnail}')`,
-                  opacity: imageHide ? 0.5 : 1
-                }}
+                imageHide={imageHide}
+                url={thumbnail}
+                isDraggingImageOver={isDraggingImageOver}
               >
                 {cutoutThumbnail ? (
                   <ThumbnailCutout src={cutoutThumbnail} />

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -6,7 +6,6 @@ import {
   selectSharedState,
   selectCollectionItemHasMediaOverrides
 } from 'shared/selectors/shared';
-import imageDragIcon from 'images/icons/image-drag-icon.svg';
 import {
   DRAG_DATA_COLLECTION_ITEM_IMAGE_OVERRIDE,
   DRAG_DATA_GRID_IMAGE_URL
@@ -35,13 +34,20 @@ const DragIntentContainer = styled.div<{
   }`};
 `;
 
-const dragImage = new Image();
-dragImage.src = imageDragIcon;
+// The visual representation of an image as it is being dragged.
+// This needs to be rendered by the DOM before it can be used by the Drag&Drop API, so we pushed it off to the side.
+const DraggingImageContainer = styled('div')`
+  position: absolute;
+  transform: translateX(-9999px);
+`;
 
 class DraggableArticleImageContainer extends React.Component<ComponentProps> {
+  private dragNode: React.RefObject<HTMLDivElement>;
   constructor(props: ComponentProps) {
     super(props);
+    this.dragNode = React.createRef();
   }
+
   public render() {
     const { children } = this.props;
     return (
@@ -51,6 +57,9 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
         canDrag={this.props.canDrag}
         title="Drag this media to add it to other articles"
       >
+        <DraggingImageContainer innerRef={this.dragNode}>
+          <img width="83px" height="50px" src={this.props.activeImageUrl} />
+        </DraggingImageContainer>
         {children}
       </DragIntentContainer>
     );
@@ -70,7 +79,10 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
         this.props.activeImageUrl
       );
     }
-    e.dataTransfer.setDragImage(dragImage, -25, 50);
+    if (this.dragNode.current) {
+      e.dataTransfer.setDragImage(this.dragNode.current, -25, 50);
+    }
+
     this.setState({ isDragging: true });
   };
 }

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -11,6 +11,7 @@ import {
   DRAG_DATA_GRID_IMAGE_URL
 } from 'constants/image';
 import { createSelectActiveImageUrl } from 'shared/selectors/collectionItem';
+import { theme } from 'constants/theme';
 
 interface ContainerProps {
   id: string;
@@ -58,7 +59,7 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
         title="Drag this media to add it to other articles"
       >
         <DraggingImageContainer innerRef={this.dragNode}>
-          <img width="83px" height="50px" src={this.props.activeImageUrl} />
+          <img width={theme.shared.thumbnailImage.width} height={theme.shared.thumbnailImage.height} src={this.props.activeImageUrl} />
         </DraggingImageContainer>
         {children}
       </DragIntentContainer>

--- a/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
+++ b/client-v2/src/shared/components/article/DraggableArticleImageContainer.tsx
@@ -4,13 +4,13 @@ import { connect } from 'react-redux';
 import { State } from 'types/State';
 import {
   selectSharedState,
-  selectCollectionItemHasMediaOverrides
+  selectCollectionItemHasMediaOverrides,
+  createSelectArticleFromArticleFragment
 } from 'shared/selectors/shared';
 import {
   DRAG_DATA_COLLECTION_ITEM_IMAGE_OVERRIDE,
   DRAG_DATA_GRID_IMAGE_URL
 } from 'constants/image';
-import { createSelectActiveImageUrl } from 'shared/selectors/collectionItem';
 import { theme } from 'constants/theme';
 
 interface ContainerProps {
@@ -20,7 +20,7 @@ interface ContainerProps {
 
 interface ComponentProps extends ContainerProps {
   canDrag: boolean;
-  activeImageUrl: string | undefined;
+  currentImageUrl: string | undefined;
   hasImageOverrides: boolean;
 }
 
@@ -59,7 +59,11 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
         title="Drag this media to add it to other articles"
       >
         <DraggingImageContainer innerRef={this.dragNode}>
-          <img width={theme.shared.thumbnailImage.width} height={theme.shared.thumbnailImage.height} src={this.props.activeImageUrl} />
+          <img
+            width={theme.shared.thumbnailImage.width}
+            height={theme.shared.thumbnailImage.height}
+            src={this.props.currentImageUrl}
+          />
         </DraggingImageContainer>
         {children}
       </DragIntentContainer>
@@ -74,10 +78,10 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
         this.props.id
       );
     }
-    if (this.props.activeImageUrl) {
+    if (this.props.currentImageUrl) {
       e.dataTransfer.setData(
         DRAG_DATA_GRID_IMAGE_URL,
-        this.props.activeImageUrl
+        this.props.currentImageUrl
       );
     }
     if (this.dragNode.current) {
@@ -89,12 +93,14 @@ class DraggableArticleImageContainer extends React.Component<ComponentProps> {
 }
 
 const mapStateToProps = () => {
-  const selectActiveImageUrl = createSelectActiveImageUrl();
+  const selectArticle = createSelectArticleFromArticleFragment();
+
   return (state: State, { id, canDrag = true }: ContainerProps) => {
-    const activeImageUrl = selectActiveImageUrl(selectSharedState(state), id);
+    const article = selectArticle(selectSharedState(state), id);
+
     return {
-      activeImageUrl,
-      canDrag: !!activeImageUrl && canDrag,
+      currentImageUrl: article && article.thumbnail,
+      canDrag: article ? !!article.thumbnail && canDrag : false,
       hasImageOverrides: selectCollectionItemHasMediaOverrides(
         selectSharedState(state),
         id

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -100,6 +100,11 @@ const collectionItem = {
   backgroundHover: colors.whiteMedium
 };
 
+const thumbnailImage = {
+  width: '83px',
+  height: '50px'
+}
+
 export const theme = {
   colors,
   base,
@@ -107,7 +112,8 @@ export const theme = {
   input,
   label,
   collectionItem,
-  collection
+  collection,
+  thumbnailImage
 };
 
 export type Theme = typeof theme;

--- a/client-v2/src/shared/selectors/collectionItem.ts
+++ b/client-v2/src/shared/selectors/collectionItem.ts
@@ -17,33 +17,6 @@ const createSelectCollectionItemType = () =>
     }
   );
 
-const createSelectActiveImageUrl = () =>
-  createSelector(
-    selectArticleFragment,
-    selectExternalArticleFromArticleFragment,
-    (articleFragment, externalArticle): string | undefined => {
-      if (!articleFragment || !articleFragment.meta) {
-        return;
-      }
-      if (articleFragment.meta.imageReplace) {
-        return articleFragment.meta.imageSrcOrigin;
-      }
-      if (articleFragment.meta.imageCutoutReplace) {
-        return articleFragment.meta.imageCutoutSrcOrigin;
-      }
-      if (articleFragment.meta.imageSlideshowReplace) {
-        return (
-          articleFragment.meta.slideshow &&
-          articleFragment.meta.slideshow[0] &&
-          articleFragment.meta.slideshow[0].origin
-        );
-      }
-      return externalArticle && externalArticle.fields.thumbnail
-        ? externalArticle.fields.thumbnail
-        : undefined;
-    }
-  );
-
 const createSelectCutoutUrl = () =>
   createSelector(
     selectExternalArticleFromArticleFragment,
@@ -52,8 +25,4 @@ const createSelectCutoutUrl = () =>
     }
   );
 
-export {
-  createSelectCollectionItemType,
-  createSelectActiveImageUrl,
-  createSelectCutoutUrl
-};
+export { createSelectCollectionItemType, createSelectCutoutUrl };


### PR DESCRIPTION
## What's changed?

When dragging and dropping images - it was not always obvious on the UI where the new image was being dropped. 

Occasionally this led to pictures getting put in weird places. 

This PR does not change the functionality of image drag and drop but just makes the visual feedback clearer. 

BEFORE 
<img width="679" alt="Screenshot 2019-07-26 at 11 21 04" src="https://user-images.githubusercontent.com/10324129/61945335-99658300-af97-11e9-87c9-38d0bc9c5417.png">


AFTER 
<img width="746" alt="Screenshot 2019-07-26 at 11 25 47" src="https://user-images.githubusercontent.com/10324129/61945553-30323f80-af98-11e9-85e4-0137d9ae3e98.png">



## Implementation notes

Because there were 2 different ways of getting thumbnail image from state, I have deleted one. One using the general article and a specific selector for activeImageUrl. 

We have opted to always go for the general article one. And have deleted the other selector

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
