### PR TITLE
Trust client timestamp and retrofit collection DB tests

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -75,7 +75,7 @@ class EditionsController(db: EditionsDB,
   def updateCollection(collectionId: String) = AccessAPIAuthAction(parse.json[EditionsFrontendCollectionWrapper]) { req =>
     val form = req.body
     val collectionToUpdate = EditionsFrontendCollectionWrapper.toCollection(form)
-    val updatedCollection = db.updateCollection(collectionToUpdate)
+    val updatedCollection = db.updateCollection(collectionToUpdate, OffsetDateTime.now())
     for {
       issueId <- db.getIssueIdFromCollectionId(updatedCollection.id)
       issue <- db.getIssue(issueId)
@@ -94,7 +94,7 @@ class EditionsController(db: EditionsDB,
 
   def publishIssue(id: String) = AccessAPIAuthAction { req =>
     db.getIssue(id).map { issue =>
-      publishing.publish(issue, req.user)
+      publishing.publish(issue, req.user, OffsetDateTime.now())
       NoContent
     }.getOrElse(NotFound(s"Issue $id not found"))
   }

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -75,7 +75,7 @@ class EditionsController(db: EditionsDB,
   def updateCollection(collectionId: String) = AccessAPIAuthAction(parse.json[EditionsFrontendCollectionWrapper]) { req =>
     val form = req.body
     val collectionToUpdate = EditionsFrontendCollectionWrapper.toCollection(form)
-    val updatedCollection = db.updateCollection(collectionToUpdate, OffsetDateTime.now())
+    val updatedCollection = db.updateCollection(collectionToUpdate)
     for {
       issueId <- db.getIssueIdFromCollectionId(updatedCollection.id)
       issue <- db.getIssue(issueId)

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -67,7 +67,7 @@ trait CollectionsQueries {
     val updatedCollections = convertRowsToCollections(rows)
 
     // we have filtered on a single id so this list should only contain one collection
-    assert(updatedCollections.size == 1)
+    assert(updatedCollections.size == 1, s"Retrieved ${updatedCollections.size} collections from DB but there should be exactly one. Failing fast.")
 
     updatedCollections.head
   }

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -33,13 +33,12 @@ trait CollectionsQueries {
     convertRowsToCollections(rows)
   }
 
-  def updateCollection(collection: EditionsCollection, now: OffsetDateTime): EditionsCollection  = DB localTx { implicit session =>
-    // always truncate any date times going into the DB to millis
-    val truncatedNow = EditionsDB.truncateDateTime(now)
+  def updateCollection(collection: EditionsCollection): EditionsCollection  = DB localTx { implicit session =>
+    val lastUpdated = collection.lastUpdated.map(EditionsDB.dateTimeFromMillis)
     sql"""
       UPDATE collections
       SET is_hidden = ${collection.isHidden},
-          updated_on = $truncatedNow,
+          updated_on = $lastUpdated,
           updated_by = ${collection.updatedBy},
           updated_email = ${collection.updatedEmail}
       WHERE id = ${collection.id}

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -1,5 +1,8 @@
 package services.editions.db
 
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+
 import scalikejdbc._
 
 class EditionsDB(url: String, user: String, password: String) extends IssueQueries with CollectionsQueries {
@@ -7,3 +10,6 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
   ConnectionPool.singleton(url, user, password)
 }
 
+object EditionsDB {
+  def truncateDateTime(odt: OffsetDateTime): OffsetDateTime = odt.truncatedTo(ChronoUnit.MILLIS)
+}

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -1,6 +1,6 @@
 package services.editions.db
 
-import java.time.OffsetDateTime
+import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.time.temporal.ChronoUnit
 
 import scalikejdbc._
@@ -11,5 +11,6 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
 }
 
 object EditionsDB {
+  def dateTimeFromMillis(millis: Long): OffsetDateTime = Instant.ofEpochMilli(millis).atOffset(ZoneOffset.UTC)
   def truncateDateTime(odt: OffsetDateTime): OffsetDateTime = odt.truncatedTo(ChronoUnit.MILLIS)
 }

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -1,5 +1,7 @@
 package services.editions.publishing
 
+import java.time.OffsetDateTime
+
 import com.gu.pandomainauth.model.User
 import model.editions.EditionsIssue
 import services.editions.db.EditionsDB
@@ -11,14 +13,14 @@ class EditionsPublishing(publishedBucket: PublishedIssuesBucket, previewBucket: 
     previewBucket.putIssue(previewIssue)
   }
 
-  def publish(issue: EditionsIssue, user: User) = {
+  def publish(issue: EditionsIssue, user: User, now: OffsetDateTime) = {
     val publishedIssue = issue.toPublishedIssue
 
     // Archive a copy
     publishedBucket.putIssue(publishedIssue)
 
     // Bump the recently published counters
-    db.publishIssue(issue.id, user)
+    db.publishIssue(issue.id, user, now)
 
     // Push new version to API
     // TODO invoke publish lambda

--- a/build.sbt
+++ b/build.sbt
@@ -138,9 +138,19 @@ lazy val root = (project in file("."))
     )
     .settings(inConfig(UsesDatabaseTest)(Defaults.testTasks): _*)
     .settings(testOptions in UsesDatabaseTest := Seq(
-        Tests.Argument(TestFrameworks.ScalaTest, "-n","fixtures.UsesDatabase"))
-    )
+        Tests.Argument(TestFrameworks.ScalaTest,
+            // only include tests with this tag
+            "-n", "fixtures.UsesDatabase",
+            // show full stack traces when an exception is thrown
+            "-oF"
+        )
+    ))
     // We exclude in other tests
     .settings(testOptions in Test := Seq(
-        Tests.Argument(TestFrameworks.ScalaTest, "-l", "fixtures.UsesDatabase"))
-    )
+        Tests.Argument(TestFrameworks.ScalaTest, 
+            // exclude tests tagged with UsesDatabase
+            "-l", "fixtures.UsesDatabase",
+            // show full stack traces when an exception is thrown
+            "-oF"
+        )
+    ))

--- a/test/fixtures/EditionsDBService.scala
+++ b/test/fixtures/EditionsDBService.scala
@@ -2,13 +2,13 @@ package fixtures
 
 import com.whisk.docker.impl.dockerjava.DockerKitDockerJava
 import com.whisk.docker.scalatest.DockerTestKit
-import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
 import play.api.db.{Database, Databases}
 import play.api.db.evolutions.Evolutions
 import services.editions.db.EditionsDB
 
 trait EditionsDBService extends DockerTestKit with DockerKitDockerJava with DockerPostgresService
-  with BeforeAndAfterAll { self: Suite =>
+  with BeforeAndAfterAll with BeforeAndAfter { self: Suite =>
 
   var editionsDB: EditionsDB = _
   var database: Database = _
@@ -24,5 +24,11 @@ trait EditionsDBService extends DockerTestKit with DockerKitDockerJava with Dock
     editionsDB = new EditionsDB(dbUrl, dbUser, dbPassword)
   }
 
-  def withEvolutions[T]: (=> T) => T = Evolutions.withEvolutions[T](database)
+  before {
+    Evolutions.applyEvolutions(database)
+  }
+
+  after {
+    Evolutions.cleanupEvolutions(database)
+  }
 }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -237,7 +237,11 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       updatedBrexshit.lastUpdated.value shouldBe futureMillis
 
       // check we are storing some metadata
+      updatedBrexshit.items.find(_.pageCode == "654789").value.addedOn shouldBe future.toInstant.toEpochMilli
       updatedBrexshit.items.find(_.pageCode == "654789").value.metadata.value shouldBe simpleMetadata
+
+      // check that the added time hasn't modified
+      updatedBrexshit.items.find(_.pageCode == "76543").value.addedOn shouldBe now.toInstant.toEpochMilli
     }
 
   }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -224,7 +224,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
         items = items
       )
 
-      editionsDB.updateCollection(evenMoreBrexshit, future)
+      editionsDB.updateCollection(evenMoreBrexshit)
 
       val collections = editionsDB.getCollections(List(GetCollectionsFilter(brexshit.id, None)))
       collections.size shouldBe 1


### PR DESCRIPTION
## What's changed?

This fixes the issue that we were seeing where the following message was being seen when editing content. It typically occurred when inside an edit form when the next poll of colleciton updates were done.

![unnamed](https://user-images.githubusercontent.com/1236466/61896426-e0f2fd00-af0c-11e9-9fe0-dee3a27fd62f.png)

The fix has been to trust the clients timestamp and use that in the database rather than the server timestamp. This is a bit of a kludge but any other fix requires a significant overhaul of various bits of the frontend and the introduction of article level ids on the backend.

I highly recommend reviewing this using the individual commits - the actual fix is in the last commit.

## Implementation notes

The original fix was to ensure that the endpoint returned the updated collection read back from the DB (rather than parrot back the one sent by the client). This has been left in as the 'right' behaviour even though we don't rely on it.

Whilst implementing this I have simplified the way with deal with timestamps. We now use millisecond resolution timestamps when saving to the database. Timestamps coming from the client use this resolution anyway but when the server is creating a timestamp this might be an nanosecond resolution. At all points where we having incoming timestamps into a DB endpoint they must be truncated to millis so that queries make sense. This has allowed the rounding logic to be safely removed.

Additionally this adds tests for more of the database interface to increase coverage to the area I've touched in this PR.

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
