### PR TITLE
Styling and persistence for inline form

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -103,7 +103,9 @@ const SlideshowLabel = styled('div')`
   margin-bottom: 12px;
 `;
 
-const ImageWrapper = styled('div')`
+const ImageCol = styled(Col)`
+  flex: initial;
+  flex-shrink: 0;
   transition: opacity 0.15s;
   opacity: ${(props: { faded: boolean }) => (props.faded ? 0.6 : 1)};
 `;
@@ -121,10 +123,15 @@ const FieldsContainerWrap = styled(Row)`
     ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
+const SlideshowCol = styled(Col)`
+  max-width: 100px;
+  min-width: 0;
+`;
+
 const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
   <>
     {fields.map((name, index) => (
-      <Col key={`${name}-${index}`}>
+      <SlideshowCol key={`${name}-${index}`}>
         <Field
           name={name}
           component={InputImage}
@@ -132,7 +139,7 @@ const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
           criteria={imageCriteria}
           frontId={frontId}
         />
-      </Col>
+      </SlideshowCol>
     ))}
   </>
 );
@@ -159,8 +166,7 @@ const CheckboxFieldsContainer: React.SFC<{
 };
 
 const FieldContainer = styled(Col)<{ isClipboard: boolean }>`
-  flex-basis: calc(100% / 3);
-  max-width: calc(100% / 3);
+  flex-basis: calc(100% / 4);
   min-width: ${({ isClipboard }) => (isClipboard ? '180px' : '125px')}
     /* Prevents labels breaking across lines */;
   margin-bottom: 8px;
@@ -273,8 +279,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       );
     };
 
-    // only one of the image fields can be set to true at any time.
-
     const hasKickerSuggestions = !!(
       kickerOptions.webTitle || kickerOptions.sectionName
     );
@@ -314,7 +318,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               label="Kicker"
               component={InputText}
               placeholder="Add custom kicker"
-              useHeadlineFont
               format={value => {
                 if (showKickerTag) {
                   return kickerOptions.webTitle;
@@ -340,7 +343,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 label="Headline"
                 placeholder={articleCapiFieldValues.headline}
                 component={InputTextArea}
-                useHeadlineFont
                 rows="2"
                 originalValue={articleCapiFieldValues.headline}
                 data-testid="edit-form-headline-field"
@@ -424,26 +426,24 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           </InputGroup>
           <RowContainer>
             <Row flexDirection={isClipboard ? 'column' : 'row'}>
-              <Col>
-                <ImageWrapper faded={imageHide}>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name={this.getImageFieldName()}
-                    component={InputImage}
-                    disabled={imageHide}
-                    criteria={imageCriteria}
-                    frontId={frontId}
-                    defaultImageUrl={
-                      imageCutoutReplace
-                        ? cutoutImage
-                        : articleCapiFieldValues.thumbnail
-                    }
-                    useDefault={!imageCutoutReplace && !imageReplace}
-                    message={imageCutoutReplace ? 'Add cutout' : 'Add image'}
-                    onChange={this.handleImageChange}
-                  />
-                </ImageWrapper>
-              </Col>
+              <ImageCol faded={imageHide}>
+                <ConditionalField
+                  permittedFields={editableFields}
+                  name={this.getImageFieldName()}
+                  component={InputImage}
+                  disabled={imageHide}
+                  criteria={imageCriteria}
+                  frontId={frontId}
+                  defaultImageUrl={
+                    imageCutoutReplace
+                      ? cutoutImage
+                      : articleCapiFieldValues.thumbnail
+                  }
+                  useDefault={!imageCutoutReplace && !imageReplace}
+                  message={imageCutoutReplace ? 'Add cutout' : 'Add image'}
+                  onChange={this.handleImageChange}
+                />
+              </ImageCol>
               <Col flex={2}>
                 <InputGroup>
                   <ConditionalField
@@ -481,6 +481,19 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     onChange={_ => this.changeImageField('imageCutoutReplace')}
                   />
                 </InputGroup>
+                <InputGroup>
+                  <ConditionalField
+                    permittedFields={editableFields}
+                    name="imageSlideshowReplace"
+                    component={InputCheckboxToggleInline}
+                    label="Slideshow"
+                    id={getInputId(articleFragmentId, 'slideshow')}
+                    type="checkbox"
+                    onChange={_ =>
+                      this.changeImageField('imageSlideshowReplace')
+                    }
+                  />
+                </InputGroup>
               </Col>
             </Row>
             <ConditionalComponent
@@ -488,17 +501,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               name={['primaryImage', 'imageHide']}
             />
           </RowContainer>
-          <InputGroup>
-            <ConditionalField
-              permittedFields={editableFields}
-              name="imageSlideshowReplace"
-              component={InputCheckboxToggleInline}
-              label="Slideshow"
-              id={getInputId(articleFragmentId, 'slideshow')}
-              type="checkbox"
-              onChange={_ => this.changeImageField('imageSlideshowReplace')}
-            />
-          </InputGroup>
           {imageSlideshowReplace && (
             <RowContainer>
               <SlideshowRow>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -39,7 +39,7 @@ import {
 } from 'bundles/frontsUIBundle';
 import { bindActionCreators } from 'redux';
 import ArticleFragmentFormInline from '../ArticleFragmentFormInline';
-import { updateArticleFragmentMeta as updateArticleFragmentMetaAction } from 'shared/actions/ArticleFragments';
+import { updateArticleFragmentMeta as updateArticleFragmentMetaAction } from 'actions/ArticleFragments';
 import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
 
 const imageDropTypes = [

--- a/client-v2/src/shared/components/input/InputCheckboxToggleInline.tsx
+++ b/client-v2/src/shared/components/input/InputCheckboxToggleInline.tsx
@@ -4,14 +4,13 @@ import { WrappedFieldMetaProps, WrappedFieldInputProps } from 'redux-form';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
-import HorizontalRule from '../layout/HorizontalRule';
 
 const checkboxHeight = 17;
 const checkboxWidth = 28;
 
 const CheckboxContainer = styled('div')`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 `;
 
 const Label = InputLabel.extend`
@@ -53,7 +52,7 @@ const CheckboxLabel = styled('label')`
     position: absolute;
     top: 0;
     bottom: 0;
-    right: 10px;
+    right: 11px;
     border: ${({ theme }) =>
       `2px solid ${theme.shared.input.checkboxBorderColor}`};
     border-radius: ${checkboxHeight}px;
@@ -107,6 +106,5 @@ export default ({
         </Label>
       </CheckboxContainer>
     </InputContainer>
-    <HorizontalRule />
   </>
 );

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -30,8 +30,12 @@ const ImageContainer = styled('div')<{
   flex-direction: column;
   position: relative;
   width: 100%;
-  max-width: ${props => (props.small ? '100px' : '180px')};
-  height: ${props => (props.small ? '50px' : '115px')};
+  max-width: ${props => !props.small && '180px'};
+  ${({ small }) =>
+    small &&
+    `min-width: 50px;
+    padding: 40%;`}
+  height: ${props => (props.small ? '0' : '115px')};
   transition: background-color 0.15s;
 `;
 
@@ -51,7 +55,14 @@ const AddImageButton = styled(ButtonDefault)<{ small?: boolean }>`
   text-shadow: 0 0 2px black;
 `;
 
-const ImageComponent = styled.div`
+const ImageComponent = styled.div<{ small: boolean }>`
+  ${({ small }) =>
+    small &&
+    `position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;`}
   background-size: cover;
   flex-grow: 1;
   cursor: grab;
@@ -187,6 +198,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
               draggable
               onDragStart={this.handleDragStart}
               onDrop={this.handleDrop}
+              small={small}
             >
               {hasImage ? (
                 <ButtonDelete

--- a/client-v2/src/shared/components/layout/HideableFormSection.tsx
+++ b/client-v2/src/shared/components/layout/HideableFormSection.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from 'react';
 import { DownCaretIcon } from '../icons/Icons';
-import { styled, theme } from 'shared/constants/theme';
+import { styled } from 'shared/constants/theme';
 import InputLabel from '../input/InputLabel';
 
 interface Props {
   label: string;
 }
 
-const HideableFormSectionContainer = styled.div`
-  border-bottom: 1px solid ${theme.base.colors.borderColor};
-`;
+const HideableFormSectionContainer = styled.div``;
 
 const FormSectionHeader = styled.div`
   padding-top: 6px;
@@ -23,7 +21,7 @@ const CaretContainer = styled.span<{ isOpen: boolean }>`
   vertical-align: middle;
   transition: transform 0.15s;
   ${({ isOpen }) =>
-    isOpen ? `transform: rotate(90deg)` : `transform: rotate(-90deg)`};
+    isOpen ? `transform: rotate(0deg)` : `transform: rotate(-90deg)`};
 `;
 
 const HideableFormSection: React.SFC<Props> = ({ children, label }) => {


### PR DESCRIPTION
## What's changed?

A few changes to the inline form:

- the slideshow fields size themselves proportionally
- the checkbox fields have had a small spacing tweak and wrap four to a row in wide forms
- the form itself saves correctly!

I've tested the _other_ form, too, and it appears to be unchanged and working correctly.

Before:

<img width="748" alt="Screenshot 2019-07-25 at 18 58 56" src="https://user-images.githubusercontent.com/7767575/61897349-c4f05b00-af0e-11e9-8667-aacb230bed33.png">

After: 

<img width="747" alt="Screenshot 2019-07-25 at 19 02 26" src="https://user-images.githubusercontent.com/7767575/61897356-c883e200-af0e-11e9-8c00-62dba069215b.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
