### PR TITLE
Expand clipboard when it contains open forms

### DIFF
--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -40,7 +40,7 @@ const ClipboardWrapper = styled<
   'data-testid': 'clipboard-wrapper'
 })`
   width: ${({ theme, clipboardHasOpenForms }) =>
-    clipboardHasOpenForms ? theme.front.minWidth : 200}px;
+    clipboardHasOpenForms ? theme.front.minWidth : 220}px;
   background: ${({ theme }) => theme.shared.collection.background};
   border-top: 1px solid ${({ theme }) => theme.shared.colors.greyLightPinkish};
   overflow-y: scroll;

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -12,7 +12,8 @@ import {
 import {
   editorSelectArticleFragment,
   editorClearArticleFragmentSelection,
-  selectIsClipboardOpen
+  selectIsClipboardOpen,
+  createSelectCollectionIdsWithOpenForms
 } from 'bundles/frontsUIBundle';
 import { clipboardId } from 'constants/fronts';
 import { ArticleFragment as TArticleFragment } from 'shared/types/Collection';
@@ -30,11 +31,16 @@ import FocusWrapper from './FocusWrapper';
 import { bindActionCreators } from 'redux';
 
 const ClipboardWrapper = styled<
-  HTMLProps<HTMLDivElement> & { 'data-testid'?: string },
+  HTMLProps<HTMLDivElement> & {
+    'data-testid'?: string;
+    clipboardHasOpenForms: boolean;
+  },
   'div'
 >('div').attrs({
   'data-testid': 'clipboard-wrapper'
 })`
+  width: ${({ theme, clipboardHasOpenForms }) =>
+    clipboardHasOpenForms ? theme.front.minWidth : 200}px;
   background: ${({ theme }) => theme.shared.collection.background};
   border-top: 1px solid ${({ theme }) => theme.shared.colors.greyLightPinkish};
   overflow-y: scroll;
@@ -62,12 +68,13 @@ interface ClipboardProps {
   clearArticleFragmentSelection: () => void;
   removeCollectionItem: (id: string) => void;
   removeSupportingCollectionItem: (parentId: string, id: string) => void;
-  isClipboardOpen: boolean;
   handleFocus: () => void;
   handleArticleFocus: (articleFragment: TArticleFragment) => void;
   handleBlur: () => void;
   dispatch: Dispatch;
+  isClipboardOpen: boolean;
   isClipboardFocused: boolean;
+  clipboardHasOpenForms: boolean;
 }
 
 // Styled component typings for ref seem to be broken so any refs
@@ -113,17 +120,25 @@ class Clipboard extends React.Component<ClipboardProps> {
   };
 
   public render() {
+    const {
+      isClipboardOpen,
+      clipboardHasOpenForms,
+      selectArticleFragment,
+      removeCollectionItem,
+      removeSupportingCollectionItem
+    } = this.props;
     return (
       <React.Fragment>
-        {this.props.isClipboardOpen && (
+        {isClipboardOpen && (
           <ClipboardWrapper
             tabIndex={0}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
             innerRef={this.clipboardWrapper as Ref}
+            clipboardHasOpenForms={clipboardHasOpenForms}
           >
             <StyledDragIntentContainer
-              active={!this.props.isClipboardOpen}
+              active={!isClipboardOpen}
               delay={300}
               onDragIntentStart={() => this.setState({ preActive: true })}
               onDragIntentEnd={() => this.setState({ preActive: false })}
@@ -157,11 +172,9 @@ class Clipboard extends React.Component<ClipboardProps> {
                             showMeta={false}
                             canDragImage={false}
                             textSize="small"
-                            onSelect={this.props.selectArticleFragment}
+                            onSelect={selectArticleFragment}
                             onDelete={() =>
-                              this.props.removeCollectionItem(
-                                articleFragment.uuid
-                              )
+                              removeCollectionItem(articleFragment.uuid)
                             }
                           >
                             <ArticleFragmentLevel
@@ -178,10 +191,10 @@ class Clipboard extends React.Component<ClipboardProps> {
                                   size="small"
                                   showMeta={false}
                                   onSelect={id =>
-                                    this.props.selectArticleFragment(id, true)
+                                    selectArticleFragment(id, true)
                                   }
                                   onDelete={() =>
-                                    this.props.removeSupportingCollectionItem(
+                                    removeSupportingCollectionItem(
                                       articleFragment.uuid,
                                       supporting.uuid
                                     )
@@ -216,10 +229,17 @@ class Clipboard extends React.Component<ClipboardProps> {
   };
 }
 
-const mapStateToProps = (state: State) => ({
-  isClipboardOpen: selectIsClipboardOpen(state),
-  isClipboardFocused: selectIsClipboardFocused(state)
-});
+const mapStateToProps = () => {
+  const selectCollectionIdsWithOpenForms = createSelectCollectionIdsWithOpenForms();
+  return (state: State) => ({
+    isClipboardOpen: selectIsClipboardOpen(state),
+    isClipboardFocused: selectIsClipboardFocused(state),
+    clipboardHasOpenForms: !!selectCollectionIdsWithOpenForms(
+      state,
+      clipboardId
+    ).length
+  });
+};
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearArticleFragmentSelection: () =>
@@ -260,7 +280,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   dispatch
 });
 
-type TStateProps = ReturnType<typeof mapStateToProps>;
+type TStateProps = ReturnType<ReturnType<typeof mapStateToProps>>;
 type TDispatchProps = ReturnType<typeof mapDispatchToProps>;
 
 const mergeProps = (

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -72,13 +72,11 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
   display: flex;
   flex-direction: column;
   flex: 1;
-  height: calc(100% - 10px);
   background-color: ${({ theme }) => theme.base.colors.formBackground};
 `;
 
 const FormContent = styled('div')`
   flex: 1;
-  overflow: hidden;
 `;
 
 const RowContainer = styled('div')`
@@ -89,7 +87,6 @@ const ButtonContainer = styled('div')`
   margin-left: auto;
   margin-right: -10px;
   margin-bottom: -10px;
-  line-height: 0;
 `;
 
 const SlideshowRow = styled(Row)`
@@ -147,28 +144,22 @@ const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
 const CheckboxFieldsContainer: React.SFC<{
   children: JSX.Element[];
   editableFields: string[];
-  isClipboard: boolean;
-}> = ({ children, editableFields, isClipboard }) => {
+}> = ({ children, editableFields }) => {
   const childrenToRender = children.filter(child =>
     shouldRenderField(child.props.name, editableFields)
   );
   return (
     <FieldsContainerWrap>
       {childrenToRender.map(child => {
-        return (
-          <FieldContainer isClipboard={isClipboard} key={child.props.name}>
-            {child}
-          </FieldContainer>
-        );
+        return <FieldContainer key={child.props.name}>{child}</FieldContainer>;
       })}
     </FieldsContainerWrap>
   );
 };
 
-const FieldContainer = styled(Col)<{ isClipboard: boolean }>`
+const FieldContainer = styled(Col)`
   flex-basis: calc(100% / 4);
-  min-width: ${({ isClipboard }) => (isClipboard ? '180px' : '125px')}
-    /* Prevents labels breaking across lines */;
+  min-width: 125px; /* Prevents labels breaking across lines */
   margin-bottom: 8px;
 `;
 
@@ -177,17 +168,6 @@ const KickerSuggestionsContainer = styled.div`
   right: 10px;
   top: 5px;
   font-size: 12px;
-`;
-
-const KickerSuggestionsContainerClipboard = styled.div`
-  position: relative;
-  top: 5px;
-  font-size: 12px;
-  display: flex;
-  flex-direction: column;
-  button {
-    width: fit-content;
-  }
 `;
 
 const getInputId = (articleFragmentId: string, label: string) =>
@@ -283,8 +263,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       kickerOptions.webTitle || kickerOptions.sectionName
     );
 
-    const isClipboard = frontId === 'clipboard';
-
     return (
       <FormContainer
         data-testid="edit-form"
@@ -303,16 +281,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
         )}
         <FormContent>
           <InputGroup>
-            {hasKickerSuggestions &&
-              (isClipboard ? (
-                <KickerSuggestionsContainerClipboard>
-                  {getKickerContents()}
-                </KickerSuggestionsContainerClipboard>
-              ) : (
-                <KickerSuggestionsContainer>
-                  {getKickerContents()}
-                </KickerSuggestionsContainer>
-              ))}
+            {hasKickerSuggestions && (
+              <KickerSuggestionsContainer>
+                {getKickerContents()}
+              </KickerSuggestionsContainer>
+            )}
             <ConditionalField
               name="customKicker"
               label="Kicker"
@@ -348,10 +321,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 data-testid="edit-form-headline-field"
               />
             )}
-            <CheckboxFieldsContainer
-              isClipboard={isClipboard}
-              editableFields={editableFields}
-            >
+            <CheckboxFieldsContainer editableFields={editableFields}>
               <Field
                 name="isBoosted"
                 component={InputCheckboxToggleInline}
@@ -425,7 +395,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             </HideableFormSection>
           </InputGroup>
           <RowContainer>
-            <Row flexDirection={isClipboard ? 'column' : 'row'}>
+            <Row>
               <ImageCol faded={imageHide}>
                 <ConditionalField
                   permittedFields={editableFields}

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -38,10 +38,8 @@ const Container = styled(ContentContainer)<ContainerProps>`
   ${({ isClosed }) => (isClosed ? 'padding: 0; height: 100%' : '')}
 `;
 
-export const overviewMinWidth = 160;
-
 const ContainerBody = styled.div`
-  width: ${overviewMinWidth}px;
+  width: ${({ theme }) => theme.front.overviewMinWidth}px;
   overflow-y: scroll;
 `;
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -28,7 +28,6 @@ import { RadioButton, RadioGroup } from 'components/inputs/RadioButtons';
 import { PreviewEyeIcon, ClearIcon } from 'shared/components/icons/Icons';
 import { createFrontId } from 'util/editUtils';
 import { formMinWidth } from './ArticleFragmentForm';
-import { overviewMinWidth } from './FrontCollectionsOverview';
 import EditModeVisibility from 'components/util/EditModeVisibility';
 
 const FrontHeader = styled(SectionHeader)`
@@ -57,8 +56,6 @@ const StageSelectButtons = styled('div')`
   padding: 0px 15px;
 `;
 
-const singleFrontMinWidth = 380;
-
 const SingleFrontContainer = styled('div')<{
   isOverviewOpen: boolean;
   isFormOpen: boolean;
@@ -70,12 +67,12 @@ const SingleFrontContainer = styled('div')<{
    * of the front container proportionally to keep the collection container the
    * same width.
    */
-  min-width: ${({ isOverviewOpen, isFormOpen }) =>
+  min-width: ${({ isOverviewOpen, isFormOpen, theme }) =>
     isFormOpen
-      ? singleFrontMinWidth + formMinWidth + 10
+      ? theme.front.minWidth + formMinWidth + 10
       : isOverviewOpen
-      ? singleFrontMinWidth + overviewMinWidth + 10
-      : singleFrontMinWidth}px;
+      ? theme.front.minWidth + theme.front.overviewMinWidth + 10
+      : theme.front.minWidth}px;
   flex: 1 1;
   height: 100%;
 `;

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -29,7 +29,6 @@ const ClipboardItemContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
-  width: 200px;
 `;
 
 const ClipboardDropContainer = styled(CollectionDropContainer)<{

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -42,7 +42,9 @@ const capiInterface = {
 const front = {
   frontListBorder: '#5E5E5E',
   frontListLabel: shared.colors.greyMediumLight,
-  frontListButton: shared.colors.greyDark
+  frontListButton: shared.colors.greyDark,
+  minWidth: 380,
+  overviewMinWidth: 160
 };
 
 const form = {


### PR DESCRIPTION
## What's changed?

The clipboard now expands when any of its cards are in form mode. Editing card meta in the clipboard is now easier as a result, and we can get rid of clipboard-specific styling.

![clipboard-form](https://user-images.githubusercontent.com/7767575/61940592-a8473800-af8d-11e9-8b11-eeefd7960a53.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
