### PR TITLE
tweak editions link style

### DIFF
--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -16,6 +16,11 @@ interface ComponentProps {
   publishEditionsIssue: (id: string) => Promise<void>;
 }
 
+const ManageLink = styled(Link)`
+  color: white;
+  text-decoration: none;
+`;
+
 const EditionIssueInfo = styled.div`
   height: 100%;
   display: inline-block;
@@ -44,14 +49,14 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
 
     return (
       <>
-        <Link to="/manage-editions/daily-edition">
+        <ManageLink to="/manage-editions/daily-edition">
           <EditionIssueInfo>
             <EditionTitle>{startCase(editionsIssue.displayName)}</EditionTitle>
             <EditionDate>
               {new Date(editionsIssue.issueDate).toDateString()}
             </EditionDate>
           </EditionIssueInfo>
-        </Link>
+        </ManageLink>
         <EditionPublish>
           <EditModeVisibility visibleMode="editions">
             <Button

--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -44,7 +44,7 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
 
     return (
       <>
-        <Link to="/v2/manage-editions/daily-edition">
+        <Link to="/manage-editions/daily-edition">
           <EditionIssueInfo>
             <EditionTitle>{startCase(editionsIssue.displayName)}</EditionTitle>
             <EditionDate>

--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -10,6 +10,7 @@ import startCase from 'lodash/startCase';
 import EditModeVisibility from './util/EditModeVisibility';
 import Button from '../shared/components/input/ButtonDefault';
 import { Link } from 'react-router-dom';
+import urls from 'constants/urls';
 
 interface ComponentProps {
   editionsIssue: EditionsIssue;
@@ -49,7 +50,7 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
 
     return (
       <>
-        <ManageLink to="/manage-editions/daily-edition">
+        <ManageLink to={urls.manageEditions}>
           <EditionIssueInfo>
             <EditionTitle>{startCase(editionsIssue.displayName)}</EditionTitle>
             <EditionDate>

--- a/client-v2/src/constants/urls.ts
+++ b/client-v2/src/constants/urls.ts
@@ -1,5 +1,6 @@
 export default {
   capiLiveUrl: '/api/live',
   capiPreviewUrl: '/api/preview',
+  manageEditions: '/manage-editions/daily-edition',
   appRoot: 'v2'
 };


### PR DESCRIPTION
## What's changed?
Style the Editions link from #870. Also corrects path.

### Before
![image](https://user-images.githubusercontent.com/836140/61950692-902fe280-afa6-11e9-8e72-291b250ad7e8.png)

### After
![image](https://user-images.githubusercontent.com/836140/61950670-8312f380-afa6-11e9-8454-b128e2dcc49a.png)


## Implementation notes
![img](https://media.giphy.com/media/LN6AfV6TxxJtu/giphy.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
