### PR TITLE
don't restrict Grid cropping ratio for Editions

### DIFF
--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -22,6 +22,8 @@ import { RubbishBinIcon, AddImageIcon } from '../icons/Icons';
 import imageDragIcon from 'images/icons/image-drag-icon.svg';
 import { DRAG_DATA_GRID_IMAGE_URL } from 'constants/image';
 import ImageDragIntentIndicator from '../ImageDragIntentIndicator';
+import { EditMode } from 'types/EditMode';
+import { selectEditMode } from '../../../selectors/pathSelectors';
 
 const ImageContainer = styled('div')<{
   small?: boolean;
@@ -143,7 +145,7 @@ export interface InputImageContainerProps {
 }
 
 type ComponentProps = InputImageContainerProps &
-  WrappedFieldProps & { gridUrl: string | null };
+  WrappedFieldProps & { gridUrl: string | null; editMode: EditMode };
 
 interface ComponentState {
   isHovering: boolean;
@@ -168,9 +170,11 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       gridUrl,
       useDefault,
       defaultImageUrl,
-      message = 'Add image'
+      message = 'Add image',
+      editMode
     } = this.props;
-    const gridSearchUrl = `${gridUrl}?cropType=landscape`;
+    const gridSearchUrl =
+      editMode === 'editions' ? `${gridUrl}` : `${gridUrl}?cropType=landscape`;
     const hasImage = !useDefault && !!input.value && !!input.value.thumb;
     const imageUrl =
       !useDefault && input.value && input.value.thumb
@@ -362,7 +366,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 
 const mapStateToProps = (state: State) => {
   return {
-    gridUrl: selectGridUrl(state)
+    gridUrl: selectGridUrl(state),
+    editMode: selectEditMode(state)
   };
 };
 

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -173,6 +173,15 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       message = 'Add image',
       editMode
     } = this.props;
+
+    if (!gridUrl) {
+      return (
+        <div>
+          <code>gridUrl</code> config value missing
+        </div>
+      );
+    }
+
     const gridSearchUrl =
       editMode === 'editions' ? `${gridUrl}` : `${gridUrl}?cropType=landscape`;
     const hasImage = !useDefault && !!input.value && !!input.value.thumb;


### PR DESCRIPTION
## What's changed?
[Card](https://trello.com/c/4zQC27P5/63-picture-overrides-should-allow-any-aspect-ratio-crop)

At the moment the aspect ratio is locked to 5:3 for picture overrides. As the overridden image can be a portrait crop, we should allow other crop sizes when overriding images for Editions fronts cards.

## Implementation notes
Another possible route to achieve this is to have a `restrictToLandscape: boolean` prop on `InputImage`, which is arguable cleaner, however it's a bigger diff... move fast...

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
