### PR TITLE
Obscure the distracting feed (is it just me?!)

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -18,8 +18,14 @@ object InlineForm extends FeatureSwitch(
   enabled = false
 )
 
+object ObscureFeed extends FeatureSwitch(
+  key = "obscure-feed",
+  title = "Obscure the feed -- it's distracting for developers!",
+  enabled = false
+)
+
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(InlineForm)
+  val all: List[FeatureSwitch] = List(InlineForm, ObscureFeed)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     userDataSwitches match {

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -15,7 +15,7 @@ import {
   HoverOphanButton,
   HoverAddToClipboardButton
 } from 'shared/components/input/HoverActionButtons';
-
+import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
 import { insertArticleFragment } from 'actions/ArticleFragments';
 import noop from 'lodash/noop';
 import { getPaths } from 'util/paths';
@@ -29,6 +29,8 @@ import {
   dragOffsetY
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import { media } from 'shared/util/mediaQueries';
+import { State } from 'types/State';
+import { selectSharedState } from 'shared/selectors/shared';
 
 const Container = styled('div')`
   display: flex;
@@ -61,7 +63,7 @@ const Title = styled(`h2`)`
   font-weight: normal;
 `;
 
-const VisitedWrapper = styled.a`
+const FeedItemContainer = styled.a<{ blur: boolean }>`
   text-decoration: none;
   display: flex;
   color: inherit;
@@ -70,6 +72,7 @@ const VisitedWrapper = styled.a`
   :visited ${Title} {
     color: ${({ theme }) => theme.capiInterface.textVisited};
   }
+  ${({ blur }) => blur && 'filter: blur(10px);'}
 `;
 
 const MetaContainer = styled('div')`
@@ -115,6 +118,7 @@ const DraggingArticleContainer = styled('div')`
 
 interface FeedItemProps {
   article: CapiArticle;
+  shouldObscureFeed: boolean;
   onAddToClipboard: (article: CapiArticle) => void;
 }
 
@@ -148,7 +152,7 @@ class FeedItem extends React.Component<FeedItemProps> {
     this.dragNode = React.createRef();
   }
   public render() {
-    const { article, onAddToClipboard = noop } = this.props;
+    const { article, onAddToClipboard = noop, shouldObscureFeed } = this.props;
     return (
       <Container
         data-testid="feed-item"
@@ -159,10 +163,11 @@ class FeedItem extends React.Component<FeedItemProps> {
           <DraggingArticleComponent headline={article.webTitle} />
         </DraggingArticleContainer>
 
-        <VisitedWrapper
+        <FeedItemContainer
           href={getPaths(article.id).live}
           onClick={e => e.preventDefault()}
           aria-disabled
+          blur={shouldObscureFeed}
         >
           <MetaContainer>
             <Tone
@@ -206,7 +211,7 @@ class FeedItem extends React.Component<FeedItemProps> {
               )}')`
             }}
           />
-        </VisitedWrapper>
+        </FeedItemContainer>
         <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
           <HoverActionsButtonWrapper
             buttons={[
@@ -239,6 +244,13 @@ class FeedItem extends React.Component<FeedItemProps> {
   };
 }
 
+const mapStateToProps = (state: State) => ({
+  shouldObscureFeed: selectFeatureValue(
+    selectSharedState(state),
+    'obscure-feed'
+  )
+});
+
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
     onAddToClipboard: (article: CapiArticle) =>
@@ -253,6 +265,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
 };
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(FeedItem);

--- a/test/FeaturesSpec.scala
+++ b/test/FeaturesSpec.scala
@@ -1,4 +1,4 @@
-import model.{FeatureSwitch, FeatureSwitches, InlineForm }
+import model.{FeatureSwitch, FeatureSwitches, InlineForm, ObscureFeed }
 import org.scalatest.{Matchers, WordSpec}
 
 class FeaturesSpec extends WordSpec with Matchers {
@@ -9,15 +9,15 @@ class FeaturesSpec extends WordSpec with Matchers {
 
       "return default feature switches when user data contains no pre-existing switches" in {
         val testSwitch = FeatureSwitch("test","test", enabled = true)
-        FeatureSwitches.updateFeatureSwitchesForUser(None, testSwitch) should contain theSameElementsAs List(InlineForm, testSwitch)
+        FeatureSwitches.updateFeatureSwitchesForUser(None, testSwitch) should contain theSameElementsAs List(testSwitch) ++ FeatureSwitches.all
       }
 
       "return an updated list of feature switches" in {
         val unchangedSwitch = FeatureSwitch("test","test", enabled = true)
         val switchToChange = InlineForm
         val userDataSwitches: Option[List[FeatureSwitch]] = Some(List(switchToChange, unchangedSwitch))
-
-        FeatureSwitches.updateFeatureSwitchesForUser(userDataSwitches, switchToChange) should contain theSameElementsAs List(switchToChange, unchangedSwitch)
+        val remainingSwitches = FeatureSwitches.all diff List(switchToChange)
+        FeatureSwitches.updateFeatureSwitchesForUser(userDataSwitches, switchToChange) should contain theSameElementsAs List(switchToChange, unchangedSwitch) ++ remainingSwitches
       }
 
     }


### PR DESCRIPTION
## What's changed?

Add a feature switch that blurs the feed. No longer will developers be blasted with a firehose of news! 💥 You can still scroll, drag, and hover to click as usual.

<img width="421" alt="Screenshot 2019-07-29 at 17 40 40" src="https://user-images.githubusercontent.com/7767575/62065957-02fbc080-b228-11e9-93b8-4a787aa2dfd6.png">

## Implementation notes

I _think_ this is the first time I've used `filter: blur`?

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
