### PR TITLE
RECENTLY REMOVED: display 5 most recently removed articles on each collection

### DIFF
--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -120,6 +120,7 @@ describe('Collection actions', () => {
           metadata: undefined,
           platform: undefined,
           previously: ['uuid'],
+          previouslyArticleFragmentIds: [],
           type: 'type'
         },
         testCollection2: {
@@ -133,6 +134,7 @@ describe('Collection actions', () => {
           metadata: undefined,
           platform: undefined,
           previously: ['uuid'],
+          previouslyArticleFragmentIds: [],
           type: 'type'
         }
       });
@@ -167,6 +169,7 @@ describe('Collection actions', () => {
           metadata: undefined,
           platform: undefined,
           previously: ['uuid'],
+          previouslyArticleFragmentIds: [],
           groups: undefined,
           frontsToolSettings: undefined
         },
@@ -181,6 +184,7 @@ describe('Collection actions', () => {
           metadata: undefined,
           platform: undefined,
           previously: ['uuid'],
+          previouslyArticleFragmentIds: [],
           type: 'type'
         },
         testCollection2: {
@@ -194,6 +198,7 @@ describe('Collection actions', () => {
           metadata: undefined,
           platform: undefined,
           previously: ['uuid'],
+          previouslyArticleFragmentIds: [],
           type: 'type'
         }
       });

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -6,7 +6,8 @@ import config from 'fixtures/config';
 import { stateWithCollection, capiArticle } from 'shared/fixtures/shared';
 import {
   getCollectionsApiResponse,
-  getCollectionsApiResponseWithoutStoriesVisible
+  getCollectionsApiResponseWithoutStoriesVisible,
+  getCollectionsApiResponseWithPreviouslyDeletedArticles
 } from 'fixtures/collectionsEndpointResponse';
 import { actions as collectionActions } from 'shared/bundles/collectionsBundle';
 import {
@@ -203,6 +204,30 @@ describe('Collection actions', () => {
         }
       });
     });
+
+    it('should extract previously deleted articles to previouslyArticleFragmentIds', async () => {
+      const collectionIds = ['testCollection1'];
+      fetchMock.post(
+        '/collections',
+        getCollectionsApiResponseWithPreviouslyDeletedArticles
+      );
+      await store.dispatch(getCollections(collectionIds) as any);
+      expect(store.getState().shared.collections.data.testCollection1).toEqual({
+        displayName: 'testCollection',
+        draft: ['uuid'],
+        frontsToolSettings: undefined,
+        groups: undefined,
+        id: 'testCollection1',
+        lastUpdated: 1547479667115,
+        live: ['uuid'],
+        metadata: undefined,
+        platform: undefined,
+        previously: ['uuid'],
+        previouslyArticleFragmentIds: ['articleFragId1', 'articleFragId2'],
+        type: 'type'
+      });
+    });
+
     it('should send only collection id and type in request body when returnOnlyUpdatedCollection is false or default', async () => {
       const collectionIds = ['testCollection1', 'testCollection2'];
       const request = fetchMock.post('/collections', getCollectionsApiResponse);

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -6,8 +6,7 @@ import config from 'fixtures/config';
 import { stateWithCollection, capiArticle } from 'shared/fixtures/shared';
 import {
   getCollectionsApiResponse,
-  getCollectionsApiResponseWithoutStoriesVisible,
-  getCollectionsApiResponseWithPreviouslyDeletedArticles
+  getCollectionsApiResponseWithoutStoriesVisible
 } from 'fixtures/collectionsEndpointResponse';
 import { actions as collectionActions } from 'shared/bundles/collectionsBundle';
 import {
@@ -202,29 +201,6 @@ describe('Collection actions', () => {
           previouslyArticleFragmentIds: [],
           type: 'type'
         }
-      });
-    });
-
-    it('should extract previously deleted articles to previouslyArticleFragmentIds', async () => {
-      const collectionIds = ['testCollection1'];
-      fetchMock.post(
-        '/collections',
-        getCollectionsApiResponseWithPreviouslyDeletedArticles
-      );
-      await store.dispatch(getCollections(collectionIds) as any);
-      expect(store.getState().shared.collections.data.testCollection1).toEqual({
-        displayName: 'testCollection',
-        draft: ['uuid'],
-        frontsToolSettings: undefined,
-        groups: undefined,
-        id: 'testCollection1',
-        lastUpdated: 1547479667115,
-        live: ['uuid'],
-        metadata: undefined,
-        platform: undefined,
-        previously: ['uuid'],
-        previouslyArticleFragmentIds: ['articleFragId1', 'articleFragId2'],
-        type: 'type'
       });
     });
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -18,7 +18,7 @@ import {
   createSelectCollectionStageGroups,
   createSelectCollectionEditWarning,
   selectSharedState,
-  createSelectFivePreviouslyLiveArticlesInCollection
+  createSelectPreviouslyLiveArticlesInCollection
 } from 'shared/selectors/shared';
 import {
   selectIsCollectionOpen,
@@ -211,7 +211,7 @@ class Collection extends React.Component<CollectionProps> {
 const createMapStateToProps = () => {
   const selectCollectionStageGroups = createSelectCollectionStageGroups();
   const selectEditWarning = createSelectCollectionEditWarning();
-  const selectPreviously = createSelectFivePreviouslyLiveArticlesInCollection();
+  const selectPreviously = createSelectPreviouslyLiveArticlesInCollection();
   return (
     state: State,
     {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -54,7 +54,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   hasUnpublishedChanges: boolean;
   canPublish: boolean;
   groups: Group[];
-  previousGroups: Group[];
+  previousGroup: Group;
   displayEditWarning: boolean;
   isCollectionLocked: boolean;
   isEditFormOpen: boolean;
@@ -104,7 +104,7 @@ class Collection extends React.Component<CollectionProps> {
       children,
       alsoOn,
       groups,
-      previousGroups,
+      previousGroup: previousGroup,
       browsingStage,
       hasUnpublishedChanges,
       canPublish = true,
@@ -195,17 +195,7 @@ class Collection extends React.Component<CollectionProps> {
                   front. If the deleted articles were never launched they will
                   not appear here.
                 </PreviouslyCollectionInfo>
-                {previousGroups.map(group => {
-                  const firstFiveArticlesInGroup = group.articleFragments.slice(
-                    0,
-                    5
-                  );
-                  const smallerGroup = {
-                    ...group,
-                    articleFragments: firstFiveArticlesInGroup
-                  };
-                  return children(smallerGroup, true, false);
-                })}
+                {children(previousGroup, true, false)}
               </PreviouslyGroupsWrapper>
             )}
           </PreviouslyCollectionContainer>
@@ -238,7 +228,7 @@ const createMapStateToProps = () => {
         collectionSet: browsingStage,
         collectionId
       }),
-      previousGroups: selectPreviously(selectSharedState(state), {
+      previousGroup: selectPreviously(selectSharedState(state), {
         collectionId
       }),
       displayEditWarning: selectEditWarning(selectSharedState(state), {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -185,7 +185,17 @@ class Collection extends React.Component<CollectionProps> {
             </PreviouslyCollectionToggle>
             {isPreviouslyOpen && (
               <PreviouslyGroupsWrapper>
-                {previousGroups.map(group => children(group, true, false))}
+                {previousGroups.map(group => {
+                  const firstFiveArticlesInGroup = group.articleFragments.slice(
+                    0,
+                    5
+                  );
+                  const smallerGroup = {
+                    ...group,
+                    articleFragments: firstFiveArticlesInGroup
+                  };
+                  return children(smallerGroup, true, false);
+                })}
               </PreviouslyGroupsWrapper>
             )}
           </PreviouslyCollectionContainer>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -64,9 +64,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   fetchPreviousCollectionArticles: (id: string) => void;
 };
 
-const PreviouslyCollectionContainer = styled('div')`
-  opacity: 0.5;
-`;
+const PreviouslyCollectionContainer = styled('div')``;
 
 const PreviouslyCollectionToggle = styled(CollectionMetaContainer)`
   align-items: center;
@@ -77,11 +75,14 @@ const PreviouslyCollectionToggle = styled(CollectionMetaContainer)`
 
 const PreviouslyGroupsWrapper = styled.div`
   padding-top: 0.25em;
+  opacity: 0.5;
 `;
 
 const PreviouslyCollectionInfo = styled('div')`
   background: ${theme.shared.colors.greyVeryLight};
   color: ${theme.shared.colors.blackDark};
+  padding: 4px 6px;
+  font-size: 14px;
 `;
 
 class Collection extends React.Component<CollectionProps> {
@@ -189,14 +190,16 @@ class Collection extends React.Component<CollectionProps> {
               <ButtonCircularCaret active={isPreviouslyOpen} />
             </PreviouslyCollectionToggle>
             {isPreviouslyOpen && (
-              <PreviouslyGroupsWrapper>
+              <>
                 <PreviouslyCollectionInfo>
                   This contains the 5 most recently deleted articles from the
                   live front. If the deleted articles were never launched they
                   will not appear here.
                 </PreviouslyCollectionInfo>
-                {children(previousGroup, true, false)}
-              </PreviouslyGroupsWrapper>
+                <PreviouslyGroupsWrapper>
+                  {children(previousGroup, true, false)}
+                </PreviouslyGroupsWrapper>
+              </>
             )}
           </PreviouslyCollectionContainer>
         </EditModeVisibility>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -30,7 +30,7 @@ import { getArticlesForCollections } from 'actions/Collections';
 import { collectionItemSets } from 'constants/fronts';
 import CollectionMetaContainer from 'shared/components/collection/CollectionMetaContainer';
 import ButtonCircularCaret from 'shared/components/input/ButtonCircularCaret';
-import { styled } from 'constants/theme';
+import { theme, styled } from 'constants/theme';
 import EditModeVisibility from 'components/util/EditModeVisibility';
 
 interface CollectionPropsBeforeState {
@@ -80,8 +80,8 @@ const PreviouslyGroupsWrapper = styled.div`
 `;
 
 const PreviouslyCollectionInfo = styled('div')`
-  background: '#c9c9c9';
-  color: #121212;
+  background: ${theme.shared.colors.greyVeryLight};
+  color: ${theme.shared.colors.blackDark};
 `;
 
 class Collection extends React.Component<CollectionProps> {
@@ -191,9 +191,9 @@ class Collection extends React.Component<CollectionProps> {
             {isPreviouslyOpen && (
               <PreviouslyGroupsWrapper>
                 <PreviouslyCollectionInfo>
-                  You will find 5 most recently deleted articles from live
-                  front. If the deleted articles were never launched they will
-                  not appear here.
+                  This contains the 5 most recently deleted articles from the
+                  live front. If the deleted articles were never launched they
+                  will not appear here.
                 </PreviouslyCollectionInfo>
                 {children(previousGroup, true, false)}
               </PreviouslyGroupsWrapper>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -18,7 +18,7 @@ import {
   createSelectCollectionStageGroups,
   createSelectCollectionEditWarning,
   selectSharedState,
-  createSelectPreviouslyLiveArticlesInCollection
+  createSelectFivePreviouslyLiveArticlesInCollection
 } from 'shared/selectors/shared';
 import {
   selectIsCollectionOpen,
@@ -208,7 +208,7 @@ class Collection extends React.Component<CollectionProps> {
 const createMapStateToProps = () => {
   const selectCollectionStageGroups = createSelectCollectionStageGroups();
   const selectEditWarning = createSelectCollectionEditWarning();
-  const selectPreviously = createSelectPreviouslyLiveArticlesInCollection();
+  const selectPreviously = createSelectFivePreviouslyLiveArticlesInCollection();
   return (
     state: State,
     {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -79,6 +79,11 @@ const PreviouslyGroupsWrapper = styled.div`
   padding-top: 0.25em;
 `;
 
+const PreviouslyCollectionInfo = styled('div')`
+  background: '#c9c9c9';
+  color: #121212;
+`;
+
 class Collection extends React.Component<CollectionProps> {
   public state = {
     isPreviouslyOpen: false
@@ -180,11 +185,16 @@ class Collection extends React.Component<CollectionProps> {
               onClick={this.togglePreviouslyOpen}
               data-testid="previously-toggle"
             >
-              Recently removed
+              Recently removed from launched front
               <ButtonCircularCaret active={isPreviouslyOpen} />
             </PreviouslyCollectionToggle>
             {isPreviouslyOpen && (
               <PreviouslyGroupsWrapper>
+                <PreviouslyCollectionInfo>
+                  You will find 5 most recently deleted articles from live
+                  front. If the deleted articles were never launched they will
+                  not appear here.
+                </PreviouslyCollectionInfo>
                 {previousGroups.map(group => {
                   const firstFiveArticlesInGroup = group.articleFragments.slice(
                     0,

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -81,37 +81,6 @@ export const getCollectionsApiResponse = [
   }
 ];
 
-export const getCollectionsApiResponseWithPreviouslyDeletedArticles = [
-  {
-    id: 'testCollection1',
-    collection: {
-      displayName: 'testCollection1',
-      live: ['abc', 'def'],
-      draft: [],
-      lastUpdated: 1547479667115,
-      previously: [
-        {
-          id: 'internal-code/page/qrt',
-          meta: null,
-          frontPublicationDate: 123,
-          publishedBy: 'A Dev'
-        },
-        {
-          id: 'internal-code/page/xyz',
-          meta: null,
-          frontPublicationDate: 124,
-          publishedBy: 'Another Dev'
-        }
-      ],
-      type: 'type'
-    },
-    storiesVisibleByStage: {
-      live: { desktop: 4, mobile: 4 },
-      draft: { desktop: 4, mobile: 4 }
-    }
-  }
-];
-
 export const getCollectionsApiResponseWithoutStoriesVisible = [
   {
     id: 'testCollection1',

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -81,6 +81,37 @@ export const getCollectionsApiResponse = [
   }
 ];
 
+export const getCollectionsApiResponseWithPreviouslyDeletedArticles = [
+  {
+    id: 'testCollection1',
+    collection: {
+      displayName: 'testCollection1',
+      live: ['abc', 'def'],
+      draft: [],
+      lastUpdated: 1547479667115,
+      previously: [
+        {
+          id: 'internal-code/page/qrt',
+          meta: null,
+          frontPublicationDate: 123,
+          publishedBy: 'A Dev'
+        },
+        {
+          id: 'internal-code/page/xyz',
+          meta: null,
+          frontPublicationDate: 124,
+          publishedBy: 'Another Dev'
+        }
+      ],
+      type: 'type'
+    },
+    storiesVisibleByStage: {
+      live: { desktop: 4, mobile: 4 },
+      draft: { desktop: 4, mobile: 4 }
+    }
+  }
+];
+
 export const getCollectionsApiResponseWithoutStoriesVisible = [
   {
     id: 'testCollection1',

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -527,6 +527,68 @@ const collection = {
   type: 'type'
 };
 
+const collectionWithPreviously = {
+  live: [
+    liveArticle,
+    {
+      id: 'article/draft/1',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    },
+    {
+      id: 'a/long/path/2',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {}
+    }
+  ],
+  previously: [
+    {
+      id: 'internal-code/page/qrt',
+      meta: {},
+      frontPublicationDate: 123,
+      publishedBy: 'A Dev'
+    },
+    {
+      id: 'internal-code/page/xyz',
+      meta: {},
+      frontPublicationDate: 124,
+      publishedBy: 'Another Dev'
+    }
+  ],
+  id: 'exampleCollection',
+  displayName: 'Example Collection',
+  type: 'type'
+};
+
+const normalisedCollectonWithPreviously = {
+  displayName: 'testCollection',
+  draft: ['uuid'],
+  entities: {
+    articleFragments: {
+      uuid1: {
+        id: 'internal-code/page/qrt',
+        uuid: 'uuid1'
+      },
+      uuid2: {
+        id: 'internal-code/page/xyz',
+        uuid: 'uuid2'
+      }
+    }
+  },
+  frontsToolSettings: undefined,
+  groups: undefined,
+  id: 'testCollection1',
+  lastUpdated: 1547479667115,
+  live: ['uuid'],
+  metadata: undefined,
+  platform: undefined,
+  previously: ['uuid'],
+  previouslyArticleFragmentIds: [],
+  type: 'type'
+};
+
 const collectionConfig = {
   id: 'exampleCollection',
   displayName: 'Example Collection',
@@ -569,6 +631,10 @@ const stateWithCollection: any = {
           },
           automatedCollection: {
             displayName: 'automated',
+            type: 'type'
+          },
+          testCollection5: {
+            displayName: 'testCollection5',
             type: 'type'
           }
         }
@@ -784,6 +850,8 @@ export {
   capiArticle,
   capiArticleWithVideo,
   collection,
+  collectionWithPreviously,
+  normalisedCollectonWithPreviously,
   collectionWithSupportingArticles,
   stateWithCollection,
   stateWithCollectionAndSupporting,

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -226,11 +226,15 @@ const createSelectPreviouslyLiveArticlesInCollection = () => {
   const selectCollection = createSelectCollection();
   return createShallowEqualResultSelector(
     selectCollection,
-    selectGroups,
-    (collection: Collection | void, groups: { [id: string]: Group }): Group[] =>
-      ((collection && collection[collectionItemSets.previously]) || []).map(
-        id => groups[id]
-      )
+    (collection: Collection | void): Group => ({
+      id: null,
+      name: null,
+      uuid: 'previously',
+      articleFragments: (
+        (collection && collection.previouslyArticleFragmentIds) ||
+        []
+      ).slice(0, 5)
+    })
   );
 };
 

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -222,10 +222,14 @@ const createSelectCollectionStageGroups = () => {
   );
 };
 
-const createSelectPreviouslyLiveArticlesInCollection = () => {
+const createSelectFivePreviouslyLiveArticlesInCollection = () => {
   const selectCollection = createSelectCollection();
   return createShallowEqualResultSelector(
     selectCollection,
+    // All components that display articles do so using Groups. As a result, we have to create
+    // a Group here, to be able to render the previously removed articles.
+    // This will return the UUIDs for the 5 most recently removed articles.
+    // TODO: consider how we could change this interface, so we don't need to create this.
     (collection: Collection | void): Group => ({
       id: null,
       name: null,
@@ -528,7 +532,7 @@ export {
   createSelectSupportingArticles,
   createSelectCollection,
   createSelectCollectionStageGroups,
-  createSelectPreviouslyLiveArticlesInCollection,
+  createSelectFivePreviouslyLiveArticlesInCollection,
   createDemornalisedArticleFragment,
   selectSharedState,
   selectArticleFragment,

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -222,7 +222,7 @@ const createSelectCollectionStageGroups = () => {
   );
 };
 
-const createSelectFivePreviouslyLiveArticlesInCollection = () => {
+const createSelectPreviouslyLiveArticlesInCollection = () => {
   const selectCollection = createSelectCollection();
   return createShallowEqualResultSelector(
     selectCollection,
@@ -532,7 +532,7 @@ export {
   createSelectSupportingArticles,
   createSelectCollection,
   createSelectCollectionStageGroups,
-  createSelectFivePreviouslyLiveArticlesInCollection,
+  createSelectPreviouslyLiveArticlesInCollection,
   createDemornalisedArticleFragment,
   selectSharedState,
   selectArticleFragment,

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -110,9 +110,11 @@ type CollectionWithNestedArticles = CollectionFromResponse & {
   id: string;
 };
 
+// previouslyArticleFragmentIds is stored in a separate key to avoid losing ordering information during normalisation.
 interface Collection {
   live?: string[];
   previously?: string[];
+  previouslyArticleFragmentIds?: string[]; // this contains ids for deleted articles on a collection
   draft?: string[];
   id: string;
   lastUpdated?: number;

--- a/client-v2/src/shared/util/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/util/__tests__/shared.spec.ts
@@ -1,14 +1,17 @@
 import {
   collection,
+  collectionWithPreviously,
   collectionConfig,
   collectionWithoutGroups,
   collectionWithSupportingArticles,
   stateWithCollection,
-  stateWithCollectionAndSupporting
+  stateWithCollectionAndSupporting,
+  normalisedCollectonWithPreviously
 } from 'shared/fixtures/shared';
 import {
   normaliseCollectionWithNestedArticles,
-  denormaliseCollection
+  denormaliseCollection,
+  createPreviouslyArticleFragmentIds
 } from '../shared';
 
 describe('Shared utilities', () => {
@@ -178,6 +181,16 @@ describe('Shared utilities', () => {
         groups: undefined
       });
       expect(Object.keys(result.groups)).toHaveLength(4);
+    });
+  });
+  describe('createPreviouslyArticleFragmentIds', () => {
+    it('should create an array of article fragment ids of recently removed articles', () => {
+      const result = createPreviouslyArticleFragmentIds(
+        collectionWithPreviously,
+        normalisedCollectonWithPreviously
+      );
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(['uuid1', 'uuid2']);
     });
   });
 });

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -13,6 +13,7 @@ import { CollectionConfig } from 'types/FaciaApi';
 import v4 from 'uuid/v4';
 import keyBy from 'lodash/keyBy';
 import sortBy from 'lodash/sortBy';
+import compact from 'lodash/compact';
 
 const createGroup = (
   id: string | null,
@@ -136,12 +137,22 @@ const normaliseCollectionWithNestedArticles = (
     normalisedCollection,
     collectionConfig
   );
+  const previouslyArticleFragmentIds = compact(collection.previously || []).map(
+    nestedArticleFragment => {
+      const maybeArticleFragment = Object.entries(normalisedCollection.entities
+        .articleFragments as {
+        [uuid: string]: ArticleFragment;
+      }).find(([_, article]) => article.id === nestedArticleFragment.id);
+      return maybeArticleFragment ? maybeArticleFragment[0] : undefined;
+    }
+  );
   return {
     normalisedCollection: {
       ...normalisedCollection.result,
       live,
       draft,
-      previously
+      previously,
+      previouslyArticleFragmentIds
     },
     groups: addedGroups,
     articleFragments: normalisedCollection.entities.articleFragments || {}

--- a/client-v2/src/shared/util/shared.ts
+++ b/client-v2/src/shared/util/shared.ts
@@ -124,6 +124,18 @@ const addGroups = (
     { live: [], draft: [], previously: [], addedGroups: {} } as ReduceResult
   );
 
+const createPreviouslyArticleFragmentIds = (
+  collection: CollectionWithNestedArticles,
+  normalisedCollection: any
+) =>
+  compact(collection.previously || []).map(nestedArticleFragment => {
+    const maybeArticleFragment = Object.entries(normalisedCollection.entities
+      .articleFragments as {
+      [uuid: string]: ArticleFragment;
+    }).find(([_, article]) => article.id === nestedArticleFragment.id);
+    return maybeArticleFragment ? maybeArticleFragment[0] : undefined;
+  });
+
 const normaliseCollectionWithNestedArticles = (
   collection: CollectionWithNestedArticles,
   collectionConfig: CollectionConfig
@@ -137,14 +149,9 @@ const normaliseCollectionWithNestedArticles = (
     normalisedCollection,
     collectionConfig
   );
-  const previouslyArticleFragmentIds = compact(collection.previously || []).map(
-    nestedArticleFragment => {
-      const maybeArticleFragment = Object.entries(normalisedCollection.entities
-        .articleFragments as {
-        [uuid: string]: ArticleFragment;
-      }).find(([_, article]) => article.id === nestedArticleFragment.id);
-      return maybeArticleFragment ? maybeArticleFragment[0] : undefined;
-    }
+  const previouslyArticleFragmentIds = createPreviouslyArticleFragmentIds(
+    collection,
+    normalisedCollection
   );
   return {
     normalisedCollection: {
@@ -179,4 +186,8 @@ function denormaliseCollection(
   });
 }
 
-export { normaliseCollectionWithNestedArticles, denormaliseCollection };
+export {
+  normaliseCollectionWithNestedArticles,
+  denormaliseCollection,
+  createPreviouslyArticleFragmentIds
+};


### PR DESCRIPTION
## What's changed?

This PR limits the number of displayed articles in each collection's "recently removed" section to 5. Previously the number was unlimited.

It also changes the text and title of the box. 

Additionally there was a bug with the old implementation, which meant that articles in recently removed didn't turn up in the order in which they had been removed. They were bunched by group instead of a strict time order. 

OLD
![Screenshot 2019-07-30 at 16 27 16](https://user-images.githubusercontent.com/10324129/62143088-53862300-b2e7-11e9-8960-94547fda0713.png)


NEW 
![Screenshot 2019-07-30 at 16 32 25](https://user-images.githubusercontent.com/10324129/62151004-4113e580-b2f7-11e9-84ed-fee031562da4.png)


## Implementation notes

Why is this PR so complicated?

 Because we need to remake some of the data structures to allow for articleFragments to be managed at a collection level, rather than at a Group level. 

Previously the denormalisation process going from the collections json removed ordering information from the collection articleFragments when putting them into Groups. 

So articleFragments were only accessible as part of Groups. We have to break them out to be saved at the Collection level. 

*How to view the recently removed behaviour*
If you launch a collection, remove an article, then launch the collection again - the most recently removed article should turn up at the top of the removed list. 



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
