### PR TITLE
Work around CAPI isLive logic

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -122,8 +122,14 @@ interface FeedItemProps {
   onAddToClipboard: (article: CapiArticle) => void;
 }
 
+// The content API drops the isLive flag on live CAPI endpoint, but keeps it in draft and print-sent.
+// We need to assume that if the isLive flag isn't present then it's because we're hitting the live endpoint
+// this makes the query to CAPI quite fragile. If anyone ever removes isLive from show-fields in the draft
+// endpoint then we'll assume *all* content is live.
 const isLive = (article: CapiArticle) =>
-  !article.fields.isLive || article.fields.isLive === 'true';
+  article.fields.isLive === undefined ||
+  article.fields.isLive === 'true' ||
+  article.fields.isLive === true;
 
 const getArticleLabel = (article: CapiArticle) => {
   const {

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -82,7 +82,7 @@ interface Tag {
   sectionName?: string;
 }
 
-type CapiBool = 'true' | 'false';
+type CapiBool = 'true' | 'false' | boolean;
 
 interface CapiArticleFields {
   headline?: string;


### PR DESCRIPTION
## What's changed?

As the comment says, concierge drops the `isLive` field from the live CAPI endpoint. The journalism team are going to fix this but in the meantime here's a workaround.

As soon as this logic is changed in CAPI we should undo the `=== undefined` part of the expression as this will make the logic fragile to someone accidentally removing the `isLive` flag from the proxied CAPI query.

Additionally the `CapiBool` type has been updated to reflect the inconsistency between the proxied request and the prefill request that uses the CAPI client.
