### PR TITLE
Setup defaults for new issue

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -13,6 +13,8 @@ import play.api.db.evolutions.EvolutionsComponents
 import play.api.routing.Router
 import play.filters.cors.CORSConfig
 import play.filters.cors.CORSConfig.Origins
+import filters._
+import model.editions.EditionsTemplates
 import router.Routes
 import services._
 import services.editions.EditionsTemplating
@@ -43,7 +45,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
 
   // Editions services
   val editionsDb = new EditionsDB(config.postgres.url, config.postgres.user, config.postgres.password)
-  val templating = new EditionsTemplating(capi)
+  val templating = new EditionsTemplating(EditionsTemplates.templates, capi)
   val publishingBucket = new EditionsBucket(s3Client, config.aws.publishedEditionsIssuesBucket)
   val previewBucket = new EditionsBucket(s3Client, config.aws.previewEditionsIssuesBucket)
   val editionsPublishing = new EditionsPublishing(publishingBucket, previewBucket, editionsDb)

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -24,7 +24,7 @@ class EditionsController(db: EditionsDB,
                          capi: Capi,
                          val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps)  with Logging {
 
-  def postIssue(name: String) = AccessAPIAuthAction(parse.json[CreateIssue]) { req =>
+  def createIssue(name: String) = AccessAPIAuthAction(parse.json[CreateIssue]) { req =>
     val form = req.body
 
     templating.generateEditionTemplate(name, form.issueDate).map { skeleton =>

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -35,6 +35,8 @@ case class ArticleMetadata (
 
 object ArticleMetadata {
   implicit val format = Json.format[ArticleMetadata]
+
+  val default = ArticleMetadata(None, None, None, None, None, None, None, None, None, None)
 }
 
 case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) {

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -4,8 +4,8 @@ import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
 case class Image (
-  height: Int,
-  width: Int,
+  height: Option[Int],
+  width: Option[Int],
   origin: String,
   src: String,
   thumb: Option[String] = None

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -93,8 +93,13 @@ case class EditionsFrontSkeleton(
 
 case class EditionsCollectionSkeleton(
     name: String,
-    items: List[String],
+    items: List[EditionsArticleSkeleton],
     prefill: Option[CapiPrefillQuery],
     presentation: CollectionPresentation,
     hidden: Boolean
+)
+
+case class EditionsArticleSkeleton(
+    pageCode: String,
+    metadata: ArticleMetadata
 )

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -18,7 +18,7 @@ object PublishedMediaType extends PlayEnum[PublishedMediaType] {
   override def values = findValues
 }
 
-case class PublishedImage(height: Int, width: Int, src: String)
+case class PublishedImage(height: Option[Int], width: Option[Int], src: String)
 
 case class PublishedFurniture(
   kicker: Option[String],

--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -90,7 +90,7 @@ object ClientArticleMetadata {
       articleMetadata.replaceImage.map(_.origin),
       articleMetadata.replaceImage.flatMap(_.thumb),
 
-      articleMetadata.cutoutImage.map(_ => mediaType == MediaType.Cutout),
+      articleMetadata.mediaType.map(_ == MediaType.Cutout),
       articleMetadata.cutoutImage.map(_.src),
       articleMetadata.cutoutImage.flatMap(_.height).map(_.toString),
       articleMetadata.cutoutImage.flatMap(_.width).map(_.toString),

--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -34,12 +34,12 @@ case class ClientArticleMetadata (
 ) {
   def toArticleMetadata: ArticleMetadata = {
     val cutoutImage: Option[Image] = (imageCutoutSrcHeight, imageCutoutSrcWidth, imageCutoutSrc, imageCutoutSrcOrigin) match {
-      case (Some(height), Some(width), Some(src), Some(origin)) => Some(Image(height.toInt, width.toInt, origin, src))
+      case (height, width, Some(src), Some(origin)) => Some(Image(height.map(_.toInt), width.map(_.toInt), origin, src))
       case _ => None
     }
 
     val replaceImage: Option[Image] = (imageSrcHeight, imageSrcWidth, imageSrc, imageSrcOrigin, imageSrcThumb) match {
-      case (Some(height), Some(width), Some(src), Some(origin), Some(thumb)) => Some(Image(height.toInt, width.toInt, origin, src, Some(thumb)))
+      case (height, width, Some(src), Some(origin), Some(thumb)) => Some(Image(height.map(_.toInt), width.map(_.toInt), origin, src, Some(thumb)))
       case _ => None
     }
 
@@ -85,15 +85,15 @@ object ClientArticleMetadata {
 
       articleMetadata.replaceImage.map(_ => mediaType == MediaType.Image),
       articleMetadata.replaceImage.map(_.src),
-      articleMetadata.replaceImage.map(_.height.toString),
-      articleMetadata.replaceImage.map(_.width.toString),
+      articleMetadata.replaceImage.flatMap(_.height).map(_.toString),
+      articleMetadata.replaceImage.flatMap(_.width).map(_.toString),
       articleMetadata.replaceImage.map(_.origin),
       articleMetadata.replaceImage.flatMap(_.thumb),
 
       articleMetadata.cutoutImage.map(_ => mediaType == MediaType.Cutout),
       articleMetadata.cutoutImage.map(_.src),
-      articleMetadata.cutoutImage.map(_.height.toString),
-      articleMetadata.cutoutImage.map(_.width.toString),
+      articleMetadata.cutoutImage.flatMap(_.height).map(_.toString),
+      articleMetadata.cutoutImage.flatMap(_.width).map(_.toString),
       articleMetadata.cutoutImage.map(_.origin),
 
       articleMetadata.slideshowImages.map(_ => mediaType == MediaType.Slideshow),

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -21,7 +21,12 @@ import okhttp3.{Call, Callback, Request, Response}
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-case class PrefillMetadata(showByline: Boolean, showQuotedHeadline: Boolean, cutout: Option[String])
+case class PrefillMetadata(
+                            showByline: Boolean,
+                            showQuotedHeadline: Boolean,
+                            imageCutoutReplace: Boolean,
+                            cutout: Option[String]
+                          )
 
 class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionContext) extends GuardianContentClient(config.contentApi.editionsKey) with Capi with Logging {
   override def targetUrl: String = config.contentApi.editionsPrefillHost
@@ -178,7 +183,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
         .flatMap(_.bylineLargeImageUrl)
         .headOption
     } else None
-    PrefillMetadata(metadata.showByline, metadata.showQuotedHeadline, maybeCutout)
+    PrefillMetadata(metadata.showByline, metadata.showQuotedHeadline, metadata.imageCutoutReplace, maybeCutout)
   }
 }
 

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -10,6 +10,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
+import scala.language.postfixOps
+
 class EditionsTemplating(capi: Capi) extends Logging {
   def generateEditionTemplate(name: String, localDate: LocalDate): Option[EditionsIssueSkeleton] = {
    EditionsTemplates.templates
@@ -57,7 +59,7 @@ class EditionsTemplating(capi: Capi) extends Logging {
         showByline = Some(capiMetadata.showByline),
         showQuotedHeadline = Some(capiMetadata.showQuotedHeadline),
         mediaType = if (capiMetadata.cutout.isDefined) Some(MediaType.Cutout) else None,
-        cutoutImage = capiMetadata.cutout.map(url => Image(0, 0, url, url))
+        cutoutImage = capiMetadata.cutout.map(url => Image(None, None, url, url))
       )
       EditionsArticleSkeleton(pageCode, metadata)
     }

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -2,6 +2,7 @@ package services.editions
 
 import java.time.{LocalDate, LocalTime, ZonedDateTime}
 
+import logging.Logging
 import model.editions._
 import services.Capi
 
@@ -9,7 +10,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
-class EditionsTemplating(capi: Capi) {
+class EditionsTemplating(capi: Capi) extends Logging {
   def generateEditionTemplate(name: String, localDate: LocalDate): Option[EditionsIssueSkeleton] = {
    EditionsTemplates.templates
       .get(name)
@@ -55,7 +56,8 @@ class EditionsTemplating(capi: Capi) {
       val metadata = ArticleMetadata.default.copy(
         showByline = Some(capiMetadata.showByline),
         showQuotedHeadline = Some(capiMetadata.showQuotedHeadline),
-        mediaType = if (capiMetadata.imageCutoutReplace) Some(MediaType.Cutout) else None
+        mediaType = if (capiMetadata.cutout.isDefined) Some(MediaType.Cutout) else None,
+        cutoutImage = capiMetadata.cutout.map(url => Image(0, 0, url, url))
       )
       EditionsArticleSkeleton(pageCode, metadata)
     }

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -4,6 +4,7 @@ import java.time.{LocalDate, OffsetDateTime}
 
 import com.gu.pandomainauth.model.User
 import model.editions._
+import play.api.libs.json.Json
 import scalikejdbc._
 import services.editions.{DbEditionsArticle, DbEditionsCollection, DbEditionsFront}
 import services.editions.CollectionsHelpers._
@@ -60,14 +61,15 @@ trait IssueQueries {
           RETURNING id;
           """.map(_.string("id")).single().apply().get
 
-          collection.items.zipWithIndex.foreach { case (pageCode, tIndex) =>
+          collection.items.zipWithIndex.foreach { case (article, tIndex) =>
               sql"""
                     INSERT INTO articles (
                     collection_id,
                     page_code,
                     index,
-                    added_on
-                    ) VALUES ($collectionId, $pageCode, $tIndex, $truncatedNow)
+                    added_on,
+                    metadata
+                    ) VALUES ($collectionId, ${article.pageCode}, $tIndex, $truncatedNow, ${Json.toJson(article.metadata).toString}::JSONB)
                  """.execute().apply()
           }
         }

--- a/conf/routes
+++ b/conf/routes
@@ -103,8 +103,7 @@ POST        /api/usage                               controllers.GridProxy.addUs
 # Editions
 GET         /editions-api/editions                               controllers.EditionsController.getAvailableEditions
 GET         /editions-api/editions/:name/issues                  controllers.EditionsController.listIssues(name)
-POST        /editions-api/editions/:name/issues                  controllers.EditionsController.postIssue(name)
-
+POST        /editions-api/editions/:name/issues                  controllers.EditionsController.createIssue(name)
 GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
 GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)
 POST        /editions-api/issues/:id/publish                     controllers.EditionsController.publishIssue(id)

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -3,6 +3,7 @@ package services
 import java.time.{LocalDate, ZonedDateTime}
 
 import com.gu.contentapi.client.model.v1.SearchResponse
+import fixtures.TestEdition
 import org.scalatest.{FreeSpec, Matchers}
 import model.editions._
 import services.editions.EditionsTemplating
@@ -17,7 +18,7 @@ class editionTemplateTest extends FreeSpec with Matchers {
     override def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
     override def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[(String, PrefillMetadata)]] = Future.successful(Nil)
   }
-  val templating = new EditionsTemplating(TestCapi)
+  val templating = new EditionsTemplating(TestEdition.templates, TestCapi)
 
 //  "createEdition" - {
 //    "should return Monday's content for Monday" in {

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -15,7 +15,7 @@ class editionTemplateTest extends FreeSpec with Matchers {
   object TestCapi extends Capi {
     override def getPreviewHeaders(url: String): Seq[(String, String)] = Seq.empty[(String, String)]
     override def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
-    override def getPrefillArticlePageCodes(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[String]] = Future.successful(Nil)
+    override def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[(String, PrefillMetadata)]] = Future.successful(Nil)
   }
   val templating = new EditionsTemplating(TestCapi)
 

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -16,7 +16,7 @@ class editionTemplateTest extends FreeSpec with Matchers {
   object TestCapi extends Capi {
     override def getPreviewHeaders(url: String): Seq[(String, String)] = Seq.empty[(String, String)]
     override def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
-    override def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[(String, PrefillMetadata)]] = Future.successful(Nil)
+    override def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = Future.successful(Nil)
   }
   val templating = new EditionsTemplating(TestEdition.templates, TestCapi)
 

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -1,0 +1,116 @@
+package fixtures
+
+import java.time.ZoneId
+
+import model.editions.{CapiPrefillQuery, CollectionTemplate, Daily, EditionTemplate, FrontTemplate, WeekDay, WeekDays}
+import model.editions.templates.TemplateDefaults
+
+object TestEdition {
+  val template = EditionTemplate(
+    List(
+      FrontTopStories.front -> Daily(),
+      FrontNewsUkGuardian.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri)),
+      FrontNewsUkGuardianSaturday.front -> WeekDays(List(WeekDay.Sat)),
+      FrontCulture.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs)),
+      FrontSpecialSpecial2.front -> Daily(),
+    ),
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily()
+  )
+
+  val templates: Map[String, EditionTemplate] = Map("test-edition" -> template)
+}
+
+object FrontTopStories {
+  val collectionTopStories = CollectionTemplate(
+    name = "Top Stories",
+    prefill = None,
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+
+  val front = FrontTemplate(
+    name = "Top Stories",
+    collections = List(collectionTopStories),
+    presentation = TemplateDefaults.defaultFrontPresentation
+  )
+}
+
+object FrontNewsUkGuardian {
+  val collectionNewsFrontPage = CollectionTemplate(
+    name = "Front Page",
+    prefill =  Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val collectionNewsUkNewsGuardian = CollectionTemplate(
+    name = "UK News",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val collectionNewsWeather = CollectionTemplate(
+    name = "Weather",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val front = FrontTemplate(
+    name = "UK News",
+    collections = List(collectionNewsFrontPage, collectionNewsUkNewsGuardian, collectionNewsWeather),
+    presentation = TemplateDefaults.defaultFrontPresentation
+  )
+}
+
+object FrontNewsUkGuardianSaturday {
+  val collectionNewsFrontPage = CollectionTemplate(
+    name = "Front Page",
+    prefill =  Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val collectionNewsSpecial1 = CollectionTemplate(
+    name = "News Special",
+    prefill = None,
+    presentation = TemplateDefaults.defaultCollectionPresentation,
+    hidden = true
+  )
+  val collectionNewsWeather = CollectionTemplate(
+    name = "Weather",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val front = FrontTemplate(
+    name = "UK News",
+    collections = List(collectionNewsFrontPage, collectionNewsSpecial1, collectionNewsWeather),
+    presentation = TemplateDefaults.defaultFrontPresentation
+  )
+}
+
+object FrontCulture {
+  val collectionCultureArts = CollectionTemplate(
+    name = "Arts",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val collectionCultureTVandRadio = CollectionTemplate(
+    name = "TV & Radio",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+  val front = FrontTemplate(
+    name = "Culture",
+    collections = List(collectionCultureArts, collectionCultureTVandRadio),
+    presentation = TemplateDefaults.defaultFrontPresentation
+  )
+}
+
+object FrontSpecialSpecial2 {
+  val collectionSpecialSpecial2 = CollectionTemplate(
+    name = "Special",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement")),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+
+  val front = FrontTemplate(
+    name = "Special 2",
+    collections = List(collectionSpecialSpecial2),
+    presentation = TemplateDefaults.defaultFrontPresentation,
+    hidden = true
+  )
+}

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -95,11 +95,11 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           showQuotedHeadline = false,
           mediaType = PublishedMediaType.Cutout,
           imageSrcOverride = Some(
-            PublishedImage(height = 1280, width = 720, "https://media.giphy.com/media/yV5iknckcXcc/source.gif")
+            PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/yV5iknckcXcc/source.gif")
           ),
           slideshowImages = Some(List(
-            PublishedImage(height = 1280, width = 720, "https://media.giphy.com/media/TLulTJKuyLgMU/source.gif"),
-            PublishedImage(height = 1280, width = 720, "https://media.giphy.com/media/GuWSJPF6bEkKs/source.gif")
+            PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/TLulTJKuyLgMU/source.gif"),
+            PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/GuWSJPF6bEkKs/source.gif")
           ))
         ))
 

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -32,10 +32,10 @@ class PublishedIssueTest extends FreeSpec with Matchers {
         Some("byline"),
         Some(MediaType.Image),
         None,
-        Some(Image(100, 100, "file://image-1.gif", "file://image-1.jpg")),
+        Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg")),
         Some(List(
-          Image(100, 100, "file://image-2.gif", "file://image-2.jpg"),
-          Image(100, 100, "file://image-3.gif", "file://image-3.jpg")
+          Image(Some(100), Some(100), "file://image-2.gif", "file://image-2.jpg"),
+          Image(Some(100), Some(100), "file://image-3.gif", "file://image-3.jpg")
         ))
       )
       val article = EditionsArticle("123456", 0, Some(furniture))
@@ -49,7 +49,7 @@ class PublishedIssueTest extends FreeSpec with Matchers {
         showByline = true,
         showQuotedHeadline = true,
         mediaType = PublishedMediaType.Image,
-        imageSrcOverride = Some(PublishedImage(100, 100, "file://image-1.jpg")),
+        imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg")),
         slideshowImages = None
       )
     }

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -45,7 +45,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         None,
         Some(MediaType.Hide),
-        Some(Image(100, 100, "file://origin-new-pokemon.gif", "file://new-pokemon.gif")),
+        Some(Image(Some(100), Some(100), "file://origin-new-pokemon.gif", "file://new-pokemon.gif")),
         None,
         None
       )
@@ -77,10 +77,10 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(MediaType.Image),
         None,
-        Some(Image(100, 100, "file://elephant.jpg", "file://elephant.png")),
+        Some(Image(Some(100), Some(100), "file://elephant.jpg", "file://elephant.png")),
         Some(List(
-          Image(100, 100, "file://elephant-playing-in-mud.jpg", "file://elephant-playing-in-mud.png"),
-          Image(100, 100, "file://elephant-spraying-water.jpg", "file://elephant-spraying-water.png")
+          Image(Some(100), Some(100), "file://elephant-playing-in-mud.jpg", "file://elephant-playing-in-mud.png"),
+          Image(Some(100), Some(100), "file://elephant-spraying-water.jpg", "file://elephant-spraying-water.png")
         ))
       )
 
@@ -99,8 +99,8 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
 
       clientArticleMetadata.imageSlideshowReplace shouldBe Some(false)
       clientArticleMetadata.slideshow shouldBe Some(List(
-        Image(100, 100, "file://elephant-playing-in-mud.jpg", "file://elephant-playing-in-mud.png"),
-        Image(100, 100, "file://elephant-spraying-water.jpg", "file://elephant-spraying-water.png")
+        Image(Some(100), Some(100), "file://elephant-playing-in-mud.jpg", "file://elephant-playing-in-mud.png"),
+        Image(Some(100), Some(100), "file://elephant-spraying-water.jpg", "file://elephant-spraying-water.png")
       ))
     }
 
@@ -158,16 +158,16 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       articleMetadata.mediaType.isDefined shouldBe true
       articleMetadata.mediaType.get shouldBe MediaType.Image
       articleMetadata.replaceImage shouldBe Some(Image(
-        100,
-        100,
+        Some(100),
+        Some(100),
         "file://lightning.gif",
         "file://lightning.jpg",
         Some("file://lightning.png")
       ))
 
       articleMetadata.cutoutImage shouldBe Some(Image(
-        100,
-        100,
+        Some(100),
+        Some(100),
         "file://broom.gif",
         "file://broom.jpg"
       ))

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -122,6 +122,25 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
 
       clientArticleMetadata.imageReplace shouldBe None
     }
+
+    "should explicitly set cutout to false if media type is set but not to a cutout" in {
+      val articleMetadata = ArticleMetadata(
+        Some("Teenage Mutant Ninja Turtles"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(MediaType.UseArticleTrail),
+        None,
+        None,
+        None
+      )
+
+      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+
+      clientArticleMetadata.imageCutoutReplace shouldBe Some(false)
+    }
   }
 
   "ClientArticleMetadata to ArticleMetadata" - {

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -1,0 +1,47 @@
+package services.editions
+
+import java.time.{LocalDate, ZonedDateTime}
+
+import com.gu.contentapi.client.model.v1.SearchResponse
+import fixtures.TestEdition
+import model.editions.{ArticleMetadata, CapiPrefillQuery, EditionsArticleSkeleton, Image, MediaType}
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import services.{Capi, PrefillMetadata}
+
+import scala.concurrent.Future
+
+class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
+  "Creating a template" - {
+    "Sets the prefill metadata from CAPI" in {
+      val fakeCapi = new Capi {
+        def getPreviewHeaders(url: String): Seq[(String, String)] = ???
+        def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[(String, PrefillMetadata)]] = {
+          capiPrefillQuery.queryString match {
+            case "?tag=theguardian/mainsection/topstories" => Future.successful(List(
+              "123456" -> PrefillMetadata(false, false, None)
+            ))
+            case "?tag=theguardian/g2/arts" => Future.successful(List(
+              "345678" -> PrefillMetadata(true, true, Some("https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif"))
+            ))
+          }
+        }
+        def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = ???
+      }
+      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
+      val issue = templating.generateEditionTemplate("test-edition", LocalDate.of(2019, 9, 30)).value
+      issue.fronts.size shouldBe 4
+      val frontPage = issue.fronts.find(_.name == "UK News").value.collections.find(_.name == "Front Page").value
+      frontPage.items.size shouldBe 1
+      frontPage.items.head.pageCode shouldBe "123456"
+      frontPage.items.head.metadata shouldBe ArticleMetadata.default
+      val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
+      arts.items.size shouldBe 1
+      arts.items.head.pageCode shouldBe "345678"
+      arts.items.head.metadata.showByline.value shouldBe true
+      arts.items.head.metadata.showQuotedHeadline.value shouldBe true
+      arts.items.head.metadata.mediaType.value shouldBe MediaType.Cutout
+      arts.items.head.metadata.cutoutImage.value shouldBe
+        Image(None, None, "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif", "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif")
+    }
+  }
+}

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -4,9 +4,9 @@ import java.time.{LocalDate, ZonedDateTime}
 
 import com.gu.contentapi.client.model.v1.SearchResponse
 import fixtures.TestEdition
-import model.editions.{ArticleMetadata, CapiPrefillQuery, EditionsArticleSkeleton, Image, MediaType}
+import model.editions.{ArticleMetadata, CapiPrefillQuery, Image, MediaType}
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
-import services.{Capi, PrefillMetadata}
+import services.{Capi, Prefill}
 
 import scala.concurrent.Future
 
@@ -15,14 +15,14 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
     "Sets the prefill metadata from CAPI" in {
       val fakeCapi = new Capi {
         def getPreviewHeaders(url: String): Seq[(String, String)] = ???
-        def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[(String, PrefillMetadata)]] = {
+        def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = {
           capiPrefillQuery.queryString match {
             case "?tag=theguardian/mainsection/topstories" => Future.successful(List(
-              "123456" -> PrefillMetadata(false, false, false, None)
+              Prefill(123456, false, false, false, None)
             ))
             case "?tag=theguardian/g2/arts" => Future.successful(List(
-              "345678" -> PrefillMetadata(true, true, true, Some("https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif")),
-              "574893" -> PrefillMetadata(true, true, true, None),
+              Prefill(345678, true, true, true, Some("https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif")),
+              Prefill(574893, true, true, true, None),
             ))
           }
         }

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -18,10 +18,11 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
         def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[(String, PrefillMetadata)]] = {
           capiPrefillQuery.queryString match {
             case "?tag=theguardian/mainsection/topstories" => Future.successful(List(
-              "123456" -> PrefillMetadata(false, false, None)
+              "123456" -> PrefillMetadata(false, false, false, None)
             ))
             case "?tag=theguardian/g2/arts" => Future.successful(List(
-              "345678" -> PrefillMetadata(true, true, Some("https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif"))
+              "345678" -> PrefillMetadata(true, true, true, Some("https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif")),
+              "574893" -> PrefillMetadata(true, true, true, None),
             ))
           }
         }
@@ -35,13 +36,20 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
       frontPage.items.head.pageCode shouldBe "123456"
       frontPage.items.head.metadata shouldBe ArticleMetadata.default
       val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
-      arts.items.size shouldBe 1
-      arts.items.head.pageCode shouldBe "345678"
-      arts.items.head.metadata.showByline.value shouldBe true
-      arts.items.head.metadata.showQuotedHeadline.value shouldBe true
-      arts.items.head.metadata.mediaType.value shouldBe MediaType.Cutout
-      arts.items.head.metadata.cutoutImage.value shouldBe
+      arts.items.size shouldBe 2
+      val arts1 = arts.items.head
+      arts1.pageCode shouldBe "345678"
+      arts1.metadata.showByline.value shouldBe true
+      arts1.metadata.showQuotedHeadline.value shouldBe true
+      arts1.metadata.mediaType.value shouldBe MediaType.Cutout
+      arts1.metadata.cutoutImage.value shouldBe
         Image(None, None, "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif", "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif")
+      val arts2 = arts.items.tail.head
+      arts2.pageCode shouldBe "574893"
+      arts2.metadata.showByline.value shouldBe true
+      arts2.metadata.showQuotedHeadline.value shouldBe true
+      arts2.metadata.mediaType.value shouldBe MediaType.UseArticleTrail
+      arts2.metadata.cutoutImage shouldBe None
     }
   }
 }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -7,7 +7,6 @@ import fixtures.{EditionsDBService, UsesDatabase}
 import model.editions._
 import model.forms.GetCollectionsFilter
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
-import services.PrefillMetadata
 
 class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with OptionValues {
 

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -7,6 +7,7 @@ import fixtures.{EditionsDBService, UsesDatabase}
 import model.editions._
 import model.forms.GetCollectionsFilter
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import services.PrefillMetadata
 
 class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with OptionValues {
 
@@ -43,8 +44,10 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
   private def front(name: String, collections: EditionsCollectionSkeleton*): EditionsFrontSkeleton =
     EditionsFrontSkeleton(name, collections.toList, FrontPresentation(), hidden = false, canRename = false)
 
-  private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: String*): EditionsCollectionSkeleton =
+  private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticleSkeleton*): EditionsCollectionSkeleton =
     EditionsCollectionSkeleton(name, articles.toList, prefill, CollectionPresentation(), hidden = false)
+
+  private def article(pageCode: String): EditionsArticleSkeleton = EditionsArticleSkeleton(pageCode, ArticleMetadata.default)
 
   "The editions DB" - {
     "should insert an empty issue" taggedAs UsesDatabase in {
@@ -80,13 +83,29 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should insert fronts, collections and articles" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),"12345", "23456"),
-          collection("international", None,"34567", "45678", "56789")
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          ),
+          collection("international", None,
+            article("34567"),
+            article("45678"),
+            article("56789")
+          )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),"54321", "65432"),
-          collection("brexshit", None,"76543", "87654"),
-          collection("sigh", None,"98765", "09876")
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+            article("54321"),
+            article("65432")
+          ),
+          collection("brexshit", None,
+            article("76543"),
+            article("87654")
+          ),
+          collection("sigh", None,
+            article("98765"),
+            article("09876")
+          )
         )
       )
 
@@ -116,17 +135,26 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow lookup of issue by collection id" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")), "12345", "23456")
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          )
         )
       )
       insertSkeletonIssue(2019, 9, 29,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")), "54321", "65432")
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("54321"),
+            article("65432")
+          )
         )
       )
       insertSkeletonIssue(2019, 9, 28,
         front("news/uk",
-          collection("politics", None, "14789", "32147")
+          collection("politics", None,
+            article("14789"),
+            article("32147")
+          )
         )
       )
 
@@ -140,13 +168,28 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow a set of collections to be fetched individually" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),"12345", "23456"),
-          collection("international", None,"34567", "45678", "56789")
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          ),
+          collection("international", None,article("34567"),
+            article("45678"),
+            article("56789")
+          )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),"54321", "65432"),
-          collection("brexshit", None,"76543", "87654"),
-          collection("sigh", None,"98765", "09876")
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+            article("54321"),
+            article("65432")
+          ),
+          collection("brexshit", None,
+            article("76543"),
+            article("87654")
+          ),
+          collection("sigh", None,
+            article("98765"),
+            article("09876")
+          )
         )
       )
 
@@ -168,13 +211,29 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow collections to be filtered by timestamp" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),"12345", "23456"),
-          collection("international", None,"34567", "45678", "56789")
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          ),
+          collection("international", None,
+            article("34567"),
+            article("45678"),
+            article("56789")
+          )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),"54321", "65432"),
-          collection("brexshit", None,"76543", "87654"),
-          collection("sigh", None,"98765", "09876")
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+            article("54321"),
+            article("65432")
+          ),
+          collection("brexshit", None,
+            article("76543"),
+            article("87654")
+          ),
+          collection("sigh", None,
+            article("98765"),
+            article("09876")
+          )
         )
       )
 
@@ -199,13 +258,29 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow updating of a collection" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),"12345", "23456"),
-          collection("international", None,"34567", "45678", "56789")
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          ),
+          collection("international", None,
+            article("34567"),
+            article("45678"),
+            article("56789")
+          )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),"54321", "65432"),
-          collection("brexshit", None,"76543", "87654"),
-          collection("sigh", None,"98765", "09876")
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+            article("54321"),
+            article("65432")
+          ),
+          collection("brexshit", None,
+            article("76543"),
+            article("87654")
+          ),
+          collection("sigh", None,
+            article("98765"),
+            article("09876")
+          )
         )
       )
 


### PR DESCRIPTION
## What's changed?

Content added to a front has some default options applied depending on the type of content. For example, a piece of content that has the Comment tone will automatically have the `showByline` and `showQuoteHeadline` flags set to true and will also set the media type to a cutout of the content's author.

In the network fronts tool this currently happens on the client side. In the editions varient a piece of content can be added either by prefilling containers using CAPI queries or in the same way as on a network front by dragging content over. At present neither correctly applies the defaults to added content - it appears to work but is never saved to the database or propagated downstream.

This PR addresses the prefilling stage by evaluating content when an issue is created from a template and ensuring that the settings are populated correctly in the database.

## Implementation notes

A few notes:
 - This is not super DRY in so far as it duplicates a small amount of core logic for evaluating the settings in the CAPI interface used by editions
 - Whilst the settings available are many we only honour `showByline`, `showQuoteHeadline` and `imageCutoutReplace` as they are the only ones that are currently modified on a per content basis
 - Actually that's not quite true: `showMainVideo` is modified for video content but video content is not supported in editions so we don't check for it
 - When `imageCutoutReplace` is set we pull in the first `bylineLargeImageUrl` from the contributor tags to use as the cutout image
 - We've made image dimensions optional throughout editions as we don't know it for the cutout image and can't find it out unless we download it - the app team has said that this is OK and they'll come back to us if they need it for any reason
 - We assume that if a cutout is desired (i.e. it's a comment tone) but a cutout cannot be found in any contributor tag that we should fall back to the article's trail image
 - I've added some basic template tests. In order to do this I've created a new `test-edition` that won't change and restructured the template engine to be more easily tested.
 - This tests the way the templating engine deals with the response from the CAPI interface but does NOT test the CAPI query code.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE
