### PR TITLE
Metadata display: updating integration tests to match new behaviour

### DIFF
--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -19,6 +19,7 @@ const EDIT_FORM = 'edit-form';
 const EDIT_FORM_HEADLINE_FIELD = 'edit-form-headline-field';
 const EDIT_FORM_SAVE_BUTTON = 'edit-form-save-button';
 const EDIT_FORM_BREAKING_NEWS_TOGGLE = 'edit-form-breaking-news-toggle';
+const BREAKING_NEWS_SELECTOR = 'breaking-news';
 
 const FRONTS_MENU_BUTTON = 'fronts-menu-button';
 const FRONTS_MENU_ITEM = 'fronts-menu-item';
@@ -84,6 +85,11 @@ export const collectionItemHeadline = (collectionIndex, itemIndex = 0) =>
 export const collectionItemKicker = (collectionIndex, itemIndex = 0) =>
   collectionItem(collectionIndex, itemIndex).find(
     `[data-testid="${KICKER_SELECTOR}"]`
+  );
+
+export const collectionItemBreakingNews = (collectionIndex, itemIndex = 0) =>
+  collectionItem(collectionIndex, itemIndex).find(
+    `[data-testid="${BREAKING_NEWS_SELECTOR}"]`
   );
 
 export const collectionDiscardButton = collectionIndex =>

--- a/client-v2/integration/tests/edit-item-metadata.spec.js
+++ b/client-v2/integration/tests/edit-item-metadata.spec.js
@@ -7,6 +7,7 @@ import {
   collectionItem,
   collectionItemHeadline,
   collectionItemKicker,
+  collectionItemBreakingNews,
   editFormHeadlineInput,
   editFormSaveButton,
   editFormBreakingNewsToggle,
@@ -51,7 +52,7 @@ test('Metadata edits are persisted in collections- "breaking news" toggle button
     .click(firstCollectionStory)
     .click(breakingNewsToggle)
     .click(editFormSaveButton())
-    .expect(collectionItemKicker(0, 0).textContent)
+    .expect(collectionItemBreakingNews(0, 0).textContent)
     .contains(`Breaking news`);
 });
 
@@ -64,6 +65,6 @@ test('Metadata edits are persisted in clipboard- "breaking news" toggle button',
     .click(breakingNewsToggle)
     .click(editFormSaveButton())
     .dragToElement(clipboardItem(0), firstCollectionFirstDropZone) // Kickers are not visible in clipboard, drag to collection to view
-    .expect(collectionItemKicker(0, 0).textContent)
+    .expect(collectionItemBreakingNews(0, 0).textContent)
     .contains(`Breaking news`);
 });

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -212,7 +212,9 @@ const articleBodyDefault = React.memo(
             isBoosted) && (
             <ArticleMetadataProperties>
               {isBreaking && (
-                <ArticleMetadataProperty>Breaking news</ArticleMetadataProperty>
+                <ArticleMetadataProperty data-testid="breaking-news">
+                  Breaking news
+                </ArticleMetadataProperty>
               )}
               {showByline && (
                 <ArticleMetadataProperty>Show byline</ArticleMetadataProperty>


### PR DESCRIPTION
## What's changed?

The integration tests did not accurately reflect the new metadata display behaviour. Now they do.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
