### PR TITLE
Front Renaming - Frontend

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -116,7 +116,6 @@ class EditionsController(db: EditionsDB,
   }
 
   def putFrontMetadata(id: String) = AccessAPIAuthAction(parse.json[EditionsFrontMetadata]) { req =>
-    db.updateFrontMetadata(id, req.body)
-    NoContent
+    Ok(Json.toJson(db.updateFrontMetadata(id, req.body)))
   }
 }

--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -32,7 +32,7 @@ case class EditionsFront(
   def toPublishedFront: PublishedFront = {
     PublishedFront(
       id,
-      displayName,
+      metadata.flatMap(_.nameOverride).getOrElse(displayName),
       collections.filterNot(_.isHidden).map(_.toPublishedCollection)
     )
   }

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -5,7 +5,7 @@ import scalikejdbc._
 import play.api.libs.json._
 
 trait FrontsQueries {
-  def updateFrontMetadata(id: String, metadata: EditionsFrontMetadata): Boolean = DB localTx { implicit session =>
+  def updateFrontMetadata(id: String, metadata: EditionsFrontMetadata): Option[EditionsFrontMetadata] = DB localTx { implicit session =>
     sql"""
           UPDATE fronts
           SET metadata = ${metadata.toPGobject}
@@ -36,16 +36,4 @@ trait FrontsQueries {
       }).single().apply().get
     Json.fromJson[EditionsFrontMetadata](Json.parse(rawJson)).get
   }
-
-  def mergeFrontMetadata(id: String, metadata: EditionsFrontMetadata): Boolean = DB localTx { implicit session =>
-    val original = getFrontMetadata(id)
-    val mergedMetadata = mergeMetadatas(metadata, original)
-    updateFrontMetadata(id, mergedMetadata)
-
-  }
-
-  def mergeMetadatas(additionalMetadata: EditionsFrontMetadata, originalMetadata: EditionsFrontMetadata): EditionsFrontMetadata = {
-    Json.fromJson[EditionsFrontMetadata](Json.toJson(originalMetadata).as[JsObject] ++ Json.toJson(additionalMetadata).as[JsObject]).get
-  }
-
 }

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -11,6 +11,15 @@ trait FrontsQueries {
           SET metadata = ${metadata.toPGobject}
           WHERE id = $id
       """.execute().apply()
+
+    sql"""
+        SELECT metadata FROM fronts WHERE id = $id
+      """.map { rs =>
+      rs.stringOpt("metadata").map { metadataString =>
+        // Throw if we can't parse the metadata to signal to the user that something is broken
+        Json.parse(metadataString).validate[EditionsFrontMetadata].get
+      }
+    }.single().apply().flatten
   }
 
   def getFrontMetadata(id: String): EditionsFrontMetadata = DB localTx { implicit session =>

--- a/client-v2/integration/fixtures/edition.js
+++ b/client-v2/integration/fixtures/edition.js
@@ -8,7 +8,7 @@ module.exports = {
   launchedEmail: 'r.b@gu.com',
   fronts: [
     {
-      id: 'rich/test',
+      id: 'regular_front',
       displayName: 'rich/test',
       isHidden: false,
       // updatedOn?: number,
@@ -37,6 +37,23 @@ module.exports = {
           // updatedBy?: string,
           // updatedEmail?: string,
           items: []
+        }
+      ]
+    },
+    {
+      id: 'special_front',
+      displayName: 'Special 1',
+      canRename: true,
+      isHidden: false,
+      collections: [
+        {
+          id: 'collection-special',
+          displayName: 'Special Collection',
+          isHidden: false,
+          items: [],
+          prefill: {
+            queryString: 'this-doesnt-matter'
+          }
         }
       ]
     }

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -20,6 +20,9 @@ const EDIT_FORM_HEADLINE_FIELD = 'edit-form-headline-field';
 const EDIT_FORM_SAVE_BUTTON = 'edit-form-save-button';
 const EDIT_FORM_BREAKING_NEWS_TOGGLE = 'edit-form-breaking-news-toggle';
 const BREAKING_NEWS_SELECTOR = 'breaking-news';
+const RENAME_FRONT_BUTTON = 'rename-front-button';
+const RENAME_FRONT_INPUT = 'rename-front-input';
+const FRONT_NAME = 'front-name';
 
 const FRONTS_MENU_BUTTON = 'fronts-menu-button';
 const FRONTS_MENU_ITEM = 'fronts-menu-item';
@@ -133,6 +136,10 @@ export const frontDropZone = maybeGetNth(
 export const frontItemAddToClipboardHoverButton = maybeGetNth(
   select(FRONT_SELECTOR, ADD_TO_CLIPBOARD_BUTTON)
 );
+
+export const renameFrontButton = maybeGetNth(select(RENAME_FRONT_BUTTON));
+export const renameFrontInput = select(RENAME_FRONT_INPUT);
+export const frontName = maybeGetNth(select(FRONT_NAME));
 
 // Front Menu //
 export const frontsMenuButton = () => select(FRONTS_MENU_BUTTON);

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -144,6 +144,11 @@ module.exports = async () =>
     app.get('/editions-api/issues/:id/summary', (_, res) =>
       res.json({ ...edition, fronts: undefined })
     );
+
+    app.put('/editions-api/fronts/:id/metadata', (req, res) => {
+      return res.json(req.body);
+    });
+
     app.get('/editions-api/collections/:id/prefill', (req, res) => {
       return res.json(prefill);
     });

--- a/client-v2/integration/tests/editions.spec.js
+++ b/client-v2/integration/tests/editions.spec.js
@@ -4,7 +4,10 @@ import {
   frontsMenuButton,
   frontsMenuItem,
   prefillButton,
-  feedItemHeadline
+  feedItemHeadline,
+  frontName,
+  renameFrontButton,
+  renameFrontInput
 } from '../selectors';
 
 fixture`Fronts edit`
@@ -28,4 +31,18 @@ test('Check prefill button renders searches properly.', async t => {
     .click(prefillButton(0))
     .expect(feedItemHeadline(0).textContent)
     .eql('Iran stokes Gulf tensions by seizing two British-linked oil tankers');
+});
+
+test('Check renaming a front works', async t => {
+  await t
+    .click(frontsMenuButton())
+    .click(frontsMenuItem(1))
+    .expect(frontName(0).textContent)
+    .eql('Special 1')
+    .click(renameFrontButton(0))
+    .selectText(renameFrontInput())
+    .typeText(renameFrontInput(), 'Super neat custom front name')
+    .pressKey('enter')
+    .expect(frontName(0).textContent)
+    .eql('Super neat custom front name');
 });

--- a/client-v2/src/actions/Editions.tsx
+++ b/client-v2/src/actions/Editions.tsx
@@ -75,6 +75,6 @@ export const updateFrontMetadata = (
       }
     });
   } catch (error) {
-    console.error('failed to put front metadata: ', error);
+    // @todo implement centralised error handling
   }
 };

--- a/client-v2/src/actions/Editions.tsx
+++ b/client-v2/src/actions/Editions.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { getIssueSummary, publishIssue } from 'services/editionsApi';
+import {
+  getIssueSummary,
+  publishIssue,
+  putFrontMetadata
+} from 'services/editionsApi';
 import { ThunkResult } from 'types/Store';
 import { Dispatch } from 'redux';
 import { actions } from 'bundles/editionsIssueBundle';
 import { startConfirmModal } from './ConfirmModal';
+import { EditionsFrontMetadata } from 'types/FaciaApi';
 
 export const getEditionIssue = (
   id: string
@@ -53,5 +58,23 @@ export const publishEditionIssue = (
         false
       )
     );
+  }
+};
+
+export const updateFrontMetadata = (
+  id: string,
+  metadata: EditionsFrontMetadata
+): ThunkResult<Promise<void>> => async (dispatch: Dispatch) => {
+  try {
+    const serverMetadata = await putFrontMetadata(id, metadata);
+    dispatch({
+      type: 'FETCH_UPDATE_METADATA_SUCCESS',
+      payload: {
+        frontId: id,
+        metadata: serverMetadata
+      }
+    });
+  } catch (error) {
+    console.error('failed to put front metadata: ', error);
   }
 };

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -163,7 +163,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     this.props.frontsActions.editorCloseFront(this.props.frontId);
   };
 
-  public renameFront = () => {
+  renameFront = () => {
     this.setState({
       frontNameValue: this.getTitle() || '',
       editingFrontName: true
@@ -186,6 +186,26 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     return;
   };
 
+  setName = () => {
+    const metadata =
+      this.state.frontNameValue !== ''
+        ? {
+            ...this.props.selectedFront.metadata,
+            nameOverride: this.state.frontNameValue
+          }
+        : {
+            ...this.props.selectedFront.metadata,
+            nameOverride: undefined
+          };
+
+    this.props.frontsActions.updateFrontMetadata(
+      this.props.selectedFront.id,
+      metadata
+    );
+
+    this.setState({ editingFrontName: false });
+  };
+
   public render() {
     const { frontId, isFormOpen, isOverviewOpen } = this.props;
     const title = this.getTitle();
@@ -194,26 +214,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     const canRename = this.props.selectedFront
       ? this.props.selectedFront.canRename
       : false;
-
-    const setName = () => {
-      const metadata =
-        this.state.frontNameValue !== ''
-          ? {
-              ...this.props.selectedFront.metadata,
-              nameOverride: this.state.frontNameValue
-            }
-          : {
-              ...this.props.selectedFront.metadata,
-              nameOverride: undefined
-            };
-
-      this.props.frontsActions.updateFrontMetadata(
-        this.props.selectedFront.id,
-        metadata
-      );
-
-      this.setState({ editingFrontName: false });
-    };
 
     return (
       <SingleFrontContainer
@@ -226,6 +226,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
           <FrontHeader greyHeader={true}>
             {editingFrontName ? (
               <FrontsHeaderInput
+                data-testid="rename-front-input"
                 value={frontNameValue}
                 autoFocus
                 onChange={e =>
@@ -233,13 +234,15 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 }
                 onKeyDown={e => {
                   if (e.key === 'Enter') {
-                    setName();
+                    this.setName();
                   }
                 }}
-                onBlur={setName}
+                onBlur={this.setName}
               />
             ) : (
-              <FrontsHeaderText title={title}>{title}</FrontsHeaderText>
+              <FrontsHeaderText title={title} data-testid="front-name">
+                {title}
+              </FrontsHeaderText>
             )}
             <FrontHeaderMeta>
               <EditModeVisibility visibleMode="fronts">
@@ -270,7 +273,11 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 </StageSelectButtons>
               </EditModeVisibility>
               {canRename && (
-                <FrontHeaderButton onClick={this.renameFront} size="l">
+                <FrontHeaderButton
+                  data-testid="rename-front-button"
+                  onClick={this.renameFront}
+                  size="l"
+                >
                   Rename
                 </FrontHeaderButton>
               )}

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -163,49 +163,6 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     this.props.frontsActions.editorCloseFront(this.props.frontId);
   };
 
-  renameFront = () => {
-    this.setState({
-      frontNameValue: this.getTitle() || '',
-      editingFrontName: true
-    });
-  };
-
-  getTitle = () => {
-    const { selectedFront } = this.props;
-
-    if (selectedFront) {
-      if (selectedFront.metadata && selectedFront.metadata.nameOverride) {
-        return selectedFront.metadata.nameOverride;
-      } else {
-        return startCase(
-          this.props.selectedFront.displayName || this.props.selectedFront.id
-        );
-      }
-    }
-
-    return;
-  };
-
-  setName = () => {
-    const metadata =
-      this.state.frontNameValue !== ''
-        ? {
-            ...this.props.selectedFront.metadata,
-            nameOverride: this.state.frontNameValue
-          }
-        : {
-            ...this.props.selectedFront.metadata,
-            nameOverride: undefined
-          };
-
-    this.props.frontsActions.updateFrontMetadata(
-      this.props.selectedFront.id,
-      metadata
-    );
-
-    this.setState({ editingFrontName: false });
-  };
-
   public render() {
     const { frontId, isFormOpen, isOverviewOpen } = this.props;
     const title = this.getTitle();
@@ -300,6 +257,49 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
       </SingleFrontContainer>
     );
   }
+
+  private renameFront = () => {
+    this.setState({
+      frontNameValue: this.getTitle() || '',
+      editingFrontName: true
+    });
+  };
+
+  private getTitle = () => {
+    const { selectedFront } = this.props;
+
+    if (selectedFront) {
+      if (selectedFront.metadata && selectedFront.metadata.nameOverride) {
+        return selectedFront.metadata.nameOverride;
+      } else {
+        return startCase(
+          this.props.selectedFront.displayName || this.props.selectedFront.id
+        );
+      }
+    }
+
+    return;
+  };
+
+  private setName = () => {
+    const metadata =
+      this.state.frontNameValue !== ''
+        ? {
+            ...this.props.selectedFront.metadata,
+            nameOverride: this.state.frontNameValue
+          }
+        : {
+            ...this.props.selectedFront.metadata,
+            nameOverride: undefined
+          };
+
+    this.props.frontsActions.updateFrontMetadata(
+      this.props.selectedFront.id,
+      metadata
+    );
+
+    this.setState({ editingFrontName: false });
+  };
 }
 
 const createMapStateToProps = () => {

--- a/client-v2/src/reducers/frontsReducer.ts
+++ b/client-v2/src/reducers/frontsReducer.ts
@@ -42,6 +42,13 @@ const reducer = (
     };
   }
   switch (action.type) {
+    case 'FETCH_UPDATE_METADATA_SUCCESS': {
+      return set(
+        ['frontsConfig', 'data', 'fronts', action.payload.frontId, 'metadata'],
+        action.payload.metadata,
+        newState
+      );
+    }
     case 'FETCH_LAST_PRESSED_SUCCESS': {
       return set(
         ['lastPressed', action.payload.frontId],

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -2,6 +2,7 @@ import { EditionsIssue } from 'types/Edition';
 import { Moment } from 'moment';
 import pandaFetch from './pandaFetch';
 import { CAPISearchQueryResponse } from './capiQuery';
+import { EditionsFrontMetadata } from 'types/FaciaApi';
 
 const dateFormat = 'YYYY-MM-DD';
 
@@ -85,5 +86,18 @@ export const getPrefills = async (
   return pandaFetch(`/editions-api/collections/${id}/prefill`, {
     method: 'get',
     credentials: 'same-origin'
+  }).then(response => response.json());
+};
+
+export const putFrontMetadata = (
+  id: string,
+  metadata: EditionsFrontMetadata
+) => {
+  return pandaFetch(`/editions-api/fronts/${id}/metadata`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(metadata)
   }).then(response => response.json());
 };

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -13,7 +13,11 @@ import {
 } from 'shared/types/Action';
 import { PersistMeta } from 'util/storeMiddleware';
 import { Config } from './Config';
-import { FrontsConfig, VisibleArticlesResponse } from './FaciaApi';
+import {
+  FrontsConfig,
+  VisibleArticlesResponse,
+  EditionsFrontMetadata
+} from './FaciaApi';
 import { BatchAction } from 'redux-batched-actions';
 import { Stages } from 'shared/types/Collection';
 import {
@@ -288,6 +292,14 @@ interface IsPrefillMode {
   };
 }
 
+interface EditionsFrontMetadataUpdate {
+  type: 'FETCH_UPDATE_METADATA_SUCCESS';
+  payload: {
+    frontId: string;
+    metadata: EditionsFrontMetadata;
+  };
+}
+
 type SetFocusState = ReturnType<typeof setFocusState>;
 type ResetFocusState = ReturnType<typeof resetFocusState>;
 
@@ -339,6 +351,7 @@ type Action =
   | SetFocusState
   | ResetFocusState
   | ActionSetFeatureValue
+  | EditionsFrontMetadataUpdate
   | IsPrefillMode
   | SetHidden
   | ChangedBrowsingStage;

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -22,6 +22,12 @@ interface FrontConfigResponse {
   title?: string;
   webTitle?: string;
   navSection?: string;
+  canRename?: boolean;
+  metadata?: EditionsFrontMetadata;
+}
+
+interface EditionsFrontMetadata {
+  nameOverride?: string;
 }
 
 type Platform = 'Web' | 'Platform';
@@ -131,5 +137,6 @@ export {
   CollectionResponse,
   EditionCollectionResponse,
   VisibleArticlesResponse,
-  FrontsToolSettings
+  FrontsToolSettings,
+  EditionsFrontMetadata
 };

--- a/test/model/editions/EditionsFrontMetadataTest.scala
+++ b/test/model/editions/EditionsFrontMetadataTest.scala
@@ -21,22 +21,4 @@ class EditionsFrontMetadataTest extends FreeSpec with Matchers {
     }
 
   }
-
-
-  "Editions Front Metadata Data merging" - {
-    val editionsFrontMetadataSwatchOnly = EditionsFrontMetadata(None, Some(Swatch.Opinion))
-    val editionsFrontMetadataNewnameOnly = EditionsFrontMetadata(Some(name), None)
-
-    "should merge Name Overrides correctly" in {
-      object DumbObject extends FrontsQueries
-      DumbObject.mergeMetadatas(editionsFrontMetadataSwatchOnly, editionsFrontMetadataNewnameOnly) shouldBe editionsFrontMetadata
-    }
-
-    "should merge Swatches correctly" in {
-      object DumbObject extends FrontsQueries
-      DumbObject.mergeMetadatas(editionsFrontMetadataNewnameOnly, editionsFrontMetadataSwatchOnly) shouldBe editionsFrontMetadata
-    }
-
-  }
-
 }

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -154,5 +154,41 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       publishedFront.collections.size shouldBe 3
       publishedFront.collections.find(_.id == "special") shouldBe None
     }
+
+    "Fronts should not override name if there's not one defined" in {
+      val front = EditionsFront(
+        "id",
+        "Original Name",
+        0,
+        false,
+        false,
+        None,
+        None,
+        None,
+        Some(EditionsFrontMetadata(None, None)),
+        Nil)
+
+      val published = front.toPublishedFront
+
+      published shouldBe Some(PublishedFront("id", "Original Name", Nil))
+    }
+
+    "Fronts should override name correctly" in {
+      val front = EditionsFront(
+        "id",
+        "Original Name",
+        0,
+        false,
+        false,
+        None,
+        None,
+        None,
+        Some(EditionsFrontMetadata(Some("New Name"), None)),
+        Nil)
+
+      val published = front.toPublishedFront
+
+      published shouldBe Some(PublishedFront("id", "New Name", Nil))
+    }
   }
 }

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -170,10 +170,10 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
 
       val published = front.toPublishedFront
 
-      published shouldBe Some(PublishedFront("id", "Original Name", Nil))
+      published shouldBe PublishedFront("id", "Original Name", Nil)
     }
 
-    "Fronts should override name correctly" in {
+    "Front name should be overriden correctly" in {
       val front = EditionsFront(
         "id",
         "Original Name",
@@ -188,7 +188,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
 
       val published = front.toPublishedFront
 
-      published shouldBe Some(PublishedFront("id", "New Name", Nil))
+      published shouldBe PublishedFront("id", "New Name", Nil)
     }
   }
 }


### PR DESCRIPTION
## What's changed?

Add a button to rename a front!

![image](https://user-images.githubusercontent.com/5560113/62479071-8bd4a800-b7a4-11e9-9705-79fffccb79c9.png)

This only appears on fronts with the `canRename` flag set to true.

It works by replacing the title with an input box and focusing that box. Any blur or pressing enter will submit the new title. To go back to the old one just enter nothing.

## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
