### PR TITLE
Remove slideshow option for Editions

### DIFF
--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -29,14 +29,13 @@ case class ArticleMetadata (
 
   // keep overrides even if not used so user can switch back w/out needing to re-crop
   cutoutImage: Option[Image],
-  replaceImage: Option[Image],
-  slideshowImages: Option[List[Image]]
+  replaceImage: Option[Image]
 )
 
 object ArticleMetadata {
   implicit val format = Json.format[ArticleMetadata]
 
-  val default = ArticleMetadata(None, None, None, None, None, None, None, None, None, None)
+  val default = ArticleMetadata(None, None, None, None, None, None, None, None, None)
 }
 
 case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) {
@@ -45,13 +44,6 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
       meta.mediaType match {
         case Some(MediaType.Image) => meta.replaceImage.map(_.toPublishedImage)
         case Some(MediaType.Cutout) => meta.cutoutImage.map(_.toPublishedImage)
-        case _ => None
-      }
-    })
-
-    val slideshowImages: Option[List[PublishedImage]] = metadata.flatMap(meta => {
-      meta.mediaType match {
-        case Some(MediaType.Slideshow) => meta.slideshowImages.map(_.map(_.toPublishedImage))
         case _ => None
       }
     })
@@ -66,8 +58,7 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
         showByline = metadata.flatMap(_.showByline).getOrElse(false),
         showQuotedHeadline = metadata.flatMap(_.showQuotedHeadline).getOrElse(false),
         mediaType = metadata.flatMap(_.mediaType).map(_.toPublishedMediaType).getOrElse(PublishedMediaType.UseArticleTrail),
-        imageSrcOverride = imageSrcOverride,
-        slideshowImages = slideshowImages
+        imageSrcOverride = imageSrcOverride
       )
     )
   }

--- a/app/model/editions/MediaType.scala
+++ b/app/model/editions/MediaType.scala
@@ -8,7 +8,6 @@ sealed abstract class MediaType extends EnumEntry with Uncapitalised {
     case MediaType.UseArticleTrail => PublishedMediaType.UseArticleTrail
     case MediaType.Hide => PublishedMediaType.Hide
     case MediaType.Cutout => PublishedMediaType.Cutout
-    case MediaType.Slideshow => PublishedMediaType.Slideshow
     case MediaType.Image => PublishedMediaType.Image
   }
 }
@@ -17,7 +16,6 @@ object MediaType extends PlayEnum[MediaType] {
   case object UseArticleTrail extends MediaType
   case object Hide extends MediaType
   case object Cutout extends MediaType
-  case object Slideshow extends MediaType
   case object Image extends MediaType
 
   override def values = findValues

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -12,7 +12,6 @@ object PublishedMediaType extends PlayEnum[PublishedMediaType] {
   case object UseArticleTrail extends PublishedMediaType
   case object Hide extends PublishedMediaType
   case object Cutout extends PublishedMediaType
-  case object Slideshow extends PublishedMediaType
   case object Image extends PublishedMediaType
 
   override def values = findValues
@@ -28,8 +27,7 @@ case class PublishedFurniture(
   showByline: Boolean,
   showQuotedHeadline: Boolean,
   mediaType: PublishedMediaType,
-  imageSrcOverride: Option[PublishedImage],
-  slideshowImages: Option[List[PublishedImage]]
+  imageSrcOverride: Option[PublishedImage]
 )
 
 case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)

--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -27,10 +27,7 @@ case class ClientArticleMetadata (
   imageCutoutSrc: Option[String],
   imageCutoutSrcHeight: Option[String],
   imageCutoutSrcWidth: Option[String],
-  imageCutoutSrcOrigin: Option[String],
-
-  imageSlideshowReplace: Option[Boolean],
-  slideshow: Option[List[Image]]
+  imageCutoutSrcOrigin: Option[String]
 ) {
   def toArticleMetadata: ArticleMetadata = {
     val cutoutImage: Option[Image] = (imageCutoutSrcHeight, imageCutoutSrcWidth, imageCutoutSrc, imageCutoutSrcOrigin) match {
@@ -43,11 +40,10 @@ case class ClientArticleMetadata (
       case _ => None
     }
 
-    val imageOption = (imageHide, imageReplace, imageCutoutReplace, imageSlideshowReplace) match {
-      case (Some(true), _, _, _) => MediaType.Hide
-      case (_, Some(true), _, _) => MediaType.Image
-      case (_, _, Some(true), _) => MediaType.Cutout
-      case (_, _, _, Some(true)) => MediaType.Slideshow
+    val imageOption = (imageHide, imageReplace, imageCutoutReplace) match {
+      case (Some(true), _, _) => MediaType.Hide
+      case (_, Some(true), _) => MediaType.Image
+      case (_, _, Some(true)) => MediaType.Cutout
       case _ => MediaType.UseArticleTrail
     }
 
@@ -60,8 +56,7 @@ case class ClientArticleMetadata (
       byline,
       Some(imageOption),
       cutoutImage,
-      replaceImage,
-      slideshow
+      replaceImage
     )
   }
 }
@@ -94,10 +89,7 @@ object ClientArticleMetadata {
       articleMetadata.cutoutImage.map(_.src),
       articleMetadata.cutoutImage.flatMap(_.height).map(_.toString),
       articleMetadata.cutoutImage.flatMap(_.width).map(_.toString),
-      articleMetadata.cutoutImage.map(_.origin),
-
-      articleMetadata.slideshowImages.map(_ => mediaType == MediaType.Slideshow),
-      articleMetadata.slideshowImages
+      articleMetadata.cutoutImage.map(_.origin)
     )
   }
 }

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -73,16 +73,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
             |      "height" : 1280,
             |      "width" : 720,
             |      "src" : "https://media.giphy.com/media/yV5iknckcXcc/source.gif"
-            |    },
-            |    "slideshowImages" : [ {
-            |      "height" : 1280,
-            |      "width" : 720,
-            |      "src" : "https://media.giphy.com/media/TLulTJKuyLgMU/source.gif"
-            |    }, {
-            |      "height" : 1280,
-            |      "width" : 720,
-            |      "src" : "https://media.giphy.com/media/GuWSJPF6bEkKs/source.gif"
-            |    } ]
+            |    }
             |  }
             |}""".stripMargin
 
@@ -96,11 +87,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           mediaType = PublishedMediaType.Cutout,
           imageSrcOverride = Some(
             PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/yV5iknckcXcc/source.gif")
-          ),
-          slideshowImages = Some(List(
-            PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/TLulTJKuyLgMU/source.gif"),
-            PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/GuWSJPF6bEkKs/source.gif")
-          ))
+          )
         ))
 
         val json = Json.prettyPrint(Json.toJson(article))

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -11,15 +11,15 @@ class PublishedIssueTest extends FreeSpec with Matchers {
       val article = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
       val publishedArticle = article.toPublishedArticle
       publishedArticle.internalPageCode shouldBe 1234456
-      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None)
+      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None)
     }
 
     "furniture defaults should be populated correctly" in {
-      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None, None)
+      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None)
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
 
-      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None)
+      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None)
     }
 
     "furniture should be populated when specified" in {
@@ -32,11 +32,7 @@ class PublishedIssueTest extends FreeSpec with Matchers {
         Some("byline"),
         Some(MediaType.Image),
         None,
-        Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg")),
-        Some(List(
-          Image(Some(100), Some(100), "file://image-2.gif", "file://image-2.jpg"),
-          Image(Some(100), Some(100), "file://image-3.gif", "file://image-3.jpg")
-        ))
+        Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg"))
       )
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
@@ -49,8 +45,7 @@ class PublishedIssueTest extends FreeSpec with Matchers {
         showByline = true,
         showQuotedHeadline = true,
         mediaType = PublishedMediaType.Image,
-        imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg")),
-        slideshowImages = None
+        imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg"))
       )
     }
   }

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -15,7 +15,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         None,
         None,
-        None,
         None
       )
 
@@ -33,7 +32,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       clientArticleMetadata.imageHide shouldBe None
       clientArticleMetadata.imageReplace shouldBe None
       clientArticleMetadata.imageCutoutReplace shouldBe None
-      clientArticleMetadata.imageSlideshowReplace shouldBe None
     }
 
     "should persist cutout image when selected override is hide image" in {
@@ -46,7 +44,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(MediaType.Hide),
         Some(Image(Some(100), Some(100), "file://origin-new-pokemon.gif", "file://new-pokemon.gif")),
-        None,
         None
       )
 
@@ -64,44 +61,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       clientArticleMetadata.imageCutoutSrcWidth shouldBe Some("100")
 
       clientArticleMetadata.imageReplace shouldBe None
-      clientArticleMetadata.imageSlideshowReplace shouldBe None
-    }
-
-    "should persist slideshow images when selected override is replace image" in {
-      val articleMetadata = ArticleMetadata(
-        Some("Elephants declared best animal"),
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(MediaType.Image),
-        None,
-        Some(Image(Some(100), Some(100), "file://elephant.jpg", "file://elephant.png")),
-        Some(List(
-          Image(Some(100), Some(100), "file://elephant-playing-in-mud.jpg", "file://elephant-playing-in-mud.png"),
-          Image(Some(100), Some(100), "file://elephant-spraying-water.jpg", "file://elephant-spraying-water.png")
-        ))
-      )
-
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
-
-      clientArticleMetadata.headline.isDefined shouldBe true
-      clientArticleMetadata.headline.get shouldBe "Elephants declared best animal"
-
-      clientArticleMetadata.imageReplace shouldBe Some(true)
-      clientArticleMetadata.imageSrc shouldBe Some("file://elephant.png")
-      clientArticleMetadata.imageSrcOrigin shouldBe Some("file://elephant.jpg")
-      clientArticleMetadata.imageSrcHeight shouldBe Some("100")
-      clientArticleMetadata.imageSrcWidth shouldBe Some("100")
-
-      clientArticleMetadata.imageHide shouldBe None
-
-      clientArticleMetadata.imageSlideshowReplace shouldBe Some(false)
-      clientArticleMetadata.slideshow shouldBe Some(List(
-        Image(Some(100), Some(100), "file://elephant-playing-in-mud.jpg", "file://elephant-playing-in-mud.png"),
-        Image(Some(100), Some(100), "file://elephant-spraying-water.jpg", "file://elephant-spraying-water.png")
-      ))
     }
 
     "should only set an image override boolean if its fields are also set" in {
@@ -113,7 +72,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         None,
         Some(MediaType.Image),
-        None,
         None,
         None
       )
@@ -132,7 +90,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         None,
         Some(MediaType.UseArticleTrail),
-        None,
         None,
         None
       )
@@ -164,9 +121,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some("file://broom.jpg"),
         Some("100"),
         Some("100"),
-        Some("file://broom.gif"),
-        None,
-        None
+        Some("file://broom.gif")
       )
 
       val articleMetadata = cam.toArticleMetadata

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -23,8 +23,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     byline = None,
     mediaType = None,
     cutoutImage = None,
-    replaceImage = None,
-    slideshowImages = None
+    replaceImage = None
   )
 
   private def insertSkeletonIssue(year: Int, month: Int, dom: Int, fronts: EditionsFrontSkeleton*): String = {


### PR DESCRIPTION
## What's changed?
Remove the option to use a slideshow for the image option within Editions as it's just not needed.

## Implementation notes
Clientside changes (https://github.com/guardian/facia-tool/pull/895) should go out first.

## Checklist

### General
- [x] 🤖 Relevant tests ~added~ removed
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
