### PR TITLE
Add tone to content meta

### DIFF
--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -91,6 +91,7 @@ interface CollectionContextProps {
     [id: string]: AlsoOnDetail;
   };
   browsingStage: CollectionItemSets;
+  size?: 'medium' | 'default';
   handleMove: (move: Move<TArticleFragment>) => void;
   handleInsert: (e: React.DragEvent, to: PosSpec) => void;
   selectArticleFragment: (id: string, isSupporting: boolean) => void;
@@ -121,6 +122,7 @@ class CollectionContext extends React.Component<
       priority,
       alsoOn,
       browsingStage,
+      size = 'default',
       handleMove,
       handleInsert,
       handleArticleFocus,
@@ -175,6 +177,7 @@ class CollectionContext extends React.Component<
                         uuid={articleFragment.uuid}
                         parentId={group.uuid}
                         isUneditable={isUneditable}
+                        size={size}
                         getNodeProps={() => getAfNodeProps(isUneditable)}
                         onSelect={() =>
                           selectArticleFragment(articleFragment.uuid, false)

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -39,6 +39,7 @@ import ButtonRoundedWithLabel, {
 import sortBy from 'lodash/sortBy';
 import debounce from 'lodash/debounce';
 import { bindActionCreators } from 'redux';
+import WithDimensions from 'components/util/WithDimensions';
 
 const FrontContainer = styled('div')`
   height: 100%;
@@ -299,40 +300,46 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
               onScroll={this.handleScroll}
               innerRef={ref => (this.collectionContainerElement = ref)}
             >
-              <Root id={this.props.id} data-testid={this.props.id}>
-                {front.collections.map(collectionId => (
-                  <CollectionContainer
-                    key={collectionId}
-                    innerRef={ref =>
-                      (this.collectionElements[collectionId] = ref)
-                    }
-                  >
-                    <Collection
-                      id={collectionId}
-                      frontId={this.props.id}
-                      priority={front.priority}
-                      browsingStage={this.props.browsingStage}
-                      alsoOn={this.props.alsoOn}
-                      handleInsert={this.handleInsert}
-                      handleMove={this.handleMove}
-                      selectArticleFragment={(
-                        articleFragmentId,
-                        isSupporting
-                      ) =>
-                        this.props.selectArticleFragment(
-                          articleFragmentId,
-                          collectionId,
-                          this.props.id,
-                          isSupporting
-                        )
-                      }
-                      handleArticleFocus={this.handleArticleFocus}
-                    />
-                  </CollectionContainer>
-                ))}
-              </Root>
+              <WithDimensions element={this.collectionContainerElement}>
+                {({ width }) => (
+                  <Root id={this.props.id} data-testid={this.props.id}>
+                    {front.collections.map(collectionId => (
+                      <CollectionContainer
+                        key={collectionId}
+                        innerRef={ref =>
+                          (this.collectionElements[collectionId] = ref)
+                        }
+                      >
+                        <Collection
+                          id={collectionId}
+                          frontId={this.props.id}
+                          priority={front.priority}
+                          browsingStage={this.props.browsingStage}
+                          alsoOn={this.props.alsoOn}
+                          handleInsert={this.handleInsert}
+                          handleMove={this.handleMove}
+                          size={width && width > 500 ? 'default' : 'medium'}
+                          selectArticleFragment={(
+                            articleFragmentId,
+                            isSupporting
+                          ) =>
+                            this.props.selectArticleFragment(
+                              articleFragmentId,
+                              collectionId,
+                              this.props.id,
+                              isSupporting
+                            )
+                          }
+                          handleArticleFocus={this.handleArticleFocus}
+                        />
+                      </CollectionContainer>
+                    ))}
+                  </Root>
+                )}
+              </WithDimensions>
             </FrontCollectionsContainer>
           </FrontContentContainer>
+
           {(overviewIsOpen || isFormOpen) && (
             <FrontDetailContainer>
               <FrontDetailView

--- a/client-v2/src/fixtures/derivedArticle.ts
+++ b/client-v2/src/fixtures/derivedArticle.ts
@@ -29,5 +29,6 @@ export default {
   publishedBy: 'Philip McMahon',
   uuid: 'fc87955e-fa51-4994-b6cb-bf1c55e0a212',
   supporting: [],
-  kicker: 'News'
+  kicker: 'News',
+  tone: undefined
 } as DerivedArticle;

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -8,7 +8,7 @@ import BasePlaceholder from '../BasePlaceholder';
 import { getPillarColor } from 'shared/util/getPillarColor';
 import CollectionItemMetaContainer from '../collectionItem/CollectionItemMetaContainer';
 import CollectionItemContent from '../collectionItem/CollectionItemContent';
-import { notLiveLabels } from 'constants/fronts';
+import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import TextPlaceholder from 'shared/components/TextPlaceholder';
 import { ThumbnailSmall, ThumbnailCutout } from '../Thumbnail';
 import CollectionItemMetaHeading from '../collectionItem/CollectionItemMetaHeading';
@@ -86,6 +86,10 @@ const ArticleHeadingContainerWrapper = styled('div')`
   padding: 0 0 0 4px;
 `;
 
+const Tone = styled('span')`
+  font-weight: normal;
+`;
+
 interface ArticleBodyProps {
   newspaperEditionDate?: string;
   firstPublicationDate?: string;
@@ -120,6 +124,7 @@ interface ArticleBodyProps {
   canDragImage?: boolean;
   isDraggingImageOver: boolean;
   isBoosted?: boolean;
+  tone?: string | undefined;
 }
 
 const articleBodyDefault = React.memo(
@@ -155,7 +160,8 @@ const articleBodyDefault = React.memo(
     showMeta = true,
     canDragImage = true,
     isDraggingImageOver,
-    isBoosted
+    isBoosted,
+    tone
   }: ArticleBodyProps) => {
     const ArticleHeadingContainer =
       size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
@@ -173,8 +179,17 @@ const articleBodyDefault = React.memo(
               </>
             )}
             {size === 'default' && isLive && (
-              <CollectionItemMetaHeading>
+              <CollectionItemMetaHeading
+                style={{
+                  color: getPillarColor(
+                    pillarId,
+                    isLive,
+                    tone === liveBlogTones.dead
+                  )
+                }}
+              >
                 {startCase(sectionName)}
+                <Tone> / {tone}</Tone>
               </CollectionItemMetaHeading>
             )}
             {type === 'liveblog' && (
@@ -255,7 +270,6 @@ const articleBodyDefault = React.memo(
                 html
                 data-testid="headline"
                 displaySize={size}
-                showLargeHeadline={showLargeHeadline}
               >
                 {headline}
               </CollectionItemHeading>

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -171,14 +171,14 @@ const articleBodyDefault = React.memo(
     return (
       <>
         {showMeta && (
-          <CollectionItemMetaContainer>
+          <CollectionItemMetaContainer size={size}>
             {displayPlaceholders && (
               <>
                 <TextPlaceholder data-testid="loading-placeholder" />
-                {size === 'default' && <TextPlaceholder width={25} />}
+                {size !== 'small' && <TextPlaceholder width={25} />}
               </>
             )}
-            {size === 'default' && isLive && (
+            {size !== 'small' && isLive && (
               <CollectionItemMetaHeading
                 style={{
                   color: getPillarColor(
@@ -254,7 +254,7 @@ const articleBodyDefault = React.memo(
               {displayPlaceholders && (
                 <>
                   <TextPlaceholder />
-                  {size === 'default' && <TextPlaceholder width={25} />}
+                  {size !== 'small' && <TextPlaceholder width={25} />}
                 </>
               )}
               {kicker && (
@@ -277,7 +277,7 @@ const articleBodyDefault = React.memo(
             {displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
           </ArticleHeadingContainerWrapper>
         </CollectionItemContent>
-        {size === 'default' &&
+        {size !== 'small' &&
           (displayPlaceholders ? (
             <ThumbnailPlaceholder />
           ) : (

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeading.tsx
@@ -3,9 +3,10 @@ import { styled } from 'shared/constants/theme';
 import { sanitizeHTML } from 'shared/util/sanitizeHTML';
 import { media } from 'shared/util/mediaQueries';
 import { theme } from 'constants/theme';
+import { CollectionItemSizes } from 'shared/types/Collection';
 
 const Wrapper = styled('span')<{
-  displaySize?: 'small' | 'default';
+  displaySize?: CollectionItemSizes;
   showLargeHeadline?: boolean;
 }>`
   font-family: TS3TextSans;
@@ -18,7 +19,7 @@ const Wrapper = styled('span')<{
 type CollectionItemHeading = {
   children?: string;
   html?: boolean;
-  displaySize?: 'small' | 'default';
+  displaySize?: CollectionItemSizes;
   showLargeHeadline?: boolean;
 } & React.HTMLProps<HTMLSpanElement>;
 

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
@@ -3,21 +3,37 @@ import { styled } from 'shared/constants/theme';
 
 import ShortVerticalPinline from 'shared/components/layout/ShortVerticalPinline';
 import { media } from 'shared/util/mediaQueries';
+import { CollectionItemSizes } from 'shared/types/Collection';
 
-const metaContainerWidth = 80;
-const metaContainerWidthSmall = 60;
+const metaContainerSizeWidthMap = {
+  default: 100,
+  medium: 80,
+  small: 60
+} as { [Sizes in CollectionItemSizes]: number };
 
-const MetaContainer = styled('div')`
+const MetaContainer = styled('div')<{ size?: CollectionItemSizes }>`
   position: relative;
   flex-shrink: 0;
-  width: ${metaContainerWidth}px;
-  ${media.large`width: ${metaContainerWidthSmall}px;`}
-  ${media.large`word-break: break-word`}
+  /* If we have a size property, use that. */
+  width: ${({ size }) => size && `${metaContainerSizeWidthMap[size]}px`};
+  /* If we don't, fall back to media queries. */
+  ${({ size }) =>
+    !size &&
+    media.large`
+      width: ${metaContainerSizeWidthMap.small}px;
+      word-break: break-word;
+    `}
   padding: 0 4px;
 `;
 
-export default ({ children }: { children?: React.ReactNode }) => (
-  <MetaContainer>
+export default ({
+  children,
+  size = 'default'
+}: {
+  children?: React.ReactNode;
+  size?: CollectionItemSizes;
+}) => (
+  <MetaContainer size={size}>
     {children}
     <ShortVerticalPinline />
   </MetaContainer>

--- a/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemMetaContainer.tsx
@@ -9,8 +9,9 @@ const metaContainerWidthSmall = 60;
 
 const MetaContainer = styled('div')`
   position: relative;
-  min-width: ${metaContainerWidth}px;
-  ${media.large`min-width: ${metaContainerWidthSmall}px;`}
+  flex-shrink: 0;
+  width: ${metaContainerWidth}px;
+  ${media.large`width: ${metaContainerWidthSmall}px;`}
   ${media.large`word-break: break-word`}
   padding: 0 4px;
 `;

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -37,6 +37,15 @@ const capiArticle = {
       webUrl: 'https://www.theguardian.com/world/hurricane-florence',
       apiUrl: 'https://content.guardianapis.com/world/hurricane-florence',
       references: []
+    },
+    {
+      id: 'tone/news',
+      type: 'tone',
+      webTitle: 'News',
+      webUrl: 'https://www.theguardian.com/tone/news',
+      apiUrl: 'https://preview.content.guardianapis.com/tone/news',
+      references: [],
+      internalName: 'News (Tone)'
     }
   ],
   blocks: {

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -3,7 +3,8 @@ import { createSelector } from 'reselect';
 import {
   getThumbnail,
   getPrimaryTag,
-  getContributorImage
+  getContributorImage,
+  getTone
 } from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
@@ -156,7 +157,8 @@ const createSelectArticleFromArticleFragment = () =>
         firstPublicationDate: externalArticle
           ? externalArticle.fields.firstPublicationDate
           : undefined,
-        frontPublicationDate: articleFragment.frontPublicationDate
+        frontPublicationDate: articleFragment.frontPublicationDate,
+        tone: externalArticle ? getTone(externalArticle.tags) : undefined
       };
     }
   );

--- a/client-v2/src/shared/types/Article.ts
+++ b/client-v2/src/shared/types/Article.ts
@@ -16,6 +16,7 @@ type DerivedArticle = Partial<
     cutoutThumbnail?: string | undefined;
     kicker?: string;
     isLive: boolean;
+    tone: string | undefined;
   };
 
 export { DerivedArticle };

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -14,7 +14,7 @@ type CollectionItemSets = 'draft' | 'live' | 'previously';
 type Stages = 'draft' | 'live';
 
 type CollectionItemTypes = 'SNAP_LINK' | 'ARTICLE';
-type CollectionItemSizes = 'default' | 'small';
+type CollectionItemSizes = 'default' | 'medium' | 'small';
 
 interface NestedArticleFragmentRootFields {
   id: string;

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -1,6 +1,8 @@
-import { Element, Tag } from 'types/Capi';
+import { Element, Tag, CapiArticle } from 'types/Capi';
 import { ExternalArticle } from '../shared/types/ExternalArticle';
 import { ArticleFragmentMeta } from '../shared/types/Collection';
+import { notLiveLabels, liveBlogTones } from 'constants/fronts';
+import startCase from 'lodash/startCase';
 
 const getIdFromURL = (url: string): string | null => {
   const [, id = null] =
@@ -94,10 +96,41 @@ const getTags = (externalArticle: ExternalArticle): Tag[] =>
 const getPrimaryTag = (externalArticle: ExternalArticle): Tag | null =>
   getTags(externalArticle)[0] || null;
 
+const getTone = (tags: Tag[] | undefined): string | undefined => {
+  const tag = (tags || []).find(_ => _.type === 'tone');
+  return tag ? tag.webTitle : undefined;
+};
+
+const isLive = (article: CapiArticle) =>
+  !article.fields.isLive || article.fields.isLive === 'true';
+
+const getArticleLabel = (article: CapiArticle) => {
+  const {
+    fields: { firstPublicationDate },
+    sectionName,
+    frontsMeta: { tone }
+  } = article;
+  if (!isLive(article)) {
+    if (firstPublicationDate) {
+      return notLiveLabels.takenDown;
+    }
+    return notLiveLabels.draft;
+  }
+
+  if (tone === liveBlogTones.dead || tone === liveBlogTones.live) {
+    return startCase(liveBlogTones.live);
+  }
+
+  return startCase(sectionName);
+};
+
 export {
   getIdFromURL,
   getThumbnailFromElements,
   getThumbnail,
   getContributorImage,
-  getPrimaryTag
+  getPrimaryTag,
+  getTone,
+  getArticleLabel,
+  isLive
 };


### PR DESCRIPTION
## What's changed?

Add the content tone to the feed and collection cards.

Before:

<img width="414" alt="Screenshot 2019-08-06 at 08 56 46" src="https://user-images.githubusercontent.com/7767575/62521787-35a94880-b828-11e9-804b-3dbcb10fe373.png">

After:

<img width="414" alt="Screenshot 2019-08-06 at 08 56 12" src="https://user-images.githubusercontent.com/7767575/62521790-393ccf80-b828-11e9-98d5-ed6ad53b1ad5.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
