### PR TITLE
Add WithDimensions component

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -125,6 +125,7 @@
     "redux-form": "^8.2.4",
     "redux-thunk": "^2.2.0",
     "reselect": "^4.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "sanitize-html": "^1.20.0",
     "shallowequal": "^1.1.0",
     "styled-components": "^3.2.5",

--- a/client-v2/src/components/util/WithDimensions.tsx
+++ b/client-v2/src/components/util/WithDimensions.tsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+
+interface Dimensions {
+  width: number | undefined;
+  height: number | undefined;
+}
+
+interface Props {
+  element: HTMLElement | null | undefined;
+  children: ({ width, height }: Dimensions) => JSX.Element;
+}
+
+const initialState = { width: undefined, height: undefined } as Dimensions;
+
+const WithDimensions = ({ element, children }: Props) => {
+  const [dimensions, setDimensions] = useState(initialState);
+  useEffect(
+    () => {
+      if (!element) {
+        return;
+      }
+      const observer = new ResizeObserver(([firstEntry]) => {
+        if (!firstEntry) {
+          return;
+        }
+        const { width, height } = firstEntry.contentRect;
+        setDimensions({ width, height });
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    },
+    [element]
+  );
+  return children(dimensions);
+};
+
+export default WithDimensions;

--- a/client-v2/src/components/util/WithDimensions.tsx
+++ b/client-v2/src/components/util/WithDimensions.tsx
@@ -13,6 +13,17 @@ interface Props {
 
 const initialState = { width: undefined, height: undefined } as Dimensions;
 
+/**
+ * Supplies the dimensions of the given element to its children.
+ *
+ * ```
+ * <WithDimensions element={this.someHTMLElement}>
+ *  {({ width, height }) => (
+ *    <p>`The dimensions of the given element are ${width} x ${height}`</p>
+ *  )
+ * </WithDimensions>
+ * ```
+ */
 const WithDimensions = ({ element, children }: Props) => {
   const [dimensions, setDimensions] = useState(initialState);
   useEffect(

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -8573,6 +8573,11 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-1.0.0.tgz#4eaeea41ed040d1702457df64a42b2b07d246f9f"


### PR DESCRIPTION
## What's changed?

Adds a WithDimensions component. It supplies the dimensions of the given element to its children:

```
<WithDimensions element={this.exampleElement}>
  {({ width, height }) => (
    <p>`The dimensions of the given element are ${width} x ${height}`</p>
  )
</WithDimensions>
```

## Implementation notes

I had a brief stab at writing a unit test for this component but it's quite difficult due to the way it plugs into refs and the component lifecycle. I'd be super happy to get one in, so if anyone has any advice or would like to pair I'm all 👂s!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
