### PR TITLE
Specify prefill query timezone

### DIFF
--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -53,7 +53,6 @@ trait CollectionsQueries {
     }.list().apply()
 
     rows.headOption.map { case (issueDate, prefill, _) =>
-      println(issueDate.toString)
       PrefillUpdate(issueDate, prefill, rows.map(_._3))
     }
   }


### PR DESCRIPTION
## What's changed?

CAPI doesn't use UTC offsets in the newspaper edition date so we need to a rather funky set of operations to convert the `Europe/London` date time which the daily edition uses to a timezoneless date time. The query previously didn't set the timezone correctly so it ended up being truncated to one day in the past, oops.

To get around this we grab the timezone we handily saved for later in the issue.

I suspect this worked locally because our local machines are set to be in `Europe/London` so we didn't need to explicitly set it.

![image](https://user-images.githubusercontent.com/5560113/62557800-97d96c00-b86f-11e9-88c0-e8650dca884e.png)

Here's a picture of the piece of content David made that we previously couldn't find.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
