### PR TITLE
allow a container to be hidden/shown

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -13,7 +13,8 @@ import {
 import { actions } from 'shared/bundles/collectionsBundle';
 import {
   selectHasUnpublishedChanges,
-  selectCollectionHasPrefill, selectCollectionIsHidden
+  selectCollectionHasPrefill,
+  selectCollectionIsHidden
 } from 'selectors/frontsSelectors';
 import { selectIsCollectionLocked } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
@@ -157,10 +158,7 @@ class Collection extends React.Component<CollectionProps> {
                   onClick={() => this.props.setHidden(id, !isHidden)}
                   title="Toggle the visibility of this container in this issue."
                 >
-                  {isHidden
-                    ? 'Unhide Container'
-                    : 'Hide Container'
-                  }
+                  {isHidden ? 'Unhide Container' : 'Hide Container'}
                 </Button>
                 {hasPrefill && (
                   <Button
@@ -288,7 +286,8 @@ const mapDispatchToProps = (
   { browsingStage }: CollectionPropsBeforeState
 ) => ({
   fetchPrefill: (id: string) => dispatch(fetchPrefill(id)),
-  setHidden: (id: string, isHidden: boolean) => dispatch(actions.setHiddenAndPersist(id, isHidden)),
+  setHidden: (id: string, isHidden: boolean) =>
+    dispatch(actions.setHiddenAndPersist(id, isHidden)),
   publishCollection: (id: string, frontId: string) =>
     dispatch(publishCollection(id, frontId)),
   discardDraftChangesToCollection: (id: string) =>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -10,6 +10,7 @@ import {
   discardDraftChangesToCollection,
   openCollectionsAndFetchTheirArticles
 } from 'actions/Collections';
+import { actions } from 'shared/bundles/collectionsBundle';
 import {
   selectHasUnpublishedChanges,
   selectCollectionHasPrefill, selectCollectionIsHidden
@@ -68,7 +69,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   fetchPreviousCollectionArticles: (id: string) => void;
   fetchPrefill: (id: string) => void;
   hasPrefill: boolean;
-  toggleHidden: (id: string) => void;
+  setHidden: (id: string, isHidden: boolean) => void;
   isHidden: boolean;
 };
 
@@ -153,7 +154,7 @@ class Collection extends React.Component<CollectionProps> {
                 <Button
                   size="l"
                   priority="default"
-                  onClick={() => this.props.toggleHidden(id)}
+                  onClick={() => this.props.setHidden(id, !isHidden)}
                   title="Toggle the visibility of this container in this issue."
                 >
                   {isHidden
@@ -287,7 +288,7 @@ const mapDispatchToProps = (
   { browsingStage }: CollectionPropsBeforeState
 ) => ({
   fetchPrefill: (id: string) => dispatch(fetchPrefill(id)),
-  toggleHidden: (id: string) => dispatch(fetchPrefill(id)), // TODO: this obviously needs to toggle whether a collection is hidden or not
+  setHidden: (id: string, isHidden: boolean) => dispatch(actions.setHidden(id, isHidden)),
   publishCollection: (id: string, frontId: string) =>
     dispatch(publishCollection(id, frontId)),
   discardDraftChangesToCollection: (id: string) =>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -288,7 +288,7 @@ const mapDispatchToProps = (
   { browsingStage }: CollectionPropsBeforeState
 ) => ({
   fetchPrefill: (id: string) => dispatch(fetchPrefill(id)),
-  setHidden: (id: string, isHidden: boolean) => dispatch(actions.setHidden(id, isHidden)),
+  setHidden: (id: string, isHidden: boolean) => dispatch(actions.setHiddenAndPersist(id, isHidden)),
   publishCollection: (id: string, frontId: string) =>
     dispatch(publishCollection(id, frontId)),
   discardDraftChangesToCollection: (id: string) =>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -12,7 +12,7 @@ import {
 } from 'actions/Collections';
 import {
   selectHasUnpublishedChanges,
-  selectCollectionHasPrefill
+  selectCollectionHasPrefill, selectCollectionIsHidden
 } from 'selectors/frontsSelectors';
 import { selectIsCollectionLocked } from 'selectors/collectionSelectors';
 import { State } from 'types/State';
@@ -68,6 +68,8 @@ type CollectionProps = CollectionPropsBeforeState & {
   fetchPreviousCollectionArticles: (id: string) => void;
   fetchPrefill: (id: string) => void;
   hasPrefill: boolean;
+  toggleHidden: (id: string) => void;
+  isHidden: boolean;
 };
 
 const PreviouslyCollectionContainer = styled('div')``;
@@ -123,7 +125,8 @@ class Collection extends React.Component<CollectionProps> {
       hasMultipleFrontsOpen,
       isEditFormOpen,
       discardDraftChangesToCollection: discardDraftChanges,
-      hasPrefill
+      hasPrefill,
+      isHidden
     } = this.props;
 
     const { isPreviouslyOpen } = this.state;
@@ -146,8 +149,19 @@ class Collection extends React.Component<CollectionProps> {
           canPublish &&
           !isEditFormOpen && (
             <Fragment>
-              {hasPrefill && (
-                <EditModeVisibility visibleMode="editions">
+              <EditModeVisibility visibleMode="editions">
+                <Button
+                  size="l"
+                  priority="default"
+                  onClick={() => this.props.toggleHidden(id)}
+                  title="Toggle the visibility of this container in this issue."
+                >
+                  {isHidden
+                    ? 'Unhide Container'
+                    : 'Hide Container'
+                  }
+                </Button>
+                {hasPrefill && (
                   <Button
                     data-testid="prefill-button"
                     size="l"
@@ -157,8 +171,8 @@ class Collection extends React.Component<CollectionProps> {
                   >
                     Suggest Articles
                   </Button>
-                </EditModeVisibility>
-              )}
+                )}
+              </EditModeVisibility>
               <EditModeVisibility visibleMode="fronts">
                 <Button
                   size="l"
@@ -245,6 +259,7 @@ const createMapStateToProps = () => {
   ) => {
     const selectDoesCollectionHaveOpenForms = createSelectDoesCollectionHaveOpenForms();
     return {
+      isHidden: selectCollectionIsHidden(state, collectionId),
       hasPrefill: selectCollectionHasPrefill(state, collectionId),
       hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
         collectionId
@@ -272,6 +287,7 @@ const mapDispatchToProps = (
   { browsingStage }: CollectionPropsBeforeState
 ) => ({
   fetchPrefill: (id: string) => dispatch(fetchPrefill(id)),
+  toggleHidden: (id: string) => dispatch(fetchPrefill(id)), // TODO: this obviously needs to toggle whether a collection is hidden or not
   publishCollection: (id: string, frontId: string) =>
     dispatch(publishCollection(id, frontId)),
   discardDraftChangesToCollection: (id: string) =>

--- a/client-v2/src/lib/createAsyncResourceBundle/index.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/index.ts
@@ -1,5 +1,5 @@
 import without from 'lodash/without';
-import { Action }from 'types/action';
+import { Action } from 'types/Action';
 
 interface BaseResource {
   id: string;
@@ -278,7 +278,9 @@ function createAsyncResourceBundle<Resource>(
     payload: { error, id, time: Date.now() }
   });
 
-  const isAction = (action: Actions<Resource> | Action): action is Actions<Resource> => {
+  const isAction = (
+    action: Actions<Resource> | Action
+  ): action is Actions<Resource> => {
     return (action as Actions<Resource>).entity !== undefined;
   };
 
@@ -288,7 +290,6 @@ function createAsyncResourceBundle<Resource>(
       state: State<Resource> = initialState,
       action: Actions<Resource> | Action
     ): State<Resource> => {
-
       if (!isAction(action)) {
         return state;
       }

--- a/client-v2/src/lib/createAsyncResourceBundle/index.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/index.ts
@@ -1,4 +1,5 @@
 import without from 'lodash/without';
+import { Action }from 'types/action';
 
 interface BaseResource {
   id: string;
@@ -277,12 +278,21 @@ function createAsyncResourceBundle<Resource>(
     payload: { error, id, time: Date.now() }
   });
 
+  const isAction = (action: Actions<Resource> | Action): action is Actions<Resource> => {
+    return (action as Actions<Resource>).entity !== undefined;
+  };
+
   return {
     initialState,
     reducer: (
       state: State<Resource> = initialState,
-      action: Actions<Resource>
+      action: Actions<Resource> | Action
     ): State<Resource> => {
+
+      if (!isAction(action)) {
+        return state;
+      }
+
       // The entity property lets us scope by module, whilst keeping
       // the 'type' property typed as string literal unions.
       if (action.entity !== entityName) {

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -127,6 +127,9 @@ const selectCollectionConfig = (state: State, id: string): CollectionConfig =>
 const selectCollectionHasPrefill = (state: State, id: string): boolean =>
   !!(selectCollectionConfig(state, id) || { prefill: undefined }).prefill;
 
+const selectCollectionIsHidden = (state: State, id: string): boolean =>
+  !!selectCollectionConfig(state, id).isHidden;
+
 const selectFrontsIds = createSelector(
   [selectFronts],
   (fronts): string[] => {
@@ -344,6 +347,7 @@ export {
   selectFronts,
   selectCollectionConfig,
   selectCollectionHasPrefill,
+  selectCollectionIsHidden,
   selectFrontsConfig,
   selectCollectionConfigs,
   selectFrontsIds,

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -8,7 +8,8 @@ import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
 import {
-  createSelectArticlesInCollection, createSelectCollection,
+  createSelectArticlesInCollection,
+  createSelectCollection,
   selectSharedState
 } from 'shared/selectors/shared';
 import { createShallowEqualResultSelector } from 'shared/util/selectorUtils';
@@ -129,8 +130,13 @@ const selectCollectionHasPrefill = (state: State, id: string): boolean =>
 
 const selectCollection = createSelectCollection();
 
-const selectCollectionIsHidden = (state: State, collectionId: string): boolean => {
-  const collection = selectCollection(selectSharedState(state), {collectionId});
+const selectCollectionIsHidden = (
+  state: State,
+  collectionId: string
+): boolean => {
+  const collection = selectCollection(selectSharedState(state), {
+    collectionId
+  });
   return !!collection && !!collection.isHidden;
 };
 

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -8,7 +8,7 @@ import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
 
 import { CollectionItemSets, Stages } from 'shared/types/Collection';
 import {
-  createSelectArticlesInCollection,
+  createSelectArticlesInCollection, createSelectCollection,
   selectSharedState
 } from 'shared/selectors/shared';
 import { createShallowEqualResultSelector } from 'shared/util/selectorUtils';
@@ -127,8 +127,12 @@ const selectCollectionConfig = (state: State, id: string): CollectionConfig =>
 const selectCollectionHasPrefill = (state: State, id: string): boolean =>
   !!(selectCollectionConfig(state, id) || { prefill: undefined }).prefill;
 
-const selectCollectionIsHidden = (state: State, id: string): boolean =>
-  !!selectCollectionConfig(state, id).isHidden;
+const selectCollection = createSelectCollection();
+
+const selectCollectionIsHidden = (state: State, collectionId: string): boolean => {
+  const collection = selectCollection(selectSharedState(state), {collectionId});
+  return !!collection && !!collection.isHidden;
+};
 
 const selectFrontsIds = createSelector(
   [selectFronts],

--- a/client-v2/src/shared/bundles/collectionsBundle.ts
+++ b/client-v2/src/shared/bundles/collectionsBundle.ts
@@ -1,6 +1,7 @@
 import { State as SharedState } from '../types/State';
 import createAsyncResourceBundle, {State, Actions} from 'lib/createAsyncResourceBundle';
 import { Collection } from 'shared/types/Collection';
+import { addPersistMetaToAction } from '../../util/action';
 
 const collectionsEntityName = 'collections';
 
@@ -51,7 +52,7 @@ const collectionSelectors = {
   }
 };
 
-const SET_HIDDEN = 'SET_HIDDEN' as 'SET_HIDDEN'
+const SET_HIDDEN = 'SET_HIDDEN' as 'SET_HIDDEN';
 
 const setHidden = (collectionId: string, isHidden: boolean) => ({
   entity: collectionsEntityName,
@@ -62,11 +63,20 @@ const setHidden = (collectionId: string, isHidden: boolean) => ({
   }
 });
 
-type SetHidden = ReturnType<typeof setHidden>
+const setHiddenAndPersist = addPersistMetaToAction(
+  setHidden,
+  {
+    persistTo: 'collection',
+    key: 'collectionId',
+    entity: 'collection'
+  }
+);
+
+export type SetHidden = ReturnType<typeof setHidden>
 
 const collectionActions = {
   ...actions,
-  setHidden
+  setHiddenAndPersist
 };
 
 type CollectionActions = Actions<Collection> | SetHidden

--- a/client-v2/src/shared/bundles/collectionsBundle.ts
+++ b/client-v2/src/shared/bundles/collectionsBundle.ts
@@ -1,5 +1,8 @@
 import { State as SharedState } from '../types/State';
-import createAsyncResourceBundle, {State, Actions} from 'lib/createAsyncResourceBundle';
+import createAsyncResourceBundle, {
+  State,
+  Actions
+} from 'lib/createAsyncResourceBundle';
 import { Collection } from 'shared/types/Collection';
 import { addPersistMetaToAction } from '../../util/action';
 
@@ -11,7 +14,9 @@ const {
   reducer,
   selectors,
   initialState
-} = createAsyncResourceBundle<Collection>(collectionsEntityName, { indexById: true });
+} = createAsyncResourceBundle<Collection>(collectionsEntityName, {
+  indexById: true
+});
 
 const collectionSelectors = {
   ...selectors,
@@ -63,31 +68,29 @@ const setHidden = (collectionId: string, isHidden: boolean) => ({
   }
 });
 
-const setHiddenAndPersist = addPersistMetaToAction(
-  setHidden,
-  {
-    persistTo: 'collection',
-    key: 'collectionId',
-    entity: 'collection'
-  }
-);
+const setHiddenAndPersist = addPersistMetaToAction(setHidden, {
+  persistTo: 'collection',
+  key: 'collectionId',
+  entity: 'collection'
+});
 
-export type SetHidden = ReturnType<typeof setHidden>
+export type SetHidden = ReturnType<typeof setHidden>;
 
 const collectionActions = {
   ...actions,
   setHiddenAndPersist
 };
 
-type CollectionActions = Actions<Collection> | SetHidden
+type CollectionActions = Actions<Collection> | SetHidden;
 
-const collectionReducer = (state: State<Collection>, action: CollectionActions): State<Collection> => {
+const collectionReducer = (
+  state: State<Collection>,
+  action: CollectionActions
+): State<Collection> => {
   const updatedState = reducer(state, action);
-  switch(action.type) {
+  switch (action.type) {
     case SET_HIDDEN: {
-      console.log(`Fielding SET_HIDDEN action with payload ${JSON.stringify(action.payload)}`);
       if (!updatedState.data[action.payload.collectionId]) {
-        console.log('Collection not known');
         return updatedState;
       }
 
@@ -101,7 +104,6 @@ const collectionReducer = (state: State<Collection>, action: CollectionActions):
           }
         }
       };
-      console.log(`Whoop! Updated state is now ${freshState}`);
       return freshState;
     }
     default: {

--- a/client-v2/src/shared/bundles/collectionsBundle.ts
+++ b/client-v2/src/shared/bundles/collectionsBundle.ts
@@ -5,6 +5,7 @@ import createAsyncResourceBundle, {
 } from 'lib/createAsyncResourceBundle';
 import { Collection } from 'shared/types/Collection';
 import { addPersistMetaToAction } from '../../util/action';
+import set from 'lodash/fp/set';
 
 const collectionsEntityName = 'collections';
 
@@ -94,17 +95,11 @@ const collectionReducer = (
         return updatedState;
       }
 
-      const freshState = {
-        ...updatedState,
-        data: {
-          ...updatedState.data,
-          [action.payload.collectionId]: {
-            ...updatedState.data[action.payload.collectionId],
-            isHidden: action.payload.isHidden
-          }
-        }
-      };
-      return freshState;
+      return set(
+        ['data', action.payload.collectionId, 'isHidden'],
+        action.payload.isHidden,
+        updatedState
+      );
     }
     default: {
       return updatedState;

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -128,6 +128,7 @@ interface Collection {
   uneditable?: boolean;
   type: string;
   frontsToolSettings?: FrontsToolSettings;
+  isHidden?: boolean;
 }
 
 interface ArticleTag {

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -41,6 +41,7 @@ import {
 import { setFocusState, resetFocusState } from '../bundles/focusBundle';
 import { ActionSetFeatureValue } from 'shared/redux/modules/featureSwitches';
 import { ReactNode } from 'react';
+import { SetHidden } from '../shared/bundles/collectionsBundle';
 
 interface EditorOpenCurrentFrontsMenu {
   type: typeof EDITOR_OPEN_CURRENT_FRONTS_MENU;
@@ -332,7 +333,8 @@ type Action =
   | SetFocusState
   | ResetFocusState
   | ActionSetFeatureValue
-  | IsPrefillMode;
+  | IsPrefillMode
+  | SetHidden;
 
 export {
   ActionError,

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -50,6 +50,7 @@ interface CollectionConfigResponse {
   platform?: Platform;
   frontsToolSettings?: FrontsToolSettings;
   prefill?: EditionsPrefill;
+  isHidden?: boolean;
 }
 
 interface FrontsConfigResponse {

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -50,7 +50,6 @@ interface CollectionConfigResponse {
   platform?: Platform;
   frontsToolSettings?: FrontsToolSettings;
   prefill?: EditionsPrefill;
-  isHidden?: boolean;
 }
 
 interface FrontsConfigResponse {
@@ -108,6 +107,7 @@ interface EditionCollectionFromResponse {
   groups?: string[];
   metadata?: Array<{ type: string }>;
   uneditable?: boolean;
+  isHidden?: boolean;
 }
 
 interface EditionCollectionResponse {

--- a/client-v2/src/util/storeMiddleware.ts
+++ b/client-v2/src/util/storeMiddleware.ts
@@ -123,7 +123,7 @@ const persistCollectionOnEdit = (
    *   but it should also listen for edits to collections.
    */
   const getCollectionIdsForActions = (actions: Action[]) => {
-    const idsAndEntities: { id: string; entity: Entity }[] = actions.map(
+    const idsAndEntities: Array<{ id: string; entity: Entity }> = actions.map(
       // A sneaky 'any' here, as it's difficult to handle dynamic key
       // values with static action types.
       (act: any) => {
@@ -137,7 +137,7 @@ const persistCollectionOnEdit = (
       }
     );
     const collectionIds: string[] = idsAndEntities.reduce(
-      (acc, {id, entity}) => {
+      (acc, { id, entity }) => {
         if (entity === 'collection') {
           return acc.concat(id);
         }


### PR DESCRIPTION
## What's changed?
Allow a container to be hidden within an Edition's Front.

**Hidden**
![image](https://user-images.githubusercontent.com/836140/62720290-a2c40600-ba01-11e9-8e15-e6403a0031f9.png)

**Unhidden**
![image](https://user-images.githubusercontent.com/836140/62720306-aa83aa80-ba01-11e9-9cb0-8ba9c2a04815.png)

## Implementation notes
Pairing on this was a lot of fun!

Possible TODOs for followup PRs:
- Cleaner UX
- Only allow specific containers to be hidden (we don't have a model for this yet)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
