### PR TITLE
Add user data to page JSON, even if it doesn't exist yet

### DIFF
--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -45,7 +45,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps
     else
       maybeUserData.map(_.clipboardArticles.getOrElse(List()))
 
-    val maybeUserDataForDefaults = UserDataForDefaults.fromUserData(
+    val userDataForDefaults = UserDataForDefaults.fromUserData(
       maybeUserData.getOrElse(UserData(userEmail)),
       clipboardArticles
     )
@@ -69,7 +69,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps
       Metadata.tags.map {
         case (_, meta) => meta
       },
-      Some(maybeUserDataForDefaults),
+      Some(userDataForDefaults),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
     )

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -45,7 +45,10 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps
     else
       maybeUserData.map(_.clipboardArticles.getOrElse(List()))
 
-    val maybeUserDataForDefaults = maybeUserData.map { data => UserDataForDefaults.fromUserData(data, clipboardArticles) }
+    val maybeUserDataForDefaults = UserDataForDefaults.fromUserData(
+      maybeUserData.getOrElse(UserData(userEmail)),
+      clipboardArticles
+    )
 
     val conf = Defaults(
       isDev,
@@ -66,7 +69,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps
       Metadata.tags.map {
         case (_, meta) => meta
       },
-      maybeUserDataForDefaults,
+      Some(maybeUserDataForDefaults),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
     )

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -30,11 +30,11 @@ object UserData {
   */
 case class UserData(
                      email: String,
-                     clipboardArticles: Option[List[Trail]],
-                     editionsClipboardArticles: Option[List[Trail]],
-                     frontIds: Option[List[String]],
-                     frontIdsByPriority: Option[Map[String, List[String]]],
-                     favouriteFrontIdsByPriority: Option[Map[String, List[String]]],
+                     clipboardArticles: Option[List[Trail]] = None,
+                     editionsClipboardArticles: Option[List[Trail]] = None,
+                     frontIds: Option[List[String]] = None,
+                     frontIdsByPriority: Option[Map[String, List[String]]] = None,
+                     favouriteFrontIdsByPriority: Option[Map[String, List[String]]] = None,
                      featureSwitches: Option[List[FeatureSwitch]] = Some(List.empty[FeatureSwitch])
 )
 


### PR DESCRIPTION
## What's changed?

Add user data to page JSON, even if it doesn't exist yet. At the moment, nothing's coming through, which means new users don't see the correct results for feature switch defaults.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
