### PR TITLE
add sport score field to inline form

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -399,6 +399,14 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               originalValue={articleCapiFieldValues.trailText}
               label="Trail text"
             />
+            <ConditionalField
+              permittedFields={editableFields}
+              name="sportScore"
+              label="Sport Score"
+              component={InputText}
+              placeholder=""
+              originalValue={''}
+            />
           </InputGroup>
           <RowContainer>
             <Row>


### PR DESCRIPTION
## What's changed?
Add sport score field to inline form too. Related to https://github.com/guardian/facia-tool/pull/886.

![image](https://user-images.githubusercontent.com/836140/62770862-d2bbe980-ba93-11e9-8b12-7214c9fab3ba.png)

## Implementation notes
n/a

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
