### PR TITLE
Correct tone in collection items

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -189,7 +189,7 @@ const articleBodyDefault = React.memo(
                 }}
               >
                 {startCase(sectionName)}
-                <Tone> / {tone}</Tone>
+                <Tone> / {startCase(tone)}</Tone>
               </CollectionItemMetaHeading>
             )}
             {type === 'liveblog' && (

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -3,8 +3,7 @@ import { createSelector } from 'reselect';
 import {
   getThumbnail,
   getPrimaryTag,
-  getContributorImage,
-  getTone
+  getContributorImage
 } from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
@@ -158,7 +157,7 @@ const createSelectArticleFromArticleFragment = () =>
           ? externalArticle.fields.firstPublicationDate
           : undefined,
         frontPublicationDate: articleFragment.frontPublicationDate,
-        tone: externalArticle ? getTone(externalArticle.tags) : undefined
+        tone: externalArticle ? externalArticle.frontsMeta.tone : undefined
       };
     }
   );

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -96,11 +96,6 @@ const getTags = (externalArticle: ExternalArticle): Tag[] =>
 const getPrimaryTag = (externalArticle: ExternalArticle): Tag | null =>
   getTags(externalArticle)[0] || null;
 
-const getTone = (tags: Tag[] | undefined): string | undefined => {
-  const tag = (tags || []).find(_ => _.type === 'tone');
-  return tag ? tag.webTitle : undefined;
-};
-
 const isLive = (article: CapiArticle) =>
   !article.fields.isLive || article.fields.isLive === 'true';
 
@@ -130,7 +125,6 @@ export {
   getThumbnail,
   getContributorImage,
   getPrimaryTag,
-  getTone,
   getArticleLabel,
   isLive
 };


### PR DESCRIPTION
## What's changed?

The tone in collection items was not right. This PR corrects that by deriving tone from `frontsMeta`, as we do in v1.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
