### PR TITLE
Remove unnecessary form fields for e-mail priorities.

### DIFF
--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -39,7 +39,8 @@ const formValues = {
   showKickerSection: false,
   trailText:
     'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him',
-  sportScore: ''
+  sportScore: '',
+  showMainVideo: false
 };
 
 const createStateWithChangedFormFields = (

--- a/client-v2/src/selectors/__tests__/formSelectors.spec.ts
+++ b/client-v2/src/selectors/__tests__/formSelectors.spec.ts
@@ -2,30 +2,28 @@ import cloneDeep from 'lodash/cloneDeep';
 import {
   createSelectFormFieldsForCollectionItem,
   defaultFields,
-  supportingFields
+  supportingFields,
+  emailFieldsToExclude
 } from '../formSelectors';
 import { state, stateWithVideoArticle } from 'fixtures/form';
+import without from 'lodash/without';
 
 describe('Form utils', () => {
-  describe('getFormFieldsForCollectionItem', () => {
+  describe('selectFormFieldsForCollectionItem', () => {
     it("should handle articles that don't exist in the state", () => {
       const selectFormFields = createSelectFormFieldsForCollectionItem();
-      expect(selectFormFields(state as any, 'who-are-you')).toEqual([]);
+      expect(selectFormFields(state, 'who-are-you')).toEqual([]);
     });
     it('should give default fields for articles', () => {
       const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selectFormFields(state as any, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
+        selectFormFields(state, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
       ).toEqual(defaultFields);
     });
     it('should give supporting fields for articles in supporting positions', () => {
       const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selectFormFields(
-          state as any,
-          '95e2bfc0-8999-4e6e-a359-19960967c1e0',
-          true
-        )
+        selectFormFields(state, '95e2bfc0-8999-4e6e-a359-19960967c1e0', true)
       ).toEqual(supportingFields);
     });
     it('should add isBoosted for dynamic collection configs', () => {
@@ -34,10 +32,7 @@ describe('Form utils', () => {
         'dynamic/example';
       const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selectFormFields(
-          localState as any,
-          '95e2bfc0-8999-4e6e-a359-19960967c1e0'
-        )
+        selectFormFields(localState, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
       ).toEqual([...defaultFields, 'isBoosted']);
     });
     it('should add showLivePlayable for live blogs', () => {
@@ -47,20 +42,26 @@ describe('Form utils', () => {
       ].fields.liveBloggingNow = 'true';
       const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
-        selectFormFields(
-          localState as any,
-          '95e2bfc0-8999-4e6e-a359-19960967c1e0'
-        )
+        selectFormFields(localState, '95e2bfc0-8999-4e6e-a359-19960967c1e0')
       ).toEqual([...defaultFields, 'showLivePlayable']);
     });
     it('should add showMainVideo for articles with video as the main media', () => {
       const selectFormFields = createSelectFormFieldsForCollectionItem();
       expect(
         selectFormFields(
-          stateWithVideoArticle as any,
+          stateWithVideoArticle,
           '95e2bfc0-8999-4e6e-a359-19960967c1e0'
         )
       ).toEqual([...defaultFields, 'showMainVideo']);
+    });
+    it("should remove breaking news, large headline and slideshows when we're in priority 'email'", () => {
+      const selectFormFields = createSelectFormFieldsForCollectionItem();
+      expect(
+        selectFormFields(
+          { ...state, path: '/v2/email' },
+          '95e2bfc0-8999-4e6e-a359-19960967c1e0'
+        )
+      ).toEqual(without(defaultFields, ...emailFieldsToExclude));
     });
   });
 });

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -8,7 +8,9 @@ import { hasMainVideo } from 'shared/util/derivedArticle';
 import { isCollectionConfigDynamic } from '../util/frontsUtils';
 import { createSelector } from 'reselect';
 import { State } from 'types/State';
-import { selectEditMode } from './pathSelectors';
+import { selectEditMode, selectPriority } from './pathSelectors';
+import { FormFields } from 'util/form';
+import without from 'lodash/without';
 
 export const defaultFields = [
   'headline',
@@ -26,7 +28,7 @@ export const defaultFields = [
   'primaryImage',
   'cutoutImage',
   'slideshow'
-];
+] as FormFields[];
 
 export const supportingFields = [
   'headline',
@@ -34,7 +36,16 @@ export const supportingFields = [
   'isBreaking',
   'showKickerSection',
   'showKickerCustom'
-];
+] as FormFields[];
+
+export const emailFieldsToExclude = [
+  'isBreaking',
+  'showLargeHeadline',
+  'slideshow',
+  'cutoutImage',
+  'imageSlideshowReplace',
+  'imageCutoutReplace'
+] as FormFields[];
 
 const selectIsSupporting = (_: unknown, __: unknown, isSupporting: boolean) =>
   isSupporting;
@@ -59,14 +70,21 @@ export const createSelectFormFieldsForCollectionItem = () => {
     selectParentCollectionConfig,
     selectIsSupporting,
     selectEditMode,
-    (derivedArticle, parentCollectionConfig, isSupporting, editMode) => {
+    selectPriority,
+    (
+      derivedArticle,
+      parentCollectionConfig,
+      isSupporting,
+      editMode,
+      priority
+    ) => {
       if (!derivedArticle) {
         return [];
       }
       if (isSupporting) {
         return supportingFields;
       }
-      const fields = defaultFields.slice();
+      let fields = defaultFields.slice();
 
       if (isCollectionConfigDynamic(parentCollectionConfig)) {
         fields.push('isBoosted');
@@ -76,6 +94,10 @@ export const createSelectFormFieldsForCollectionItem = () => {
       }
       if (hasMainVideo(derivedArticle)) {
         fields.push('showMainVideo');
+      }
+
+      if (priority === 'email') {
+        fields = without(fields, ...emailFieldsToExclude);
       }
 
       if (editMode === 'editions') {

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -1,14 +1,14 @@
 import { State } from 'types/State';
-import { matchIssuePath } from 'routes/routes';
+import { matchIssuePath, matchFrontsEditPath } from 'routes/routes';
 import urls from 'constants/urls';
 import { EditMode } from 'types/EditMode';
 
 const matchRootPath = new RegExp(`^\/${urls.appRoot}`);
 const maybeRemoveV2Prefix = (path: string) => path.replace(matchRootPath, '');
-
 const selectFullPath = (state: State) => state.path;
 const selectV2SubPath = (state: State) =>
   maybeRemoveV2Prefix(selectFullPath(state));
+
 const selectEditMode = (state: State): EditMode => {
   if (!!matchIssuePath(selectV2SubPath(state))) {
     return 'editions';
@@ -17,4 +17,13 @@ const selectEditMode = (state: State): EditMode => {
   }
 };
 
-export { selectFullPath, selectV2SubPath, selectEditMode };
+const selectPriority = (state: State) => {
+  const path = selectV2SubPath(state);
+  const match = matchFrontsEditPath(path) || matchIssuePath(path);
+  if (!match || !match.params.priority) {
+    return;
+  }
+  return match.params.priority;
+};
+
+export { selectFullPath, selectV2SubPath, selectEditMode, selectPriority };

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -34,7 +34,10 @@ export interface ArticleFragmentFormData {
   showKickerTag: boolean;
   showKickerSection: boolean;
   imageReplace: boolean;
+  showMainVideo: boolean;
 }
+
+export type FormFields = keyof ArticleFragmentFormData;
 
 export interface ImageData {
   src?: string;
@@ -122,7 +125,8 @@ export const getInitialValuesForArticleFragmentForm = (
           thumb: article.imageCutoutSrc
         },
         slideshow: slideshow.concat(slideshowBackfill),
-        sportScore: article.sportScore || ''
+        sportScore: article.sportScore || '',
+        showMainVideo: !!article.showMainVideo
       }
     : undefined;
 };

--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -1,8 +1,7 @@
 import { fetchStaleOpenCollections } from 'actions/Collections';
 import { Dispatch } from 'types/Store';
 import { Store } from 'types/Store';
-import { matchFrontsEditPath, matchIssuePath } from 'routes/routes';
-import { selectV2SubPath } from 'selectors/pathSelectors';
+import { selectPriority } from 'selectors/pathSelectors';
 
 /**
  * TODO: do we want to check if there are any collectionUpdates going out here
@@ -14,12 +13,10 @@ export default (store: Store) =>
     if ((window as any).IS_INTEGRATION) {
       return;
     }
-    const path = selectV2SubPath(store.getState());
-    const match = matchFrontsEditPath(path) || matchIssuePath(path);
-    if (!match || !match.params.priority) {
+
+    const priority = selectPriority(store.getState());
+    if (!priority) {
       return;
     }
-    (store.dispatch as Dispatch)(
-      fetchStaleOpenCollections(match.params.priority)
-    );
+    (store.dispatch as Dispatch)(fetchStaleOpenCollections(priority));
   }, 10000);


### PR DESCRIPTION
## What's changed?

Remove unnecessary fields when we're in the `email` priority.

<img width="427" alt="Screenshot 2019-08-09 at 14 13 29" src="https://user-images.githubusercontent.com/7767575/62781444-f12fde00-baaf-11e9-8024-63b057b0b26f.png">

Look at that lovely concise form!

## Implementation notes

I've taken the first step towards slightly more typesafe form code in this PR by adding the `FormFields` type, derived from the keys of the form output. As a result, incorrect strings in lists of fields elsewhere will now throw type errors.

Perhaps the next step is to store these in a map and key into them when we instantiate fields, to ensure our field names in the form component match across our codebase.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
