### PR TITLE
Show indicator in overview when forms are open

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -17,6 +17,7 @@ import {
   createSelectArticlesInCollection
 } from 'shared/selectors/shared';
 import EditModeVisibility from 'components/util/EditModeVisibility';
+import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUIBundle';
 
 interface FrontCollectionOverviewContainerProps {
   frontId: string;
@@ -30,6 +31,7 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
   articleCount: number;
   openCollection: (id: string) => void;
   hasUnpublishedChanges: boolean;
+  hasOpenForms: boolean;
 };
 
 const Container = styled.div<{ isSelected: boolean }>`
@@ -106,7 +108,8 @@ const CollectionOverview = ({
   openCollection,
   frontId,
   hasUnpublishedChanges,
-  isSelected
+  isSelected,
+  hasOpenForms
 }: FrontCollectionOverviewProps) =>
   collection ? (
     <Container
@@ -130,6 +133,15 @@ const CollectionOverview = ({
         <ItemCount>({articleCount})</ItemCount>
       </TextContainerLeft>
       <TextContainerRight>
+        {!!hasOpenForms && (
+          <StatusWarning
+            priority="default"
+            size="s"
+            title="This collection has open forms"
+          >
+            !
+          </StatusWarning>
+        )}
         {collection &&
           collection.lastUpdated &&
           (!!hasUnpublishedChanges ? (
@@ -150,19 +162,29 @@ const CollectionOverview = ({
 const mapStateToProps = () => {
   const selectCollection = createSelectCollection();
   const selectArticlesInCollection = createSelectArticlesInCollection();
-
-  return (state: State, props: FrontCollectionOverviewContainerProps) => ({
+  const selectCollectionIdsWithOpenForms = createSelectCollectionIdsWithOpenForms();
+  return (
+    state: State,
+    {
+      frontId,
+      collectionId,
+      browsingStage: collectionSet
+    }: FrontCollectionOverviewContainerProps
+  ) => ({
     collection: selectCollection(selectSharedState(state), {
-      collectionId: props.collectionId
+      collectionId
     }),
     articleCount: selectArticlesInCollection(selectSharedState(state), {
-      collectionSet: props.browsingStage,
-      collectionId: props.collectionId,
+      collectionSet,
+      collectionId,
       includeSupportingArticles: false
     }).length,
     hasUnpublishedChanges: selectHasUnpublishedChanges(state, {
-      collectionId: props.collectionId
-    })
+      collectionId
+    }),
+    hasOpenForms:
+      selectCollectionIdsWithOpenForms(state, frontId).indexOf(collectionId) !==
+      -1
   });
 };
 


### PR DESCRIPTION
## What's changed?

Show an indicator in the container overview when forms are open in it.

![Screenshot 2019-08-09 at 14 36 03](https://user-images.githubusercontent.com/7767575/62783012-5f29d480-bab3-11e9-8581-04ff8c6ae9a5.png)

## Implementation notes

This was actually present in the `inline-form` prototype, but didn't make it into the PR proper, so this PR simply restores the balance.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
