### PR TITLE
Disable editing kicker if breaking news toggle is `true`

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -214,7 +214,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       imageReplace,
       imageCutoutReplace,
       cutoutImage,
-      imageSlideshowReplace
+      imageSlideshowReplace,
+      isBreaking
     } = this.props;
 
     const getKickerContents = () => {
@@ -288,6 +289,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               name="customKicker"
               label="Kicker"
               component={InputText}
+              disabled={isBreaking}
+              title={
+                isBreaking &&
+                "You cannot edit the kicker if the 'Breaking News' toggle is set."
+              }
               labelContent={
                 hasKickerSuggestions ? (
                   <KickerSuggestionsContainer>
@@ -595,6 +601,7 @@ interface ContainerProps {
   showKickerSection: boolean;
   articleCapiFieldValues: CapiFields;
   imageReplace: boolean;
+  isBreaking: boolean;
 }
 
 interface InterfaceProps {
@@ -664,6 +671,7 @@ const createMapStateToProps = () => {
       showByline: valueSelector(state, 'showByline'),
       showKickerTag: valueSelector(state, 'showKickerTag'),
       showKickerSection: valueSelector(state, 'showKickerSection'),
+      isBreaking: valueSelector(state, 'isBreaking'),
       cutoutImage: externalArticle
         ? getContributorImage(externalArticle)
         : undefined

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -291,8 +291,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               component={InputText}
               disabled={isBreaking}
               title={
-                isBreaking &&
-                "You cannot edit the kicker if the 'Breaking News' toggle is set."
+                isBreaking
+                  ? "You cannot edit the kicker if the 'Breaking News' toggle is set."
+                  : ''
               }
               labelContent={
                 hasKickerSuggestions ? (

--- a/client-v2/src/shared/components/input/InputBase.ts
+++ b/client-v2/src/shared/components/input/InputBase.ts
@@ -27,4 +27,8 @@ export default styled('input')<{
     outline: none;
     border: solid 1px ${props => props.theme.shared.input.borderColorFocus};
   }
+  :disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;


### PR DESCRIPTION
## What's changed?

Disable editing the kicker if breaking news toggle is `true`.

![breaking-news-kicker](https://user-images.githubusercontent.com/7767575/62783619-af556680-bab4-11e9-8228-a1415b012636.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
