### PR TITLE
render error message in a more accessible place

### DIFF
--- a/client-v2/src/components/Editions/ManageEdition.tsx
+++ b/client-v2/src/components/Editions/ManageEdition.tsx
@@ -62,6 +62,11 @@ class ManageEdition extends React.Component<
         <h2>{startCase(this.props.match.params.editionName)}</h2>
         <h4>Select a date to create or edit an issue.</h4>
         <div>
+          {this.state.infoMessage && (
+            <InformationMsg status={this.state.isError ? 'error' : 'info'}>
+              {this.state.infoMessage}
+            </InformationMsg>
+          )}
           <span>
             <SingleDatePicker
               date={this.state.date}
@@ -82,11 +87,6 @@ class ManageEdition extends React.Component<
             </SpinnerContainer>
           )}
         </div>
-        {this.state.infoMessage && (
-          <InformationMsg status={this.state.isError ? 'error' : 'info'}>
-            {this.state.infoMessage}
-          </InformationMsg>
-        )}
         {this.state.date && this.renderIssueData()}
       </>
     );


### PR DESCRIPTION
## What's changed?
moves the error message from below the date picker to the side, to make it more accessible

**Before** (you can just about see the red warning under the date picker)
![image](https://user-images.githubusercontent.com/836140/62785702-16751a00-bab9-11e9-91e1-8e2e8e6a9b86.png)


**After** (error message in clear sight)
![image](https://user-images.githubusercontent.com/836140/62785670-06f5d100-bab9-11e9-8987-63fccbe675b4.png)


## Implementation notes
n/a

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
