### PR TITLE
Add media indicators to cards

### DIFF
--- a/client-v2/src/fixtures/derivedArticle.ts
+++ b/client-v2/src/fixtures/derivedArticle.ts
@@ -30,5 +30,6 @@ export default {
   uuid: 'fc87955e-fa51-4994-b6cb-bf1c55e0a212',
   supporting: [],
   kicker: 'News',
-  tone: undefined
+  tone: undefined,
+  hasMainVideo: false
 } as DerivedArticle;

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -4,7 +4,7 @@ import {
   createSelectArticleFromArticleFragment
 } from 'shared/selectors/shared';
 import { selectCollectionConfig } from 'selectors/frontsSelectors';
-import { hasMainVideo } from 'shared/util/derivedArticle';
+import { hasMainVideo } from 'shared/util/externalArticle';
 import { isCollectionConfigDynamic } from '../util/frontsUtils';
 import { createSelector } from 'reselect';
 import { State } from 'types/State';

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -27,6 +27,7 @@ import DraggableArticleImageContainer from './DraggableArticleImageContainer';
 import { media } from 'shared/util/mediaQueries';
 import { PageViewStory } from 'shared/types/PageViewData';
 import ArticleGraph from './ArticleGraph';
+import { VideoIcon } from '../icons/Icons';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -103,6 +104,7 @@ const Tone = styled('span')`
   font-weight: normal;
 `;
 
+
 const ImageAndGraphWrapper = styled('div')<{ size: CollectionItemSizes }>`
   display: flex;
   flex-direction: row;
@@ -110,6 +112,19 @@ const ImageAndGraphWrapper = styled('div')<{ size: CollectionItemSizes }>`
     props.size === 'medium' &&
     `flex-wrap: wrap-reverse;
     justify-content: flex-end;`}
+`;
+
+const VideoIconContainer = styled('div')`
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
 `;
 
 interface ArticleBodyProps {
@@ -146,6 +161,8 @@ interface ArticleBodyProps {
   canDragImage?: boolean;
   isDraggingImageOver: boolean;
   isBoosted?: boolean;
+  hasMainVideo?: boolean;
+  showMainVideo?: boolean;
   tone?: string | undefined;
   featureFlagPageViewData?: boolean;
   canShowPageViewData: boolean;
@@ -189,7 +206,9 @@ const articleBodyDefault = React.memo(
     tone,
     featureFlagPageViewData,
     canShowPageViewData,
-    pageViewStory
+    pageViewStory,
+    hasMainVideo,
+    showMainVideo
   }: ArticleBodyProps) => {
     const ArticleHeadingContainer =
       size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
@@ -330,12 +349,18 @@ const articleBodyDefault = React.memo(
                   {cutoutThumbnail ? (
                     <ThumbnailCutout src={cutoutThumbnail} />
                   ) : null}
+                  {hasMainVideo && (
+                  <VideoIconContainer>
+                    <VideoIcon />
+                  </VideoIconContainer>
+                )}
                 </ThumbnailSmall>
                 <ImageMetadataContainer>
-                  {imageSlideshowReplace && 'Slideshow'}
-                  {imageReplace && 'Image replaced'}
-                  {imageCutoutReplace && 'Cutout replaced'}
-                </ImageMetadataContainer>
+                {imageSlideshowReplace && 'Slideshow'}
+                {imageReplace && 'Image replaced'}
+                {imageCutoutReplace && 'Cutout replaced'}
+                {showMainVideo && 'Show video'}
+              </ImageMetadataContainer>
               </DraggableArticleImageContainer>
             ))}
         </ImageAndGraphWrapper>

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -104,7 +104,6 @@ const Tone = styled('span')`
   font-weight: normal;
 `;
 
-
 const ImageAndGraphWrapper = styled('div')<{ size: CollectionItemSizes }>`
   display: flex;
   flex-direction: row;
@@ -350,17 +349,17 @@ const articleBodyDefault = React.memo(
                     <ThumbnailCutout src={cutoutThumbnail} />
                   ) : null}
                   {hasMainVideo && (
-                  <VideoIconContainer>
-                    <VideoIcon />
-                  </VideoIconContainer>
-                )}
+                    <VideoIconContainer>
+                      <VideoIcon />
+                    </VideoIconContainer>
+                  )}
                 </ThumbnailSmall>
                 <ImageMetadataContainer>
-                {imageSlideshowReplace && 'Slideshow'}
-                {imageReplace && 'Image replaced'}
-                {imageCutoutReplace && 'Cutout replaced'}
-                {showMainVideo && 'Show video'}
-              </ImageMetadataContainer>
+                  {imageSlideshowReplace && 'Slideshow'}
+                  {imageReplace && 'Image replaced'}
+                  {imageCutoutReplace && 'Cutout replaced'}
+                  {showMainVideo && 'Show video'}
+                </ImageMetadataContainer>
               </DraggableArticleImageContainer>
             ))}
         </ImageAndGraphWrapper>

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -250,6 +250,24 @@ const PreviewEyeIcon = ({
   </svg>
 );
 
+const VideoIcon = ({}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    width="13"
+    height="10"
+    viewBox="0 0 13 9"
+  >
+    <defs>
+      <path
+        id="a"
+        d="M1.2 0L0 1.2v6l1.2 1.2h6.9V0H1.2zM12 .5l-3 3v1.8l3 3h.9V.5H12z"
+      />
+    </defs>
+    <use fill="#333" fillRule="evenodd" xlinkHref="#a" />
+  </svg>
+);
+
 export {
   DownCaretIcon,
   RubbishBinIcon,
@@ -261,5 +279,6 @@ export {
   MagnifyingGlassIcon,
   AddImageIcon,
   StarIcon,
-  PreviewEyeIcon
+  PreviewEyeIcon,
+  VideoIcon
 };

--- a/client-v2/src/shared/selectors/__tests__/shared.spec.ts
+++ b/client-v2/src/shared/selectors/__tests__/shared.spec.ts
@@ -267,7 +267,7 @@ describe('Shared selectors', () => {
   describe('createArticleFromArticleFragmentSelector', () => {
     it('should create a selector that returns an article (externalArticle + articleFragment) referenced by the given article fragment', () => {
       const selector = createSelectArticleFromArticleFragment();
-      expect(selector(state, 'af1')).toEqual({
+      expect(selector(state, 'af1')).toMatchObject({
         id: 'ea1',
         pillarName: 'external-pillar',
         frontPublicationDate: 1,
@@ -281,7 +281,7 @@ describe('Shared selectors', () => {
         firstPublicationDate: '2018-10-19T10:30:39Z'
       });
 
-      expect(selector(state, 'af1WithOverrides')).toEqual({
+      expect(selector(state, 'af1WithOverrides')).toMatchObject({
         id: 'ea1',
         customKicker: 'fragment-kicker',
         pillarName: 'external-pillar',
@@ -302,28 +302,13 @@ describe('Shared selectors', () => {
     });
     it('should set isLive property to false if article is not live', () => {
       const selector = createSelectArticleFromArticleFragment();
-      expect(selector(state, 'af2')).toEqual({
-        id: 'ea2',
-        pillarName: 'external-pillar',
-        firstPublicationDate: '2018-10-19T10:30:39Z',
-        uuid: 'af2',
-        headline: 'external-headline',
-        thumbnail: undefined,
-        trailText: 'external-trailText',
-        byline: 'external-byline',
+      expect(selector(state, 'af2')).toMatchObject({
         isLive: false
       });
     });
     it('should set isLive to true if property is missing', () => {
       const selector = createSelectArticleFromArticleFragment();
-      expect(selector(state, 'af3')).toEqual({
-        id: 'ea3',
-        pillarName: 'external-pillar',
-        uuid: 'af3',
-        headline: 'external-headline',
-        thumbnail: undefined,
-        trailText: 'external-trailText',
-        byline: 'external-byline',
+      expect(selector(state, 'af3')).toMatchObject({
         isLive: true
       });
     });
@@ -351,7 +336,14 @@ describe('Shared selectors', () => {
         showKickerTag: false,
         showLivePlayable: false,
         showMainVideo: false,
-        showQuotedHeadline: false
+        showQuotedHeadline: false,
+        hasMainVideo: false,
+        kicker: undefined,
+        pillarId: undefined,
+        tone: undefined,
+        cutoutThumbnail: undefined,
+        firstPublicationDate: undefined,
+        frontPublicationDate: undefined
       });
     });
   });

--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -20,6 +20,7 @@ import { State } from '../types/State';
 import { collectionItemSets } from 'constants/fronts';
 import { createShallowEqualResultSelector } from 'shared/util/selectorUtils';
 import { DerivedArticle } from 'shared/types/Article';
+import { hasMainVideo } from 'shared/util/externalArticle';
 
 // Selects the shared part of the application state mounted at its default point, '.shared'.
 const selectSharedState = (rootState: any): State => rootState.shared;
@@ -157,7 +158,9 @@ const createSelectArticleFromArticleFragment = () =>
           ? externalArticle.fields.firstPublicationDate
           : undefined,
         frontPublicationDate: articleFragment.frontPublicationDate,
-        tone: externalArticle ? externalArticle.frontsMeta.tone : undefined
+        tone: externalArticle ? externalArticle.frontsMeta.tone : undefined,
+        hasMainVideo: !!externalArticle && hasMainVideo(externalArticle),
+        showMainVideo: !!articleMeta.showMainVideo
       };
     }
   );

--- a/client-v2/src/shared/types/Article.ts
+++ b/client-v2/src/shared/types/Article.ts
@@ -17,6 +17,7 @@ type DerivedArticle = Partial<
     kicker?: string;
     isLive: boolean;
     tone: string | undefined;
+    hasMainVideo: boolean;
   };
 
 export { DerivedArticle };

--- a/client-v2/src/shared/util/externalArticle.ts
+++ b/client-v2/src/shared/util/externalArticle.ts
@@ -1,8 +1,9 @@
-import { DerivedArticle } from 'shared/types/Article';
 import { oc } from 'ts-optchain';
 import { Element } from 'types/Capi';
+import { ExternalArticle } from 'shared/types/ExternalArticle';
+import { DerivedArticle } from 'shared/types/Article';
 
-export const hasMainVideo = (article: DerivedArticle) => {
+export const hasMainVideo = (article: ExternalArticle | DerivedArticle) => {
   return (
     hasMainMediaVideoAtom(article) ||
     getArticleMainElementType(article) === 'video'
@@ -10,12 +11,16 @@ export const hasMainVideo = (article: DerivedArticle) => {
 };
 
 // this function probably refers to old-style video pages which have a main element of type video
-export function getArticleMainElementType(article: DerivedArticle) {
+export function getArticleMainElementType(
+  article: ExternalArticle | DerivedArticle
+) {
   const element = (article.elements || []).find(_ => _.relation === 'main');
   return element ? element.type : undefined;
 }
 
-export function hasMainMediaVideoAtom(article: DerivedArticle) {
+export function hasMainMediaVideoAtom(
+  article: ExternalArticle | DerivedArticle
+) {
   const mainBlockElement = oc(article).blocks.main.elements([])[0] || undefined;
 
   function hasMediaAtomMainMedia(blockElement: Element) {

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -3,7 +3,6 @@ import { ExternalArticle } from '../shared/types/ExternalArticle';
 import { ArticleFragmentMeta } from '../shared/types/Collection';
 import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import startCase from 'lodash/startCase';
-import { hasMainMediaVideoAtom } from 'shared/util/externalArticle';
 
 const getIdFromURL = (url: string): string | null => {
   const [, id = null] =

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -3,6 +3,7 @@ import { ExternalArticle } from '../shared/types/ExternalArticle';
 import { ArticleFragmentMeta } from '../shared/types/Collection';
 import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import startCase from 'lodash/startCase';
+import { hasMainMediaVideoAtom } from 'shared/util/externalArticle';
 
 const getIdFromURL = (url: string): string | null => {
   const [, id = null] =

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -100,6 +100,7 @@ export const getInitialValuesForArticleFragmentForm = (
         showLargeHeadline: article.showLargeHeadline || false,
         showKickerTag: article.showKickerTag || false,
         showKickerSection: article.showKickerSection || false,
+        showMainVideo: article.showMainVideo || false,
         customKicker: article.customKicker || '',
         isBreaking: article.isBreaking || false,
         showLivePlayable: article.showLivePlayable || false,

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -126,8 +126,7 @@ export const getInitialValuesForArticleFragmentForm = (
           thumb: article.imageCutoutSrc
         },
         slideshow: slideshow.concat(slideshowBackfill),
-        sportScore: article.sportScore || '',
-        showMainVideo: !!article.showMainVideo
+        sportScore: article.sportScore || ''
       }
     : undefined;
 };


### PR DESCRIPTION
## What's changed?

Adds media indicators to cards if they a) contain video main media ...

<img width="411" alt="Screenshot 2019-08-09 at 15 48 36" src="https://user-images.githubusercontent.com/7767575/62787807-6d7cee00-babd-11e9-9823-87fcc571d85b.png">

... and b) have it set to override their normal image.

<img width="411" alt="Screenshot 2019-08-09 at 15 48 46" src="https://user-images.githubusercontent.com/7767575/62787804-6bb32a80-babd-11e9-803f-2fbb46903009.png">

## Implementation notes

I moved `derivedArticle.ts` in `utils/` and renamed to better reflect its versatility as part of this PR.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
