### PR TITLE
always set customKicker aka deprecate showKickerTag and showKickerSection

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -192,6 +192,17 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
     const isEditionsMode = editMode === 'editions';
 
+    const setCustomKicker = (customKickerValue: string) => {
+      change('customKicker', customKickerValue);
+      change('showKickerCustom', true);
+
+      // kicker suggestions now set the value of `customKicker` rather than set a flag
+      // set the old flags to false
+      ['showKickerTag', 'showKickerSection'].forEach(field =>
+        change(field, false)
+      );
+    };
+
     return (
       <FormContainer onSubmit={handleSubmit} data-testid="edit-form">
         <CollectionHeadingPinline>
@@ -238,11 +249,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 return value;
               }}
               onChange={e => {
-                change('showKickerCustom', true);
-                change('showKickerTag', false);
-                change('showKickerSection', false);
                 if (e) {
-                  change('customKicker', e.target.value);
+                  setCustomKicker(e.target.value);
                 }
               }}
             />
@@ -258,15 +266,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   buttonText={kickerOptions.webTitle}
                   selected={showKickerTag}
                   size="s"
-                  onClick={() => {
-                    if (!showKickerTag) {
-                      change('showKickerTag', true);
-                      change('showKickerSection', false);
-                      change('showKickerCustom', false);
-                    } else {
-                      change('showKickerTag', false);
-                    }
-                  }}
+                  onClick={() => setCustomKicker(kickerOptions.webTitle!)}
                 />
               )}{' '}
               {kickerOptions.sectionName && (
@@ -277,15 +277,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   selected={showKickerSection}
                   size="s"
                   buttonText={kickerOptions.sectionName}
-                  onClick={() => {
-                    if (!showKickerSection) {
-                      change('showKickerSection', true);
-                      change('showKickerTag', false);
-                      change('showKickerCustom', false);
-                    } else {
-                      change('showKickerSection', false);
-                    }
-                  }}
+                  onClick={() => setCustomKicker(kickerOptions.sectionName!)}
                 />
               )}
             </ConditionalComponent>

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -226,7 +226,13 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
     const isEditionsMode = editMode === 'editions';
 
+    // const assertion to prevent type widening, necessary to keep `type KickerField` below DRY
+    // see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions
     const kickerFields = ['showKickerTag', 'showKickerSection'] as const;
+
+    // In an effort to be DRY, create a type of all values from the `kickerFields` array that can be accessed by a number.
+    // That is, a union of the values.
+    // i.e. KickerField = 'showKickerTag' | 'showKickerSection'
     type KickerField = typeof kickerFields[number];
 
     const setCustomKicker = (customKickerValue: string) => {

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -226,6 +226,32 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
     const isEditionsMode = editMode === 'editions';
 
+    const kickerFields = ['showKickerTag', 'showKickerSection'] as const;
+    type KickerField = typeof kickerFields[number];
+
+    const setCustomKicker = (customKickerValue: string) => {
+      change('customKicker', customKickerValue);
+      change('showKickerCustom', true);
+      kickerFields.forEach(field => change(field, false));
+    };
+
+    const handleKickerChange = (
+      customKickerValue: string,
+      showField: boolean,
+      fieldName: KickerField
+    ) => {
+      if (isEditionsMode) {
+        setCustomKicker(customKickerValue);
+      } else {
+        if (!showField) {
+          kickerFields.forEach(field => change(field, field === fieldName));
+          change('showKickerCustom', false);
+        } else {
+          change(fieldName, false);
+        }
+      }
+    };
+
     const getKickerContents = () => {
       return (
         <>
@@ -237,20 +263,13 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               buttonText={kickerOptions.webTitle}
               selected={showKickerTag}
               size="s"
-              onClick={() => {
-                if (editMode === 'editions') {
-                  change('customKicker', kickerOptions.webTitle);
-                }
-                else {
-                  if (!showKickerTag) {
-                    change('showKickerTag', true);
-                    change('showKickerSection', false);
-                    change('showKickerCustom', false);
-                  } else {
-                    change('showKickerTag', false);
-                  }
-                }
-              }}
+              onClick={() =>
+                handleKickerChange(
+                  kickerOptions.webTitle!,
+                  showKickerTag,
+                  'showKickerTag'
+                )
+              }
             />
           )}
           &nbsp;
@@ -261,20 +280,13 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               selected={showKickerSection}
               size="s"
               buttonText={kickerOptions.sectionName}
-              onClick={() => {
-                if (editMode === 'editions') {
-                  change('customKicker', kickerOptions.sectionName);
-                }
-                else {
-                  if (!showKickerSection) {
-                    change('showKickerSection', true);
-                    change('showKickerTag', false);
-                    change('showKickerCustom', false);
-                  } else {
-                    change('showKickerSection', false);
-                  }
-                }
-              }}
+              onClick={() =>
+                handleKickerChange(
+                  kickerOptions.sectionName!,
+                  showKickerSection,
+                  'showKickerSection'
+                )
+              }
             />
           )}
         </>
@@ -333,11 +345,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 return value;
               }}
               onChange={e => {
-                change('showKickerCustom', true);
-                change('showKickerTag', false);
-                change('showKickerSection', false);
                 if (e) {
-                  change('customKicker', e.target.value);
+                  setCustomKicker(e.target.value);
                 }
               }}
             />

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -238,12 +238,17 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               selected={showKickerTag}
               size="s"
               onClick={() => {
-                if (!showKickerTag) {
-                  change('showKickerTag', true);
-                  change('showKickerSection', false);
-                  change('showKickerCustom', false);
-                } else {
-                  change('showKickerTag', false);
+                if (editMode === 'editions') {
+                  change('customKicker', kickerOptions.webTitle);
+                }
+                else {
+                  if (!showKickerTag) {
+                    change('showKickerTag', true);
+                    change('showKickerSection', false);
+                    change('showKickerCustom', false);
+                  } else {
+                    change('showKickerTag', false);
+                  }
                 }
               }}
             />
@@ -257,12 +262,17 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               size="s"
               buttonText={kickerOptions.sectionName}
               onClick={() => {
-                if (!showKickerSection) {
-                  change('showKickerSection', true);
-                  change('showKickerTag', false);
-                  change('showKickerCustom', false);
-                } else {
-                  change('showKickerSection', false);
+                if (editMode === 'editions') {
+                  change('customKicker', kickerOptions.sectionName);
+                }
+                else {
+                  if (!showKickerSection) {
+                    change('showKickerSection', true);
+                    change('showKickerTag', false);
+                    change('showKickerCustom', false);
+                  } else {
+                    change('showKickerSection', false);
+                  }
                 }
               }}
             />

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -226,36 +226,15 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
     const isEditionsMode = editMode === 'editions';
 
-    // const assertion to prevent type widening, necessary to keep `type KickerField` below DRY
-    // see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions
-    const kickerFields = ['showKickerTag', 'showKickerSection'] as const;
-
-    // In an effort to be DRY, create a type of all values from the `kickerFields` array that can be accessed by a number.
-    // That is, a union of the values.
-    // i.e. KickerField = 'showKickerTag' | 'showKickerSection'
-    type KickerField = typeof kickerFields[number];
-
     const setCustomKicker = (customKickerValue: string) => {
       change('customKicker', customKickerValue);
       change('showKickerCustom', true);
-      kickerFields.forEach(field => change(field, false));
-    };
 
-    const handleKickerChange = (
-      customKickerValue: string,
-      showField: boolean,
-      fieldName: KickerField
-    ) => {
-      if (isEditionsMode) {
-        setCustomKicker(customKickerValue);
-      } else {
-        if (!showField) {
-          kickerFields.forEach(field => change(field, field === fieldName));
-          change('showKickerCustom', false);
-        } else {
-          change(fieldName, false);
-        }
-      }
+      // kicker suggestions now set the value of `customKicker` rather than set a flag
+      // set the old flags to false
+      ['showKickerTag', 'showKickerSection'].forEach(field =>
+        change(field, false)
+      );
     };
 
     const getKickerContents = () => {
@@ -269,13 +248,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               buttonText={kickerOptions.webTitle}
               selected={showKickerTag}
               size="s"
-              onClick={() =>
-                handleKickerChange(
-                  kickerOptions.webTitle!,
-                  showKickerTag,
-                  'showKickerTag'
-                )
-              }
+              onClick={() => setCustomKicker(kickerOptions.webTitle!)}
             />
           )}
           &nbsp;
@@ -286,13 +259,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               selected={showKickerSection}
               size="s"
               buttonText={kickerOptions.sectionName}
-              onClick={() =>
-                handleKickerChange(
-                  kickerOptions.sectionName!,
-                  showKickerSection,
-                  'showKickerSection'
-                )
-              }
+              onClick={() => setCustomKicker(kickerOptions.sectionName!)}
             />
           )}
         </>


### PR DESCRIPTION
## What's changed?
Updates the behaviour of the kicker suggestions - rather than setting the `showKickerTag` or `showKickerSection` flag, set the `customKicker` to the text value of the suggestion.

## Implementation notes
Change is applied to both Fronts and Editions.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
