### PR TITLE
Update the links to the PGP keys

### DIFF
--- a/client-v2/integration/fixtures/capi-prefill.js
+++ b/client-v2/integration/fixtures/capi-prefill.js
@@ -132,7 +132,7 @@ module.exports = {
               'https://preview.content.guardianapis.com/profile/julianborger',
             references: [],
             bio:
-              '<p>Julian Borger is the Guardian\'s world affairs editor. He was previously a correspondent in the US, the Middle East, eastern Europe and the Balkans. His book on the pursuit and capture of the Balkan war criminals, <a href="https://bookshop.theguardian.com/catalog/product/view/id/359254/?utm_source=editoriallink&amp;utm_medium=merch&amp;utm_campaign=article">The Butcher\'s Trail</a>, is published by Other Press. Click <a href="https://pgp.theguardian.com/PublicKeys/Julian%20Borger.pub.txt">here</a> for Julian\'s public key</p>',
+              '<p>Julian Borger is the Guardian\'s world affairs editor. He was previously a correspondent in the US, the Middle East, eastern Europe and the Balkans. His book on the pursuit and capture of the Balkan war criminals, <a href="https://bookshop.theguardian.com/catalog/product/view/id/359254/?utm_source=editoriallink&amp;utm_medium=merch&amp;utm_campaign=article">The Butcher\'s Trail</a>, is published by Other Press. Click <a href="https://www.theguardian.com/pgp/PublicKeys/Julian%20Borger.pub.txt">here</a> for Julian\'s public key</p>',
             bylineImageUrl:
               'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2016/1/8/1452247825373/Julian-Borger.jpg',
             bylineLargeImageUrl:
@@ -1270,7 +1270,7 @@ module.exports = {
               'https://preview.content.guardianapis.com/profile/charlie-phillips',
             references: [],
             bio:
-              '<p>Charlie Phillips is head of documentaries at the Guardian.&nbsp;Click <a href="https://pgp.theguardian.com/PublicKeys/Charlie%20Phillips.pub.txt">here</a> for Charlie Phillip\'s public key</p>',
+              '<p>Charlie Phillips is head of documentaries at the Guardian.&nbsp;Click <a href="https://www.theguardian.com/pgp/PublicKeys/Charlie%20Phillips.pub.txt">here</a> for Charlie Phillip\'s public key</p>',
             bylineImageUrl:
               'https://uploads.guim.co.uk/2018/08/22/Charlie-Phillips.jpg',
             bylineLargeImageUrl:
@@ -1766,7 +1766,7 @@ module.exports = {
               'https://preview.content.guardianapis.com/profile/julianborger',
             references: [],
             bio:
-              '<p>Julian Borger is the Guardian\'s world affairs editor. He was previously a correspondent in the US, the Middle East, eastern Europe and the Balkans. His book on the pursuit and capture of the Balkan war criminals, <a href="https://bookshop.theguardian.com/catalog/product/view/id/359254/?utm_source=editoriallink&amp;utm_medium=merch&amp;utm_campaign=article">The Butcher\'s Trail</a>, is published by Other Press. Click <a href="https://pgp.theguardian.com/PublicKeys/Julian%20Borger.pub.txt">here</a> for Julian\'s public key</p>',
+              '<p>Julian Borger is the Guardian\'s world affairs editor. He was previously a correspondent in the US, the Middle East, eastern Europe and the Balkans. His book on the pursuit and capture of the Balkan war criminals, <a href="https://bookshop.theguardian.com/catalog/product/view/id/359254/?utm_source=editoriallink&amp;utm_medium=merch&amp;utm_campaign=article">The Butcher\'s Trail</a>, is published by Other Press. Click <a href="https://www.theguardian.com/pgp/PublicKeys/Julian%20Borger.pub.txt">here</a> for Julian\'s public key</p>',
             bylineImageUrl:
               'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2016/1/8/1452247825373/Julian-Borger.jpg',
             bylineLargeImageUrl:
@@ -2961,7 +2961,7 @@ module.exports = {
               'https://preview.content.guardianapis.com/profile/charlie-phillips',
             references: [],
             bio:
-              '<p>Charlie Phillips is head of documentaries at the Guardian.&nbsp;Click <a href="https://pgp.theguardian.com/PublicKeys/Charlie%20Phillips.pub.txt">here</a> for Charlie Phillip\'s public key</p>',
+              '<p>Charlie Phillips is head of documentaries at the Guardian.&nbsp;Click <a href="https://www.theguardian.com/pgp/PublicKeys/Charlie%20Phillips.pub.txt">here</a> for Charlie Phillip\'s public key</p>',
             bylineImageUrl:
               'https://uploads.guim.co.uk/2018/08/22/Charlie-Phillips.jpg',
             bylineLargeImageUrl:


### PR DESCRIPTION
## What is changing?

This PR replaces four links to PGP keys so that they use [the updated page](https://www.theguardian.com/pgp). 

`https://pgp.theguardian.com/...` is changing to `https://www.theguardian.com/pgp/...`

The content linked to is the same, but **we will be retiring pgp.theguardian.com** **very soon** so this update ensures that the links still go somewhere valid.

## Why is this changing?

The new and updated PGP site is now live at https://www.theguardian.com/pgp

It has been redesigned and is no longer a subdomain. This is to follow the same security recommendations as our SecureDrop landing page (https://www.theguardian.com/securedrop).

## Implementation notes

N/A 👾👽👾👽

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
