### PR TITLE
don't restrict image ratio for Editions

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentForm.tsx
@@ -40,9 +40,14 @@ import {
 } from 'util/form';
 import { CapiFields } from 'util/form';
 import { Dispatch } from 'types/Store';
-import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
+import {
+  articleFragmentImageCriteria,
+  editionsArticleFragmentImageCriteria
+} from 'constants/image';
 import { selectors as collectionSelectors } from 'shared/bundles/collectionsBundle';
 import { getContributorImage } from 'util/CAPIUtils';
+import { EditMode } from 'types/EditMode';
+import { selectEditMode } from 'selectors/pathSelectors';
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -129,7 +134,7 @@ const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
           name={name}
           component={InputImage}
           small
-          criteria={imageCriteria}
+          criteria={articleFragmentImageCriteria}
           frontId={frontId}
         />
       </Col>
@@ -181,8 +186,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       showKickerTag,
       showKickerSection,
       frontId,
-      articleExists
+      articleExists,
+      editMode
     } = this.props;
+
+    const isEditionsMode = editMode === 'editions';
 
     return (
       <FormContainer onSubmit={handleSubmit} data-testid="edit-form">
@@ -385,7 +393,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     name={this.getImageFieldName()}
                     component={InputImage}
                     disabled={imageHide}
-                    criteria={imageCriteria}
+                    criteria={
+                      isEditionsMode
+                        ? editionsArticleFragmentImageCriteria
+                        : articleFragmentImageCriteria
+                    }
                     frontId={frontId}
                     defaultImageUrl={
                       imageCutoutReplace
@@ -535,6 +547,7 @@ interface ContainerProps {
   showKickerSection: boolean;
   articleCapiFieldValues: CapiFields;
   imageReplace: boolean;
+  editMode: EditMode;
 }
 
 interface InterfaceProps {
@@ -606,7 +619,8 @@ const createMapStateToProps = () => {
       showKickerSection: selectValue(state, 'showKickerSection'),
       cutoutImage: externalArticle
         ? getContributorImage(externalArticle)
-        : undefined
+        : undefined,
+      editMode: selectEditMode(state)
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -40,9 +40,14 @@ import {
 } from 'util/form';
 import { CapiFields } from 'util/form';
 import { Dispatch } from 'types/Store';
-import { articleFragmentImageCriteria as imageCriteria } from 'constants/image';
+import {
+  articleFragmentImageCriteria,
+  editionsArticleFragmentImageCriteria
+} from 'constants/image';
 import { selectors as collectionSelectors } from 'shared/bundles/collectionsBundle';
 import { getContributorImage } from 'util/CAPIUtils';
+import { EditMode } from 'types/EditMode';
+import { selectEditMode } from 'selectors/pathSelectors';
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -132,7 +137,7 @@ const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
           name={name}
           component={InputImage}
           small
-          criteria={imageCriteria}
+          criteria={articleFragmentImageCriteria}
           frontId={frontId}
         />
       </SlideshowCol>
@@ -215,8 +220,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       imageCutoutReplace,
       cutoutImage,
       imageSlideshowReplace,
-      isBreaking
+      isBreaking,
+      editMode
     } = this.props;
+
+    const isEditionsMode = editMode === 'editions';
 
     const getKickerContents = () => {
       return (
@@ -423,7 +431,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   name={this.getImageFieldName()}
                   component={InputImage}
                   disabled={imageHide}
-                  criteria={imageCriteria}
+                  criteria={
+                    isEditionsMode
+                      ? editionsArticleFragmentImageCriteria
+                      : articleFragmentImageCriteria
+                  }
                   frontId={frontId}
                   defaultImageUrl={
                     imageCutoutReplace
@@ -603,6 +615,7 @@ interface ContainerProps {
   articleCapiFieldValues: CapiFields;
   imageReplace: boolean;
   isBreaking: boolean;
+  editMode: EditMode;
 }
 
 interface InterfaceProps {
@@ -675,7 +688,8 @@ const createMapStateToProps = () => {
       isBreaking: valueSelector(state, 'isBreaking'),
       cutoutImage: externalArticle
         ? getContributorImage(externalArticle)
-        : undefined
+        : undefined,
+      editMode: selectEditMode(state)
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -26,7 +26,8 @@ import {
   ValidationResponse
 } from 'shared/util/validateImageSrc';
 import {
-  articleFragmentImageCriteria as imageCriteria,
+  articleFragmentImageCriteria,
+  editionsArticleFragmentImageCriteria,
   DRAG_DATA_COLLECTION_ITEM_IMAGE_OVERRIDE,
   DRAG_DATA_GRID_IMAGE_URL
 } from 'constants/image';
@@ -41,6 +42,8 @@ import { bindActionCreators } from 'redux';
 import ArticleFragmentFormInline from '../ArticleFragmentFormInline';
 import { updateArticleFragmentMeta as updateArticleFragmentMetaAction } from 'actions/ArticleFragments';
 import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
+import { EditMode } from 'types/EditMode';
+import { selectEditMode } from 'selectors/pathSelectors';
 
 const imageDropTypes = [
   ...gridDropTypes,
@@ -75,6 +78,7 @@ type ArticleContainerProps = ContainerProps & {
   isFaded: boolean;
   displayInlineForm: boolean;
   numSupportingArticles: number;
+  editMode: EditMode;
 };
 
 class CollectionItem extends React.Component<ArticleContainerProps> {
@@ -214,6 +218,11 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       return;
     }
 
+    const isEditionsMode = this.props.editMode === 'editions';
+    const imageCriteria = isEditionsMode
+      ? editionsArticleFragmentImageCriteria
+      : articleFragmentImageCriteria;
+
     // Our drag contains Grid data
     validateImageEvent(e, this.props.frontId, imageCriteria)
       .then(imageData =>
@@ -239,7 +248,8 @@ const createMapStateToProps = () => {
         selectSharedState(state),
         'inline-form'
       ),
-      numSupportingArticles
+      numSupportingArticles,
+      editMode: selectEditMode(state)
     };
   };
 };

--- a/client-v2/src/constants/image.ts
+++ b/client-v2/src/constants/image.ts
@@ -4,6 +4,10 @@ export const articleFragmentImageCriteria = {
   heightAspectRatio: 3
 };
 
+export const editionsArticleFragmentImageCriteria = {
+  minWidth: 400
+};
+
 export const gridDataTransferTypes = {
   cropsData: 'application/vnd.mediaservice.crops+json',
   gridUrl: 'application/vnd.mediaservice.kahuna.uri',


### PR DESCRIPTION
## What's changed?
We don't want to restrict Editions images to a 5:3 ratio.

## Implementation notes
n/a

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
