### PR TITLE
Filter out hidden collections & add tests for hidden fronts/collection

### DIFF
--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -29,15 +29,12 @@ case class EditionsFront(
     metadata: Option[EditionsFrontMetadata],
     collections: List[EditionsCollection]
 ) {
-  def toPublishedFront: Option[PublishedFront] = {
-    if (isHidden)
-      None
-    else
-      Some(PublishedFront(
-        id,
-        displayName,
-        collections.map(_.toPublishedCollection)
-      ))
+  def toPublishedFront: PublishedFront = {
+    PublishedFront(
+      id,
+      displayName,
+      collections.filterNot(_.isHidden).map(_.toPublishedCollection)
+    )
   }
 }
 

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -23,7 +23,7 @@ case class EditionsIssue(
     displayName,
     OffsetDateTime.ofInstant(Instant.ofEpochMilli(issueDate), ZoneId.of(timezoneId)),
     version,
-    fronts.flatMap(_.toPublishedFront)
+    fronts.filterNot(_.isHidden).map(_.toPublishedFront)
   )
 }
 

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -1,10 +1,74 @@
 package model.editions
 
-import java.time.{OffsetDateTime, ZoneOffset}
+import java.time.{OffsetDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
 
-class PublishedIssueTest extends FreeSpec with Matchers {
+class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
+
+  val LondonZone = ZoneId.of("Europe/London")
+  val nowDateTime = ZonedDateTime.of(2019, 10, 11, 0, 0, 0, 0, LondonZone)
+  val nowMilli = nowDateTime.toInstant.toEpochMilli
+
+  private def issue(year: Int, month: Int, dom: Int, fronts: EditionsFront*): EditionsIssue = {
+    val dateTime = ZonedDateTime.of(year, month, dom, 0, 0, 0, 0, LondonZone)
+    val dateTimeMilli = dateTime.toInstant.toEpochMilli
+    EditionsIssue(
+      "test-edition",
+      "Test Edition",
+      LondonZone.toString,
+      dateTimeMilli,
+      dateTimeMilli,
+      "User",
+      "user@example.con",
+      None,
+      None,
+      None,
+      fronts.zipWithIndex.map{case (f, x) => f.copy(index=x)}.toList
+    )
+  }
+
+  private def front(name: String, collections: EditionsCollection*): EditionsFront =
+    EditionsFront(
+      name,
+      name,
+      0,
+      canRename = false,
+      isHidden = false,
+      None,
+      None,
+      None,
+      None,
+      collections.toList
+    )
+
+  implicit class RichEditionsFront(thisFront: EditionsFront) {
+    def hide: EditionsFront = thisFront.copy(isHidden = true)
+  }
+
+  private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticle*): EditionsCollection =
+    EditionsCollection(
+      name,
+      name,
+      isHidden = false,
+      None,
+      None,
+      None,
+      prefill,
+      articles.toList
+    )
+
+  implicit class RichEditionsCollection(thisCollection: EditionsCollection) {
+    def hide: EditionsCollection = thisCollection.copy(isHidden = true)
+  }
+
+  private def article(pageCode: String): EditionsArticle =
+    EditionsArticle(
+      pageCode,
+      nowMilli,
+      Some(ArticleMetadata.default)
+    )
+
   "PublishedArticles" - {
     "article fields should be populated correctly" in {
       val now = OffsetDateTime.of(2019, 9, 30, 10, 23, 0, 0, ZoneOffset.ofHours(1))
@@ -49,6 +113,46 @@ class PublishedIssueTest extends FreeSpec with Matchers {
         imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg")),
         sportScore = Some("sport-score")
       )
+    }
+  }
+
+  "PublishedIssue" - {
+    "fronts should be filtered out when hidden" in {
+      val testIssue = issue(2019, 9, 30,
+        front("uk-news",
+          collection("london", None),
+          collection("financial", None)
+        ),
+        front("culture",
+          collection("art", None),
+          collection("theatre", None)
+        ),
+        front("special",
+          collection("magic", None)
+        ).hide
+      )
+      testIssue.fronts.size shouldBe 3
+      val publishedIssue = testIssue.toPublishedIssue(None)
+      publishedIssue.fronts.size shouldBe 2
+      publishedIssue.fronts.find(_.name == "special") shouldBe None
+    }
+  }
+
+  "PublishedFront" - {
+    "collections should be filtered out when hidden" in {
+      val testFront = front("uk-news",
+        collection("london", None),
+        collection("financial", None),
+        collection("special", None).hide,
+        collection("weather", None)
+      )
+
+      testFront.collections.size shouldBe 4
+      testFront.collections.find(_.id == "special").value
+
+      val publishedFront = testFront.toPublishedFront
+      publishedFront.collections.size shouldBe 3
+      publishedFront.collections.find(_.id == "special") shouldBe None
     }
   }
 }


### PR DESCRIPTION
## What's changed?

We realised after merging #903 that hidden collections are still handed downstream. This fixes that and adds a couple of tests for this behaviour.

### General
- [X] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE