### PR TITLE
POP-UP: Pop on v1 directing users to v2

### DIFF
--- a/app/views/templates/header.scala.html
+++ b/app/views/templates/header.scala.html
@@ -1,4 +1,5 @@
-@(stage: String, identity: Option[com.gu.pandomainauth.model.User] = None, isDev: Boolean)
+@(stage: String, identity: Option[com.gu.pandomainauth.model.User] = None,
+isDev: Boolean)
 
 <header>
     <div class="header__group header__logo">
@@ -16,12 +17,14 @@
     }">
         <div class="topAction__unit">
             <button class="dropdown__trigger topAction__expand" data-bind="toggleClick: isMainActionVisible">
-                <span>@identity.map(_.firstName).getOrElse("") @identity.map(_.lastName).getOrElse("")</span>
+                <span>@identity.map(_.firstName).getOrElse("")
+                    @identity.map(_.lastName).getOrElse("")</span>
                 <i class="fa fa-chevron-down dropdown__trigger__icon"></i>
             </button>
             <ul class="dropdown__item topAction__dropdown">
                 <li class="dropdown__item">
-                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">Send Feedback</a>
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform"
+                        target="_blank">Send Feedback</a>
                 </li>
                 <!-- ko if: !layout.configVisible() -->
                 <li class="dropdown__item" data-bind="click: chooseLayout">

--- a/app/views/templates/header.scala.html
+++ b/app/views/templates/header.scala.html
@@ -12,6 +12,8 @@ isDev: Boolean)
         </a>
     </div>
 
+    <div class="header__group v2-popup">There's a new version of the fronts tool. Please&nbsp;<a href="https://fronts.gutools.co.uk/v2">try it by clicking here</a>.</div>
+
     <div class="header__group topAction dropdown closed" data-bind="css: {
         closed: !isMainActionVisible()
     }">

--- a/public/src/css/header.css
+++ b/public/src/css/header.css
@@ -12,7 +12,7 @@ header {
     background: #ffffff;
     border-bottom: 1px solid #dcdcdc;
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
     flex: 0 0 50px;
 }
 
@@ -53,7 +53,8 @@ main {
 }
 
 .header__logo {
-    flex: 1;
+    flex: auto 0 1;
+    padding-right: 10px;
 }
 
 .header__logo-link {
@@ -76,7 +77,7 @@ main {
     margin: 0;
     width: 100%;
     outline: none;
-    background-color: #FFF;
+    background-color: #fff;
     line-height: 49px;
     height: 49px;
     font-size: 12px;
@@ -138,14 +139,14 @@ main {
 }
 .topAction__dropdown .dropdown__item {
     margin-bottom: 0;
-    border: 1px solid #DCDCDC;
+    border: 1px solid #dcdcdc;
     border-top: 0;
     display: block;
     padding: 1em 0.5em;
-    background-color: #FFF;
+    background-color: #fff;
 }
 .topAction__dropdown .dropdown__item:hover {
-    background-color: #F0F0F0;
+    background-color: #f0f0f0;
 }
 
 .updating {
@@ -167,11 +168,11 @@ main {
 }
 
 .secondary-action__button:hover {
-    background-color: #DCDCDC;
+    background-color: #dcdcdc;
 }
 
 .action__save {
-    background-color: #EF5350;
+    background-color: #ef5350;
 }
 
 .action__save:hover {
@@ -180,4 +181,17 @@ main {
 
 .dropdown__trigger__icon {
     margin-left: 7px;
+}
+
+.header__group.v2-popup {
+    flex: auto 1 1;
+    color: red;
+    padding-left: 10px;
+    padding-right: 10px;
+    justify-self: flex-start;
+}
+
+.header__group.v2-popup a {
+    color: red;
+    text-decoration: underline;
 }


### PR DESCRIPTION
## What's changed?

We want users on V1 to get the message that they should switch over to V2. 

This adds a permanent change to the header that should run until v1 is deprecated at the end of Aug 2019.

QUESTION: should this be dismissable? and on what basis? ie on a cookie, or on the user data, or after each refresh? 

![Screenshot 2019-08-13 at 18 15 42](https://user-images.githubusercontent.com/10324129/62963041-17c77f00-bdf8-11e9-986c-1f53b7054bf8.png)

![Screenshot 2019-08-13 at 18 16 12](https://user-images.githubusercontent.com/10324129/62963048-1d24c980-bdf8-11e9-8ba1-fb1b14f7c527.png)


## Implementation notes

_Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made)_

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
