### PR TITLE
Sort feed by latest published rather than first published as default

### DIFF
--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -215,7 +215,7 @@ class FeedsContainer extends React.Component<
     displaySearchFilters: false,
     inputState: initState,
     displayPrevResults: false,
-    sortByParam: 'first-publication'
+    sortByParam: 'published'
   };
 
   private interval: null | number = null;


### PR DESCRIPTION
## What's changed?

Our users find it more useful if the feed displays stories sorted by 'latest published' rather than 'first published'. This change alters the default sorting behaviour of the feed to display by 'latest published', with the option to sort by 'first published' still available in the existing drop-down menu.

![Screenshot 2019-08-14 at 09 49 08](https://user-images.githubusercontent.com/12645938/63007576-ce6b4400-be78-11e9-9bbd-94484f74cb9f.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
