### PR TITLE
Add analytics event for card image drop

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -45,6 +45,7 @@ import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selecto
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from 'selectors/pathSelectors';
 import { PageViewStory } from 'shared/types/PageViewData';
+import { events } from 'services/GA';
 
 const imageDropTypes = [
   ...gridDropTypes,
@@ -213,6 +214,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
   };
 
   private handleImageDrop = (e: React.DragEvent<HTMLElement>) => {
+    events.imageAdded(this.props.frontId, 'drop-into-card');
     e.preventDefault();
     e.persist();
 

--- a/client-v2/src/services/GA.ts
+++ b/client-v2/src/services/GA.ts
@@ -34,7 +34,11 @@ const init = () => {
   });
 };
 
-type ImageAdditionMethod = 'drop' | 'paste' | 'click to modal';
+type ImageAdditionMethod =
+  | 'drop'
+  | 'drop-into-card'
+  | 'paste'
+  | 'click to modal';
 
 // NOTE: you are unable to set custom dimensions on events, so the final gtag argument {} being passed in below are not currently working.
 const events = {


### PR DESCRIPTION
## What's changed?

Add an analytics event for card image drop -- we're not sure if anyone's using it, except possibly by accident!

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
