### PR TITLE
Collection names in export

### DIFF
--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -15,6 +15,7 @@ case class EditionsCollection(
 ) {
   def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
+    displayName,
     items.map(_.toPublishedArticle)
   )
 }

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -33,7 +33,7 @@ case class PublishedFurniture(
 
 case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)
 
-case class PublishedCollection(id: String, items: List[PublishedArticle])
+case class PublishedCollection(id: String, name: String, items: List[PublishedArticle])
 
 case class PublishedFront(id: String, name: String, collections: List[PublishedCollection], swatch: Swatch)
 

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -56,6 +56,20 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       json shouldBe expectedJson
     }
 
+    "test serialisation of a published collection" in {
+      val expectedJson =
+        """{
+          |  "id" : "id",
+          |  "name" : "Display Name",
+          |  "items" : [ ]
+          |}""".stripMargin
+
+      val collection = PublishedCollection("id", "Display Name", Nil)
+      val json = Json.prettyPrint(Json.toJson(collection))
+
+      json shouldBe expectedJson
+    }
+
     "test serialisation of article furniture" - {
       "should output all the fields in the format expected by the editions backend" in {
         val expectedJson =

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -155,6 +155,28 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       publishedFront.collections.find(_.id == "special") shouldBe None
     }
 
+    "collection displayName should be provided" in {
+      val test = EditionsCollection(
+        "id",
+        "Display Name",
+        isHidden = false,
+        None,
+        None,
+        None,
+        None,
+        Nil
+      )
+      val testFront = front("uk-news",
+        collection("london", None),
+        test
+      )
+
+      val publishedFront = testFront.toPublishedFront
+      publishedFront.collections.size shouldBe 2
+      val publishedTestCollection = publishedFront.collections.find(_.id == "id").value
+      publishedTestCollection.name shouldBe "Display Name"
+    }
+
     "Fronts should not override name if there's not one defined" in {
       val front = EditionsFront(
         "id",
@@ -173,7 +195,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       published shouldBe PublishedFront("id", "Original Name", Nil, Swatch.Neutral)
     }
 
-    "Front name should be overriden correctly" in {
+    "Front name should be overridden correctly" in {
       val front = EditionsFront(
         "id",
         "Original Name",


### PR DESCRIPTION
## What's changed?

This PR ensures that the display name of each collection is included in the data that is sent downstream.

### General
- [X] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
