### PR TITLE
Render fewer things on load

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -10,7 +10,7 @@ import {
   discardDraftChangesToCollection,
   openCollectionsAndFetchTheirArticles
 } from 'actions/Collections';
-import { actions } from 'shared/bundles/collectionsBundle';
+import { actions, selectors } from 'shared/bundles/collectionsBundle';
 import {
   selectHasUnpublishedChanges,
   selectCollectionHasPrefill,
@@ -65,6 +65,7 @@ type CollectionProps = CollectionPropsBeforeState & {
   isCollectionLocked: boolean;
   isEditFormOpen: boolean;
   isOpen: boolean;
+  hasContent: boolean;
   hasMultipleFrontsOpen: boolean;
   onChangeOpenState: (id: string, isOpen: boolean) => void;
   fetchPreviousCollectionArticles: (id: string) => void;
@@ -128,7 +129,8 @@ class Collection extends React.Component<CollectionProps> {
       isEditFormOpen,
       discardDraftChangesToCollection: discardDraftChanges,
       hasPrefill,
-      isHidden
+      isHidden,
+      hasContent
     } = this.props;
 
     const { isPreviouslyOpen } = this.state;
@@ -214,30 +216,31 @@ class Collection extends React.Component<CollectionProps> {
         }
       >
         {groups.map(group => children(group, isUneditable, true))}
-
-        <EditModeVisibility visibleMode="fronts">
-          <PreviouslyCollectionContainer data-testid="previously">
-            <PreviouslyCollectionToggle
-              onClick={this.togglePreviouslyOpen}
-              data-testid="previously-toggle"
-            >
-              Recently removed from launched front
-              <ButtonCircularCaret active={isPreviouslyOpen} />
-            </PreviouslyCollectionToggle>
-            {isPreviouslyOpen && (
-              <>
-                <PreviouslyCollectionInfo>
-                  This contains the 5 most recently deleted articles from the
-                  live front. If the deleted articles were never launched they
-                  will not appear here.
-                </PreviouslyCollectionInfo>
-                <PreviouslyGroupsWrapper>
-                  {children(previousGroup, true, false)}
-                </PreviouslyGroupsWrapper>
-              </>
-            )}
-          </PreviouslyCollectionContainer>
-        </EditModeVisibility>
+        {hasContent && (
+          <EditModeVisibility visibleMode="fronts">
+            <PreviouslyCollectionContainer data-testid="previously">
+              <PreviouslyCollectionToggle
+                onClick={this.togglePreviouslyOpen}
+                data-testid="previously-toggle"
+              >
+                Recently removed from launched front
+                <ButtonCircularCaret active={isPreviouslyOpen} />
+              </PreviouslyCollectionToggle>
+              {isPreviouslyOpen && (
+                <>
+                  <PreviouslyCollectionInfo>
+                    This contains the 5 most recently deleted articles from the
+                    live front. If the deleted articles were never launched they
+                    will not appear here.
+                  </PreviouslyCollectionInfo>
+                  <PreviouslyGroupsWrapper>
+                    {children(previousGroup, true, false)}
+                  </PreviouslyGroupsWrapper>
+                </>
+              )}
+            </PreviouslyCollectionContainer>
+          </EditModeVisibility>
+        )}
       </CollectionDisplay>
     );
   }
@@ -276,7 +279,8 @@ const createMapStateToProps = () => {
       }),
       isOpen: selectIsCollectionOpen(state, collectionId),
       hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
-      isEditFormOpen: selectDoesCollectionHaveOpenForms(state, collectionId)
+      isEditFormOpen: selectDoesCollectionHaveOpenForms(state, collectionId),
+      hasContent: !!selectors.selectById(selectSharedState(state), collectionId)
     };
   };
 };

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -224,7 +224,7 @@ const articleBodyDefault = React.memo(
                 {size !== 'small' && <TextPlaceholder width={25} />}
               </>
             )}
-            {size !== 'small' && isLive && (
+            {!displayPlaceholders && size !== 'small' && isLive && (
               <CollectionItemMetaHeading
                 style={{
                   color: getPillarColor(


### PR DESCRIPTION
## What's changed?

This PR cleans up a few bits and pieces that don't need to be rendered when things are loading -- the tag info and the recently removed articles. Removing them reduces both clutter and the number of things we have to render when things are loading.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
