### PR TITLE
Sparklines: only call ophan when collections have loaded

### DIFF
--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -57,9 +57,11 @@ export default (store: Store) =>
 
     openFrontsWithCollectionsArticles.forEach(front => {
       front.collections.forEach(collection => {
-        (store.dispatch as Dispatch)(
-          getPageViewData(front.frontId, collection.articles, collection.id)
-        );
+        if (collection.articles.length > 0) {
+          (store.dispatch as Dispatch)(
+            getPageViewData(front.frontId, collection.articles, collection.id)
+          );
+        }
       });
     });
   }, 10000);


### PR DESCRIPTION
## What's changed?

When a front is first opened, it's possible that a call will be made to Ophan that retrieves no data, e.g.: 

> `GET /ophan/histogram?referring-path=/au/technology&hours=1&interval=10`

This happens when the call occurs after the front is opened, but before it's collections/articles have loaded. Since this will retrieve no page view data, it's both useless to the Fronts tool and creates unnecessary traffic for Ophan. 

This PR implements a small check on the number of articles on the front and will only request page view data if there _are_ articles to query on.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
