### PR TITLE
Don't display the v2 banner on e-mail priorities

### DIFF
--- a/app/controllers/ViewsController.scala
+++ b/app/controllers/ViewsController.scala
@@ -22,7 +22,7 @@ class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean
     val identity = request.user
     Cached(60) {
       Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),
-        assetsManager.pathForCollections, crypto.encrypt(identity.email), true, priority))
+        assetsManager.pathForCollections, crypto.encrypt(identity.email), priority != "email", priority))
     }
   }
 


### PR DESCRIPTION
## What's changed?

Removes the v2 banner on the `email` priority. E-mail fronts aren't quite ready yet, and Celine is worried about non tech-savvy users making the switch and being ... troubled.

They've got the front bookmarked, so we can keep the message on the root route.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
