### PR TITLE
Apply media overrides - backend code only

### DIFF
--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -30,13 +30,15 @@ case class ArticleMetadata (
 
   // keep overrides even if not used so user can switch back w/out needing to re-crop
   cutoutImage: Option[Image],
-  replaceImage: Option[Image]
+
+  replaceImage: Option[Image],
+  applyMediaOverrides: Option[Boolean]
 )
 
 object ArticleMetadata {
   implicit val format = Json.format[ArticleMetadata]
 
-  val default = ArticleMetadata(None, None, None, None, None, None, None, None, None, None)
+  val default = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None)
 }
 
 case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) {

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -32,7 +32,7 @@ case class ArticleMetadata (
   cutoutImage: Option[Image],
 
   replaceImage: Option[Image],
-  applyMediaOverrides: Option[Boolean]
+  overrideArticleMainMedia: Option[Boolean]
 )
 
 object ArticleMetadata {
@@ -63,7 +63,7 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
         mediaType = metadata.flatMap(_.mediaType).map(_.toPublishedMediaType).getOrElse(PublishedMediaType.UseArticleTrail),
         imageSrcOverride = imageSrcOverride,
         sportScore = metadata.flatMap(_.sportScore),
-        overrideArticleMedia = metadata.flatMap(_.applyMediaOverrides).getOrElse(true)
+        overrideArticleMainMedia = metadata.flatMap(_.overrideArticleMainMedia).getOrElse(true)
       )
     )
   }

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -62,7 +62,8 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
         showQuotedHeadline = metadata.flatMap(_.showQuotedHeadline).getOrElse(false),
         mediaType = metadata.flatMap(_.mediaType).map(_.toPublishedMediaType).getOrElse(PublishedMediaType.UseArticleTrail),
         imageSrcOverride = imageSrcOverride,
-        sportScore = metadata.flatMap(_.sportScore)
+        sportScore = metadata.flatMap(_.sportScore),
+        overrideArticleMedia = metadata.flatMap(_.applyMediaOverrides).getOrElse(true)
       )
     )
   }

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -29,7 +29,7 @@ case class PublishedFurniture(
   mediaType: PublishedMediaType,
   imageSrcOverride: Option[PublishedImage],
   sportScore: Option[String],
-  overrideArticleMedia: Boolean
+  overrideArticleMainMedia: Boolean
 )
 
 case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -28,7 +28,8 @@ case class PublishedFurniture(
   showQuotedHeadline: Boolean,
   mediaType: PublishedMediaType,
   imageSrcOverride: Option[PublishedImage],
-  sportScore: Option[String]
+  sportScore: Option[String],
+  overrideArticleMedia: Boolean
 )
 
 case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)

--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -28,7 +28,9 @@ case class ClientArticleMetadata (
   imageCutoutSrc: Option[String],
   imageCutoutSrcHeight: Option[String],
   imageCutoutSrcWidth: Option[String],
-  imageCutoutSrcOrigin: Option[String]
+  imageCutoutSrcOrigin: Option[String],
+
+  applyMediaOverrides: Option[Boolean]
 ) {
   def toArticleMetadata: ArticleMetadata = {
     val cutoutImage: Option[Image] = (imageCutoutSrcHeight, imageCutoutSrcWidth, imageCutoutSrc, imageCutoutSrcOrigin) match {
@@ -60,7 +62,8 @@ case class ClientArticleMetadata (
       sportScore,
       Some(imageOption),
       cutoutImage,
-      replaceImage
+      replaceImage,
+      applyMediaOverrides
     )
   }
 }
@@ -94,7 +97,9 @@ object ClientArticleMetadata {
       articleMetadata.cutoutImage.map(_.src),
       articleMetadata.cutoutImage.flatMap(_.height).map(_.toString),
       articleMetadata.cutoutImage.flatMap(_.width).map(_.toString),
-      articleMetadata.cutoutImage.map(_.origin)
+      articleMetadata.cutoutImage.map(_.origin),
+
+      articleMetadata.applyMediaOverrides
     )
   }
 }

--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -30,7 +30,7 @@ case class ClientArticleMetadata (
   imageCutoutSrcWidth: Option[String],
   imageCutoutSrcOrigin: Option[String],
 
-  applyMediaOverrides: Option[Boolean]
+  overrideArticleMainMedia: Option[Boolean]
 ) {
   def toArticleMetadata: ArticleMetadata = {
     val cutoutImage: Option[Image] = (imageCutoutSrcHeight, imageCutoutSrcWidth, imageCutoutSrc, imageCutoutSrcOrigin) match {
@@ -63,7 +63,7 @@ case class ClientArticleMetadata (
       Some(imageOption),
       cutoutImage,
       replaceImage,
-      applyMediaOverrides
+      overrideArticleMainMedia
     )
   }
 }
@@ -99,7 +99,7 @@ object ClientArticleMetadata {
       articleMetadata.cutoutImage.flatMap(_.width).map(_.toString),
       articleMetadata.cutoutImage.map(_.origin),
 
-      articleMetadata.applyMediaOverrides
+      articleMetadata.overrideArticleMainMedia
     )
   }
 }

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -8,6 +8,7 @@ import initialState from 'fixtures/initialState';
 import { State } from 'types/State';
 
 const formValues = {
+  applyMediaOverrides:false,
   byline: 'Caroline Davies',
   customKicker: '',
   cutoutImage: {

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -8,7 +8,7 @@ import initialState from 'fixtures/initialState';
 import { State } from 'types/State';
 
 const formValues = {
-  applyMediaOverrides:false,
+  applyMediaOverrides: false,
   byline: 'Caroline Davies',
   customKicker: '',
   cutoutImage: {

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -8,7 +8,7 @@ import initialState from 'fixtures/initialState';
 import { State } from 'types/State';
 
 const formValues = {
-  applyMediaOverrides: false,
+  overrideArticleMainMedia: false,
   byline: 'Caroline Davies',
   customKicker: '',
   cutoutImage: {

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -101,7 +101,7 @@ export const createSelectFormFieldsForCollectionItem = () => {
       }
 
       if (editMode === 'editions') {
-        fields.push("applyMediaOverrides")
+        fields.push('applyMediaOverrides');
         if (
           derivedArticle.sectionName === 'Sport' ||
           derivedArticle.sectionName === 'Football'

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -101,7 +101,7 @@ export const createSelectFormFieldsForCollectionItem = () => {
       }
 
       if (editMode === 'editions') {
-        fields.push('applyMediaOverrides');
+        fields.push('overrideArticleMainMedia');
         if (
           derivedArticle.sectionName === 'Sport' ||
           derivedArticle.sectionName === 'Football'

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -101,6 +101,7 @@ export const createSelectFormFieldsForCollectionItem = () => {
       }
 
       if (editMode === 'editions') {
+        fields.push("applyMediaOverrides")
         if (
           derivedArticle.sectionName === 'Sport' ||
           derivedArticle.sectionName === 'Football'

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -70,6 +70,7 @@ interface ArticleFragmentRootMeta {
     height?: string;
     origin?: string;
   }>;
+  applyMediaOverrides?: boolean;
 }
 
 type ArticleFragmentRootFields = NestedArticleFragmentRootFields & {

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -70,7 +70,7 @@ interface ArticleFragmentRootMeta {
     height?: string;
     origin?: string;
   }>;
-  applyMediaOverrides?: boolean;
+  overrideArticleMainMedia?: boolean;
 }
 
 type ArticleFragmentRootFields = NestedArticleFragmentRootFields & {

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -35,7 +35,7 @@ export interface ArticleFragmentFormData {
   showKickerTag: boolean;
   showKickerSection: boolean;
   imageReplace: boolean;
-  applyMediaOverrides: boolean;
+  overrideArticleMainMedia: boolean;
   showMainVideo: boolean;
 }
 
@@ -129,7 +129,7 @@ export const getInitialValuesForArticleFragmentForm = (
           thumb: article.imageCutoutSrc
         },
         slideshow: slideshow.concat(slideshowBackfill),
-        applyMediaOverrides: article.applyMediaOverrides || false,
+        overrideArticleMainMedia: article.overrideArticleMainMedia || false,
         sportScore: article.sportScore || ''
       }
     : undefined;

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -35,6 +35,7 @@ export interface ArticleFragmentFormData {
   showKickerTag: boolean;
   showKickerSection: boolean;
   imageReplace: boolean;
+  applyMediaOverrides: boolean;
   showMainVideo: boolean;
 }
 
@@ -128,6 +129,7 @@ export const getInitialValuesForArticleFragmentForm = (
           thumb: article.imageCutoutSrc
         },
         slideshow: slideshow.concat(slideshowBackfill),
+        applyMediaOverrides: article.applyMediaOverrides || false,
         sportScore: article.sportScore || ''
       }
     : undefined;

--- a/test/model/editions/ArticleMetadataTest.scala
+++ b/test/model/editions/ArticleMetadataTest.scala
@@ -1,0 +1,72 @@
+package model.editions
+
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.libs.json.Json
+
+class ArticleMetadataTest extends FreeSpec with Matchers {
+
+  val articleMetadata = ArticleMetadata(
+    Some("headline"),
+    Some("customKicker"),
+    Some("trailText"),
+    Some(true),
+    Some(true),
+    Some("byline"),
+    None,
+    Some(MediaType.Hide),
+    Some(Image(
+      Some(1),
+      Some(2),
+      "origin",
+      "src",
+      Some("thumb")
+    )),
+    Some(Image(
+      Some(3),
+      Some(4),
+      "origin2",
+      "src2",
+      Some("thumb2")
+    )),
+    Some(true)
+  )
+
+  private val articleMetadataAsString =
+    """
+      |{"headline":"headline",
+      | "customKicker":"customKicker",
+      | "trailText":"trailText",
+      | "showQuotedHeadline":true,
+      | "showByline":true,
+      | "byline":"byline",
+      | "mediaType":"hide",
+      | "cutoutImage":{
+      |     "height":1,
+      |     "width":2,
+      |     "origin":"origin",
+      |     "src":"src",
+      |     "thumb":"thumb"
+      | },
+      | "replaceImage":{
+      |   "height":3,
+      |   "width":4,
+      |   "origin":"origin2",
+      |   "src":"src2",
+      |   "thumb":"thumb2"
+      | },
+      | "applyMediaOverrides":true}
+    """.stripMargin.split('\n').map(_.trim).mkString //remove leading/trailing whitespace and join into a single string
+
+  "Article Metadata Data to/from Json" - {
+
+    "should serialise correctly" in {
+      Json.toJson(articleMetadata).toString() shouldBe articleMetadataAsString
+    }
+
+    "should deserialise correctly" in {
+      Json.fromJson[ArticleMetadata](Json.parse(articleMetadataAsString)).get shouldBe articleMetadata
+    }
+
+  }
+
+}

--- a/test/model/editions/ArticleMetadataTest.scala
+++ b/test/model/editions/ArticleMetadataTest.scala
@@ -54,7 +54,7 @@ class ArticleMetadataTest extends FreeSpec with Matchers {
       |   "src":"src2",
       |   "thumb":"thumb2"
       | },
-      | "applyMediaOverrides":true}
+      | "overrideArticleMainMedia":true}
     """.stripMargin.split('\n').map(_.trim).mkString //remove leading/trailing whitespace and join into a single string
 
   "Article Metadata Data to/from Json" - {

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -89,7 +89,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
             |      "src" : "https://media.giphy.com/media/yV5iknckcXcc/source.gif"
             |    },
             |    "sportScore" : "Sport Score",
-            |    "overrideArticleMedia" : true
+            |    "overrideArticleMainMedia" : true
             |  }
             |}""".stripMargin
 
@@ -105,7 +105,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           imageSrcOverride = Some(
             PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/yV5iknckcXcc/source.gif")
           ),
-          overrideArticleMedia = true
+          overrideArticleMainMedia = true
         ))
 
         val json = Json.prettyPrint(Json.toJson(article))

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -88,7 +88,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
             |      "width" : 720,
             |      "src" : "https://media.giphy.com/media/yV5iknckcXcc/source.gif"
             |    },
-            |    "sportScore" : "Sport Score"
+            |    "sportScore" : "Sport Score",
+            |    "overrideArticleMedia" : true
             |  }
             |}""".stripMargin
 
@@ -103,7 +104,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           mediaType = PublishedMediaType.Cutout,
           imageSrcOverride = Some(
             PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/yV5iknckcXcc/source.gif")
-          )
+          ),
+          overrideArticleMedia = true
         ))
 
         val json = Json.prettyPrint(Json.toJson(article))

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -113,7 +113,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         mediaType = PublishedMediaType.Image,
         imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg")),
         sportScore = Some("sport-score"),
-        overrideArticleMedia = false
+        overrideArticleMainMedia = false
       )
     }
   }

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -75,7 +75,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val article = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
       val publishedArticle = article.toPublishedArticle
       publishedArticle.internalPageCode shouldBe 1234456
-      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None)
+      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true)
     }
 
     "furniture defaults should be populated correctly" in {
@@ -83,7 +83,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
 
-      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None)
+      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true)
     }
 
     "furniture should be populated when specified" in {
@@ -98,7 +98,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         Some(MediaType.Image),
         None,
         Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg")),
-        Some(true)
+        Some(false)
       )
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
@@ -112,7 +112,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         showQuotedHeadline = true,
         mediaType = PublishedMediaType.Image,
         imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg")),
-        sportScore = Some("sport-score")
+        sportScore = Some("sport-score"),
+        overrideArticleMedia = false
       )
     }
   }

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -79,7 +79,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     "furniture defaults should be populated correctly" in {
-      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None, None)
+      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None)
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
 
@@ -97,7 +97,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         Some("sport-score"),
         Some(MediaType.Image),
         None,
-        Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg"))
+        Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg")),
+        Some(true)
       )
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -143,7 +143,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
   "ClientArticleMetadata to ArticleMetadata" - {
 
     def getEmptyClientArticleMetadata = ClientArticleMetadata(
-      None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+      None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
     )
 
     "should convert into ArticleMetadata with multiple image overrides" in {
@@ -207,8 +207,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         "file://broom.jpg"
       ))
 
-      articleMetadata.applyMediaOverrides shouldBe Some(true)
-      articleMetadata.applyMediaOverrides shouldBe Some(true)
+      articleMetadata.applyMediaOverrides shouldBe None
     }
 
     "should convert into ArticleMetadata without all the image information" in {

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -35,7 +35,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       clientArticleMetadata.imageHide shouldBe None
       clientArticleMetadata.imageReplace shouldBe None
       clientArticleMetadata.imageCutoutReplace shouldBe None
-      clientArticleMetadata.applyMediaOverrides shouldBe None
+      clientArticleMetadata.overrideArticleMainMedia shouldBe None
     }
 
     "should persist cutout image when selected override is hide image" in {
@@ -67,7 +67,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       clientArticleMetadata.imageCutoutSrcWidth shouldBe Some("100")
 
       clientArticleMetadata.imageReplace shouldBe None
-      clientArticleMetadata.applyMediaOverrides shouldBe None
+      clientArticleMetadata.overrideArticleMainMedia shouldBe None
     }
 
     "should persist slideshow images when selected override is replace image" in {
@@ -207,7 +207,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         "file://broom.jpg"
       ))
 
-      articleMetadata.applyMediaOverrides shouldBe None
+      articleMetadata.overrideArticleMainMedia shouldBe None
     }
 
     "should convert into ArticleMetadata without all the image information" in {

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -17,6 +17,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         None,
         None,
+        None,
         None
       )
 
@@ -34,6 +35,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       clientArticleMetadata.imageHide shouldBe None
       clientArticleMetadata.imageReplace shouldBe None
       clientArticleMetadata.imageCutoutReplace shouldBe None
+      clientArticleMetadata.applyMediaOverrides shouldBe None
     }
 
     "should persist cutout image when selected override is hide image" in {
@@ -47,6 +49,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(MediaType.Hide),
         Some(Image(Some(100), Some(100), "file://origin-new-pokemon.gif", "file://new-pokemon.gif")),
+        None,
         None
       )
 
@@ -64,6 +67,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       clientArticleMetadata.imageCutoutSrcWidth shouldBe Some("100")
 
       clientArticleMetadata.imageReplace shouldBe None
+      clientArticleMetadata.applyMediaOverrides shouldBe None
     }
 
     "should persist slideshow images when selected override is replace image" in {
@@ -78,6 +82,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some(MediaType.Image),
         None,
         Some(Image(Some(100), Some(100), "file://elephant.jpg", "file://elephant.png")),
+        None
       )
 
       val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
@@ -105,6 +110,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(MediaType.Image),
         None,
+        None,
         None
       )
 
@@ -124,6 +130,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(MediaType.UseArticleTrail),
         None,
+        None,
         None
       )
 
@@ -140,6 +147,29 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
     )
 
     "should convert into ArticleMetadata with multiple image overrides" in {
+      val cam = ClientArticleMetadata(
+        Some("New Harry Potter book being written"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("J.K"),
+        None,
+        Some(true),
+        Some("file://lightning.jpg"),
+        Some("100"),
+        Some("100"),
+        Some("file://lightning.gif"),
+        Some("file://lightning.png"),
+        Some(false),
+        Some("file://broom.jpg"),
+        Some("100"),
+        Some("100"),
+        Some("file://broom.gif"),
+        Some(true)
+      )
 
       val articleMetadata = getEmptyClientArticleMetadata
         .copy(headline = Some("New Harry Potter book being written"))
@@ -176,6 +206,9 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         "file://broom.gif",
         "file://broom.jpg"
       ))
+
+      articleMetadata.applyMediaOverrides shouldBe Some(true)
+      articleMetadata.applyMediaOverrides shouldBe Some(true)
     }
 
     "should convert into ArticleMetadata without all the image information" in {

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -24,7 +24,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     mediaType = None,
     cutoutImage = None,
     replaceImage = None,
-    applyMediaOverrides = None,
+    overrideArticleMainMedia = None,
     sportScore = None
   )
 
@@ -141,7 +141,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       editionsArticle.pageCode shouldBe "12345"
 
       val articleMetadata = editionsArticle.metadata.get
-      articleMetadata.applyMediaOverrides shouldBe None
+      articleMetadata.overrideArticleMainMedia shouldBe None
 
       commentFront.metadata.get.nameOverride shouldBe None
       commentFront.metadata.get.swatch shouldBe Some(Swatch.Culture)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -24,6 +24,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     mediaType = None,
     cutoutImage = None,
     replaceImage = None,
+    applyMediaOverrides = None,
     sportScore = None
   )
 
@@ -135,6 +136,13 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       val commentFront = retrievedIssue.fronts.tail.head
       commentFront.displayName shouldBe "comment"
       commentFront.collections.length shouldBe 3
+
+      val editionsArticle = newsPoliticsCollection.items.head
+      editionsArticle.pageCode shouldBe "12345"
+
+      val articleMetadata = editionsArticle.metadata.get
+      articleMetadata.applyMediaOverrides shouldBe None
+
       commentFront.metadata.get.nameOverride shouldBe None
       commentFront.metadata.get.swatch shouldBe Some(Swatch.Culture)
     }


### PR DESCRIPTION
## What's changed?

Allows the UI code to push a value for 'apply media overrides' to the back and and then to the database.

Does not provide a way for the UI code to set the value, pending design work.

## Checklist

### General
- [X] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
