### PR TITLE
Unhiding special fronts

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -118,4 +118,10 @@ class EditionsController(db: EditionsDB,
   def putFrontMetadata(id: String) = AccessAPIAuthAction(parse.json[EditionsFrontMetadata]) { req =>
     Ok(Json.toJson(db.updateFrontMetadata(id, req.body)))
   }
+
+  def putFrontHiddenState(id: String, state: Boolean) = AccessAPIAuthAction { req =>
+    db.updateFrontHiddenState(id, state).map { state =>
+      Ok(Json.toJson(state))
+    } getOrElse NotFound(s"Front $id not found")
+  }
 }

--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -21,7 +21,7 @@ case class EditionsFront(
     id: String,
     displayName: String,
     index: Int,
-    canRename: Boolean,
+    isSpecial: Boolean,
     isHidden: Boolean,
     updatedOn: Option[Long],
     updatedBy: Option[String],
@@ -49,7 +49,7 @@ object EditionsFront {
       rs.string(prefix + "id"),
       rs.string(prefix + "name"),
       rs.int(prefix + "index"),
-      rs.boolean(prefix + "can_rename"),
+      rs.boolean(prefix + "is_special"),
       rs.boolean(prefix + "is_hidden"),
       rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
       rs.stringOpt(prefix + "updated_by"),
@@ -64,14 +64,14 @@ object EditionsFront {
       id <- rs.stringOpt(prefix + "id")
       name <- rs.stringOpt(prefix + "name")
       index <- rs.intOpt(prefix + "index")
-      canRename <- rs.booleanOpt(prefix + "can_rename")
+      isSpecial <- rs.booleanOpt(prefix + "is_special")
       isHidden <- rs.booleanOpt(prefix + "is_hidden")
     } yield
       EditionsFront(
         id,
         name,
         index,
-        canRename,
+        isSpecial,
         isHidden,
         rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
         rs.stringOpt(prefix + "updated_by"),

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -87,7 +87,7 @@ case class FrontTemplate(
     name: String,
     collections: List[CollectionTemplate],
     presentation: FrontPresentation,
-    canRename: Boolean = false,
+    isSpecial: Boolean = false,
     hidden: Boolean = false
 )
 
@@ -110,7 +110,7 @@ case class EditionsFrontSkeleton(
     collections: List[EditionsCollectionSkeleton],
     presentation: FrontPresentation,
     hidden: Boolean,
-    canRename: Boolean
+    isSpecial: Boolean
 ) {
   def metadata() = {
     val metadataParam = new PGobject()

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -50,7 +50,7 @@ object FrontSpecialSpecial1 {
     collections = List(collectionSpecialSpecial1),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true,
-    canRename = true
+    isSpecial = true
   )
 }
 
@@ -630,7 +630,7 @@ object FrontSpecialSpecial2 {
     collections = List(collectionSpecialSpecial2),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true,
-    canRename = true
+    isSpecial = true
   )
 }
 

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -42,7 +42,7 @@ class EditionsTemplating(templates: Map[String, EditionTemplate], capi: Capi) ex
                   },
                   frontTemplate.presentation,
                   frontTemplate.hidden,
-                  frontTemplate.canRename
+                  frontTemplate.isSpecial
                 )
             }))
         } else {

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -1,10 +1,11 @@
 package services.editions.db
 
+import logging.Logging
 import model.editions.EditionsFrontMetadata
 import scalikejdbc._
 import play.api.libs.json._
 
-trait FrontsQueries {
+trait FrontsQueries extends Logging {
   def updateFrontMetadata(id: String, metadata: EditionsFrontMetadata): Option[EditionsFrontMetadata] = DB localTx { implicit session =>
     sql"""
           UPDATE fronts
@@ -35,5 +36,26 @@ trait FrontsQueries {
         }
       }).single().apply().get
     Json.fromJson[EditionsFrontMetadata](Json.parse(rawJson)).get
+  }
+
+  // TODO: sihil this should really escalate an error if this is attempted when is_special is false but we don't
+  // have a clean way of doing that right now.
+  def updateFrontHiddenState(id: String, isHidden: Boolean): Option[Boolean] = DB localTx { implicit session =>
+    sql"""
+         UPDATE fronts
+         SET is_hidden = $isHidden
+         WHERE id = $id AND is_special = TRUE
+       """.execute().apply()
+
+    val newState = sql"""
+        SELECT is_hidden, is_special FROM fronts WHERE id = $id
+      """.map { rs =>
+        (rs.boolean("is_hidden"), rs.boolean("is_special"))
+      }.single().apply()
+
+    newState.map { case (isHidden, isSpecial) =>
+      if (!isSpecial) logger.warn(s"Tried to update hidden state on front $id which is not a special front")
+      isHidden
+    }
   }
 }

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -40,8 +40,8 @@ trait IssueQueries {
           name,
           is_hidden,
           metadata,
-          can_rename
-        ) VALUES (${issueId}, ${fIndex}, ${front.name}, ${front.hidden}, ${front.metadata}, ${front.canRename})
+          is_special
+        ) VALUES (${issueId}, ${fIndex}, ${front.name}, ${front.hidden}, ${front.metadata}, ${front.isSpecial})
         RETURNING id;
       """.map(_.string("id")).single().apply().get
 
@@ -138,7 +138,7 @@ trait IssueQueries {
         fronts.issue_id      AS fronts_issue_id,
         fronts.index         AS fronts_index,
         fronts.name          AS fronts_name,
-        fronts.can_rename    AS fronts_can_rename,
+        fronts.is_special    AS fronts_is_special,
         fronts.is_hidden     AS fronts_is_hidden,
         fronts.metadata      AS fronts_metadata,
         fronts.updated_on    AS fronts_updated_on,

--- a/client-v2/integration/fixtures/edition.js
+++ b/client-v2/integration/fixtures/edition.js
@@ -43,7 +43,7 @@ module.exports = {
     {
       id: 'special_front',
       displayName: 'Special 1',
-      canRename: true,
+      isSpecial: true,
       isHidden: false,
       collections: [
         {

--- a/client-v2/src/actions/Editions.tsx
+++ b/client-v2/src/actions/Editions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   getIssueSummary,
   publishIssue,
+  putFrontHiddenState,
   putFrontMetadata
 } from 'services/editionsApi';
 import { ThunkResult } from 'types/Store';
@@ -72,6 +73,24 @@ export const updateFrontMetadata = (
       payload: {
         frontId: id,
         metadata: serverMetadata
+      }
+    });
+  } catch (error) {
+    // @todo implement centralised error handling
+  }
+};
+
+export const setFrontHiddenState = (
+  id: string,
+  hidden: boolean
+): ThunkResult<Promise<void>> => async (dispatch: Dispatch) => {
+  try {
+    const serverHidden = await putFrontHiddenState(id, hidden);
+    dispatch({
+      type: 'FETCH_FRONT_HIDDEN_STATE_SUCCESS',
+      payload: {
+        frontId: id,
+        hidden: serverHidden
       }
     });
   } catch (error) {

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -32,7 +32,7 @@ import { RadioButton, RadioGroup } from 'components/inputs/RadioButtons';
 import { PreviewEyeIcon, ClearIcon } from 'shared/components/icons/Icons';
 import { createFrontId } from 'util/editUtils';
 import EditModeVisibility from 'components/util/EditModeVisibility';
-import { updateFrontMetadata } from 'actions/Editions';
+import { setFrontHiddenState, updateFrontMetadata } from 'actions/Editions';
 
 const FrontHeader = styled(SectionHeader)`
   display: flex;
@@ -126,6 +126,7 @@ type FrontsComponentProps = FrontsContainerProps & {
       frontId: string,
       metadata: EditionsFrontMetadata
     ) => void;
+    setFrontHiddenState: (id: string, hidden: boolean) => void;
   };
 };
 
@@ -164,6 +165,10 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     const { frontNameValue, editingFrontName } = this.state;
     const isSpecial = this.props.selectedFront
       ? this.props.selectedFront.isSpecial
+      : false;
+
+    const isHidden = this.props.selectedFront
+      ? this.props.selectedFront.isHidden
       : false;
 
     return (
@@ -223,13 +228,22 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                 </StageSelectButtons>
               </EditModeVisibility>
               {isSpecial && (
-                <FrontHeaderButton
-                  data-testid="rename-front-button"
-                  onClick={this.renameFront}
-                  size="l"
-                >
-                  Rename
-                </FrontHeaderButton>
+                <>
+                  <FrontHeaderButton
+                    data-testid="toggle-hidden-front-button"
+                    onClick={() => this.setFrontHiddenState(!isHidden)}
+                    size="l"
+                  >
+                    {isHidden ? 'Unhide' : 'Hide'}
+                  </FrontHeaderButton>
+                  <FrontHeaderButton
+                    data-testid="rename-front-button"
+                    onClick={this.renameFront}
+                    size="l"
+                  >
+                    Rename
+                  </FrontHeaderButton>
+                </>
               )}
               <FrontHeaderButton onClick={this.handleRemoveFront} size="l">
                 <ClearIcon size="xl" />
@@ -256,6 +270,13 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
       frontNameValue: this.getTitle() || '',
       editingFrontName: true
     });
+  };
+
+  private setFrontHiddenState = (hidden: boolean) => {
+    this.props.frontsActions.setFrontHiddenState(
+      this.props.selectedFront.id,
+      hidden
+    );
   };
 
   private getTitle = () => {
@@ -313,7 +334,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     changeBrowsingStage: (id: string, browsingStage: Stages) =>
       dispatch(changedBrowsingStage(id, browsingStage)),
     updateFrontMetadata: (id: string, metadata: EditionsFrontMetadata) =>
-      dispatch(updateFrontMetadata(id, metadata))
+      dispatch(updateFrontMetadata(id, metadata)),
+    setFrontHiddenState: (id: string, hidden: boolean) =>
+      dispatch(setFrontHiddenState(id, hidden))
   }
 });
 

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -162,8 +162,8 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
     const title = this.getTitle();
 
     const { frontNameValue, editingFrontName } = this.state;
-    const canRename = this.props.selectedFront
-      ? this.props.selectedFront.canRename
+    const isSpecial = this.props.selectedFront
+      ? this.props.selectedFront.isSpecial
       : false;
 
     return (
@@ -222,7 +222,7 @@ class Fronts extends React.Component<FrontsComponentProps, ComponentState> {
                   </RadioGroup>
                 </StageSelectButtons>
               </EditModeVisibility>
-              {canRename && (
+              {isSpecial && (
                 <FrontHeaderButton
                   data-testid="rename-front-button"
                   onClick={this.renameFront}

--- a/client-v2/src/reducers/frontsReducer.ts
+++ b/client-v2/src/reducers/frontsReducer.ts
@@ -49,6 +49,13 @@ const reducer = (
         newState
       );
     }
+    case 'FETCH_FRONT_HIDDEN_STATE_SUCCESS': {
+      return set(
+        ['frontsConfig', 'data', 'fronts', action.payload.frontId, 'isHidden'],
+        action.payload.hidden,
+        newState
+      );
+    }
     case 'FETCH_LAST_PRESSED_SUCCESS': {
       return set(
         ['lastPressed', action.payload.frontId],

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -101,3 +101,9 @@ export const putFrontMetadata = (
     body: JSON.stringify(metadata)
   }).then(response => response.json());
 };
+
+export const putFrontHiddenState = (id: string, hidden: boolean) => {
+  return pandaFetch(`/editions-api/fronts/${id}/is-hidden/${hidden}`, {
+    method: 'PUT'
+  }).then(response => response.json());
+};

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -300,6 +300,14 @@ interface EditionsFrontMetadataUpdate {
   };
 }
 
+interface EditionsFrontHiddenStateUpdate {
+  type: 'FETCH_FRONT_HIDDEN_STATE_SUCCESS';
+  payload: {
+    frontId: string;
+    hidden: boolean;
+  };
+}
+
 type SetFocusState = ReturnType<typeof setFocusState>;
 type ResetFocusState = ReturnType<typeof resetFocusState>;
 
@@ -352,6 +360,7 @@ type Action =
   | ResetFocusState
   | ActionSetFeatureValue
   | EditionsFrontMetadataUpdate
+  | EditionsFrontHiddenStateUpdate
   | IsPrefillMode
   | SetHidden
   | ChangedBrowsingStage;

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -22,7 +22,7 @@ interface FrontConfigResponse {
   title?: string;
   webTitle?: string;
   navSection?: string;
-  canRename?: boolean;
+  isSpecial?: boolean;
   metadata?: EditionsFrontMetadata;
 }
 

--- a/conf/evolutions/default/5.sql
+++ b/conf/evolutions/default/5.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE fronts RENAME COLUMN can_rename TO is_special;
+
+# --- !Downs
+
+ALTER TABLE fronts RENAME COLUMN is_special TO can_rename;

--- a/conf/routes
+++ b/conf/routes
@@ -108,6 +108,7 @@ POST        /editions-api/issues/:id/publish                     controllers.Edi
 GET         /editions-api/issues/:id/preview                     controllers.EditionsController.getPreviewEdition(id)
 
 PUT         /editions-api/fronts/:frontId/metadata               controllers.EditionsController.putFrontMetadata(frontId)
+PUT         /editions-api/fronts/:frontId/is-hidden/:state       controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
 
 POST        /editions-api/collections                            controllers.EditionsController.getCollections
 PUT         /editions-api/collections/:collectionId              controllers.EditionsController.updateCollection(collectionId)

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -33,7 +33,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       name,
       name,
       0,
-      canRename = false,
+      isSpecial = false,
       isHidden = false,
       None,
       None,

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -41,7 +41,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
   }
 
   private def front(name: String, collections: EditionsCollectionSkeleton*): EditionsFrontSkeleton =
-    EditionsFrontSkeleton(name, collections.toList, FrontPresentation(Swatch.Culture), hidden = false, canRename = false)
+    EditionsFrontSkeleton(name, collections.toList, FrontPresentation(Swatch.Culture), hidden = false, isSpecial = false)
 
   private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticleSkeleton*): EditionsCollectionSkeleton =
     EditionsCollectionSkeleton(name, articles.toList, prefill, CollectionPresentation(), hidden = false)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -43,6 +43,10 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
   private def front(name: String, collections: EditionsCollectionSkeleton*): EditionsFrontSkeleton =
     EditionsFrontSkeleton(name, collections.toList, FrontPresentation(Swatch.Culture), hidden = false, isSpecial = false)
 
+  implicit class RichFrontSkeleton(frontSkel: EditionsFrontSkeleton) {
+    def special() = frontSkel.copy(isSpecial = true, hidden = true)
+  }
+
   private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticleSkeleton*): EditionsCollectionSkeleton =
     EditionsCollectionSkeleton(name, articles.toList, prefill, CollectionPresentation(), hidden = false)
 
@@ -320,6 +324,57 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       // check that the added time hasn't modified
       updatedBrexshit.items.find(_.pageCode == "76543").value.addedOn shouldBe now.toInstant.toEpochMilli
+    }
+
+    "should allow a special front's hidden status to be changed" in {
+      val id = insertSkeletonIssue(2019, 9, 30,
+        front("news/uk",
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          )
+        ).special()
+      )
+      val retrievedIssue = editionsDB.getIssue(id).value
+      val specialFront = retrievedIssue.fronts.head
+      specialFront.isSpecial shouldBe true
+      specialFront.isHidden shouldBe true
+
+      editionsDB.updateFrontHiddenState(specialFront.id, isHidden = false)
+
+      val retrievedIssue2 = editionsDB.getIssue(id).value
+      val specialFront2 = retrievedIssue2.fronts.head
+      specialFront2.isSpecial shouldBe true
+      specialFront2.isHidden shouldBe false
+
+      editionsDB.updateFrontHiddenState(specialFront.id, isHidden = true)
+
+      val retrievedIssue3 = editionsDB.getIssue(id).value
+      val specialFront3 = retrievedIssue3.fronts.head
+      specialFront3.isSpecial shouldBe true
+      specialFront3.isHidden shouldBe true
+    }
+
+    "should now allow a normal front's hidden status to be changed" in {
+      val id = insertSkeletonIssue(2019, 9, 30,
+        front("news/uk",
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+            article("12345"),
+            article("23456")
+          )
+        )
+      )
+      val retrievedIssue = editionsDB.getIssue(id).value
+      val specialFront = retrievedIssue.fronts.head
+      specialFront.isSpecial shouldBe false
+      specialFront.isHidden shouldBe false
+
+      editionsDB.updateFrontHiddenState(specialFront.id, isHidden = true)
+
+      val retrievedIssue2 = editionsDB.getIssue(id).value
+      val specialFront2 = retrievedIssue2.fronts.head
+      specialFront2.isSpecial shouldBe false
+      specialFront2.isHidden shouldBe false
     }
 
   }


### PR DESCRIPTION
## What's changed?

It has been possible to rename special fronts since #892 but it has not been possible to unhide them such that they appear in the exported data. This adds a little unhide toggle next to the rename button - only in editions and only on special fronts.

![Screenshot 2019-08-16 at 17 49 38](https://user-images.githubusercontent.com/1236466/63184256-dbda2700-c04e-11e9-9733-a8cc09a1c42b.png)

## Implementation notes

This relies on the `canRename` concept introduced in #892 but it made sense to rename that to `isSpecial` everywhere.

The commits are self contained and it might be easier to review them individually.

## Checklist

### General
- [X] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [X] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [X] 📷 Screenshots / GIFs of relevant UI changes included
