### PR TITLE
REPLACE IMAGE TWEAKS: Fix grid text input, make toggle more logical

### DIFF
--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -37,7 +37,7 @@
     "@types/react-router-dom": "^4.3.1",
     "@types/react-router-redux": "^5.0.16",
     "@types/react-transition-group": "^2.0.16",
-    "@types/redux-form": "^8.1.4",
+    "@types/redux-form": "^8.1.5",
     "@types/redux-mock-store": "^1.0.0",
     "@types/sanitize-html": "^1.18.2",
     "@types/styled-components": "^4.0.1",

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -48,6 +48,7 @@ import { selectors as collectionSelectors } from 'shared/bundles/collectionsBund
 import { getContributorImage } from 'util/CAPIUtils';
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from 'selectors/pathSelectors';
+import { ValidationResponse } from 'shared/util/validateImageSrc';
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -183,7 +184,6 @@ const getInputId = (articleFragmentId: string, label: string) =>
 interface FormComponentState {
   lastKnownCollectionId: string | null;
   displayImageReplaceToggle: boolean;
-  isImageReplaced: boolean;
 }
 
 class FormComponent extends React.Component<Props, FormComponentState> {
@@ -195,8 +195,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
   public state: FormComponentState = {
     lastKnownCollectionId: null,
-    displayImageReplaceToggle: false,
-    isImageReplaced: false
+    displayImageReplaceToggle: false
   };
 
   private allImageFields = [
@@ -441,10 +440,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   useDefault={!imageCutoutReplace && !imageReplace}
                   message={imageCutoutReplace ? 'Add cutout' : 'Replace image'}
                   onChange={this.handleImageChange}
-                  setDisplayImageReplaceToggle={
-                    this.setDisplayImageReplaceToggle
-                  }
-                  setImageReplaceToggleValue={this.setImageReplaceToggleValue}
                 />
               </ImageCol>
               <Col flex={2}>
@@ -494,7 +489,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                       label="Use replacement image"
                       id={getInputId(articleFragmentId, 'image-replace')}
                       type="checkbox"
-                      default={this.state.isImageReplaced}
+                      default={false}
                       onChange={_ => this.changeImageField('imageReplace')}
                     />
                   </InputGroup>
@@ -554,17 +549,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     return 'primaryImage';
   };
 
-  private setDisplayImageReplaceToggle = (display: boolean) => {
-    this.setState({ displayImageReplaceToggle: display });
-  };
-
-  private setImageReplaceToggleValue = (value: boolean) => {
-    this.props.change('imageReplace', value);
-    this.setState({ isImageReplaced: value });
-  };
-
   private handleImageChange: EventWithDataHandler<React.ChangeEvent<any>> = (
-    e,
+    e: ValidationResponse | undefined,
     ...args: [any?, any?, string?]
   ) => {
     // If we don't already have an image override enabled, enable the default imageReplace property.
@@ -572,6 +558,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     if (!this.props.imageCutoutReplace && !this.props.imageReplace) {
       this.changeImageField('imageReplace');
     }
+    const replacementImagePresent: boolean = !!e && !!e.src;
+    this.setState({ displayImageReplaceToggle: replacementImagePresent });
+
     this.props.change(this.getImageFieldName(), e);
   };
 

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -48,6 +48,7 @@ import { selectors as collectionSelectors } from 'shared/bundles/collectionsBund
 import { getContributorImage } from 'util/CAPIUtils';
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from 'selectors/pathSelectors';
+import console = require('console');
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -182,6 +183,7 @@ const getInputId = (articleFragmentId: string, label: string) =>
 
 interface FormComponentState {
   lastKnownCollectionId: string | null;
+  displayImageReplaceToggle: boolean;
 }
 
 class FormComponent extends React.Component<Props, FormComponentState> {
@@ -192,7 +194,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
   }
 
   public state: FormComponentState = {
-    lastKnownCollectionId: null
+    lastKnownCollectionId: null,
+    displayImageReplaceToggle: false
   };
 
   private allImageFields = [
@@ -437,6 +440,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   useDefault={!imageCutoutReplace && !imageReplace}
                   message={imageCutoutReplace ? 'Add cutout' : 'Replace image'}
                   onChange={this.handleImageChange}
+                  setDisplayImageReplaceToggle={
+                    this.setDisplayImageReplaceToggle
+                  }
                 />
               </ImageCol>
               <Col flex={2}>
@@ -477,7 +483,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     }
                   />
                 </InputGroup>
-                {imageReplace && (
+                {this.state.displayImageReplaceToggle && (
                   <InputGroup>
                     <ConditionalField
                       permittedFields={editableFields}
@@ -486,7 +492,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                       label="Use original image"
                       id={getInputId(articleFragmentId, 'image-replace')}
                       type="checkbox"
-                      default={false}
+                      default={true}
                       onChange={_ => this.changeImageField('imageReplace')}
                     />
                   </InputGroup>
@@ -546,6 +552,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     return 'primaryImage';
   };
 
+  private setDisplayImageReplaceToggle = (display: boolean) => {
+    console.log('display image replace toggle got hit', display);
+    this.setState({ displayImageReplaceToggle: display });
+  };
+
   private handleImageChange: EventWithDataHandler<React.ChangeEvent<any>> = (
     e,
     ...args: [any?, any?, string?]
@@ -561,7 +572,12 @@ class FormComponent extends React.Component<Props, FormComponentState> {
   private changeImageField = (fieldToSet: string) => {
     this.allImageFields.forEach(field => {
       if (field === fieldToSet) {
-        this.props.change(field, true);
+        if (fieldToSet === 'imageReplace') {
+          // this.setState({ displayImageReplaceToggle: true });
+          this.props.change(field, false);
+        } else {
+          this.props.change(field, true);
+        }
       } else {
         this.props.change(field, false);
       }

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -559,6 +559,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
   };
 
   private setImageReplaceToggleValue = (value: boolean) => {
+    this.props.change('imageReplace', value);
     this.setState({ isImageReplaced: value });
   };
 

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -549,8 +549,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     return 'primaryImage';
   };
 
-  // onChange: EventWithDataHandler<React.ChangeEvent<any>> & ((_: React.ChangeEvent<any> | undefined) => void)
-
   private handleImageChange: EventWithDataHandler<React.ChangeEvent<any>> = (
     e: unknown,
     ...args: [any?, any?, string?]

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -59,6 +59,7 @@ interface ComponentProps extends ContainerProps {
   showKickerSection: boolean;
   kickerOptions: ArticleTag;
   cutoutImage?: string;
+  primaryImage: ValidationResponse | null;
 }
 
 type Props = ComponentProps &
@@ -183,7 +184,6 @@ const getInputId = (articleFragmentId: string, label: string) =>
 
 interface FormComponentState {
   lastKnownCollectionId: string | null;
-  displayImageReplaceToggle: boolean;
 }
 
 class FormComponent extends React.Component<Props, FormComponentState> {
@@ -194,8 +194,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
   }
 
   public state: FormComponentState = {
-    lastKnownCollectionId: null,
-    displayImageReplaceToggle: false
+    lastKnownCollectionId: null
   };
 
   private allImageFields = [
@@ -224,7 +223,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       cutoutImage,
       imageSlideshowReplace,
       isBreaking,
-      editMode
+      editMode,
+      primaryImage
     } = this.props;
 
     const isEditionsMode = editMode === 'editions';
@@ -480,7 +480,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     }
                   />
                 </InputGroup>
-                {this.state.displayImageReplaceToggle && (
+                {primaryImage && !!primaryImage.src && (
                   <InputGroup>
                     <ConditionalField
                       permittedFields={editableFields}
@@ -549,8 +549,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     return 'primaryImage';
   };
 
+  // onChange: EventWithDataHandler<React.ChangeEvent<any>> & ((_: React.ChangeEvent<any> | undefined) => void)
+
   private handleImageChange: EventWithDataHandler<React.ChangeEvent<any>> = (
-    e: ValidationResponse | undefined,
+    e: unknown,
     ...args: [any?, any?, string?]
   ) => {
     // If we don't already have an image override enabled, enable the default imageReplace property.
@@ -558,8 +560,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     if (!this.props.imageCutoutReplace && !this.props.imageReplace) {
       this.changeImageField('imageReplace');
     }
-    const replacementImagePresent: boolean = !!e && !!e.src;
-    this.setState({ displayImageReplaceToggle: replacementImagePresent });
 
     this.props.change(this.getImageFieldName(), e);
   };
@@ -616,6 +616,7 @@ interface ContainerProps {
   imageReplace: boolean;
   isBreaking: boolean;
   editMode: EditMode;
+  primaryImage: ValidationResponse | null;
 }
 
 interface InterfaceProps {
@@ -689,7 +690,8 @@ const createMapStateToProps = () => {
       cutoutImage: externalArticle
         ? getContributorImage(externalArticle)
         : undefined,
-      editMode: selectEditMode(state)
+      editMode: selectEditMode(state),
+      primaryImage: valueSelector(state, 'primaryImage')
     };
   };
 };

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -435,23 +435,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                       : articleCapiFieldValues.thumbnail
                   }
                   useDefault={!imageCutoutReplace && !imageReplace}
-                  message={imageCutoutReplace ? 'Add cutout' : 'Add image'}
+                  message={imageCutoutReplace ? 'Add cutout' : 'Replace image'}
                   onChange={this.handleImageChange}
                 />
               </ImageCol>
               <Col flex={2}>
-                <InputGroup>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name="imageReplace"
-                    component={InputCheckboxToggleInline}
-                    label="Replace media"
-                    id={getInputId(articleFragmentId, 'image-replace')}
-                    type="checkbox"
-                    default={false}
-                    onChange={_ => this.changeImageField('imageReplace')}
-                  />
-                </InputGroup>
                 <InputGroup>
                   <ConditionalField
                     permittedFields={editableFields}
@@ -489,6 +477,20 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     }
                   />
                 </InputGroup>
+                {imageReplace && (
+                  <InputGroup>
+                    <ConditionalField
+                      permittedFields={editableFields}
+                      name="imageReplace"
+                      component={InputCheckboxToggleInline}
+                      label="Use original image"
+                      id={getInputId(articleFragmentId, 'image-replace')}
+                      type="checkbox"
+                      default={false}
+                      onChange={_ => this.changeImageField('imageReplace')}
+                    />
+                  </InputGroup>
+                )}
               </Col>
             </Row>
             <ConditionalComponent

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -48,7 +48,6 @@ import { selectors as collectionSelectors } from 'shared/bundles/collectionsBund
 import { getContributorImage } from 'util/CAPIUtils';
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from 'selectors/pathSelectors';
-import console = require('console');
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -184,6 +183,7 @@ const getInputId = (articleFragmentId: string, label: string) =>
 interface FormComponentState {
   lastKnownCollectionId: string | null;
   displayImageReplaceToggle: boolean;
+  isImageReplaced: boolean;
 }
 
 class FormComponent extends React.Component<Props, FormComponentState> {
@@ -195,7 +195,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
   public state: FormComponentState = {
     lastKnownCollectionId: null,
-    displayImageReplaceToggle: false
+    displayImageReplaceToggle: false,
+    isImageReplaced: false
   };
 
   private allImageFields = [
@@ -443,6 +444,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   setDisplayImageReplaceToggle={
                     this.setDisplayImageReplaceToggle
                   }
+                  setImageReplaceToggleValue={this.setImageReplaceToggleValue}
                 />
               </ImageCol>
               <Col flex={2}>
@@ -489,10 +491,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                       permittedFields={editableFields}
                       name="imageReplace"
                       component={InputCheckboxToggleInline}
-                      label="Use original image"
+                      label="Use replacement image"
                       id={getInputId(articleFragmentId, 'image-replace')}
                       type="checkbox"
-                      default={true}
+                      default={this.state.isImageReplaced}
                       onChange={_ => this.changeImageField('imageReplace')}
                     />
                   </InputGroup>
@@ -553,8 +555,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
   };
 
   private setDisplayImageReplaceToggle = (display: boolean) => {
-    console.log('display image replace toggle got hit', display);
     this.setState({ displayImageReplaceToggle: display });
+  };
+
+  private setImageReplaceToggleValue = (value: boolean) => {
+    this.setState({ isImageReplaced: value });
   };
 
   private handleImageChange: EventWithDataHandler<React.ChangeEvent<any>> = (
@@ -572,12 +577,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
   private changeImageField = (fieldToSet: string) => {
     this.allImageFields.forEach(field => {
       if (field === fieldToSet) {
-        if (fieldToSet === 'imageReplace') {
-          // this.setState({ displayImageReplaceToggle: true });
-          this.props.change(field, false);
-        } else {
-          this.props.change(field, true);
-        }
+        this.props.change(field, true);
       } else {
         this.props.change(field, false);
       }

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -144,6 +144,7 @@ export interface InputImageContainerProps {
   message?: string;
   replaceImage: boolean;
   setDisplayImageReplaceToggle: (display: boolean) => void;
+  setImageReplaceToggleValue: (value: boolean) => void;
 }
 
 type ComponentProps = InputImageContainerProps &
@@ -186,9 +187,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 
     const gridSearchUrl =
       editMode === 'editions' ? `${gridUrl}` : `${gridUrl}?cropType=landscape`;
-    const hasImage = useDefault && !!input.value && !!input.value.thumb;
+    const hasImage = !useDefault && !!input.value && !!input.value.thumb;
     const imageUrl =
-      useDefault && input.value && input.value.thumb
+      !useDefault && input.value && input.value.thumb
         ? input.value.thumb
         : defaultImageUrl;
     return (
@@ -262,6 +263,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   private handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     this.clearField();
+    this.props.setImageReplaceToggleValue(false);
     this.props.setDisplayImageReplaceToggle(false);
   };
 

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -143,8 +143,6 @@ export interface InputImageContainerProps {
   useDefault?: boolean;
   message?: string;
   replaceImage: boolean;
-  setDisplayImageReplaceToggle: (display: boolean) => void;
-  setImageReplaceToggleValue: (value: boolean) => void;
 }
 
 type ComponentProps = InputImageContainerProps &
@@ -263,8 +261,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   private handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     this.clearField();
-    this.props.setImageReplaceToggleValue(false);
-    this.props.setDisplayImageReplaceToggle(false);
   };
 
   private handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
@@ -280,8 +276,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
   private handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     events.imageAdded(this.props.frontId, 'drop');
     e.preventDefault();
-    e.persist();
-
     validateImageEvent(e, this.props.frontId, this.props.criteria)
       .then(this.props.input.onChange)
       .catch(err => {
@@ -310,7 +304,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     )
       .then(mediaItem => {
         this.props.input.onChange(mediaItem);
-        this.props.setDisplayImageReplaceToggle(true);
       })
       .catch(err => {
         alert(err);
@@ -358,7 +351,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       .then(mediaItem => {
         events.imageAdded(this.props.frontId, 'click to modal');
         this.props.input.onChange(mediaItem);
-        this.props.setDisplayImageReplaceToggle(true);
       })
       .catch(err => {
         alert(err);

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import { theme as globalTheme, styled } from 'shared/constants/theme';
 import { connect } from 'react-redux';
 import { WrappedFieldProps } from 'redux-form';
@@ -170,7 +170,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       gridUrl,
       useDefault,
       defaultImageUrl,
-      message = 'Add image',
+      message = 'Replace image',
       editMode
     } = this.props;
 
@@ -243,8 +243,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                   name="paste-url"
                   placeholder=" Paste crop url"
                   defaultValue={this.state.imageSrc}
-                  onKeyDown={this.handlePasteImgSrcSubmit(13)}
                   onChange={this.handlePasteImgSrcChange}
+                  onKeyUp={this.handlePasteImgSrcSubmit()}
+                  // onMouseUp={this.handleClickOnImgSrc}
                 />
                 <InputLabel hidden htmlFor="paste-url">
                   Paste crop url
@@ -287,33 +288,44 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       });
   };
 
+  private handleClickOnImgSrc = (
+    e: React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => {
+    if (this.state.imageSrc !== '') {
+      this.handlePasteImgSrcSubmit();
+    }
+  };
+
   private handlePasteImgSrcChange = (e: React.FormEvent<HTMLInputElement>) => {
     e.preventDefault();
     this.setState({ imageSrc: e.currentTarget.value });
+    if (e.currentTarget.value !== '') {
+      this.handlePasteImgSrcSubmit();
+    }
   };
 
-  private handlePasteImgSrcSubmit = (keyCode: number) => (
-    e: React.KeyboardEvent
+  private handlePasteImgSrcSubmit = () => (
+    e: React.FormEvent<HTMLInputElement>
   ) => {
     events.imageAdded(this.props.frontId, 'paste');
     e.persist();
-    if (e.keyCode === keyCode) {
-      e.preventDefault();
-      validateImageSrc(
-        this.state.imageSrc,
-        this.props.frontId,
-        this.props.criteria
-      )
-        .then(mediaItem => {
-          this.props.input.onChange(mediaItem);
-        })
-        .catch(err => {
-          alert(err);
-          // tslint:disable-next-line no-console
-          console.log('@todo:handle error', err);
-        });
-      this.setState({ imageSrc: '' });
-    }
+    // if (e.keyCode === keyCode) {
+    e.preventDefault();
+    validateImageSrc(
+      this.state.imageSrc,
+      this.props.frontId,
+      this.props.criteria
+    )
+      .then(mediaItem => {
+        this.props.input.onChange(mediaItem);
+      })
+      .catch(err => {
+        alert(err);
+        // tslint:disable-next-line no-console
+        console.log('@todo:handle error', err);
+      });
+    this.setState({ imageSrc: '' });
+    // }
   };
 
   private clearField = () => this.props.input.onChange(null);


### PR DESCRIPTION
## What's changed?

Replace image fields in articles: remove need to hit enter on text input & change the behaviour of the toggle.

Trello: https://trello.com/c/szlvJ9R0/787-replace-image-with-grid-url

With no replacement image present, toggle is hidden:

![Screenshot 2019-08-19 at 18 26 29](https://user-images.githubusercontent.com/10324129/63286036-01fe0200-c2af-11e9-9b13-b24be42ac9d0.png)

When replacement image is added, the toggle appears, set to true: 

![Screenshot 2019-08-19 at 18 26 52](https://user-images.githubusercontent.com/10324129/63286114-25c14800-c2af-11e9-9548-cc9bcf5c2a27.png)



## Implementation notes

- Knowledge of image replace disappears on save, meaning that the toggle itself will disappear, although it's still possible to remove the image using the little bin icon. 
- Need UX test this flow to confirm whether users understand what to do when the toggle is absent. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
