### PR TITLE
Remove stale feature switches as they enter and exit the server-side app

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -28,11 +28,17 @@ object FeatureSwitches {
   val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
-    userDataSwitches match {
+    val newSwitches = userDataSwitches match {
       case Some(switches) =>
-        all.diff(switches) ++ switches.filter(_.key != switch.key) ++ List(switch)
+        val defaultSwitches = all.filter(defaultSwitch => !switches.exists(_.key == defaultSwitch.key) && defaultSwitch.key != switch.key)
+        defaultSwitches ++ switches.filter(_.key != switch.key) ++ List(switch)
       case None =>
         all.filter(_.key != switch.key) ++ List(switch)
     }
+    removeUnknownSwitches(newSwitches)
   }
+
+  def removeUnknownSwitches(featureSwitches: List[FeatureSwitch]) = 
+    featureSwitches.filter(featureSwitch =>
+      FeatureSwitches.all.exists(_.key == featureSwitch.key))
 }

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -44,7 +44,7 @@ object UserDataForDefaults {
   def fromUserData(userData: UserData, clipboardArticles: Option[List[Trail]]): UserDataForDefaults = {
     val featureSwitches = userData.featureSwitches.fold(FeatureSwitches.all) { userFeatureSwitches =>
       val unsetFeatureSwitches = FeatureSwitches.all.diff(userFeatureSwitches)
-      unsetFeatureSwitches ++ userFeatureSwitches
+      unsetFeatureSwitches ++ FeatureSwitches.removeUnknownSwitches(userFeatureSwitches)
     }
     UserDataForDefaults(
       clipboardArticles,

--- a/test/FeaturesSpec.scala
+++ b/test/FeaturesSpec.scala
@@ -1,4 +1,4 @@
-import model.{FeatureSwitch, FeatureSwitches, ObscureFeed }
+import model.{FeatureSwitch, FeatureSwitches, ObscureFeed, PageViewDataVisualisation }
 import org.scalatest.{Matchers, WordSpec}
 
 class FeaturesSpec extends WordSpec with Matchers {
@@ -8,15 +8,21 @@ class FeaturesSpec extends WordSpec with Matchers {
     "FeatureSwitches.updateFeatureSwitchesForUser is called" must {
 
       "return default feature switches when user data contains no pre-existing switches" in {
+        val testSwitch = ObscureFeed.copy(enabled = true)
+        FeatureSwitches.updateFeatureSwitchesForUser(None, testSwitch) should contain theSameElementsAs List(testSwitch) ++ FeatureSwitches.all.filter(_.key != testSwitch.key)
+      }
+
+      "return feature switches stripped of any switches that aren't already specified" in {
         val testSwitch = FeatureSwitch("test","test", enabled = true)
-        FeatureSwitches.updateFeatureSwitchesForUser(None, testSwitch) should contain theSameElementsAs List(testSwitch) ++ FeatureSwitches.all
+        FeatureSwitches.updateFeatureSwitchesForUser(None, testSwitch) should contain theSameElementsAs FeatureSwitches.all
       }
 
       "return an updated list of feature switches" in {
-        val unchangedSwitch = FeatureSwitch("test","test", enabled = true)
-        val switchToChange = ObscureFeed
-        val userDataSwitches: Option[List[FeatureSwitch]] = Some(List(switchToChange, unchangedSwitch))
-        val remainingSwitches = FeatureSwitches.all diff List(switchToChange)
+        val unchangedSwitch = PageViewDataVisualisation
+        val userDataSwitches: Option[List[FeatureSwitch]] = Some(List(unchangedSwitch))
+        val switchToChange = ObscureFeed.copy(enabled = true)
+        val remainingSwitches = FeatureSwitches.all.filter(switch =>
+          !List(unchangedSwitch, switchToChange).exists(_.key == switch.key))
         FeatureSwitches.updateFeatureSwitchesForUser(userDataSwitches, switchToChange) should contain theSameElementsAs List(switchToChange, unchangedSwitch) ++ remainingSwitches
       }
 


### PR DESCRIPTION
## What's changed?

Remove stale feature switches as they enter and exit the app --
- exit so the user doesn't see them when they no longer exist in the app but are still in user data 
- enter so we trim stale settings as user data is updated.

In the process, fixes a bug where it was possible to append more than one of the same switch to their settings.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
