### PR TITLE
update `isLive` definition

### DIFF
--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -96,8 +96,12 @@ const getTags = (externalArticle: ExternalArticle): Tag[] =>
 const getPrimaryTag = (externalArticle: ExternalArticle): Tag | null =>
   getTags(externalArticle)[0] || null;
 
-const isLive = (article: CapiArticle) =>
-  !article.fields.isLive || article.fields.isLive === 'true';
+const isLive = (article: CapiArticle) => {
+  // `isLive` is `undefined` if item is from Live CAPI, so return `true`
+  // if we're from Preview CAPI, coerce `isLive` (string) field into a Boolean
+  const isLive = article.fields.isLive;
+  return isLive === undefined || Boolean(isLive);
+};
 
 const getArticleLabel = (article: CapiArticle) => {
   const {

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -99,8 +99,8 @@ const getPrimaryTag = (externalArticle: ExternalArticle): Tag | null =>
 const isLive = (article: CapiArticle) => {
   // `isLive` is `undefined` if item is from Live CAPI, so return `true`
   // if we're from Preview CAPI, coerce `isLive` (string) field into a Boolean
-  const isLive = article.fields.isLive;
-  return isLive === undefined || Boolean(isLive);
+  const isLiveField = article.fields.isLive;
+  return isLiveField === undefined || Boolean(isLiveField);
 };
 
 const getArticleLabel = (article: CapiArticle) => {


### PR DESCRIPTION
## What's changed?
If an article comes from live CAPI, it won't have the `isLive` field, for obvious reasons.

Previously, articles from live CAPI with a `firstPublicationDate` were rendering as `Taken Down` because `isLive` was returning false.

## Implementation notes
n/a

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
