### PR TITLE
Snap links

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -155,6 +155,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 isUneditable={isUneditable}
                 {...getNodeProps()}
                 onDelete={this.onDelete}
+                onAddToClipboard={onAddToClipboard}
                 onClick={isUneditable ? undefined : () => onSelect(uuid)}
                 size={size}
                 textSize={textSize}

--- a/client-v2/src/shared/components/input/HoverActionButtonWrapper.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtonWrapper.tsx
@@ -40,6 +40,7 @@ interface HoverButtonInterface {
 export interface ButtonPropsFromWrapper {
   showToolTip: () => void;
   hideToolTip: () => void;
+  isSnapLink?: boolean;
 }
 interface WrapperProps<ButtonProps> {
   buttons: HoverButtonInterface[];

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -80,13 +80,20 @@ const HoverViewButton = ({
   isLive,
   urlPath = '',
   showToolTip,
-  hideToolTip
+  hideToolTip,
+  isSnapLink = false
 }: ButtonProps) => (
   <Link
     onClick={e => {
       e.stopPropagation();
     }}
-    href={isLive ? getPaths(urlPath).live : getPaths(urlPath).preview}
+    href={
+      isSnapLink
+        ? urlPath
+        : isLive
+        ? getPaths(urlPath).live
+        : getPaths(urlPath).preview
+    }
   >
     <ActionButton
       tabIndex={-1}

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -8,7 +8,10 @@ import CollectionItemMetaContainer from '../collectionItem/CollectionItemMetaCon
 import CollectionItemMetaHeading from '../collectionItem/CollectionItemMetaHeading';
 import { ThumbnailSmall } from '../Thumbnail';
 import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
-import { HoverDeleteButton } from '../input/HoverActionButtons';
+import {
+  HoverDeleteButton,
+  HoverAddToClipboardButton
+} from '../input/HoverActionButtons';
 import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import { ArticleFragment, CollectionItemSizes } from 'shared/types/Collection';
 import {
@@ -32,6 +35,7 @@ interface ContainerProps {
   onDragOver?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
   onDelete?: (uuid: string) => void;
+  onAddToClipboard?: (uuid: string) => void;
   onClick?: () => void;
   id: string;
   draggable?: boolean;
@@ -54,6 +58,7 @@ const SnapLink = ({
   textSize = 'default',
   showMeta = true,
   onDelete,
+  onAddToClipboard,
   children,
   articleFragment,
   isUneditable,
@@ -87,9 +92,13 @@ const SnapLink = ({
           justify={'space-between'}
         >
           <HoverActionsButtonWrapper
-            buttons={[{ text: 'Delete', component: HoverDeleteButton }]}
+            buttons={[
+              { text: 'Delete', component: HoverDeleteButton },
+              { text: 'Clipboard', component: HoverAddToClipboardButton }
+            ]}
             buttonProps={{
-              onDelete
+              onDelete,
+              onAddToClipboard
             }}
             size={size}
             toolTipPosition={'top'}

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -30,6 +30,10 @@ const SnapLinkBodyContainer = styled(CollectionItemBody)`
   border-top-color: ${({ theme }) => theme.shared.base.colors.borderColor};
 `;
 
+const SnapLinkURL = styled('p')`
+  font-size: 12px;
+`;
+
 interface ContainerProps {
   selectSharedState?: (state: any) => State;
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
@@ -87,6 +91,12 @@ const SnapLink = ({
             <CollectionItemMetaHeading>Snap link </CollectionItemMetaHeading>
           )}
           <CollectionItemHeading html>{headline}</CollectionItemHeading>
+          <SnapLinkURL>
+            snap link url: &nbsp;
+            <a href={urlPath} target="_blank">
+              {urlPath}
+            </a>
+          </SnapLinkURL>
         </CollectionItemContent>
         {size === 'default' && <ThumbnailSmall />}
         <HoverActionsAreaOverlay

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -24,6 +24,7 @@ import CollectionItemHeading from '../collectionItem/CollectionItemHeading';
 import CollectionItemContent from '../collectionItem/CollectionItemContent';
 import CollectionItemBody from '../collectionItem/CollectionItemBody';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
+import urls from 'shared/constants/url';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
   justify-content: space-between;
@@ -74,7 +75,17 @@ const SnapLink = ({
     (articleFragment.meta.customKicker
       ? `{ ${articleFragment.meta.customKicker} }`
       : 'No headline');
-  const urlPath = articleFragment.meta.href;
+
+  const normaliseSnapUrl = (href: string) => {
+    if (href && !/^https?:\/\//.test(href)) {
+      return 'https://' + urls.base.mainDomain + href;
+    }
+    return href;
+  };
+
+  const urlPath =
+    articleFragment.meta.href && normaliseSnapUrl(articleFragment.meta.href);
+
   return (
     <CollectionItemContainer {...rest}>
       <SnapLinkBodyContainer data-testid="snap" size={size} fade={fade}>
@@ -92,7 +103,7 @@ const SnapLink = ({
           )}
           <CollectionItemHeading html>{headline}</CollectionItemHeading>
           <SnapLinkURL>
-            snap link url: &nbsp;
+            url: &nbsp;
             <a href={urlPath} target="_blank">
               {urlPath}
             </a>

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -10,7 +10,8 @@ import { ThumbnailSmall } from '../Thumbnail';
 import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
 import {
   HoverDeleteButton,
-  HoverAddToClipboardButton
+  HoverAddToClipboardButton,
+  HoverViewButton
 } from '../input/HoverActionButtons';
 import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import { ArticleFragment, CollectionItemSizes } from 'shared/types/Collection';
@@ -69,6 +70,7 @@ const SnapLink = ({
     (articleFragment.meta.customKicker
       ? `{ ${articleFragment.meta.customKicker} }`
       : 'No headline');
+  const urlPath = articleFragment.meta.href;
   return (
     <CollectionItemContainer {...rest}>
       <SnapLinkBodyContainer data-testid="snap" size={size} fade={fade}>
@@ -93,12 +95,16 @@ const SnapLink = ({
         >
           <HoverActionsButtonWrapper
             buttons={[
-              { text: 'Delete', component: HoverDeleteButton },
-              { text: 'Clipboard', component: HoverAddToClipboardButton }
+              { text: 'View', component: HoverViewButton },
+              { text: 'Clipboard', component: HoverAddToClipboardButton },
+              { text: 'Delete', component: HoverDeleteButton }
             ]}
             buttonProps={{
+              isLive: true, // it should not be possible for a snap link to be anything other than live?
+              urlPath,
+              onAddToClipboard,
               onDelete,
-              onAddToClipboard
+              isSnapLink: true
             }}
             size={size}
             toolTipPosition={'top'}


### PR DESCRIPTION
## What's changed?

Snap links now have additional buttons on hover, allowing the link to be viewed or copied to the clipboard. Additionally, the link itself is displayed on the body of the card, replicating v1 behaviour. 

![Screenshot 2019-08-19 at 16 46 12](https://user-images.githubusercontent.com/12645938/63279478-f0156280-c2a0-11e9-9a4e-a49fcded5de0.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
