### PR TITLE
Improve performance when articles are dropped

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -368,6 +368,9 @@ const cloneArticleFragmentToTarget = (
   };
 };
 
+const addArticleFragmentToClipboard = (uuid: string) =>
+  cloneArticleFragmentToTarget(uuid, 'clipboard');
+
 const addImageToArticleFragment = (
   uuid: string,
   imageData: ValidationResponse
@@ -391,5 +394,6 @@ export {
   removeArticleFragment,
   addImageToArticleFragment,
   copyArticleFragmentImageMetaWithPersist,
-  cloneArticleFragmentToTarget
+  cloneArticleFragmentToTarget,
+  addArticleFragmentToClipboard
 };

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -16,11 +16,10 @@ import {
 } from 'shared/types/Collection';
 import SnapLink from 'shared/components/snapLink/SnapLink';
 import {
-  cloneArticleFragmentToTarget,
   copyArticleFragmentImageMetaWithPersist,
-  addImageToArticleFragment
+  addImageToArticleFragment,
+  addArticleFragmentToClipboard
 } from 'actions/ArticleFragments';
-import noop from 'lodash/noop';
 import {
   validateImageEvent,
   ValidationResponse
@@ -68,7 +67,7 @@ interface ContainerProps {
 }
 
 type ArticleContainerProps = ContainerProps & {
-  onAddToClipboard: () => void;
+  onAddToClipboard: (uuid: string) => void;
   copyCollectionItemImageMeta: (from: string, to: string) => void;
   addImageToArticleFragment: (id: string, response: ValidationResponse) => void;
   updateArticleFragmentMeta: (id: string, meta: ArticleFragmentMeta) => void;
@@ -100,7 +99,6 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       children,
       getNodeProps,
       onSelect,
-      onAddToClipboard = noop,
       type,
       size,
       textSize,
@@ -125,7 +123,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
               isUneditable={isUneditable}
               {...getNodeProps()}
               onDelete={this.onDelete}
-              onAddToClipboard={onAddToClipboard}
+              onAddToClipboard={this.handleAddToClipboard}
               onClick={isUneditable ? undefined : () => onSelect(uuid)}
               size={size}
               textSize={textSize}
@@ -198,6 +196,10 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     );
   }
 
+  private handleAddToClipboard = () => {
+    this.props.onAddToClipboard(this.props.uuid);
+  };
+
   private onDelete = () => {
     this.props.onDelete();
   };
@@ -247,21 +249,17 @@ const createMapStateToProps = () => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch, props: ContainerProps) => {
-  return {
-    onAddToClipboard: () => {
-      dispatch(cloneArticleFragmentToTarget(props.uuid, 'clipboard'));
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return bindActionCreators(
+    {
+      onAddToClipboard: addArticleFragmentToClipboard,
+      copyCollectionItemImageMeta: copyArticleFragmentImageMetaWithPersist,
+      addImageToArticleFragment,
+      updateArticleFragmentMeta: updateArticleFragmentMetaAction,
+      clearArticleFragmentSelection: editorClearArticleFragmentSelection
     },
-    ...bindActionCreators(
-      {
-        copyCollectionItemImageMeta: copyArticleFragmentImageMetaWithPersist,
-        addImageToArticleFragment,
-        updateArticleFragmentMeta: updateArticleFragmentMetaAction,
-        clearArticleFragmentSelection: editorClearArticleFragmentSelection
-      },
-      dispatch
-    )
-  };
+    dispatch
+  );
 };
 
 export default connect(

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -104,7 +104,7 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
       onDrop = noop,
       onDelete = noop,
       onClick = noop,
-      onAddToClipboard = noop,
+      onAddToClipboard,
       children,
       isUneditable,
       imageDropTypes = [],


### PR DESCRIPTION
## What's changed?

This PR improves performance when dropping cards into collections. Previously, every card would rerender. Now, just the card being moved rerenders (from and to).

The perf figures below are v. rough, but indicative. Four fronts were open, with a total of ~30 articles onscreen. The high scripting ms are due to the DEV environment.

Before:

<img width="358" alt="Screenshot 2019-08-19 at 18 42 36" src="https://user-images.githubusercontent.com/7767575/63287015-3672bd80-c2b1-11e9-9be3-334620bf9b2f.png">
After:
<img width="358" alt="Screenshot 2019-08-19 at 18 37 11" src="https://user-images.githubusercontent.com/7767575/63287024-3a064480-c2b1-11e9-941d-dcbb6dd5259b.png">



## Implementation notes

This was as simple as giving `onAddToClipboard` a stable identity. I'd love to find an idiomatic way to test for expected vs. actual rerenders so we can avoid regressions in the future -- any suggestions, postcards to the usual address 👍 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
