### PR TITLE
Bring SnapLink styling meta display in line with Articles

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -153,7 +153,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 isUneditable={isUneditable}
                 {...getNodeProps()}
                 onDelete={this.onDelete}
-                onAddToClipboard={onAddToClipboard}
+                onAddToClipboard={this.handleAddToClipboard}
                 onClick={isUneditable ? undefined : () => onSelect(uuid)}
                 size={size}
                 textSize={textSize}

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -27,6 +27,7 @@ import DraggableArticleImageContainer from './DraggableArticleImageContainer';
 import { media } from 'shared/util/mediaQueries';
 import ArticleGraph from './ArticleGraph';
 import { VideoIcon } from '../icons/Icons';
+import CollectionItemHeadingContainer from '../collectionItem/CollectionItemHeadingContainer';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -46,10 +47,6 @@ const KickerHeading = styled(CollectionItemHeading)`
       ? globalTheme.shared.collectionItem.fontSizeSmall
       : globalTheme.shared.collectionItem.fontSizeDefault};
   ${media.large`font-size: 13px;`}
-`;
-
-const ArticleHeadingContainerSmall = styled('div')`
-  width: 100%;
 `;
 
 const ArticleBodyByline = styled('div')`
@@ -93,10 +90,6 @@ const ArticleMetadataProperty = styled('div')`
   padding: 1px 4px;
   flex: 0 0 auto;
   margin: 0 2px 1px 0;
-`;
-
-const ArticleHeadingContainerWrapper = styled('div')`
-  padding: 0 0 0 4px;
 `;
 
 const Tone = styled('span')`
@@ -208,8 +201,6 @@ const articleBodyDefault = React.memo(
     showMainVideo,
     frontId
   }: ArticleBodyProps) => {
-    const ArticleHeadingContainer =
-      size === 'small' ? ArticleHeadingContainerSmall : React.Fragment;
     const displayByline = size === 'default' && showByline && byline;
     const now = Date.now();
 
@@ -294,33 +285,31 @@ const articleBodyDefault = React.memo(
               )}
             </ArticleMetadataProperties>
           )}
-          <ArticleHeadingContainerWrapper>
-            <ArticleHeadingContainer>
-              {displayPlaceholders && (
-                <>
-                  <TextPlaceholder />
-                  {size !== 'small' && <TextPlaceholder width={25} />}
-                </>
-              )}
-              {kicker && (
-                <KickerHeading
-                  displaySize={size}
-                  style={{ color: getPillarColor(pillarId, true) }}
-                  data-testid="kicker"
-                >
-                  {`${kicker} `}
-                </KickerHeading>
-              )}
-              <CollectionItemHeading
-                html
-                data-testid="headline"
+          <CollectionItemHeadingContainer size={size}>
+            {displayPlaceholders && (
+              <>
+                <TextPlaceholder />
+                {size !== 'small' && <TextPlaceholder width={25} />}
+              </>
+            )}
+            {kicker && (
+              <KickerHeading
                 displaySize={size}
+                style={{ color: getPillarColor(pillarId, true) }}
+                data-testid="kicker"
               >
-                {headline}
-              </CollectionItemHeading>
-            </ArticleHeadingContainer>
+                {`${kicker} `}
+              </KickerHeading>
+            )}
+            <CollectionItemHeading
+              html
+              data-testid="headline"
+              displaySize={size}
+            >
+              {headline}
+            </CollectionItemHeading>
             {displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
-          </ArticleHeadingContainerWrapper>
+          </CollectionItemHeadingContainer>
         </CollectionItemContent>
         <ImageAndGraphWrapper size={size}>
           {featureFlagPageViewData && canShowPageViewData && (

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -28,6 +28,7 @@ import { media } from 'shared/util/mediaQueries';
 import ArticleGraph from './ArticleGraph';
 import { VideoIcon } from '../icons/Icons';
 import CollectionItemHeadingContainer from '../collectionItem/CollectionItemHeadingContainer';
+import CollectionItemSettingsDisplay from '../collectionItem/CollectionItemSettingsDisplay';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -75,21 +76,6 @@ const PageViewDataWrapper = styled('div')`
   font-size: 12px;
   height: 35px;
   padding-bottom: 3px;
-`;
-
-const ArticleMetadataProperties = styled('div')`
-  padding: 0 4px 3px 0;
-  display: flex;
-  flex-direction: row;
-  font-size: 12px;
-  flex-wrap: wrap;
-`;
-
-const ArticleMetadataProperty = styled('div')`
-  background-color: ${({ theme }) => theme.shared.colors.whiteDark};
-  padding: 1px 4px;
-  flex: 0 0 auto;
-  margin: 0 2px 1px 0;
 `;
 
 const Tone = styled('span')`
@@ -256,35 +242,13 @@ const articleBodyDefault = React.memo(
           </CollectionItemMetaContainer>
         )}
         <CollectionItemContent displaySize={size} textSize={textSize}>
-          {(isBreaking ||
-            showByline ||
-            showQuotedHeadline ||
-            showLargeHeadline ||
-            isBoosted) && (
-            <ArticleMetadataProperties>
-              {isBreaking && (
-                <ArticleMetadataProperty data-testid="breaking-news">
-                  Breaking news
-                </ArticleMetadataProperty>
-              )}
-              {showByline && (
-                <ArticleMetadataProperty>Show byline</ArticleMetadataProperty>
-              )}
-              {showQuotedHeadline && (
-                <ArticleMetadataProperty>
-                  Quote headline
-                </ArticleMetadataProperty>
-              )}
-              {showLargeHeadline && (
-                <ArticleMetadataProperty>
-                  Large headline
-                </ArticleMetadataProperty>
-              )}
-              {isBoosted && (
-                <ArticleMetadataProperty>Boost</ArticleMetadataProperty>
-              )}
-            </ArticleMetadataProperties>
-          )}
+          <CollectionItemSettingsDisplay
+            isBreaking={isBreaking}
+            showByline={showByline}
+            showQuotedHeadline={showQuotedHeadline}
+            showLargeHeadline={showLargeHeadline}
+            isBoosted={isBoosted}
+          />
           <CollectionItemHeadingContainer size={size}>
             {displayPlaceholders && (
               <>

--- a/client-v2/src/shared/components/collectionItem/CollectionItemHeadingContainer.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemHeadingContainer.tsx
@@ -1,0 +1,9 @@
+import { styled } from 'shared/constants/theme';
+import { CollectionItemSizes } from 'shared/types/Collection';
+
+export default styled('div')<{
+  size: CollectionItemSizes;
+}>`
+  ${({ size }) => size === 'small' && 'width: 100%;'}
+  padding: 0 0 0 4px;
+`;

--- a/client-v2/src/shared/components/collectionItem/CollectionItemSettingsDisplay.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemSettingsDisplay.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { styled, theme } from 'constants/theme';
+
+const ArticleMetadataProperties = styled('div')`
+  padding: 0 4px 3px 0;
+  display: flex;
+  flex-direction: row;
+  font-size: 12px;
+  flex-wrap: wrap;
+`;
+
+const ArticleMetadataProperty = styled('div')`
+  background-color: ${theme.shared.colors.whiteDark};
+  padding: 1px 4px;
+  flex: 0 0 auto;
+  margin: 0 2px 1px 0;
+`;
+
+export default ({
+  isBreaking,
+  showByline,
+  showQuotedHeadline,
+  showLargeHeadline,
+  isBoosted
+}: {
+  isBreaking?: boolean;
+  showByline?: boolean;
+  showQuotedHeadline?: boolean;
+  showLargeHeadline?: boolean;
+  isBoosted?: boolean;
+}) =>
+  isBreaking ||
+  showByline ||
+  showQuotedHeadline ||
+  showLargeHeadline ||
+  isBoosted ? (
+    <ArticleMetadataProperties>
+      {isBreaking && (
+        <ArticleMetadataProperty data-testid="breaking-news">
+          Breaking news
+        </ArticleMetadataProperty>
+      )}
+      {showByline && (
+        <ArticleMetadataProperty>Show byline</ArticleMetadataProperty>
+      )}
+      {showQuotedHeadline && (
+        <ArticleMetadataProperty>Quote headline</ArticleMetadataProperty>
+      )}
+      {showLargeHeadline && (
+        <ArticleMetadataProperty>Large headline</ArticleMetadataProperty>
+      )}
+      {isBoosted && <ArticleMetadataProperty>Boost</ArticleMetadataProperty>}
+    </ArticleMetadataProperties>
+  ) : null;

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -26,6 +26,7 @@ import CollectionItemBody from '../collectionItem/CollectionItemBody';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
 import urls from 'shared/constants/url';
 import CollectionItemHeadingContainer from '../collectionItem/CollectionItemHeadingContainer';
+import CollectionItemSettingsDisplay from '../collectionItem/CollectionItemSettingsDisplay';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
   justify-content: space-between;
@@ -99,6 +100,13 @@ const SnapLink = ({
           </CollectionItemMetaContainer>
         )}
         <CollectionItemContent textSize={textSize}>
+          <CollectionItemSettingsDisplay
+            isBreaking={articleFragment.meta.isBreaking}
+            showByline={articleFragment.meta.showByline}
+            showQuotedHeadline={articleFragment.meta.showQuotedHeadline}
+            showLargeHeadline={articleFragment.meta.showLargeHeadline}
+            isBoosted={articleFragment.meta.isBoosted}
+          />
           <CollectionItemHeadingContainer size={size}>
             {!showMeta && (
               <CollectionItemMetaHeading>Snap link </CollectionItemMetaHeading>

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -35,6 +35,7 @@ const SnapLinkBodyContainer = styled(CollectionItemBody)`
 
 const SnapLinkURL = styled('p')`
   font-size: 12px;
+  word-break: break-all;
 `;
 
 interface ContainerProps {

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -25,6 +25,7 @@ import CollectionItemContent from '../collectionItem/CollectionItemContent';
 import CollectionItemBody from '../collectionItem/CollectionItemBody';
 import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaContent';
 import urls from 'shared/constants/url';
+import CollectionItemHeadingContainer from '../collectionItem/CollectionItemHeadingContainer';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
   justify-content: space-between;
@@ -90,7 +91,7 @@ const SnapLink = ({
     <CollectionItemContainer {...rest}>
       <SnapLinkBodyContainer data-testid="snap" size={size} fade={fade}>
         {showMeta && (
-          <CollectionItemMetaContainer>
+          <CollectionItemMetaContainer size={size}>
             <CollectionItemMetaHeading>Snap link</CollectionItemMetaHeading>
             <CollectionItemMetaContent>
               {upperFirst(articleFragment.meta.snapType)}
@@ -98,16 +99,18 @@ const SnapLink = ({
           </CollectionItemMetaContainer>
         )}
         <CollectionItemContent textSize={textSize}>
-          {!showMeta && (
-            <CollectionItemMetaHeading>Snap link </CollectionItemMetaHeading>
-          )}
-          <CollectionItemHeading html>{headline}</CollectionItemHeading>
-          <SnapLinkURL>
-            url: &nbsp;
-            <a href={urlPath} target="_blank">
-              {urlPath}
-            </a>
-          </SnapLinkURL>
+          <CollectionItemHeadingContainer size={size}>
+            {!showMeta && (
+              <CollectionItemMetaHeading>Snap link </CollectionItemMetaHeading>
+            )}
+            <CollectionItemHeading html>{headline}</CollectionItemHeading>
+            <SnapLinkURL>
+              url: &nbsp;
+              <a href={urlPath} target="_blank">
+                {urlPath}
+              </a>
+            </SnapLinkURL>
+          </CollectionItemHeadingContainer>
         </CollectionItemContent>
         {size === 'default' && <ThumbnailSmall />}
         <HoverActionsAreaOverlay


### PR DESCRIPTION
## What's changed?

Brings the snaplink styling and meta display in line with what's there for articles.

Before -- what a mess!

<img width="402" alt="Screenshot 2019-08-20 at 10 26 55" src="https://user-images.githubusercontent.com/7767575/63335463-4c29c680-c335-11e9-98cd-54a8513bf6af.png">

After -- beatific.

<img width="402" alt="Screenshot 2019-08-20 at 10 26 43" src="https://user-images.githubusercontent.com/7767575/63335475-51871100-c335-11e9-8fe1-6d6b8e5df0be.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
