### PR TITLE
Add video icon to image input ... and feed!

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -30,6 +30,9 @@ import { media } from 'shared/util/mediaQueries';
 import { State } from 'types/State';
 import { selectSharedState } from 'shared/selectors/shared';
 import { liveBlogTones } from 'constants/fronts';
+import { hasMainVideo } from 'shared/util/externalArticle';
+import { VideoIcon } from 'shared/components/icons/Icons';
+import CircularIconContainer from 'shared/components/icons/CircularIconContainer';
 
 const Container = styled('div')`
   display: flex;
@@ -119,6 +122,12 @@ const DraggingArticleContainer = styled('div')`
   transform: translateX(-9999px);
 `;
 
+const VideoIconContainer = styled(CircularIconContainer)`
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+`;
+
 interface FeedItemProps {
   article: CapiArticle;
   shouldObscureFeed: boolean;
@@ -193,7 +202,13 @@ class FeedItem extends React.Component<FeedItemProps> {
                 article.frontsMeta.defaults
               )}')`
             }}
-          />
+          >
+            {hasMainVideo(article) && (
+              <VideoIconContainer title="This media has video content.">
+                <VideoIcon />
+              </VideoIconContainer>
+            )}
+          </ArticleThumbnail>
         </FeedItemContainer>
         <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
           <HoverActionsButtonWrapper

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -225,7 +225,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       imageSlideshowReplace,
       isBreaking,
       editMode,
-      primaryImage
+      primaryImage,
+      hasMainVideo
     } = this.props;
 
     const isEditionsMode = editMode === 'editions';
@@ -433,6 +434,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   }
                   useDefault={!imageCutoutReplace && !imageReplace}
                   message={imageCutoutReplace ? 'Add cutout' : 'Replace image'}
+                  hasVideo={hasMainVideo}
+                  message={imageCutoutReplace ? 'Add cutout' : 'Add image'}
                   onChange={this.handleImageChange}
                 />
               </ImageCol>
@@ -620,6 +623,7 @@ interface ContainerProps {
   isBreaking: boolean;
   editMode: EditMode;
   primaryImage: ValidationResponse | null;
+  hasMainVideo: boolean;
 }
 
 interface InterfaceProps {
@@ -673,6 +677,7 @@ const createMapStateToProps = () => {
 
     return {
       articleExists: !!article,
+      hasMainVideo: !!article && !!article.hasMainVideo,
       collectionId: (parentCollection && parentCollection.id) || null,
       getLastUpdatedBy,
       initialValues: getInitialValuesForArticleFragmentForm(article),

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -435,7 +435,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   useDefault={!imageCutoutReplace && !imageReplace}
                   message={imageCutoutReplace ? 'Add cutout' : 'Replace image'}
                   hasVideo={hasMainVideo}
-                  message={imageCutoutReplace ? 'Add cutout' : 'Add image'}
                   onChange={this.handleImageChange}
                 />
               </ImageCol>

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -29,6 +29,7 @@ import ArticleGraph from './ArticleGraph';
 import { VideoIcon } from '../icons/Icons';
 import CollectionItemHeadingContainer from '../collectionItem/CollectionItemHeadingContainer';
 import CollectionItemSettingsDisplay from '../collectionItem/CollectionItemSettingsDisplay';
+import CircularIconContainer from '../icons/CircularIconContainer';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -91,17 +92,10 @@ const ImageAndGraphWrapper = styled('div')<{ size: CollectionItemSizes }>`
     justify-content: flex-end;`}
 `;
 
-const VideoIconContainer = styled('div')`
+const VideoIconContainer = styled(CircularIconContainer)`
   position: absolute;
   bottom: 2px;
   right: 2px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: white;
-  border-radius: 50%;
-  height: 20px;
-  width: 20px;
 `;
 
 interface ArticleBodyProps {
@@ -296,7 +290,7 @@ const articleBodyDefault = React.memo(
                     <ThumbnailCutout src={cutoutThumbnail} />
                   ) : null}
                   {hasMainVideo && (
-                    <VideoIconContainer>
+                    <VideoIconContainer title="This media has video content.">
                       <VideoIcon />
                     </VideoIconContainer>
                   )}

--- a/client-v2/src/shared/components/icons/CircularIconContainer.tsx
+++ b/client-v2/src/shared/components/icons/CircularIconContainer.tsx
@@ -1,0 +1,11 @@
+import { styled } from 'shared/constants/theme';
+
+export default styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
+`;

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -18,12 +18,13 @@ import {
 import { selectGridUrl } from 'selectors/configSelectors';
 import { State } from 'types/State';
 import { GridData, Criteria } from 'shared/types/Grid';
-import { RubbishBinIcon, AddImageIcon } from '../icons/Icons';
+import { RubbishBinIcon, AddImageIcon, VideoIcon } from '../icons/Icons';
 import imageDragIcon from 'images/icons/image-drag-icon.svg';
 import { DRAG_DATA_GRID_IMAGE_URL } from 'constants/image';
 import ImageDragIntentIndicator from '../ImageDragIntentIndicator';
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from '../../../selectors/pathSelectors';
+import CircularIconContainer from '../icons/CircularIconContainer';
 
 const ImageContainer = styled('div')<{
   small?: boolean;
@@ -59,12 +60,13 @@ const AddImageButton = styled(ButtonDefault)<{ small?: boolean }>`
 
 const ImageComponent = styled.div<{ small: boolean }>`
   ${({ small }) =>
-    small &&
-    `position: absolute;
+    small
+      ? `position: absolute;
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;`}
+    height: 100%;`
+      : 'position: relative'}
   background-size: cover;
   flex-grow: 1;
   cursor: grab;
@@ -127,6 +129,12 @@ const IconDelete = styled('div')<{
   left: ${props => (props.small ? '5px' : '9px')};
 `;
 
+const VideoIconContainer = styled(CircularIconContainer)`
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+`;
+
 const InputImageContainer = styled(InputContainer)<{
   small: boolean;
   isHovering?: boolean;
@@ -145,6 +153,7 @@ export interface InputImageContainerProps {
   small?: boolean;
   defaultImageUrl?: string;
   useDefault?: boolean;
+  hasVideo?: boolean;
   message?: string;
   replaceImage: boolean;
 }
@@ -178,7 +187,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       useDefault,
       defaultImageUrl,
       message = 'Replace image',
-      editMode
+      editMode,
+      hasVideo
     } = this.props;
 
     if (!gridUrl) {
@@ -242,6 +252,11 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                     {!!small ? null : <Label size="sm">{message}</Label>}
                   </AddImageButton>
                 </AddImageViaGridModalButton>
+              )}
+              {hasVideo && useDefault && (
+                <VideoIconContainer title="This media has video content.">
+                  <VideoIcon />
+                </VideoIconContainer>
               )}
             </ImageComponent>
             {!!small ? null : (


### PR DESCRIPTION
## What's changed?

Add a video icon to image input when video is present and an image is not set.

Behold.

<img width="179" alt="Screenshot 2019-08-20 at 12 20 40" src="https://user-images.githubusercontent.com/7767575/63343053-f6f5b100-c344-11e9-90f0-089a49f35e0e.png">

<img width="409" alt="Screenshot 2019-08-20 at 13 02 37" src="https://user-images.githubusercontent.com/7767575/63345512-d0d30f80-c34a-11e9-9c7b-24d1891ec849.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
