### PR TITLE
Snap links: add Ophan button

### DIFF
--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -109,14 +109,19 @@ const HoverOphanButton = ({
   isLive,
   urlPath,
   showToolTip,
-  hideToolTip
+  hideToolTip,
+  isSnapLink = false
 }: ButtonProps) =>
   isLive ? (
     <Link
       onClick={e => {
         e.stopPropagation();
       }}
-      href={getPaths(`https://www.theguardian.com/${urlPath}`).ophan}
+      href={
+        isSnapLink
+          ? urlPath && getPaths(urlPath).ophan
+          : getPaths(`https://www.theguardian.com/${urlPath}`).ophan
+      }
       data-testid={'ophan-hover-button'}
     >
       <ActionButton

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -11,7 +11,8 @@ import { HoverActionsButtonWrapper } from '../input/HoverActionButtonWrapper';
 import {
   HoverDeleteButton,
   HoverAddToClipboardButton,
-  HoverViewButton
+  HoverViewButton,
+  HoverOphanButton
 } from '../input/HoverActionButtons';
 import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import { ArticleFragment, CollectionItemSizes } from 'shared/types/Collection';
@@ -129,6 +130,7 @@ const SnapLink = ({
           <HoverActionsButtonWrapper
             buttons={[
               { text: 'View', component: HoverViewButton },
+              { text: 'Ophan', component: HoverOphanButton },
               { text: 'Clipboard', component: HoverAddToClipboardButton },
               { text: 'Delete', component: HoverDeleteButton }
             ]}


### PR DESCRIPTION
## What's changed?

The Ophan button is now visible on snap links.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
