### PR TITLE
Add image origin url to image input

### DIFF
--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -85,6 +85,10 @@ const AddImageViaUrlInput = styled(InputContainer)`
 
 const ImageUrlInput = styled(InputBase)`
   border: none;
+  :focus,
+  :active {
+    border: none;
+  }
   ::placeholder {
     font-size: 12px;
   }
@@ -163,6 +167,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     modalOpen: false,
     imageSrc: ''
   };
+
+  private inputRef = React.createRef<HTMLInputElement>();
 
   public render() {
     const {
@@ -243,8 +249,10 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                 <ImageUrlInput
                   name="paste-url"
                   placeholder=" Paste crop url"
-                  defaultValue={this.state.imageSrc}
+                  defaultValue={this.state.imageSrc || input.value.src}
                   onChange={this.handlePasteImgSrcChange}
+                  onFocus={this.handleFocus}
+                  innerRef={this.inputRef}
                 />
                 <InputLabel hidden htmlFor="paste-url">
                   Paste crop url
@@ -257,6 +265,12 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       </InputImageContainer>
     );
   }
+
+  private handleFocus = () => {
+    if (this.inputRef.current) {
+      this.inputRef.current.select();
+    }
+  };
 
   private handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -249,7 +249,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                 <ImageUrlInput
                   name="paste-url"
                   placeholder=" Paste crop url"
-                  defaultValue={this.state.imageSrc || input.value.src}
+                  defaultValue={
+                    this.state.imageSrc || (input.value && input.value.origin)
+                  }
                   onChange={this.handlePasteImgSrcChange}
                   onFocus={this.handleFocus}
                   innerRef={this.inputRef}


### PR DESCRIPTION
## What's changed?

Adds the current image origin url to the input. Autofocuses on focus so it's easy to copy and check. Still allows pasting of other links as usual 👍 

When a user adds an image -

<img width="177" alt="Screenshot 2019-08-20 at 16 34 00" src="https://user-images.githubusercontent.com/7767575/63361714-8496c800-c368-11e9-8eb0-b8e0c33ade14.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
