### PR TITLE
Snap links: add time elapsed since creation

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -224,7 +224,7 @@ const articleBodyDefault = React.memo(
               </CollectionItemDraftMetaContent>
             )}
             {!!frontPublicationDate && (
-              <CollectionItemMetaContent title="The time elapsed since this article was added to this front.">
+              <CollectionItemMetaContent title="The time elapsed since this card was created in the tool.">
                 {distanceInWordsStrict(now, new Date(frontPublicationDate))}
               </CollectionItemMetaContent>
             )}

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -28,6 +28,7 @@ import CollectionItemMetaContent from '../collectionItem/CollectionItemMetaConte
 import urls from 'shared/constants/url';
 import CollectionItemHeadingContainer from '../collectionItem/CollectionItemHeadingContainer';
 import CollectionItemSettingsDisplay from '../collectionItem/CollectionItemSettingsDisplay';
+import { distanceInWordsStrict } from 'date-fns';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
   justify-content: space-between;
@@ -90,6 +91,8 @@ const SnapLink = ({
   const urlPath =
     articleFragment.meta.href && normaliseSnapUrl(articleFragment.meta.href);
 
+  const now = Date.now();
+
   return (
     <CollectionItemContainer {...rest}>
       <SnapLinkBodyContainer data-testid="snap" size={size} fade={fade}>
@@ -99,6 +102,14 @@ const SnapLink = ({
             <CollectionItemMetaContent>
               {upperFirst(articleFragment.meta.snapType)}
             </CollectionItemMetaContent>
+            {!!articleFragment.frontPublicationDate && (
+              <CollectionItemMetaContent title="The time elapsed since this card was created in the tool.">
+                {distanceInWordsStrict(
+                  now,
+                  new Date(articleFragment.frontPublicationDate)
+                )}
+              </CollectionItemMetaContent>
+            )}
           </CollectionItemMetaContainer>
         )}
         <CollectionItemContent textSize={textSize}>


### PR DESCRIPTION
## What's changed?
The time elapsed since a snap link was created is now displayed on the snap link card. 

Additionally, the tooltip text relating to the `frontPublicationDate` has been updated - on snap links and regular articles - to more accurately describe what this time represents.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
