### PR TITLE
Make v2 default by redirecting

### DIFF
--- a/app/controllers/ViewsController.scala
+++ b/app/controllers/ViewsController.scala
@@ -3,6 +3,7 @@ package controllers
 import scala.concurrent.ExecutionContext
 import com.gu.pandomainauth.action.UserRequest
 import model.Cached
+import org.joda.time.DateTime
 import permissions.ConfigPermissionCheck
 import play.api.mvc._
 import services.AssetsManager
@@ -11,18 +12,36 @@ import util.{Acl, Encryption}
 class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean,
                       crypto: Encryption, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
+  private def shouldRedirectToV2(request: UserRequest[AnyContent]): Boolean = {
+    val shouldRedirectByQs: Boolean = request.queryString.getOrElse("redirect", Seq("true")).contains("true")
+
+    // TODO set correct date
+    val redirectDay = DateTime.parse("2019-12-25")
+    val shouldRedirectByDate: Boolean = DateTime.now().isAfter(redirectDay)
+
+    shouldRedirectByQs && (isDev || shouldRedirectByDate)
+  }
+
   def priorities() = AccessAuthAction { request =>
-    val identity = request.user
-    Cached(60) {
-      Ok(views.html.priority(Option(identity), config.facia.stage, isDev, true))
+    if (shouldRedirectToV2(request)) {
+      PermanentRedirect("/v2")
+    } else {
+      val identity = request.user
+      Cached(60) {
+        Ok(views.html.priority(Option(identity), config.facia.stage, isDev, true))
+      }
     }
   }
 
   def collectionEditor(priority: String) = getCollectionPermissionFilterByPriority(priority, acl)(ec) { request =>
-    val identity = request.user
-    Cached(60) {
-      Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),
-        assetsManager.pathForCollections, crypto.encrypt(identity.email), priority != "email", priority))
+    if (shouldRedirectToV2(request)) {
+      PermanentRedirect(s"/v2/$priority")
+    } else {
+      val identity = request.user
+      Cached(60) {
+        Ok(views.html.admin_main(Option(identity), config.facia.stage, overrideIsDev(request, isDev),
+          assetsManager.pathForCollections, crypto.encrypt(identity.email), priority != "email", priority))
+      }
     }
   }
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Redirect `/` to `/v2` if:

`redirect` query string is not present or is `true`

AND

(we're in DEV OR it's after Christmas 2019)

If `redirect` query string is not present, we default to `true`, however as it's not after Christmas 2019, we will not redirect. That is, there should be no impact on non DEV stages.

If, for whatever reason, we needed to go back to the index page of V1, then `?redirect=false` will do it.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
