### PR TITLE
fix isLive field calculation for external articles

### DIFF
--- a/client-v2/src/shared/selectors/shared.ts
+++ b/client-v2/src/shared/selectors/shared.ts
@@ -3,7 +3,8 @@ import { createSelector } from 'reselect';
 import {
   getThumbnail,
   getPrimaryTag,
-  getContributorImage
+  getContributorImage,
+  isLive
 } from 'util/CAPIUtils';
 import { selectors as externalArticleSelectors } from '../bundles/externalArticlesBundle';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
@@ -150,10 +151,7 @@ const createSelectArticleFromArticleFragment = () =>
         cutoutThumbnail: externalArticle
           ? getContributorImage(externalArticle)
           : undefined,
-        isLive:
-          externalArticle && externalArticle.fields.isLive
-            ? externalArticle.fields.isLive === 'true'
-            : true,
+        isLive: !!externalArticle && isLive(externalArticle),
         firstPublicationDate: externalArticle
           ? externalArticle.fields.firstPublicationDate
           : undefined,

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -98,9 +98,9 @@ const getPrimaryTag = (externalArticle: ExternalArticle): Tag | null =>
 
 const isLive = (article: CapiArticle) => {
   // `isLive` is `undefined` if item is from Live CAPI, so return `true`
-  // if we're from Preview CAPI, coerce `isLive` (string) field into a Boolean
+  // `CapiBool` is either a `string` or `boolean`, so cast it as a string and compare 🤢
   const isLiveField = article.fields.isLive;
-  return isLiveField === undefined || Boolean(isLiveField);
+  return isLiveField === undefined || isLiveField.toString() === 'true';
 };
 
 const getArticleLabel = (article: CapiArticle) => {

--- a/client-v2/src/util/__tests__/CAPIUtils.spec.ts
+++ b/client-v2/src/util/__tests__/CAPIUtils.spec.ts
@@ -6,8 +6,10 @@ import {
 import {
   getIdFromURL,
   getContributorImage,
-  getThumbnail
+  getThumbnail,
+  isLive
 } from 'util/CAPIUtils';
+import { CapiArticle } from 'types/Capi';
 
 describe('CAPIUtils', () => {
   describe('getIdFromURL', () => {
@@ -201,6 +203,66 @@ describe('CAPIUtils', () => {
           }
         )
       ).toEqual('imageSrcThumb');
+    });
+  });
+
+  describe('isLive', () => {
+    it('should return false for a draft article from preview CAPI and when isLive is a boolean', () => {
+      const article = {
+        ...capiArticleWithElementsThumbnail,
+        fields: {
+          isLive: false
+        }
+      } as CapiArticle;
+
+      expect(article.fields.isLive).toEqual(false);
+      expect(isLive(article)).toEqual(false);
+    });
+
+    it('should return false for a draft article from preview CAPI and when isLive is a string', () => {
+      const article = {
+        ...capiArticleWithElementsThumbnail,
+        fields: {
+          isLive: 'false'
+        }
+      } as CapiArticle;
+
+      expect(article.fields.isLive).toEqual('false');
+      expect(isLive(article)).toEqual(false);
+    });
+
+    it('should return true for a published article from preview CAPI and when isLive is a boolean', () => {
+      const article = {
+        ...capiArticleWithElementsThumbnail,
+        fields: {
+          isLive: true
+        }
+      } as CapiArticle;
+
+      expect(article.fields.isLive).toEqual(true);
+      expect(isLive(article)).toEqual(true);
+    });
+
+    it('should return true for a published article from preview CAPI and when isLive is a string', () => {
+      const article = {
+        ...capiArticleWithElementsThumbnail,
+        fields: {
+          isLive: 'true'
+        }
+      } as CapiArticle;
+
+      expect(article.fields.isLive).toEqual('true');
+      expect(isLive(article)).toEqual(true);
+    });
+
+    it('should return true if a CapiArticle comes from live CAPI (denoted by isLive being undefined)', () => {
+      const article = {
+        ...capiArticleWithElementsThumbnail,
+        fields: {}
+      } as CapiArticle;
+
+      expect(article.fields.isLive).toBeUndefined();
+      expect(isLive(article)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Related to https://github.com/guardian/facia-tool/pull/942.

**Before**
![image](https://user-images.githubusercontent.com/836140/63377901-e109df80-c388-11e9-9f32-7e00e009c4b4.png)

**After**
![image](https://user-images.githubusercontent.com/836140/63377747-96886300-c388-11e9-871d-22015ea22b80.png)

This also ensures the [`isLive` buttonProp](https://github.com/guardian/facia-tool/blob/580aab29cd21715131ca6a0bfcfe84bb4b98752e/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx#L214-L224) is correct for draft articles in the feed, meaning the [preview link](https://github.com/guardian/facia-tool/blob/63b1591f6aa95c4d48e58a1f1e514294a00d2be5/client-v2/src/shared/components/input/HoverActionButtons.tsx#L90-L96) goes to the correct place.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
![img](https://media.giphy.com/media/EjtN90rolA18s/giphy.gif)

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
