### PR TITLE
Fix intermittent integration test failures

### DIFF
--- a/client-v2/integration/fixtures/collection2.js
+++ b/client-v2/integration/fixtures/collection2.js
@@ -15,18 +15,7 @@ module.exports = {
         showByline: false,
         showQuotedHeadline: false,
         imageSlideshowReplace: false,
-        supporting: [
-          {
-            id: 'internal-code/page/2309422',
-            frontPublicationDate: 1540379258808,
-            meta: {}
-          },
-          {
-            id: 'internal-code/page/5224281',
-            frontPublicationDate: 1540381197498,
-            meta: {}
-          }
-        ],
+        supporting: [],
         byline: 'Jess Zimmerman',
         imageReplace: false,
         imageCutoutReplace: false,


### PR DESCRIPTION
## What's changed?

We've got problems with an intermittently failing set of integration tests in CI. As with many of life's problems, it's best illustrated with a gif. The giant cursor is testcafe's simulated cursor, and the test is running at .1 speed for demonstration purposes.

![test](https://user-images.githubusercontent.com/7767575/63417400-16e6ac80-c3f9-11e9-90c1-77d9a9a97285.gif)

_Did you see that?_ The sublinks popping open is a mistake that alters the test conditions! It happens sometimes, but not other times, because the delay for popping them open is short. It _never_ seems to happen locally -- just CI -- which is odd. Thanks to @ajwl and @jennygrahamjones who spotted this first.

Anyway, we don't need the second batch of sublinks, so removing them from the test fixes the issue. We still don't know why CI fails where local runs succeed, which is troubling -- possible candidates include

- Differences in the size of the browser viewport
- Differences in the speed at which tests run
- ... so many different things, oh god I can't even

... but this unblocks us for now.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
