### PR TITLE
Add card image overrides

### DIFF
--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -18,11 +18,7 @@ object Image {
   implicit val format = Json.format[Image]
 }
 
-case class CoverCardImages(mobile: Option[Image], tablet: Option[Image]) {
-  def toPublishedCardImage: Option[PublishedCardImage] = {
-
-  }
-}
+case class CoverCardImages(mobile: Option[Image], tablet: Option[Image])
 
 object CoverCardImages {
   implicit val format = Json.format[CoverCardImages]

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -69,7 +69,7 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
 
     val coverCardImages = metadata.flatMap { meta => {
       meta.mediaType match {
-        case Some(MediaType.OverrideCoverCard) => meta.coverCardImages.flatMap(_.toPublishedCardImage)
+        case Some(MediaType.CoverCard) => meta.coverCardImages.flatMap(_.toPublishedCardImage)
         case _ => None
       }
     }}

--- a/app/model/editions/MediaType.scala
+++ b/app/model/editions/MediaType.scala
@@ -9,7 +9,7 @@ sealed abstract class MediaType extends EnumEntry with Uncapitalised {
     case MediaType.Hide => PublishedMediaType.Hide
     case MediaType.Cutout => PublishedMediaType.Cutout
     case MediaType.Image => PublishedMediaType.Image
-    case MediaType.OverrideCoverCard => PublishedMediaType.OverrideCard
+    case MediaType.CoverCard => PublishedMediaType.CoverCard
   }
 }
 
@@ -18,7 +18,7 @@ object MediaType extends PlayEnum[MediaType] {
   case object Hide extends MediaType
   case object Cutout extends MediaType
   case object Image extends MediaType
-  case object OverrideCoverCard extends MediaType
+  case object CoverCard extends MediaType
 
   override def values = findValues
 }

--- a/app/model/editions/MediaType.scala
+++ b/app/model/editions/MediaType.scala
@@ -9,6 +9,7 @@ sealed abstract class MediaType extends EnumEntry with Uncapitalised {
     case MediaType.Hide => PublishedMediaType.Hide
     case MediaType.Cutout => PublishedMediaType.Cutout
     case MediaType.Image => PublishedMediaType.Image
+    case MediaType.OverrideCoverCard => PublishedMediaType.OverrideCard
   }
 }
 
@@ -17,6 +18,7 @@ object MediaType extends PlayEnum[MediaType] {
   case object Hide extends MediaType
   case object Cutout extends MediaType
   case object Image extends MediaType
+  case object OverrideCoverCard extends MediaType
 
   override def values = findValues
 }

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -13,7 +13,7 @@ object PublishedMediaType extends PlayEnum[PublishedMediaType] {
   case object Hide extends PublishedMediaType
   case object Cutout extends PublishedMediaType
   case object Image extends PublishedMediaType
-  case object OverrideCard extends PublishedMediaType
+  case object CoverCard extends PublishedMediaType
 
   override def values = findValues
 }

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -13,11 +13,14 @@ object PublishedMediaType extends PlayEnum[PublishedMediaType] {
   case object Hide extends PublishedMediaType
   case object Cutout extends PublishedMediaType
   case object Image extends PublishedMediaType
+  case object OverrideCard extends PublishedMediaType
 
   override def values = findValues
 }
 
 case class PublishedImage(height: Option[Int], width: Option[Int], src: String)
+
+case class PublishedCardImage(mobile: PublishedImage, tablet: PublishedImage)
 
 case class PublishedFurniture(
   kicker: Option[String],
@@ -29,7 +32,8 @@ case class PublishedFurniture(
   mediaType: PublishedMediaType,
   imageSrcOverride: Option[PublishedImage],
   sportScore: Option[String],
-  overrideArticleMainMedia: Boolean
+  overrideArticleMainMedia: Boolean,
+  coverCardImages: Option[PublishedCardImage]
 )
 
 case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)

--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -53,7 +53,7 @@ case class ClientArticleMetadata (
       case (Some(true), _, _, _) => MediaType.Hide
       case (_, Some(true), _, _) => MediaType.Image
       case (_, _, Some(true), _) => MediaType.Cutout
-      case (_, _, _, Some(true)) => MediaType.OverrideCoverCard
+      case (_, _, _, Some(true)) => MediaType.CoverCard
       case _ => MediaType.UseArticleTrail
     }
 
@@ -112,7 +112,7 @@ object ClientArticleMetadata {
 
       articleMetadata.overrideArticleMainMedia,
 
-      articleMetadata.mediaType.map {_ => mediaType == MediaType.OverrideCoverCard},
+      articleMetadata.mediaType.map {_ => mediaType == MediaType.CoverCard},
       articleMetadata.coverCardImages.flatMap(_.mobile),
       articleMetadata.coverCardImages.flatMap(_.tablet),
     )

--- a/app/services/editions/publishing/PublishedIssueFormatters.scala
+++ b/app/services/editions/publishing/PublishedIssueFormatters.scala
@@ -5,6 +5,7 @@ import play.api.libs.json.Json
 
 object PublishedIssueFormatters {
   implicit val publishedImageWrites = Json.writes[PublishedImage]
+  implicit val publishedCardImageWrites = Json.writes[PublishedCardImage]
   implicit val publishedFurnitureWrites = Json.writes[PublishedFurniture]
   implicit val publishedArticleWrites = Json.writes[PublishedArticle]
   implicit val publishedCollectionsWrites = Json.writes[PublishedCollection]

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,7 @@ libraryDependencies ++= Seq(
     "org.json4s" %% "json4s-native" % json4sVersion,
     "org.json4s" %% "json4s-jackson" % json4sVersion,
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
+    "ai.x" %% "play-json-extensions" % "0.40.2",
 
     "org.postgresql"           %  "postgresql"                   % "42.2.5",
     "org.scalikejdbc"          %% "scalikejdbc"                  % "3.1.0",

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -184,7 +184,7 @@ const KickerSuggestionsContainer = styled.div`
   font-size: 12px;
   font-weight: normal;
 `;
-const CardReplacemnetWarning = styled.div`
+const CardReplacementWarning = styled.div`
   color: red;
 `;
 
@@ -577,9 +577,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 </ImageCol>
                 <Col flex={2}>
                   {invalidCardReplacement && (
-                    <CardReplacemnetWarning>
+                    <CardReplacementWarning>
                       You must set both the mobile and tablet card overrides!
-                    </CardReplacemnetWarning>
+                    </CardReplacementWarning>
                   )}
                 </Col>
               </Row>

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -634,17 +634,17 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     this.props.change(this.getImageFieldName(), e);
   };
 
-  private allImageFields = [
-    'imageHide',
-    'imageCutoutReplace',
-    'imageSlideshowReplace',
-    'imageReplace',
-    'showMainVideo',
-    'coverCardImageReplace'
-  ];
-
   private changeImageField = (fieldToSet: string) => {
-    this.allImageFields.forEach(field => {
+    const allImageFields = [
+      'imageHide',
+      'imageCutoutReplace',
+      'imageSlideshowReplace',
+      'imageReplace',
+      'showMainVideo',
+      'coverCardImageReplace'
+    ];
+
+    allImageFields.forEach(field => {
       if (field === fieldToSet) {
         this.props.change(field, true);
       } else {

--- a/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
+++ b/client-v2/src/components/FrontsEdit/__tests__/ArticleFragmentForm.spec.ts
@@ -43,7 +43,10 @@ const formValues = {
   trailText:
     'Police noted concerns over Femi Nandap, who went on to stab lecturer, but released him',
   sportScore: '',
-  showMainVideo: false
+  showMainVideo: false,
+  coverCardImageReplace: false,
+  coverCardMobileImage: {},
+  coverCardTabletImage: {}
 };
 
 const createStateWithChangedFormFields = (

--- a/client-v2/src/constants/image.ts
+++ b/client-v2/src/constants/image.ts
@@ -8,6 +8,14 @@ export const editionsArticleFragmentImageCriteria = {
   minWidth: 400
 };
 
+export const editionsMobileCardImageCriteria = {
+  minWidth: 400
+};
+
+export const editionsTabletCardImageCriteria = {
+  minWidth: 400
+};
+
 export const gridDataTransferTypes = {
   cropsData: 'application/vnd.mediaservice.crops+json',
   gridUrl: 'application/vnd.mediaservice.kahuna.uri',

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -111,6 +111,7 @@ export const createSelectFormFieldsForCollectionItem = () => {
         ) {
           fields.push('sportScore');
         }
+        fields.push('coverCardImageReplace');
 
         return without(
           fields,

--- a/client-v2/src/shared/components/input/ButtonDefault.ts
+++ b/client-v2/src/shared/components/input/ButtonDefault.ts
@@ -134,11 +134,11 @@ export default styled(`button`)<ButtonProps>`
   margin: 0 ${({ inline }) => (inline ? '5px' : '0')};
   padding: 0 ${mapSize(paddingMap)};
   border: none;
-  :disabled,
-  :disabled:hover {
+  &:disabled,
+  &:disabled:hover {
     cursor: not-allowed;
   }
-  :hover:enabled {
+  &:hover:enabled {
     background: ${mapAction(backgroundHoverMap)};
     cursor: pointer;
   }

--- a/client-v2/src/shared/components/input/InputImage.tsx
+++ b/client-v2/src/shared/components/input/InputImage.tsx
@@ -148,6 +148,7 @@ const InputImageContainer = styled(InputContainer)<{
 `;
 
 export interface InputImageContainerProps {
+  disabled?: boolean;
   frontId: string;
   criteria?: Criteria;
   small?: boolean;
@@ -187,8 +188,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       useDefault,
       defaultImageUrl,
       message = 'Replace image',
+      hasVideo,
       editMode,
-      hasVideo
+      disabled
     } = this.props;
 
     if (!gridUrl) {
@@ -236,6 +238,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                   priority="primary"
                   small={small}
                   onClick={this.handleDelete}
+                  disabled={disabled}
                 >
                   <IconDelete small={small}>
                     <RubbishBinIcon size="s" />
@@ -247,6 +250,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                     type="button"
                     onClick={this.openModal}
                     small={small}
+                    disabled={disabled}
                   >
                     <AddImageIcon size="l" />
                     {!!small ? null : <Label size="sm">{message}</Label>}
@@ -270,6 +274,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
                   onChange={this.handlePasteImgSrcChange}
                   onFocus={this.handleFocus}
                   innerRef={this.inputRef}
+                  disabled={disabled}
                 />
                 <InputLabel hidden htmlFor="paste-url">
                   Paste crop url

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -71,6 +71,9 @@ interface ArticleFragmentRootMeta {
     origin?: string;
   }>;
   overrideArticleMainMedia?: boolean;
+  coverCardImageReplace?: boolean;
+  coverCardMobileImage?: ImageData;
+  coverCardTabletImage?: ImageData;
 }
 
 type ArticleFragmentRootFields = NestedArticleFragmentRootFields & {

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -157,20 +157,13 @@ const formToMetaFieldMap: { [fieldName: string]: string } = {
   imageCutoutSrcOrigin: 'cutoutImage'
 };
 
-export const getImageMetaFromValidationResponse = (
-  image: ImageData,
-  prefix: string = ''
-) => {
-  const imageBit = prefix !== '' ? 'Image' : 'image';
-
-  return {
-    [prefix + imageBit + 'Src']: image.src,
-    [prefix + imageBit + 'SrcThumb']: image.thumb,
-    [prefix + imageBit + 'SrcWidth']: intToStr(image.width),
-    [prefix + imageBit + 'SrcHeight']: intToStr(image.height),
-    [prefix + imageBit + 'SrcOrigin']: image.origin
-  };
-};
+export const getImageMetaFromValidationResponse = (image: ImageData) => ({
+  imageSrc: image.src,
+  imageSrcThumb: image.thumb,
+  imageSrcWidth: intToStr(image.width),
+  imageSrcHeight: intToStr(image.height),
+  imageSrcOrigin: image.origin
+});
 
 export const getArticleFragmentMetaFromFormValues = (
   state: State,

--- a/client-v2/src/util/form.ts
+++ b/client-v2/src/util/form.ts
@@ -37,6 +37,9 @@ export interface ArticleFragmentFormData {
   imageReplace: boolean;
   overrideArticleMainMedia: boolean;
   showMainVideo: boolean;
+  coverCardImageReplace: boolean;
+  coverCardMobileImage: ImageData;
+  coverCardTabletImage: ImageData;
 }
 
 export type FormFields = keyof ArticleFragmentFormData;
@@ -102,7 +105,6 @@ export const getInitialValuesForArticleFragmentForm = (
         showLargeHeadline: article.showLargeHeadline || false,
         showKickerTag: article.showKickerTag || false,
         showKickerSection: article.showKickerSection || false,
-        showMainVideo: article.showMainVideo || false,
         customKicker: article.customKicker || '',
         isBreaking: article.isBreaking || false,
         showLivePlayable: article.showLivePlayable || false,
@@ -130,7 +132,11 @@ export const getInitialValuesForArticleFragmentForm = (
         },
         slideshow: slideshow.concat(slideshowBackfill),
         overrideArticleMainMedia: article.overrideArticleMainMedia || false,
-        sportScore: article.sportScore || ''
+        sportScore: article.sportScore || '',
+        showMainVideo: !!article.showMainVideo,
+        coverCardImageReplace: article.coverCardImageReplace || false,
+        coverCardMobileImage: article.coverCardMobileImage || {},
+        coverCardTabletImage: article.coverCardTabletImage || {}
       }
     : undefined;
 };
@@ -151,13 +157,20 @@ const formToMetaFieldMap: { [fieldName: string]: string } = {
   imageCutoutSrcOrigin: 'cutoutImage'
 };
 
-export const getImageMetaFromValidationResponse = (image: ImageData) => ({
-  imageSrc: image.src,
-  imageSrcThumb: image.thumb,
-  imageSrcWidth: intToStr(image.width),
-  imageSrcHeight: intToStr(image.height),
-  imageSrcOrigin: image.origin
-});
+export const getImageMetaFromValidationResponse = (
+  image: ImageData,
+  prefix: string = ''
+) => {
+  const imageBit = prefix !== '' ? 'Image' : 'image';
+
+  return {
+    [prefix + imageBit + 'Src']: image.src,
+    [prefix + imageBit + 'SrcThumb']: image.thumb,
+    [prefix + imageBit + 'SrcWidth']: intToStr(image.width),
+    [prefix + imageBit + 'SrcHeight']: intToStr(image.height),
+    [prefix + imageBit + 'SrcOrigin']: image.origin
+  };
+};
 
 export const getArticleFragmentMetaFromFormValues = (
   state: State,

--- a/test/model/editions/ArticleMetadataTest.scala
+++ b/test/model/editions/ArticleMetadataTest.scala
@@ -28,7 +28,8 @@ class ArticleMetadataTest extends FreeSpec with Matchers {
       "src2",
       Some("thumb2")
     )),
-    Some(true)
+    Some(true),
+    None
   )
 
   private val articleMetadataAsString =

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -89,7 +89,19 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
             |      "src" : "https://media.giphy.com/media/yV5iknckcXcc/source.gif"
             |    },
             |    "sportScore" : "Sport Score",
-            |    "overrideArticleMainMedia" : true
+            |    "overrideArticleMainMedia" : true,
+            |    "coverCardImages" : {
+            |      "mobile" : {
+            |        "height" : 1337,
+            |        "width" : 1337,
+            |        "src" : "https://media.giphy.com/media/yV5iknckcXcc/source.gif"
+            |      },
+            |      "tablet" : {
+            |        "height" : 1337,
+            |        "width" : 1337,
+            |        "src" : "https://media.giphy.com/media/yV5iknckcXcc/source.gif"
+            |      }
+            |    }
             |  }
             |}""".stripMargin
 
@@ -105,7 +117,11 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           imageSrcOverride = Some(
             PublishedImage(height = Some(1280), width = Some(720), "https://media.giphy.com/media/yV5iknckcXcc/source.gif")
           ),
-          overrideArticleMainMedia = true
+          overrideArticleMainMedia = true,
+          coverCardImages = Some(PublishedCardImage(
+            mobile = PublishedImage(height = Some(1337), width = Some(1337), "https://media.giphy.com/media/yV5iknckcXcc/source.gif"),
+            tablet = PublishedImage(height = Some(1337), width = Some(1337), "https://media.giphy.com/media/yV5iknckcXcc/source.gif"))
+          )
         ))
 
         val json = Json.prettyPrint(Json.toJson(article))

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -76,15 +76,15 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val article = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
       val publishedArticle = article.toPublishedArticle
       publishedArticle.internalPageCode shouldBe 1234456
-      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true)
+      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true, None)
     }
 
     "furniture defaults should be populated correctly" in {
-      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None)
+      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None, None)
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
 
-      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true)
+      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true, None)
     }
 
     "furniture should be populated when specified" in {
@@ -99,7 +99,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         Some(MediaType.Image),
         None,
         Some(Image(Some(100), Some(100), "file://image-1.gif", "file://image-1.jpg")),
-        Some(false)
+        Some(false),
+        None
       )
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
@@ -114,7 +115,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         mediaType = PublishedMediaType.Image,
         imageSrcOverride = Some(PublishedImage(Some(100), Some(100), "file://image-1.jpg")),
         sportScore = Some("sport-score"),
-        overrideArticleMainMedia = false
+        overrideArticleMainMedia = false,
+        coverCardImages = None
       )
     }
   }

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -146,7 +146,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       )
     }
 
-    "furniture should throw if set to media type is covercard but we dont have both mobile and tablet " in {
+    "media type should fall back if there's an invalid cover card" in {
       val coverCardFurniture = articleFurniture
         .copy(mediaType = Some(MediaType.CoverCard))
         .copy(coverCardImages = Some(CoverCardImages(
@@ -163,9 +163,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         EditionsArticle("123456", 0, Some(coverCardFurniture)),
         EditionsArticle("123456", 0, Some(swapped))
       ).foreach { a =>
-        assertThrows[IllegalStateException] {
-          a.toPublishedArticle
-        }
+        a.toPublishedArticle.furniture.mediaType shouldBe PublishedMediaType.UseArticleTrail
       }
     }
   }

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -1,6 +1,6 @@
 package model.editions.client
 
-import model.editions.{ArticleMetadata, Image, MediaType}
+import model.editions.{ArticleMetadata, CoverCardImages, Image, MediaType}
 import org.scalatest.{FreeSpec, Matchers}
 
 class ClientArticleMetadataTest extends FreeSpec with Matchers {
@@ -11,6 +11,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some("Britain has summer!"),
         Some("Breaking News"),
         Some("Goneth the rain, cometh the sun"),
+        None,
         None,
         None,
         None,
@@ -50,6 +51,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some(MediaType.Hide),
         Some(Image(Some(100), Some(100), "file://origin-new-pokemon.gif", "file://new-pokemon.gif")),
         None,
+        None,
         None
       )
 
@@ -82,6 +84,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some(MediaType.Image),
         None,
         Some(Image(Some(100), Some(100), "file://elephant.jpg", "file://elephant.png")),
+        None,
         None
       )
 
@@ -111,6 +114,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some(MediaType.Image),
         None,
         None,
+        None,
         None
       )
 
@@ -131,6 +135,7 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some(MediaType.UseArticleTrail),
         None,
         None,
+        None,
         None
       )
 
@@ -143,34 +148,10 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
   "ClientArticleMetadata to ArticleMetadata" - {
 
     def getEmptyClientArticleMetadata = ClientArticleMetadata(
-      None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+      None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
     )
 
     "should convert into ArticleMetadata with multiple image overrides" in {
-      val cam = ClientArticleMetadata(
-        Some("New Harry Potter book being written"),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some("J.K"),
-        None,
-        Some(true),
-        Some("file://lightning.jpg"),
-        Some("100"),
-        Some("100"),
-        Some("file://lightning.gif"),
-        Some("file://lightning.png"),
-        Some(false),
-        Some("file://broom.jpg"),
-        Some("100"),
-        Some("100"),
-        Some("file://broom.gif"),
-        Some(true)
-      )
-
       val articleMetadata = getEmptyClientArticleMetadata
         .copy(headline = Some("New Harry Potter book being written"))
         .copy(sportScore = Some("J.K"))
@@ -211,7 +192,6 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
     }
 
     "should convert into ArticleMetadata without all the image information" in {
-
       val articleMetadata = getEmptyClientArticleMetadata
         .copy(imageReplace = Some(true))
         .copy(imageSrc = Some("file://lightning.jpg"))
@@ -221,6 +201,8 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         .copy(imageSrcThumb = Some("file://lightning.png"))
         .copy(imageCutoutReplace = Some(false))
         .copy(imageCutoutSrc = Some("file://broom.jpg"))
+        .copy(coverCardMobileImage = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))))
+        .copy(coverCardTabletImage = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))))
         .toArticleMetadata
 
       articleMetadata.mediaType.isDefined shouldBe true
@@ -238,6 +220,11 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         "file://broom.jpg",
         "file://broom.jpg"
+      ))
+
+      articleMetadata.coverCardImages shouldBe Some(CoverCardImages(
+        mobile = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))),
+        tablet = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png")))
       ))
     }
   }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -29,7 +29,8 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     cutoutImage = None,
     replaceImage = None,
     overrideArticleMainMedia = None,
-    sportScore = None
+    sportScore = None,
+    coverCardImages = None
   )
 
   private def insertSkeletonIssue(year: Int, month: Int, dom: Int, fronts: EditionsFrontSkeleton*): String = {


### PR DESCRIPTION
## What's changed?
Added new image fields to the form for cover card overrides, one for mobile and one for tablet.

Currently won't let you save if you've set only one of the two images.

Screenshot: 
![image](https://user-images.githubusercontent.com/5560113/63425854-67fe9c80-c409-11e9-8b49-d100f90af28b.png)

And if you've got a missing image:
![image](https://user-images.githubusercontent.com/5560113/63426391-9a5cc980-c40a-11e9-9a5f-80cf2dd35b82.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
