### PR TITLE
Display sublinks when form is open

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -114,6 +114,17 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       canShowPageViewData = false
     } = this.props;
 
+    const getSublinks = () => {
+      return (
+        <Sublinks
+          numSupportingArticles={numSupportingArticles}
+          toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+          showArticleSublinks={this.state.showArticleSublinks}
+          parentId={parentId}
+        />
+      );
+    };
+
     const getCard = () => {
       switch (type) {
         case collectionItemTypes.ARTICLE:
@@ -135,12 +146,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
               canShowPageViewData={canShowPageViewData}
             >
               <EditModeVisibility visibleMode="fronts">
-                <Sublinks
-                  numSupportingArticles={numSupportingArticles}
-                  toggleShowArticleSublinks={this.toggleShowArticleSublinks}
-                  showArticleSublinks={this.state.showArticleSublinks}
-                  parentId={parentId}
-                />
+                {getSublinks()}
                 {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
                 {numSupportingArticles === 0
                   ? children
@@ -162,12 +168,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 textSize={textSize}
                 showMeta={showMeta}
               />
-              <Sublinks
-                numSupportingArticles={numSupportingArticles}
-                toggleShowArticleSublinks={this.toggleShowArticleSublinks}
-                showArticleSublinks={this.state.showArticleSublinks}
-                parentId={parentId}
-              />
+              {getSublinks()}
               {numSupportingArticles === 0
                 ? children
                 : this.state.showArticleSublinks && children}
@@ -196,12 +197,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
           }}
           onCancel={() => clearArticleFragmentSelection(uuid)}
         />
-        <Sublinks
-          numSupportingArticles={numSupportingArticles}
-          toggleShowArticleSublinks={this.toggleShowArticleSublinks}
-          showArticleSublinks={this.state.showArticleSublinks}
-          parentId={parentId}
-        />
+        {getSublinks()}
         {numSupportingArticles === 0
           ? children
           : this.state.showArticleSublinks && children}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -114,16 +114,14 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       canShowPageViewData = false
     } = this.props;
 
-    const getSublinks = () => {
-      return (
-        <Sublinks
-          numSupportingArticles={numSupportingArticles}
-          toggleShowArticleSublinks={this.toggleShowArticleSublinks}
-          showArticleSublinks={this.state.showArticleSublinks}
-          parentId={parentId}
-        />
-      );
-    };
+    const getSublinks = (
+      <Sublinks
+        numSupportingArticles={numSupportingArticles}
+        toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+        showArticleSublinks={this.state.showArticleSublinks}
+        parentId={parentId}
+      />
+    );
 
     const getCard = () => {
       switch (type) {
@@ -146,7 +144,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
               canShowPageViewData={canShowPageViewData}
             >
               <EditModeVisibility visibleMode="fronts">
-                {getSublinks()}
+                {getSublinks}
                 {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
                 {numSupportingArticles === 0
                   ? children
@@ -168,7 +166,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 textSize={textSize}
                 showMeta={showMeta}
               />
-              {getSublinks()}
+              {getSublinks}
               {numSupportingArticles === 0
                 ? children
                 : this.state.showArticleSublinks && children}
@@ -197,7 +195,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
           }}
           onCancel={() => clearArticleFragmentSelection(uuid)}
         />
-        {getSublinks()}
+        {getSublinks}
         {numSupportingArticles === 0
           ? children
           : this.state.showArticleSublinks && children}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -183,18 +183,29 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     };
 
     return isSelected ? (
-      <ArticleFragmentFormInline
-        articleFragmentId={uuid}
-        isSupporting={isSupporting}
-        key={uuid}
-        form={uuid}
-        frontId={frontId}
-        onSave={meta => {
-          updateArticleFragmentMeta(uuid, meta);
-          clearArticleFragmentSelection(uuid);
-        }}
-        onCancel={() => clearArticleFragmentSelection(uuid)}
-      />
+      <>
+        <ArticleFragmentFormInline
+          articleFragmentId={uuid}
+          isSupporting={isSupporting}
+          key={uuid}
+          form={uuid}
+          frontId={frontId}
+          onSave={meta => {
+            updateArticleFragmentMeta(uuid, meta);
+            clearArticleFragmentSelection(uuid);
+          }}
+          onCancel={() => clearArticleFragmentSelection(uuid)}
+        />
+        <Sublinks
+          numSupportingArticles={numSupportingArticles}
+          toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+          showArticleSublinks={this.state.showArticleSublinks}
+          parentId={parentId}
+        />
+        {numSupportingArticles === 0
+          ? children
+          : this.state.showArticleSublinks && children}
+      </>
     ) : (
       getCard()
     );


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Previously, when an inline form was selected/opened, it would hide any sub-links that had been added to the article. Now, the sub-links are visible and can be interacted in the same way whether the form is open or closed. 

The sub-links attached to an article displaying beneath it, while the form is open:
![Screenshot 2019-08-21 at 11 40 01](https://user-images.githubusercontent.com/12645938/63425663-fd4d6100-c408-11e9-8b6b-7af43bb7a89c.png)

Same as above, but the sub-links component has been expanded:
![Screenshot 2019-08-21 at 11 40 19](https://user-images.githubusercontent.com/12645938/63425665-ff172480-c408-11e9-8a09-117c3af04679.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
