### PR TITLE
make modal more generic

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -38,6 +38,7 @@ import { ValidationResponse } from 'shared/util/validateImageSrc';
 import { MappableDropType } from 'util/collectionUtils';
 import { selectWillCollectionHitCollectionCap } from 'selectors/collectionSelectors';
 import { batchActions } from 'redux-batched-actions';
+import noop from 'lodash/noop';
 
 type InsertActionCreator = (
   id: string,
@@ -146,7 +147,7 @@ const maybeInsertGroupArticleFragment = (
               .forEach(action => dispatch(action));
           },
           // otherwise do nothing
-          () => {}
+          noop
         )
       );
     } else {

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -124,19 +124,29 @@ const maybeInsertGroupArticleFragment = (
           You can proceed, and the last article in the collection will be
           removed automatically, or you can cancel and remove articles from the
           collection yourself.`,
-          // if the user accepts then remove the moved item (if there was one),
+          // if the user accepts, then remove the moved item (if there was one),
           // remove article fragments past the cap count and finally persist
-          (removeAction ? [removeAction] : []).concat([
-            insertGroupArticleFragment(id, index, articleFragmentId),
-            maybeAddFrontPublicationDate(articleFragmentId),
-            addPersistMetaToAction(capGroupSiblings, {
-              id: articleFragmentId,
-              persistTo,
-              applyBeforeReducer: true
-            })(id, collectionCap)
-          ]),
+          () => {
+            let actions = [];
+
+            if (removeAction) {
+              actions.push(removeAction);
+            }
+
+            actions
+              .concat([
+                insertGroupArticleFragment(id, index, articleFragmentId),
+                maybeAddFrontPublicationDate(articleFragmentId),
+                addPersistMetaToAction(capGroupSiblings, {
+                  id: articleFragmentId,
+                  persistTo,
+                  applyBeforeReducer: true
+                })(id, collectionCap)
+              ])
+              .forEach(action => dispatch(action));
+          },
           // otherwise do nothing
-          []
+          () => {}
         )
       );
     } else {

--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -127,7 +127,7 @@ const maybeInsertGroupArticleFragment = (
           // if the user accepts, then remove the moved item (if there was one),
           // remove article fragments past the cap count and finally persist
           () => {
-            let actions = [];
+            const actions = [];
 
             if (removeAction) {
               actions.push(removeAction);

--- a/client-v2/src/actions/ConfirmModal.ts
+++ b/client-v2/src/actions/ConfirmModal.ts
@@ -1,14 +1,14 @@
-import { Action, StartConfirm } from 'types/Action';
+import { StartConfirm } from 'types/Action';
 import { State } from 'types/State';
 import { Dispatch } from 'types/Store';
-import { selectConfirmModalActions } from 'selectors/confirmModalSelectors';
+import { selectConfirmModalCallback } from 'selectors/confirmModalSelectors';
 import { ReactNode } from 'react';
 
 const startConfirmModal = (
   title: string,
   description: string | ReactNode,
-  onAccept: Action[],
-  onReject: Action[] = [],
+  onAccept: () => void,
+  onReject: () => void,
   showCancelButton: boolean = true
 ): StartConfirm => ({
   type: 'MODAL/START_CONFIRM',
@@ -25,8 +25,8 @@ const endConfirmModal = (accept: boolean) => (
   dispatch: Dispatch,
   getState: () => State
 ) => {
-  const actions = selectConfirmModalActions(getState(), accept) || [];
-  actions.forEach(ac => dispatch(ac));
+  const callback = selectConfirmModalCallback(getState(), accept) || (() => {});
+  callback();
   dispatch({
     type: 'MODAL/END_CONFIRM'
   });

--- a/client-v2/src/actions/Editions.tsx
+++ b/client-v2/src/actions/Editions.tsx
@@ -10,6 +10,7 @@ import { Dispatch } from 'redux';
 import { actions } from 'bundles/editionsIssueBundle';
 import { startConfirmModal } from './ConfirmModal';
 import { EditionsFrontMetadata } from 'types/FaciaApi';
+import noop from 'lodash/noop';
 
 export const getEditionIssue = (
   id: string
@@ -41,8 +42,8 @@ export const publishEditionIssue = (
             of the suport team.
           </p>
         </>,
-        () => {},
-        () => {},
+        noop,
+        noop,
         false
       )
     );
@@ -54,8 +55,8 @@ export const publishEditionIssue = (
           <p>Failed to publish issue!</p>
           <p>If this problem persists, contact the support team.</p>
         </>,
-        () => {},
-        () => {},
+        noop,
+        noop,
         false
       )
     );

--- a/client-v2/src/actions/Editions.tsx
+++ b/client-v2/src/actions/Editions.tsx
@@ -41,8 +41,8 @@ export const publishEditionIssue = (
             of the suport team.
           </p>
         </>,
-        [],
-        [],
+        () => {},
+        () => {},
         false
       )
     );
@@ -54,8 +54,8 @@ export const publishEditionIssue = (
           <p>Failed to publish issue!</p>
           <p>If this problem persists, contact the support team.</p>
         </>,
-        [],
-        [],
+        () => {},
+        () => {},
         false
       )
     );

--- a/client-v2/src/reducers/confirmModalReducer.ts
+++ b/client-v2/src/reducers/confirmModalReducer.ts
@@ -5,8 +5,8 @@ import { Action } from 'types/Action';
 type ModalState = null | {
   title: string;
   description: string;
-  onAccept: Action[];
-  onReject: Action[];
+  onAccept: () => void;
+  onReject: () => void;
   showCancelButton: boolean;
 };
 

--- a/client-v2/src/selectors/confirmModalSelectors.ts
+++ b/client-v2/src/selectors/confirmModalSelectors.ts
@@ -8,7 +8,7 @@ export const selectConfirmModalTitle = ({ confirmModal }: State) =>
 export const selectConfirmModalDescription = ({ confirmModal }: State) =>
   confirmModal ? confirmModal.description : '';
 
-export const selectConfirmModalActions = (
+export const selectConfirmModalCallback = (
   { confirmModal }: State,
   accept: boolean
 ) =>
@@ -16,7 +16,7 @@ export const selectConfirmModalActions = (
     ? accept
       ? confirmModal.onAccept
       : confirmModal.onReject
-    : null;
+    : () => {};
 
 export const selectConfirmModalShowCancelButton = ({ confirmModal }: State) =>
   confirmModal ? confirmModal.showCancelButton : true;

--- a/client-v2/src/selectors/confirmModalSelectors.ts
+++ b/client-v2/src/selectors/confirmModalSelectors.ts
@@ -1,4 +1,5 @@
 import { State } from 'types/State';
+import noop from 'lodash/noop';
 
 export const selectConfirmModalIsOpen = (state: State) => !!state.confirmModal;
 
@@ -16,7 +17,7 @@ export const selectConfirmModalCallback = (
     ? accept
       ? confirmModal.onAccept
       : confirmModal.onReject
-    : () => {};
+    : noop;
 
 export const selectConfirmModalShowCancelButton = ({ confirmModal }: State) =>
   confirmModal ? confirmModal.showCancelButton : true;

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -275,8 +275,8 @@ interface StartConfirm {
   payload: {
     title: string;
     description: string | ReactNode;
-    onAccept: Action[];
-    onReject: Action[];
+    onAccept: () => void;
+    onReject: () => void;
     showCancelButton: boolean;
   };
 }


### PR DESCRIPTION
## What's changed?
Make the modal accept call back functions instead of `Action[]` - this will allow us to do things with the confirmation modal which don't affect redux at all.

