### PR TITLE
Hide sublinks in editions

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -42,6 +42,7 @@ import { updateArticleFragmentMeta as updateArticleFragmentMetaAction } from 'ac
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from 'selectors/pathSelectors';
 import { events } from 'services/GA';
+import EditModeVisibility from 'components/util/EditModeVisibility';
 
 const imageDropTypes = [
   ...gridDropTypes,
@@ -133,16 +134,18 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
               canDragImage={canDragImage}
               canShowPageViewData={canShowPageViewData}
             >
-              <Sublinks
-                numSupportingArticles={numSupportingArticles}
-                toggleShowArticleSublinks={this.toggleShowArticleSublinks}
-                showArticleSublinks={this.state.showArticleSublinks}
-                parentId={parentId}
-              />
-              {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
-              {numSupportingArticles === 0
-                ? children
-                : this.state.showArticleSublinks && children}
+              <EditModeVisibility visibleMode="fronts">
+                <Sublinks
+                  numSupportingArticles={numSupportingArticles}
+                  toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+                  showArticleSublinks={this.state.showArticleSublinks}
+                  parentId={parentId}
+                />
+                {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
+                {numSupportingArticles === 0
+                  ? children
+                  : this.state.showArticleSublinks && children}
+              </EditModeVisibility>
             </Article>
           );
         case collectionItemTypes.SNAP_LINK:


### PR DESCRIPTION
## What's changed?
Simply wrapped the sublink rendering in the editions mode view.

Tests confirm this still works in fronts mode and doesn't work in editions mode.