### PR TITLE
Switch issue_date to be a LocalDate instead of DateTime

### DIFF
--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import java.time.{Instant, OffsetDateTime, ZoneId}
+import java.time.{Instant, LocalDate, OffsetDateTime, ZoneId}
 
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
@@ -9,7 +9,7 @@ case class EditionsIssue(
     id: String,
     displayName: String,
     timezoneId: String,
-    issueDate: Long,
+    issueDate: LocalDate,
     createdOn: Long,
     createdBy: String,
     createdEmail: String,
@@ -21,7 +21,7 @@ case class EditionsIssue(
   def toPublishedIssue(version: Option[String] = None): PublishedIssue = PublishedIssue(
     id,
     displayName,
-    OffsetDateTime.ofInstant(Instant.ofEpochMilli(issueDate), ZoneId.of(timezoneId)),
+    issueDate,
     version,
     fronts.filterNot(_.isHidden).map(_.toPublishedFront)
   )
@@ -35,7 +35,7 @@ object EditionsIssue {
       rs.string(prefix + "id"),
       rs.string(prefix + "name"),
       rs.string(prefix + "timezone_id"),
-      rs.zonedDateTime(prefix + "issue_date").toInstant.toEpochMilli,
+      rs.localDate(prefix + "issue_date"),
       rs.zonedDateTime(prefix + "created_on").toInstant.toEpochMilli,
       rs.string(prefix + "created_by"),
       rs.string(prefix + "created_email"),

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import java.time.{ZoneId, ZonedDateTime}
+import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import java.time.temporal.ChronoField
 
 import enumeratum.{EnumEntry, PlayEnum}
@@ -63,14 +63,14 @@ object CapiPrefillQuery {
 
 import WeekDay._
 trait Periodicity {
-  def isValid(date: ZonedDateTime): Boolean
+  def isValid(date: LocalDate): Boolean
 }
 case class Daily() extends Periodicity {
-  def isValid(date: ZonedDateTime) = true
+  def isValid(date: LocalDate) = true
 }
 
 case class WeekDays(days: List[WeekDay]) extends Periodicity {
-  def isValid(date: ZonedDateTime) =
+  def isValid(date: LocalDate) =
     days.exists(
       WeekDayToInt(_) == date.getDayOfWeek.get(ChronoField.DAY_OF_WEEK)
     )
@@ -100,7 +100,7 @@ case class EditionTemplate(
 // Issue skeletons are what is generated when you create a new issue for a given date
 // (Date + Template) => Skeleton
 case class EditionsIssueSkeleton(
-    issueDate: ZonedDateTime,
+    issueDate: LocalDate,
     zoneId: ZoneId,
     fronts: List[EditionsFrontSkeleton]
 )

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import java.time.OffsetDateTime
+import java.time.{LocalDate, OffsetDateTime}
 
 import enumeratum.EnumEntry.Uncapitalised
 import enumeratum.{EnumEntry, PlayEnum}
@@ -41,7 +41,7 @@ case class PublishedFront(id: String, name: String, collections: List[PublishedC
 case class PublishedIssue(
   id: String,
   name: String,
-  issueDate: OffsetDateTime,
+  issueDate: LocalDate,
   version: Option[String],
   fronts: List[PublishedFront]
 )

--- a/app/model/editions/internal/PrefillUpdate.scala
+++ b/app/model/editions/internal/PrefillUpdate.scala
@@ -1,9 +1,9 @@
 package model.editions.internal
 
-import java.time.ZonedDateTime
+import java.time.{LocalDate, ZoneId}
 
 import model.editions.CapiPrefillQuery
 
 // Small class which is returned by the database to allow fetching new prefilled articles
-case class PrefillUpdate(issueDate: ZonedDateTime, prefill: CapiPrefillQuery, currentPageCodes: List[String])
+case class PrefillUpdate(issueDate: LocalDate, zone: ZoneId, prefill: CapiPrefillQuery, currentPageCodes: List[String])
 

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -46,14 +46,14 @@ trait CollectionsQueries {
           JOIN edition_issues ON (fronts.issue_id = edition_issues.id)
           WHERE collections.id = $id
        """.map { rs =>
-      val time = rs.zonedDateTime("issue_date")
+      val date = rs.localDate("issue_date")
       val zone = ZoneId.of(rs.string("timezone_id"))
 
-      (time.withZoneSameInstant(zone), CapiPrefillQuery(rs.string("prefill")), rs.string("page_code"))
+      (date, zone, CapiPrefillQuery(rs.string("prefill")), rs.string("page_code"))
     }.list().apply()
 
-    rows.headOption.map { case (issueDate, prefill, _) =>
-      PrefillUpdate(issueDate, prefill, rows.map(_._3))
+    rows.headOption.map { case (issueDate, zone, prefill, _) =>
+      PrefillUpdate(issueDate, zone, prefill, rows.map(_._4))
     }
   }
 

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -79,11 +79,6 @@ trait IssueQueries {
   }
 
   def listIssues(editionName: String, dateFrom: LocalDate, dateTo: LocalDate) = DB readOnly { implicit session =>
-    val editionTimeZone = EditionsTemplates.templates(editionName).zoneId
-
-    val zonedIssueDateFrom = dateFrom.atStartOfDay(editionTimeZone)
-    val zonedIssueDateTo = dateTo.atStartOfDay(editionTimeZone)
-
     sql"""
     SELECT
       id,
@@ -97,7 +92,7 @@ trait IssueQueries {
       launched_by,
       launched_email
     FROM edition_issues
-    WHERE issue_date BETWEEN $zonedIssueDateFrom AND $zonedIssueDateTo AND name = $editionName
+    WHERE issue_date BETWEEN $dateFrom AND $dateTo AND name = $editionName
     """.map(EditionsIssue.fromRow(_)).list().apply()
   }
 

--- a/app/services/editions/publishing/EditionsBucket.scala
+++ b/app/services/editions/publishing/EditionsBucket.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.Json
 import PublishedIssueFormatters._
 
 class EditionsBucket(s3Client: AmazonS3, bucketName: String) {
-  def createIssuePrefix(issue: PublishedIssue): String = s"${issue.name}/${issue.issueDate.toLocalDate.toString}"
+  def createIssuePrefix(issue: PublishedIssue): String = s"${issue.name}/${issue.issueDate.toString}"
 
   def createIssueFilename(issue: PublishedIssue): String = {
     val keyname = issue.version.getOrElse("preview")

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -28,7 +28,7 @@ interface EditionsFront {
 interface EditionsIssue {
   id: string;
   displayName: string;
-  issueDate: number; // midnight on the expect publish date
+  issueDate: string; // YYYY-MM-dd
   createdOn: number;
   createdBy: string;
   createdEmail: string;

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -1,0 +1,30 @@
+# --- !Ups
+
+ALTER TABLE edition_issues ADD COLUMN temp DATE;
+
+--- Do the work to migrate from timestamps to dates stripping the time (we add an hour as a bodge as some of our data is
+--- in GMT+1 which winds up to be the day before
+-- noinspection SqlWithoutWhere
+UPDATE edition_issues SET temp = (issue_date + INTERVAL '1 hour')::TIMESTAMP::DATE;
+
+ALTER TABLE edition_issues ALTER COLUMN temp SET NOT NULL;
+DROP INDEX edition_issues_issue_date_index;
+ALTER TABLE edition_issues DROP COLUMN issue_date;
+ALTER TABLE edition_issues RENAME COLUMN temp TO issue_date;
+
+CREATE INDEX edition_issues_issue_date_index ON edition_issues(issue_date);
+
+# --- !Downs
+
+ALTER TABLE edition_issues ADD COLUMN temp TIMESTAMPTZ;
+
+--- Do the work to migrate back
+-- noinspection SqlWithoutWhere
+UPDATE edition_issues SET temp = CONCAT(issue_date, ' 00:00:00 Europe/London')::TIMESTAMP;
+
+ALTER TABLE edition_issues ALTER COLUMN temp SET NOT NULL;
+DROP INDEX edition_issues_issue_date_index;
+ALTER TABLE edition_issues DROP COLUMN issue_date;
+ALTER TABLE edition_issues RENAME COLUMN temp TO issue_date;
+
+CREATE INDEX edition_issues_issue_date_index ON edition_issues(issue_date);

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -15,8 +15,8 @@ class editionTemplateTest extends FreeSpec with Matchers {
   // Currently not testing prefills!
   object TestCapi extends Capi {
     override def getPreviewHeaders(url: String): Seq[(String, String)] = Seq.empty[(String, String)]
-    override def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
-    override def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = Future.successful(Nil)
+    override def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
+    override def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = Future.successful(Nil)
   }
   val templating = new EditionsTemplating(TestEdition.templates, TestCapi)
 

--- a/test/fixtures/EditionsDBEvolutions.scala
+++ b/test/fixtures/EditionsDBEvolutions.scala
@@ -1,0 +1,23 @@
+package fixtures
+
+import org.scalatest.{BeforeAndAfter, Suite}
+import play.api.db.Database
+import play.api.db.evolutions.{Evolutions, InconsistentDatabase}
+
+trait EditionsDBEvolutions extends BeforeAndAfter { self: Suite =>
+  def  database: Database
+
+  before {
+    try {
+      Evolutions.applyEvolutions(database)
+    } catch {
+      case fail: InconsistentDatabase =>
+        println(fail.subTitle)
+        throw fail
+    }
+  }
+
+  after {
+    Evolutions.cleanupEvolutions(database)
+  }
+}

--- a/test/fixtures/EditionsDBService.scala
+++ b/test/fixtures/EditionsDBService.scala
@@ -8,7 +8,7 @@ import play.api.db.evolutions.Evolutions
 import services.editions.db.EditionsDB
 
 trait EditionsDBService extends DockerTestKit with DockerKitDockerJava with DockerPostgresService
-  with BeforeAndAfterAll with BeforeAndAfter { self: Suite =>
+  with BeforeAndAfterAll  { self: Suite =>
 
   var editionsDB: EditionsDB = _
   var database: Database = _
@@ -22,13 +22,5 @@ trait EditionsDBService extends DockerTestKit with DockerKitDockerJava with Dock
     ))
 
     editionsDB = new EditionsDB(dbUrl, dbUser, dbPassword)
-  }
-
-  before {
-    Evolutions.applyEvolutions(database)
-  }
-
-  after {
-    Evolutions.cleanupEvolutions(database)
   }
 }

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -9,13 +9,13 @@ import services.editions.publishing.PublishedIssueFormatters._
 class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
   "EditionsIssueTest" - {
     val midnight = OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC)
-    val issueDate = LocalDate.of(2019, 9, 30).atTime(midnight)
+    val issueDate = LocalDate.of(2019, 9, 30)
 
     val issue: EditionsIssue = EditionsIssue(
       id = "4290573248905743296789524389623",
       displayName = "Daily Edition",
       timezoneId = "Europe/London",
-      issueDate = issueDate.toInstant.toEpochMilli,
+      issueDate = issueDate,
       createdOn = 0,
       createdBy = "",
       createdEmail = "",
@@ -30,7 +30,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
         """{
           |  "id" : "4290573248905743296789524389623",
           |  "name" : "Daily Edition",
-          |  "issueDate" : "2019-09-30T01:00:00+01:00",
+          |  "issueDate" : "2019-09-30",
           |  "fronts" : [ ]
           |}""".stripMargin
 
@@ -45,7 +45,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
         """{
           |  "id" : "4290573248905743296789524389623",
           |  "name" : "Daily Edition",
-          |  "issueDate" : "2019-09-30T01:00:00+01:00",
+          |  "issueDate" : "2019-09-30",
           |  "version" : "foo",
           |  "fronts" : [ ]
           |}""".stripMargin

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import java.time.{OffsetDateTime, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, OffsetDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
 
@@ -11,13 +11,14 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
   val nowMilli = nowDateTime.toInstant.toEpochMilli
 
   private def issue(year: Int, month: Int, dom: Int, fronts: EditionsFront*): EditionsIssue = {
-    val dateTime = ZonedDateTime.of(year, month, dom, 0, 0, 0, 0, LondonZone)
+    val date = LocalDate.of(year, month, dom)
+    val dateTime = date.atStartOfDay(LondonZone)
     val dateTimeMilli = dateTime.toInstant.toEpochMilli
     EditionsIssue(
       "test-edition",
       "Test Edition",
       LondonZone.toString,
-      dateTimeMilli,
+      date,
       dateTimeMilli,
       "User",
       "user@example.con",

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -15,7 +15,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
     "Sets the prefill metadata from CAPI" in {
       val fakeCapi = new Capi {
         def getPreviewHeaders(url: String): Seq[(String, String)] = ???
-        def getPrefillArticleItems(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = {
+        def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = {
           capiPrefillQuery.queryString match {
             case "?tag=theguardian/mainsection/topstories" => Future.successful(List(
               Prefill(123456, false, false, false, None)
@@ -26,7 +26,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
             ))
           }
         }
-        def getPrefillArticles(issueDate: ZonedDateTime, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = ???
+        def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = ???
       }
       val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
       val issue = templating.generateEditionTemplate("test-edition", LocalDate.of(2019, 9, 30)).value

--- a/test/services/editions/db/EditionsDBEvolutionsTest.scala
+++ b/test/services/editions/db/EditionsDBEvolutionsTest.scala
@@ -1,0 +1,89 @@
+package services.editions.db
+
+import java.sql.Date
+import java.time.{LocalDate, LocalTime, OffsetDateTime, ZoneId, ZoneOffset, ZonedDateTime}
+
+import com.gu.pandomainauth.model.User
+import fixtures.{EditionsDBService, UsesDatabase}
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import play.api.db.evolutions.{Evolution, Evolutions, EvolutionsReader, ThisClassLoaderEvolutionsReader}
+import scalikejdbc._
+
+class EditionsDBEvolutionsTest extends FreeSpec with Matchers with EditionsDBService with OptionValues {
+
+  private val now: OffsetDateTime = OffsetDateTime.of(2019, 7, 16, 17, 23, 23, 123456, ZoneOffset.ofHours(1))
+
+  private val user: User = User("Billy", "Bragg", "billy.bragg@justice.example.com", None)
+
+  private def insertSkeletonIssue(year: Int, month: Int, dom: Int): String = {
+    val zoneId = ZoneId.of("Europe/London")
+    val localDate = LocalDate.of(year, month, dom)
+    val issueDate = ZonedDateTime.of(localDate, LocalTime.MIDNIGHT, zoneId)
+    val truncatedNow = EditionsDB.truncateDateTime(now)
+
+    DB localTx { implicit session =>
+      sql"""
+            INSERT INTO edition_issues (
+              name,
+              issue_date,
+              timezone_id,
+              created_on,
+              created_by,
+              created_email
+            ) VALUES ('test-edition', $issueDate, ${zoneId.toString}, $truncatedNow, ${user.username}, ${user.email})
+            RETURNING id;
+         """.map(_.string("id")).single().apply().get
+    }
+  }
+
+  private def getIssueDate(id: String): Date = {
+    DB localTx { implicit session =>
+      sql"""
+            SELECT issue_date FROM edition_issues WHERE id = $id
+         """.map(_.date("issue_date")).single().apply().get
+    }
+  }
+
+  private def getIssueDateTime(id: String): OffsetDateTime = {
+    DB localTx { implicit session =>
+      sql"""
+            SELECT issue_date FROM edition_issues WHERE id = $id
+         """.map(_.offsetDateTime("issue_date")).single().apply().get
+    }
+  }
+
+  class FilteredEvolutionsReader(filter: Evolution => Boolean) extends EvolutionsReader {
+    val baseReader = ThisClassLoaderEvolutionsReader
+    override def evolutions(db: String): Seq[Evolution] = baseReader.evolutions(db).filter(filter)
+  }
+
+  "The issue_date evolutions (default/6.sql)" - {
+    // this is an evolution reader that only returns evolutions up to and including number 5
+    val evolveToNumberFiveEvolutionsReader = new FilteredEvolutionsReader(_.revision <= 5)
+    val evolveToNumberSixEvolutionsReader = new FilteredEvolutionsReader(_.revision <= 6)
+
+    "Show roll forward" taggedAs UsesDatabase in {
+      Evolutions.applyEvolutions(database, evolveToNumberFiveEvolutionsReader)
+      // insert some editions
+      val summerId = insertSkeletonIssue(2019, 8, 21)
+      val winterId = insertSkeletonIssue(2019, 2, 21)
+
+      Evolutions.applyEvolutions(database, evolveToNumberSixEvolutionsReader)
+      // test that the evolutions have worked as expected
+      val summerDate = getIssueDate(summerId)
+      val winterDate = getIssueDate(winterId)
+
+      summerDate.toString shouldBe "2019-08-21"
+      winterDate.toString shouldBe "2019-02-21"
+
+      Evolutions.applyEvolutions(database, evolveToNumberFiveEvolutionsReader)
+
+      val summerDateTime = getIssueDateTime(summerId)
+      val winterDateTime = getIssueDateTime(winterId)
+
+      summerDateTime.toString shouldBe "2019-08-21T00:00+01:00"
+      winterDateTime.toString shouldBe "2019-02-21T00:00Z"
+
+    }
+  }
+}

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -3,12 +3,12 @@ package services.editions.db
 import java.time._
 
 import com.gu.pandomainauth.model.User
-import fixtures.{EditionsDBService, UsesDatabase}
+import fixtures.{EditionsDBEvolutions, EditionsDBService, UsesDatabase}
 import model.editions._
 import model.forms.GetCollectionsFilter
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
 
-class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with OptionValues {
+class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with EditionsDBEvolutions with OptionValues {
 
   private val now: OffsetDateTime = OffsetDateTime.of(2019, 7, 16, 17, 23, 23, 123456, ZoneOffset.ofHours(1))
 
@@ -30,7 +30,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
   private def insertSkeletonIssue(year: Int, month: Int, dom: Int, fronts: EditionsFrontSkeleton*): String = {
     val skeleton = EditionsIssueSkeleton(
-      ZonedDateTime.of(year, month, dom, 0, 0, 0, 0, ZoneId.of("Europe/London")),
+      LocalDate.of(year, month, dom),
       ZoneId.of("Europe/London"),
       fronts.toList
     )
@@ -62,8 +62,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       retrievedIssue.createdEmail shouldBe "billy.bragg@justice.example.com"
       retrievedIssue.createdOn shouldBe now.toInstant.toEpochMilli
       retrievedIssue.createdBy shouldBe "Billy Bragg"
-      val issueDate = OffsetDateTime.ofInstant(Instant.ofEpochMilli(retrievedIssue.issueDate), ZoneId.of(retrievedIssue.timezoneId))
-      issueDate.getDayOfWeek shouldBe DayOfWeek.MONDAY
+      retrievedIssue.issueDate.getDayOfWeek shouldBe DayOfWeek.MONDAY
       retrievedIssue.launchedOn.isDefined shouldBe false
       retrievedIssue.launchedBy.isDefined shouldBe false
       retrievedIssue.launchedEmail.isDefined shouldBe false

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -81,6 +81,10 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       val someIssues = editionsDB.listIssues("daily-edition", LocalDate.of(2019, 9, 28), LocalDate.of(2019, 10, 3))
       someIssues.length shouldBe 3
+
+      val singleIssue = editionsDB.listIssues("daily-edition", LocalDate.of(2019, 9, 29), LocalDate.of(2019, 9, 29))
+      singleIssue.length shouldBe 1
+      singleIssue.head.issueDate.getDayOfMonth shouldBe 29
     }
 
     "should insert fronts, collections and articles" taggedAs UsesDatabase in {


### PR DESCRIPTION
## What's changed?
This PR changes the issueDate in the model to be a date instead of a date time. This is easier to reason about as it is a better fit and means that there are fewer conversions from and to date times in the code base.

## Implementation notes
We added tests for the DB evolution in question (`6.sql`). These tests use raw SQL as we are changing the model so can't use the models in this instance.

The implemetation fell out of the model changes nicely and eliminated several conversions.

The type on the client has changed from epoch to `YYYY-MM-dd` and the client just seems to have carried on working since Date(x) works the same for both.

## Checklist
 - [ ] Talk with @AWare to see how happy he is with the new export format

### General
- [X] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
