### PR TITLE
Add switch date to v1

### DIFF
--- a/app/views/templates/header.scala.html
+++ b/app/views/templates/header.scala.html
@@ -14,7 +14,7 @@
      @if(displayV2Message) {
          <div class="header__group v2-popup">
              <div class="v2-popup_logo"><img src="/assets/images/logo-v2.svg" /></div>
-             <div class="v2-popup_text"><span>There's a new version of the fronts tool. Please&nbsp;<a href="/v2/@priority">try it by clicking here</a></span>.</div>
+             <div class="v2-popup_text"><span>There's a new version of the fronts tool. Please&nbsp;<a href="/v2/@priority">try it by clicking here</a>. The new version will be made the default on <strong>Tuesday, 27th August.</strong></span></div>
          </div>
      }
 

--- a/public/src/css/header.css
+++ b/public/src/css/header.css
@@ -191,7 +191,10 @@ main {
 
 .v2-popup_text {
     background-color: #FFE500;
+    display: flex;
+    align-items: center;
     padding: 5px 10px;
+    height: 42px;
 }
 
  .v2-popup_text a {
@@ -202,5 +205,6 @@ main {
 .v2-popup_logo {
     background-color: #1C1D27;
     width: 26px;
-    padding: 5px 7px 1px;
+    height: 42px;
+    padding: 12px 7px 1px;
 }


### PR DESCRIPTION
## What's changed?

Adds a date to the v1 messaging.

<img width="1154" alt="Screenshot 2019-08-21 at 16 58 10" src="https://user-images.githubusercontent.com/7767575/63448561-13254b00-c436-11e9-8093-b8e1b4acbfc7.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
