### PR TITLE
Enable ingestion of gu- params on snaplink creation

### DIFF
--- a/client-v2/src/actions/ArticleFragments.ts
+++ b/client-v2/src/actions/ArticleFragments.ts
@@ -4,7 +4,7 @@ import {
   removeGroupArticleFragment,
   removeSupportingArticleFragment,
   updateArticleFragmentMeta,
-  createArticleFragment,
+  createArticleEntitiesFromDrop,
   articleFragmentsReceived,
   maybeAddFrontPublicationDate,
   copyArticleFragmentImageMeta
@@ -234,7 +234,7 @@ const insertArticleFragmentWithCreate = (
   drop: MappableDropType,
   persistTo: 'collection' | 'clipboard',
   // allow the factory to be injected for testing
-  articleFragmentFactory = createArticleFragment
+  articleFragmentFactory = createArticleEntitiesFromDrop
 ): ThunkResult<void> => {
   return (dispatch: Dispatch, getState) => {
     const insertActionCreator = getInsertionActionCreatorFromType(

--- a/client-v2/src/components/clipboard/ClipboardLevel.tsx
+++ b/client-v2/src/components/clipboard/ClipboardLevel.tsx
@@ -29,6 +29,7 @@ const ClipboardItemContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
+  width: 100%;
 `;
 
 const ClipboardDropContainer = styled(CollectionDropContainer)<{

--- a/client-v2/src/keyboard/index.ts
+++ b/client-v2/src/keyboard/index.ts
@@ -11,7 +11,7 @@ import { ThunkResult } from 'types/Store';
 import Mousetrap from 'mousetrap';
 import { selectFocusState, setFocusState } from 'bundles/focusBundle';
 import { RefDrop } from 'util/collectionUtils';
-import { createArticleFragment } from 'shared/actions/ArticleFragments';
+import { createArticleEntitiesFromDrop } from 'shared/actions/ArticleFragments';
 import { moveUp, moveDown } from './keyboardActionMaps/move';
 import { ArticleFragment } from '../shared/types/Collection';
 import { insertClipboardArticleFragment } from 'actions/Clipboard';
@@ -79,7 +79,7 @@ export const createKeyboardActionMap = (store: Store): KeyboardBindingMap => ({
         }
         const contentData: RefDrop = { type: 'REF', data: content };
         const articleFragment = await dispatch(
-          createArticleFragment(contentData)
+          createArticleEntitiesFromDrop(contentData)
         );
         if (!articleFragment) {
           return;

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -150,7 +150,7 @@ const createArticleEntitiesFromDrop = (
     const [
       maybeArticleFragment,
       maybeExternalArticle
-    ] = await getArticleEntitesFromDrop(drop);
+    ] = await getArticleEntitiesFromDrop(drop);
     if (maybeArticleFragment) {
       dispatch(articleFragmentsReceived([maybeArticleFragment]));
     }
@@ -167,7 +167,7 @@ const createArticleEntitiesFromDrop = (
  *  - a article, tag or section (either the full URL or the ID)
  *  - an external link.
  */
-const getArticleEntitesFromDrop = async (
+const getArticleEntitiesFromDrop = async (
   drop: MappableDropType
 ): Promise<TArticleEntities> => {
   if (drop.type === 'CAPI') {

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -175,7 +175,7 @@ const getArticleEntitiesFromDrop = async (
   }
   const resourceIdOrUrl = drop.data;
   const isURL = isValidURL(resourceIdOrUrl);
-  const id = isURL ? getIdFromURL(resourceIdOrUrl, true) : resourceIdOrUrl;
+  const id = isURL ? getIdFromURL(resourceIdOrUrl) : resourceIdOrUrl;
   const isNonGuLink = isURL && !id;
   if (isNonGuLink) {
     const fragment = await createLinkSnap(resourceIdOrUrl);

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -162,7 +162,7 @@ describe('articleFragments actions', () => {
             meta: {
               byline: undefined,
               headline: 'Live matches',
-              href: '/football/live',
+              href: 'football/live',
               showByline: false,
               snapCss: 'football',
               snapType: 'json.html',

--- a/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemContent.tsx
@@ -6,6 +6,7 @@ const CollectionItemContent = styled('div')<{
   textSize?: CollectionItemSizes;
 }>`
   position: relative;
+  min-width: 0;
   font-size: ${({ textSize, theme }) =>
     textSize === 'small'
       ? theme.shared.collectionItem.fontSizeSmall

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -41,6 +41,9 @@ const SnapLinkBodyContainer = styled(CollectionItemBody)`
 const SnapLinkURL = styled('p')`
   font-size: 12px;
   word-break: break-all;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 const ImageWrapper = styled('div')``;
@@ -107,7 +110,9 @@ const SnapLink = ({
           <CollectionItemMetaContainer size={size}>
             <CollectionItemMetaHeading>Snap link</CollectionItemMetaHeading>
             <CollectionItemMetaContent>
-              {upperFirst(articleFragment.meta.snapType)}
+              {upperFirst(
+                articleFragment.meta.snapCss || articleFragment.meta.snapType
+              )}
             </CollectionItemMetaContent>
             {!!articleFragment.frontPublicationDate && (
               <CollectionItemMetaContent title="The time elapsed since this card was created in the tool.">
@@ -133,9 +138,16 @@ const SnapLink = ({
             )}
             <CollectionItemHeading html>{headline}</CollectionItemHeading>
             <SnapLinkURL>
-              url: &nbsp;
+              {articleFragment.meta.snapUri && (
+                <>
+                  <strong>snap uri:&nbsp;</strong>
+                  {articleFragment.meta.snapUri}
+                  &nbsp;
+                </>
+              )}
+              <strong>url:&nbsp;</strong>
               <a href={urlPath} target="_blank">
-                {urlPath}
+                {articleFragment.meta.href}
               </a>
             </SnapLinkURL>
           </CollectionItemHeadingContainer>

--- a/client-v2/src/shared/constants/url.ts
+++ b/client-v2/src/shared/constants/url.ts
@@ -3,6 +3,7 @@ export default {
   base: {
     mainDomain: 'www.theguardian.com',
     mainDomainShort: 'theguardian.com',
+    frontendDomain: 'frontend.gutools.co.uk',
     previewDomain: 'preview.gutools.co.uk'
   },
   media: {

--- a/client-v2/src/shared/util/openGraph.ts
+++ b/client-v2/src/shared/util/openGraph.ts
@@ -1,5 +1,5 @@
 import pandaFetch from 'services/pandaFetch';
-import { isGuardianUrl, getHostname } from './url';
+import { isGuardianWebsiteUrl, getHostname } from './url';
 
 interface OpenGraphData {
   title: string | undefined;
@@ -8,7 +8,7 @@ interface OpenGraphData {
 }
 
 export default async function(url: string): Promise<OpenGraphData> {
-  const isOnSite = isGuardianUrl(url);
+  const isOnSite = isGuardianWebsiteUrl(url);
   try {
     const response = await pandaFetch(
       '/http/proxy/' + url + (isOnSite ? '?view=mobile' : '')

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -1,4 +1,4 @@
-import { getAbsolutePath, isGuardianUrl as isGuardianUrl } from './url';
+import { getAbsolutePath, isGuardianUrl } from './url';
 import fetchOpenGraphData from './openGraph';
 import { ArticleFragment, ArticleFragmentMeta } from '../types/Collection';
 import v4 from 'uuid/v4';

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -1,4 +1,4 @@
-import { getAbsolutePath, isInternalUrl } from './url';
+import { getAbsolutePath, isGuardianUrl as isGuardianUrl } from './url';
 import fetchOpenGraphData from './openGraph';
 import { ArticleFragment, ArticleFragmentMeta } from '../types/Collection';
 import v4 from 'uuid/v4';
@@ -17,7 +17,7 @@ function validateId(id: string) {
 function convertToSnap({ id, ...rest }: ArticleFragment): ArticleFragment {
   let href;
 
-  if (isInternalUrl(id)) {
+  if (isGuardianUrl(id)) {
     href = '/' + getAbsolutePath(id, true);
   } else {
     href = id;

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -1,7 +1,4 @@
-import {
-  getAbsolutePath,
-  isInternalUrl
-} from './url';
+import { getAbsolutePath, isInternalUrl } from './url';
 import fetchOpenGraphData from './openGraph';
 import { ArticleFragment, ArticleFragmentMeta } from '../types/Collection';
 import v4 from 'uuid/v4';

--- a/client-v2/src/shared/util/url.ts
+++ b/client-v2/src/shared/util/url.ts
@@ -32,14 +32,14 @@ function matchHostname(url: string, hostnames: string[]): boolean {
   return hostnames.some(_ => _ === host);
 }
 
-function isGuardianUrl(url: string) {
+function isGuardianWebsiteUrl(url: string) {
   return matchHostname(url, [
     urlConstants.base.mainDomain,
     urlConstants.base.mainDomainShort
   ]);
 }
 
-function isInternalUrl(url: string) {
+function isGuardianUrl(url: string) {
   return matchHostname(url, [
     urlConstants.base.mainDomain,
     urlConstants.base.mainDomainShort,
@@ -51,7 +51,7 @@ function isInternalUrl(url: string) {
 export {
   getAbsolutePath,
   getHostname,
+  isGuardianWebsiteUrl,
   isGuardianUrl,
-  isInternalUrl,
   isValidURL
 };

--- a/client-v2/src/shared/util/url.ts
+++ b/client-v2/src/shared/util/url.ts
@@ -27,22 +27,31 @@ function isValidURL(url: string) {
   return getHostname(url) !== window.location.hostname;
 }
 
-function isGuardianUrl(url: string) {
+function matchHostname(url: string, hostnames: string[]): boolean {
   const host = getHostname(url);
-  return (
-    host === urlConstants.base.mainDomain ||
-    host === urlConstants.base.mainDomainShort
-  );
+  return hostnames.some(_ => _ === host);
 }
 
-function isPreviewUrl(url: string) {
-  return getHostname(url) === urlConstants.base.previewDomain;
+function isGuardianUrl(url: string) {
+  return matchHostname(url, [
+    urlConstants.base.mainDomain,
+    urlConstants.base.mainDomainShort
+  ]);
+}
+
+function isInternalUrl(url: string) {
+  return matchHostname(url, [
+    urlConstants.base.mainDomain,
+    urlConstants.base.mainDomainShort,
+    urlConstants.base.previewDomain,
+    urlConstants.base.frontendDomain
+  ]);
 }
 
 export {
   getAbsolutePath,
   getHostname,
   isGuardianUrl,
-  isPreviewUrl,
+  isInternalUrl,
   isValidURL
 };

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -4,18 +4,12 @@ import { ArticleFragmentMeta } from '../shared/types/Collection';
 import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import startCase from 'lodash/startCase';
 
-const getIdFromURL = (
-  url: string,
-  ensureLeadingSlash: boolean = false
-): string | undefined => {
+const getIdFromURL = (url: string): string | undefined => {
   const [, id = null] =
     url.match(
       /^https:\/\/(?:www.theguardian.com\/|viewer.gutools.co.uk(?:\/(?:preview|live))?\/)([^?]*)/
     ) || [];
-  if (typeof id !== 'string') {
-    return;
-  }
-  return !ensureLeadingSlash || id[0] === '/' ? id : `/${id}`;
+  return typeof id === 'string' ? id : undefined;
 };
 
 // TODO: get apiKey from context (or speak directly to FrontsAPI)

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -4,12 +4,18 @@ import { ArticleFragmentMeta } from '../shared/types/Collection';
 import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import startCase from 'lodash/startCase';
 
-const getIdFromURL = (url: string): string | null => {
+const getIdFromURL = (
+  url: string,
+  ensureLeadingSlash: boolean = false
+): string | undefined => {
   const [, id = null] =
     url.match(
       /^https:\/\/(?:www.theguardian.com\/|viewer.gutools.co.uk(?:\/(?:preview|live))?\/)([^?]*)/
     ) || [];
-  return typeof id !== 'string' ? null : id;
+  if (typeof id !== 'string') {
+    return;
+  }
+  return !ensureLeadingSlash || id[0] === '/' ? id : `/${id}`;
 };
 
 // TODO: get apiKey from context (or speak directly to FrontsAPI)

--- a/client-v2/tsconfig.json
+++ b/client-v2/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es6",
     "module": "es6",
     "moduleResolution": "node",
-    "lib": ["dom", "es2017"],
+    "lib": ["dom", "dom.iterable", "es2017"],
     "jsx": "react",
     "allowJs": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## What's changed?

So, this is a thing -- in the old tool, when snaplinks are dropped, they can optionally contain `gu-` prefixed url params that are flung into the override meta. These specimens are rare, and beautiful, and when they happen we need to deal with them, e.g.:

`https://www.theguardian.com/football/live?gu-snapType=json.html&gu-snapCss=football&gu-snapUri=https%3A%2F%2Fapi.nextgen.guardianapps.co.uk%2Ffootball%2Flive.json&gu-headline=Live+matches&gu-trailText=Today%27s+matches`

This PR adds code that checks for these params and includes them. They're whitelisted to guard against arbitrary data. I've also added some presentation to ensure that snaplinks present these new properties as v1 does.

Before:

<img width="688" alt="Screenshot 2019-08-22 at 11 56 38" src="https://user-images.githubusercontent.com/7767575/63509369-eaec2980-c4d3-11e9-93eb-773f9d28d092.png">

After:

<img width="688" alt="Screenshot 2019-08-22 at 11 55 51" src="https://user-images.githubusercontent.com/7767575/63509344-d9a31d00-c4d3-11e9-8f45-9d640521f2ab.png">

## Implementation notes

I've changed a few names and refactored `createArticleEntitiesFromDrop` (to a certain extent, it still needs some love) to make it marginally more readable. But it's still a bit gross.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included