### PR TITLE
Bug: display boost toggle if story is boosted

### DIFF
--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -86,7 +86,10 @@ export const createSelectFormFieldsForCollectionItem = () => {
       }
       let fields = defaultFields.slice();
 
-      if (isCollectionConfigDynamic(parentCollectionConfig)) {
+      if (
+        isCollectionConfigDynamic(parentCollectionConfig) ||
+        derivedArticle.isBoosted
+      ) {
         fields.push('isBoosted');
       }
       if (derivedArticle.liveBloggingNow === 'true') {


### PR DESCRIPTION
## What's changed?

When stories have been boosted and are then moved into a collection that doesn't support boosting, the story still shows the Boost label but provides no way for users to toggle this off.

This change will ensure that the toggle still appears, regardless of the stories location, until the toggle has been switched off. At that time, it will disappear, unless the story is moved back into a collection that supports boosting.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
