### PR TITLE
Change kicker suggestion button style

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -179,6 +179,15 @@ const KickerSuggestionsContainer = styled.div`
   font-weight: normal;
 `;
 
+const KickerSuggestionButton = styled(InputButton)`
+  background: transparent;
+  border: 1px solid ${({ theme }) => theme.shared.colors.greyMediumLight};
+  color: ${({ theme }) => theme.shared.colors.blackDark};
+  &:hover:enabled {
+    background-color: ${({ theme }) => theme.shared.colors.greyLight};
+  }
+`;
+
 const getInputId = (articleFragmentId: string, label: string) =>
   `${articleFragmentId}-${label}`;
 
@@ -249,7 +258,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           {kickerOptions.webTitle && (
             <Field
               name="showKickerTag"
-              component={InputButton}
+              component={KickerSuggestionButton}
               buttonText={kickerOptions.webTitle}
               selected={showKickerTag}
               size="s"
@@ -260,7 +269,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           {kickerOptions.sectionName && (
             <Field
               name="showKickerSection"
-              component={InputButton}
+              component={KickerSuggestionButton}
               selected={showKickerSection}
               size="s"
               buttonText={kickerOptions.sectionName}


### PR DESCRIPTION
## What's changed?

The styling of kicker suggestions no longer matches the 'Cancel' and 'Discard' buttons.

Before:
![Screenshot 2019-08-22 at 14 28 30](https://user-images.githubusercontent.com/12645938/63518543-2a714080-c4e9-11e9-816f-ba4bc566efd0.png)

After:
![Screenshot 2019-08-22 at 14 28 03](https://user-images.githubusercontent.com/12645938/63518541-29d8aa00-c4e9-11e9-8063-2cc64bc92581.png)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
