### PR TITLE
Changes to styling of hover icons 

### DIFF
--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -46,7 +46,6 @@ const Container = styled('div')`
 
   ${HoverActionsAreaOverlay} {
     bottom: 5px;
-    right: 4px;
     position: absolute;
     visibility: hidden;
   }
@@ -210,7 +209,7 @@ class FeedItem extends React.Component<FeedItemProps> {
             )}
           </ArticleThumbnail>
         </FeedItemContainer>
-        <HoverActionsAreaOverlay justify="flex-end" data-testid="hover-overlay">
+        <HoverActionsAreaOverlay data-testid="hover-overlay">
           <HoverActionsButtonWrapper
             buttons={[
               { text: 'View', component: HoverViewButton },

--- a/client-v2/src/shared/components/icons/HoverIcons.tsx
+++ b/client-v2/src/shared/components/icons/HoverIcons.tsx
@@ -75,19 +75,22 @@ const OphanHoverIcon = ({
   </svg>
 );
 
-const ViewHoverIcon = ({ fill = theme.colors.white, size = 10 }: IconProps) => (
+const ViewHoverIcon = ({ fill = theme.colors.white }: IconProps) => (
   <svg
     style={{ pointerEvents: 'none' }}
-    width={size}
-    height={size}
-    viewBox="0 0 10 10"
+    width="18"
+    height="12"
+    viewBox="0 0 18 12"
     xmlns="http://www.w3.org/2000/svg"
     xmlnsXlink="http://www.w3.org/1999/xlink"
   >
     <title>view</title>
     <path
       fill={fill}
-      d="M6.357 3.989l-2.495-2.6L5.195 0l3.469 3.614.003-.003L10 5 5.2 10 3.868 8.61l2.5-2.604H0V3.99h6.357z"
+      fillRule="evenodd"
+      d="M17 29c3.989 0 9 5.298 9 5.298v.961s-5.011 5.298-9 5.298-9-5.298-9-5.298v-.961S13.011 29 17 29zm0 9.634c2.127 0 3.866-1.718 3.866-3.845A3.863 3.863 0 0 0 17 30.923a3.863 3.863 0 0 0-3.866 3.866c0 2.127 1.739 3.845 3.866 3.845zm0-5.134c0 .695.573 1.289 1.289 1.289h.634A1.92 1.92 0 0 1 17 36.71a1.92 1.92 0 0 1-1.923-1.922c0-1.084.86-1.944 1.923-1.944v.655z"
+      transform="translate(-8 -28)"
+    />
     />
   </svg>
 );

--- a/client-v2/src/shared/components/input/HoverActionButtons.tsx
+++ b/client-v2/src/shared/components/input/HoverActionButtons.tsx
@@ -18,7 +18,7 @@ const ActionButton = ButtonCircular.extend<{ danger?: boolean }>`
   color: ${({ theme }) => theme.shared.button.color};
   margin: 0 2px 2px 2px;
   line-height: 1;
-  &:hover {
+  &:hover:enabled {
     background: ${({ danger, theme }) =>
       danger
         ? theme.shared.button.backgroundColorHighlightFocused


### PR DESCRIPTION
## What's changed?

The 'View' hover icon is now an eyeball.

Before:
![Screenshot 2019-08-22 at 15 04 25](https://user-images.githubusercontent.com/12645938/63521358-2dbafb00-c4ee-11e9-8b45-d611a935e6f1.png)

After:
![Screenshot 2019-08-22 at 15 03 39](https://user-images.githubusercontent.com/12645938/63521359-2e539180-c4ee-11e9-9006-c3a4d5f098fa.png)

Also!
- [x] hover icons on the feed now appear on the left, rather than right, of the card 
- [x] the 'Delete' hover icon turns a lighter shade of orange when focussed 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
