### PR TITLE
Hide 'forms open' icon when collection is launched

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -57,7 +57,8 @@ import difference from 'lodash/difference';
 import { selectArticlesInCollections } from 'shared/selectors/collection';
 import {
   editorOpenCollections,
-  editorCloseCollections
+  editorCloseCollections,
+  editorCloseFormsForCollection
 } from 'bundles/frontsUIBundle';
 import flatten from 'lodash/flatten';
 import { createSelectCollectionsInOpenFronts } from 'selectors/collectionSelectors';
@@ -424,7 +425,8 @@ function publishCollection(
               collectionId,
               draftVisibleArticles,
               frontStages.live
-            )
+            ),
+            editorCloseFormsForCollection(collectionId, frontId)
           ])
         );
 

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -26,7 +26,9 @@ import {
   selectEditorFavouriteFrontIds,
   selectEditorFavouriteFrontIdsByPriority,
   editorSelectArticleFragment,
-  selectOpenArticleFragmentForms
+  selectOpenArticleFragmentForms,
+  defaultState,
+  editorCloseFormsForCollection
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import { Action } from 'types/Action';
@@ -134,108 +136,108 @@ describe('frontsUIBundle', () => {
         ).toEqual(['1', '2']);
       });
     });
-  });
-  describe('selectEditorFavouriteFrontIdsByPriority', () => {
-    it('should handle empty priorities', () => {
-      expect(
-        selectEditorFavouriteFrontIdsByPriority(initialState, 'editorial')
-      ).toEqual([]);
+    describe('selectEditorFavouriteFrontIdsByPriority', () => {
+      it('should handle empty priorities', () => {
+        expect(
+          selectEditorFavouriteFrontIdsByPriority(initialState, 'editorial')
+        ).toEqual([]);
+      });
+      it('should select priorities', () => {
+        const stateWithFronts = {
+          editor: {
+            ...initialState.editor,
+            favouriteFrontIdsByPriority: { commercial: ['1', '2'] }
+          }
+        } as any;
+        expect(
+          selectEditorFavouriteFrontIdsByPriority(stateWithFronts, 'commercial')
+        ).toEqual(['1', '2']);
+      });
     });
-    it('should select priorities', () => {
-      const stateWithFronts = {
+    describe('createSelectFrontIdWithOpenAndStarredStatesByPriority', () => {
+      const stateWithEditorFronts = {
+        ...initialState,
         editor: {
           ...initialState.editor,
-          favouriteFrontIdsByPriority: { commercial: ['1', '2'] }
+          frontIdsByPriority: {
+            commercial: ['sc-johnson-partner-zone', 'a-shot-of-sustainability']
+          },
+          favouriteFrontIdsByPriority: {
+            commercial: [
+              'sc-johnson-partner-zone',
+              'un-global-compact-partner-zone'
+            ]
+          }
         }
       } as any;
-      expect(
-        selectEditorFavouriteFrontIdsByPriority(stateWithFronts, 'commercial')
-      ).toEqual(['1', '2']);
-    });
-  });
-  describe('createSelectFrontIdWithOpenAndStarredStatesByPriority', () => {
-    const stateWithEditorFronts = {
-      ...initialState,
-      editor: {
-        ...initialState.editor,
-        frontIdsByPriority: {
-          commercial: ['sc-johnson-partner-zone', 'a-shot-of-sustainability']
-        },
-        favouriteFrontIdsByPriority: {
-          commercial: [
-            'sc-johnson-partner-zone',
-            'un-global-compact-partner-zone'
-          ]
-        }
-      }
-    } as any;
-    const selectFrontIdWithOpenAndStarredStatesByPriority = createSelectFrontIdWithOpenAndStarredStatesByPriority();
-    it('should select all fronts by priority', () => {
-      expect(
-        selectFrontIdWithOpenAndStarredStatesByPriority(
-          initialState,
-          'commercial'
-        )
-      ).toHaveLength(4);
-    });
+      const selectFrontIdWithOpenAndStarredStatesByPriority = createSelectFrontIdWithOpenAndStarredStatesByPriority();
+      it('should select all fronts by priority', () => {
+        expect(
+          selectFrontIdWithOpenAndStarredStatesByPriority(
+            initialState,
+            'commercial'
+          )
+        ).toHaveLength(4);
+      });
 
-    it('should add correct Open State meta data', () => {
-      expect(
-        selectFrontIdWithOpenAndStarredStatesByPriority(
-          stateWithEditorFronts,
-          'commercial'
-        )
-      ).toEqual([
-        {
-          id: 'a-shot-of-sustainability',
-          displayName: undefined,
-          index: 1,
-          isOpen: true,
-          isStarred: false
-        },
-        {
-          id: 'sc-johnson-partner-zone',
-          displayName: undefined,
-          index: 0,
-          isOpen: true,
-          isStarred: true
-        },
-        {
-          id: 'sustainable-business/fairtrade-partner-zone',
-          isOpen: false,
-          isStarred: false,
-          displayName: undefined,
-          index: 2
-        },
-        {
-          id: 'un-global-compact-partner-zone',
-          isOpen: false,
-          isStarred: true,
-          displayName: undefined,
-          index: 3
-        }
-      ]);
-    });
-    it('should sort fronts by id and name', () => {
-      expect(
-        selectFrontIdWithOpenAndStarredStatesByPriority(
-          stateWithEditorFronts,
-          'commercial',
-          'id'
-        ).map(_ => _.id)
-      ).toEqual([
-        'a-shot-of-sustainability',
-        'sc-johnson-partner-zone',
-        'sustainable-business/fairtrade-partner-zone',
-        'un-global-compact-partner-zone'
-      ]);
-      expect(
-        selectFrontIdWithOpenAndStarredStatesByPriority(
-          stateWithEditorFronts,
-          'commercial',
-          'index'
-        ).map(_ => _.index)
-      ).toEqual([0, 1, 2, 3]);
+      it('should add correct Open State meta data', () => {
+        expect(
+          selectFrontIdWithOpenAndStarredStatesByPriority(
+            stateWithEditorFronts,
+            'commercial'
+          )
+        ).toEqual([
+          {
+            id: 'a-shot-of-sustainability',
+            displayName: undefined,
+            index: 1,
+            isOpen: true,
+            isStarred: false
+          },
+          {
+            id: 'sc-johnson-partner-zone',
+            displayName: undefined,
+            index: 0,
+            isOpen: true,
+            isStarred: true
+          },
+          {
+            id: 'sustainable-business/fairtrade-partner-zone',
+            isOpen: false,
+            isStarred: false,
+            displayName: undefined,
+            index: 2
+          },
+          {
+            id: 'un-global-compact-partner-zone',
+            isOpen: false,
+            isStarred: true,
+            displayName: undefined,
+            index: 3
+          }
+        ]);
+      });
+      it('should sort fronts by id and name', () => {
+        expect(
+          selectFrontIdWithOpenAndStarredStatesByPriority(
+            stateWithEditorFronts,
+            'commercial',
+            'id'
+          ).map(_ => _.id)
+        ).toEqual([
+          'a-shot-of-sustainability',
+          'sc-johnson-partner-zone',
+          'sustainable-business/fairtrade-partner-zone',
+          'un-global-compact-partner-zone'
+        ]);
+        expect(
+          selectFrontIdWithOpenAndStarredStatesByPriority(
+            stateWithEditorFronts,
+            'commercial',
+            'index'
+          ).map(_ => _.index)
+        ).toEqual([0, 1, 2, 3]);
+      });
     });
   });
 
@@ -334,6 +336,56 @@ describe('frontsUIBundle', () => {
         removeGroupArticleFragment('collectionId', 'articleFragmentId')
       );
       expect(state.editor.selectedArticleFragments.frontId).toEqual([]);
+    });
+    describe('Editor close forms for collection', () => {
+      it('should do nothing when there is no form for the front', () => {
+        const state = innerReducer(
+          defaultState,
+          editorCloseFormsForCollection('collectionId', 'frontId'),
+          initialSharedState
+        );
+        expect(state.selectedArticleFragments).toEqual(
+          defaultState.selectedArticleFragments
+        );
+      });
+      it('should clear form data for the given collection id', () => {
+        const initial = {
+          ...defaultState,
+          selectedArticleFragments: {
+            frontId: [
+              {
+                id: 'articleId1',
+                isSupporting: true,
+                collectionId: 'collectionId'
+              },
+              {
+                id: 'articleId2',
+                isSupporting: true,
+                collectionId: 'collectionId2'
+              },
+              {
+                id: 'articleId3',
+                isSupporting: true,
+                collectionId: 'collectionId'
+              }
+            ]
+          }
+        };
+        const state = innerReducer(
+          initial,
+          editorCloseFormsForCollection('collectionId', 'frontId'),
+          initialSharedState
+        );
+        expect(state.selectedArticleFragments).toEqual({
+          frontId: [
+            {
+              id: 'articleId2',
+              isSupporting: true,
+              collectionId: 'collectionId2'
+            }
+          ]
+        });
+      });
     });
     describe('Clearing article selection in response to persistence events', () => {
       const stateWithSelectedArticleFragments = {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -64,6 +64,7 @@ export const EDITOR_CLOSE_OVERVIEW = 'EDITOR_CLOSE_OVERVIEW';
 export const EDITOR_OPEN_ALL_OVERVIEWS = 'EDITOR_OPEN_ALL_OVERVIEWS';
 export const EDITOR_CLOSE_ALL_OVERVIEWS = 'EDITOR_CLOSE_ALL_OVERVIEWS';
 export const CHANGED_BROWSING_STAGE = 'CHANGED_BROWSING_STAGE';
+export const EDITOR_CLOSE_FORMS_FOR_COLLECTION = 'EDITOR_CLOSE_FORMS_FOR_COLLECTION' as const;
 
 const editorOpenCollections = (
   collectionIds: string | string[]
@@ -207,6 +208,18 @@ const editorClearArticleFragmentSelection = (
   type: EDITOR_CLEAR_ARTICLE_FRAGMENT_SELECTION,
   payload: { articleFragmentId }
 });
+
+const editorCloseFormsForCollection = (
+  collectionId: string,
+  frontId: string
+) => ({
+  type: EDITOR_CLOSE_FORMS_FOR_COLLECTION,
+  payload: { collectionId, frontId }
+});
+
+type EditorCloseFormsForCollection = ReturnType<
+  typeof editorCloseFormsForCollection
+>;
 
 const editorOpenClipboard = (): EditorOpenClipboard => ({
   type: EDITOR_OPEN_CLIPBOARD
@@ -615,6 +628,21 @@ const reducer = (
         action.payload.articleFragmentId
       );
     }
+    case EDITOR_CLOSE_FORMS_FOR_COLLECTION: {
+      const maybeOpenFormsForFront =
+        state.selectedArticleFragments[action.payload.frontId];
+
+      if (!maybeOpenFormsForFront) {
+        return state;
+      }
+      return maybeOpenFormsForFront.reduce(
+        (acc, formData) =>
+          formData.collectionId === action.payload.collectionId
+            ? clearArticleFragmentSelection(acc, formData.id)
+            : acc,
+        state
+      );
+    }
     case REMOVE_SUPPORTING_ARTICLE_FRAGMENT:
     case REMOVE_GROUP_ARTICLE_FRAGMENT:
     case 'REMOVE_CLIPBOARD_ARTICLE_FRAGMENT': {
@@ -702,7 +730,10 @@ export {
   createSelectCollectionIdsWithOpenForms,
   createSelectDoesCollectionHaveOpenForms,
   OpenArticleFragmentData,
-  changedBrowsingStage
+  changedBrowsingStage,
+  EditorCloseFormsForCollection,
+  editorCloseFormsForCollection,
+  defaultState
 };
 
 export default reducer;

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -41,7 +41,8 @@ import {
   EDITOR_CLOSE_OVERVIEW,
   EDITOR_OPEN_ALL_OVERVIEWS,
   EDITOR_CLOSE_ALL_OVERVIEWS,
-  CHANGED_BROWSING_STAGE
+  CHANGED_BROWSING_STAGE,
+  EditorCloseFormsForCollection
 } from 'bundles/frontsUIBundle';
 import { setFocusState, resetFocusState } from '../bundles/focusBundle';
 import { ActionSetFeatureValue } from 'shared/redux/modules/featureSwitches';
@@ -363,7 +364,8 @@ type Action =
   | EditionsFrontHiddenStateUpdate
   | IsPrefillMode
   | SetHidden
-  | ChangedBrowsingStage;
+  | ChangedBrowsingStage
+  | EditorCloseFormsForCollection;
 
 export {
   ActionError,


### PR DESCRIPTION
## What's changed?

The 'forms open' icon now only displays when a form is actually open!

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
