### PR TITLE
Unbreak breaking news

### DIFF
--- a/app/controllers/ViewsController.scala
+++ b/app/controllers/ViewsController.scala
@@ -13,10 +13,11 @@ class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean
                       crypto: Encryption, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
   private def shouldRedirectToV2(request: UserRequest[AnyContent]): Boolean = {
-    val shouldRedirectByQs: Boolean = request.queryString.getOrElse("redirect", Seq("true")).contains("true")
+    val shouldRedirectByQs: Boolean = (request.queryString.getOrElse("redirect", Seq("true")).contains("true")
+      && !request.queryString.getOrElse("layout", Seq("")).exists(_.contains("breaking-news")))
 
     // TODO set correct date
-    val redirectDay = DateTime.parse("2019-12-25")
+    val redirectDay = DateTime.parse("2019-08-27T09:30")
     val shouldRedirectByDate: Boolean = DateTime.now().isAfter(redirectDay)
 
     shouldRedirectByQs && (isDev || shouldRedirectByDate)
@@ -34,7 +35,7 @@ class ViewsController(val acl: Acl, assetsManager: AssetsManager, isDev: Boolean
   }
 
   def collectionEditor(priority: String) = getCollectionPermissionFilterByPriority(priority, acl)(ec) { request =>
-    if (shouldRedirectToV2(request)) {
+    if (priority != "breaking-news" && shouldRedirectToV2(request)) {
       PermanentRedirect(s"/v2/$priority")
     } else {
       val identity = request.user


### PR DESCRIPTION
## What's changed?

Breaking news would still redirect to `v2` as the code currently stands. But there's no breaking news in v2! This PR makes an exception of the `breaking-news` vanity url and the breaking-news front, which incidentally is the way the fronts tool handles breaking news.

It also amends the handover time to next Tuesday, 9:30PM

Tested with different times and modes in DEV.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
