### PR TITLE
Space for the 'add front' button

### DIFF
--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -110,6 +110,7 @@ const FrontCollectionsContainer = styled('div')`
   overflow-y: scroll;
   max-height: calc(100% - 43px);
   padding-top: 1px;
+  padding-bottom: ${({ theme }) => theme.front.paddingForAddFrontButton}px;
 `;
 
 interface FrontPropsBeforeState {

--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -45,6 +45,7 @@ const Container = styled(ContentContainer)<ContainerProps>`
 const ContainerBody = styled.div`
   width: ${({ theme }) => theme.front.overviewMinWidth}px;
   overflow-y: scroll;
+  padding-bottom: ${({ theme }) => theme.front.paddingForAddFrontButton}px;
 `;
 
 const FrontCollectionsOverview = ({

--- a/client-v2/src/components/inputs/ButtonOverlay.tsx
+++ b/client-v2/src/components/inputs/ButtonOverlay.tsx
@@ -5,7 +5,7 @@ import { css } from 'styled-components';
 import Button from 'shared/components/input/ButtonDefault';
 
 const ButtonWithShadow = styled(Button)<{ active?: boolean }>`
-  box-shadow: 0 1px 10px 2px rgba(0, 0, 0, 0.15);
+  box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 10px 2px, rgba(255,255,255, 0.15) 0px 0px 2px 3px;
   width: 50px;
   height: 50px;
   padding: 5px;

--- a/client-v2/src/components/inputs/ButtonOverlay.tsx
+++ b/client-v2/src/components/inputs/ButtonOverlay.tsx
@@ -5,7 +5,8 @@ import { css } from 'styled-components';
 import Button from 'shared/components/input/ButtonDefault';
 
 const ButtonWithShadow = styled(Button)<{ active?: boolean }>`
-  box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 10px 2px, rgba(255,255,255, 0.15) 0px 0px 2px 3px;
+  box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 10px 2px,
+    rgba(255, 255, 255, 0.15) 0px 0px 2px 3px;
   width: 50px;
   height: 50px;
   padding: 5px;

--- a/client-v2/src/constants/theme.ts
+++ b/client-v2/src/constants/theme.ts
@@ -44,7 +44,8 @@ const front = {
   frontListLabel: shared.colors.greyMediumLight,
   frontListButton: shared.colors.greyDark,
   minWidth: 380,
-  overviewMinWidth: 160
+  overviewMinWidth: 160,
+  paddingForAddFrontButton: 80
 };
 
 const form = {


### PR DESCRIPTION
## What's changed?

Ever had a problem getting at the bottom right hand side of the fronts tool, because the 'add front' button was in the way? 

We've made more room in front collection views and overviews so you can scroll past the button. 

The below collection is scrolled allll the way to the bottom.

<img width="473" alt="Screenshot 2019-08-23 at 18 05 45" src="https://user-images.githubusercontent.com/7767575/63610165-a72b1a00-c5d0-11e9-81ea-eb238c72d8fd.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
