### PR TITLE
Path type

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -202,8 +202,6 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
 
     val contentApiLiveHost: String = getMandatoryString("content.api.host")
     def contentApiDraftHost: String = getMandatoryString("content.api.draft.iam-host")
-
-    val editionsPrefillHost: String = getMandatoryString("content.api.draft.iam-host")
     lazy val editionsKey: String = getMandatoryString("content.api.editions.apiKey")
 
     lazy val key: Option[String] = getString("content.api.key")

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -203,7 +203,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     val contentApiLiveHost: String = getMandatoryString("content.api.host")
     def contentApiDraftHost: String = getMandatoryString("content.api.draft.iam-host")
 
-    val editionsPrefillHost: String = getMandatoryString("content.api.editions.prefillHost")
+    val editionsPrefillHost: String = getMandatoryString("content.api.draft.iam-host")
     lazy val editionsKey: String = getMandatoryString("content.api.editions.apiKey")
 
     lazy val key: Option[String] = getString("content.api.key")

--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -34,7 +34,7 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
 
     val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
-    wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(url): _*).get().map { response =>
+    wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(Map.empty, url): _*).get().map { response =>
 
       if (response.status != OK) {
         logger.error(s"Request to capi preview with url $url failed with response $response, ${response.body}")
@@ -53,9 +53,9 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
 
     val contentApiHost = config.contentApi.contentApiLiveHost
 
-    // In the CODE and PROD environments, an api key is not required because we are using an AWS private link endpoint to connect to CAPI. 
-    // Private Link endpoints are inside the AWS account and allow other services in the account access to the API. 
-    // In DEV environments - we use a standard external API for which a key is required, and is passed in via the config. 
+    // In the CODE and PROD environments, an api key is not required because we are using an AWS private link endpoint to connect to CAPI.
+    // Private Link endpoints are inside the AWS account and allow other services in the account access to the API.
+    // In DEV environments - we use a standard external API for which a key is required, and is passed in via the config.
     val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
     wsClient.url(url).get().map { response =>
@@ -82,7 +82,7 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
   def json(url: String) = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
-    wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(url): _*).get().map { response =>
+    wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(Map.empty, url): _*).get().map { response =>
       Cached(60) {
         Ok(rewriteBody(response.body)).as("application/json")
       }

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -4,15 +4,15 @@ import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
 case class EditionsCollection(
-  id: String,
-  displayName: String,
-  isHidden: Boolean,
-  lastUpdated: Option[Long],
-  updatedBy: Option[String],
-  updatedEmail: Option[String],
-  prefill: Option[CapiPrefillQuery],
-  items: List[EditionsArticle],
-) {
+                               id: String,
+                               displayName: String,
+                               isHidden: Boolean,
+                               lastUpdated: Option[Long],
+                               updatedBy: Option[String],
+                               updatedEmail: Option[String],
+                               prefill: Option[CapiPrefillQuery],
+                               items: List[EditionsArticle],
+                             ) {
   def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
     displayName,

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -24,6 +24,8 @@ object EditionsCollection {
   implicit val format = Json.format[EditionsCollection]
 
   def fromRow(rs: WrappedResultSet, prefix: String = ""): EditionsCollection = {
+    val capiPrefillQuery: Option[CapiPrefillQuery] =
+      createMaybeCapiPrefillQuery(rs.stringOpt(prefix + "prefill"), rs.stringOpt(prefix + "path_type"))
     EditionsCollection(
       rs.string(prefix + "id"),
       rs.string(prefix + "name"),
@@ -31,9 +33,16 @@ object EditionsCollection {
       rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
       rs.stringOpt(prefix + "updated_by"),
       rs.stringOpt(prefix + "updated_email"),
-      rs.stringOpt(prefix + "prefill").map(el => CapiPrefillQuery.apply(el)),
+      capiPrefillQuery,
       Nil
     )
+  }
+
+  private def createMaybeCapiPrefillQuery(maybePrefill: Option[String], maybePathType: Option[String]): Option[CapiPrefillQuery] = {
+    (maybePrefill, maybePathType) match {
+      case (Some(prefill), Some(pathType)) => Some(CapiPrefillQuery(prefill, PathType.withName(pathType)))
+      case _ => None
+    }
   }
 
   def fromRowOpt(rs: WrappedResultSet, prefix: String = ""): Option[EditionsCollection] = {
@@ -41,7 +50,10 @@ object EditionsCollection {
       id <- rs.stringOpt(prefix + "id")
       name <- rs.stringOpt(prefix + "name")
       isHidden <- rs.booleanOpt(prefix + "is_hidden")
-    } yield
+    } yield {
+      val capiPrefillQuery: Option[CapiPrefillQuery] =
+        createMaybeCapiPrefillQuery(rs.stringOpt(prefix + "prefill"), rs.stringOpt(prefix + "path_type"))
+
       EditionsCollection(
         id,
         name,
@@ -49,8 +61,9 @@ object EditionsCollection {
         rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
         rs.stringOpt(prefix + "updated_by"),
         rs.stringOpt(prefix + "updated_email"),
-        rs.stringOpt(prefix + "prefill").map(el => CapiPrefillQuery.apply(el)),
+        capiPrefillQuery,
         Nil
       )
+    }
   }
 }

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -4,14 +4,14 @@ import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
 
 case class EditionsCollection(
-                               id: String,
-                               displayName: String,
-                               isHidden: Boolean,
-                               lastUpdated: Option[Long],
-                               updatedBy: Option[String],
-                               updatedEmail: Option[String],
-                               prefill: Option[CapiPrefillQuery],
-                               items: List[EditionsArticle],
+  id: String,
+  displayName: String,
+  isHidden: Boolean,
+  lastUpdated: Option[Long],
+  updatedBy: Option[String],
+  updatedEmail: Option[String],
+  prefill: Option[CapiPrefillQuery],
+  items: List[EditionsArticle],
 ) {
   def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
@@ -31,7 +31,7 @@ object EditionsCollection {
       rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
       rs.stringOpt(prefix + "updated_by"),
       rs.stringOpt(prefix + "updated_email"),
-      rs.stringOpt(prefix + "prefill").map(CapiPrefillQuery.apply),
+      rs.stringOpt(prefix + "prefill").map(el => CapiPrefillQuery.apply(el)),
       Nil
     )
   }
@@ -49,7 +49,7 @@ object EditionsCollection {
         rs.zonedDateTimeOpt(prefix + "updated_on").map(_.toInstant.toEpochMilli),
         rs.stringOpt(prefix + "updated_by"),
         rs.stringOpt(prefix + "updated_email"),
-        rs.stringOpt(prefix + "prefill").map(CapiPrefillQuery.apply),
+        rs.stringOpt(prefix + "prefill").map(el => CapiPrefillQuery.apply(el)),
         Nil
       )
   }

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -76,6 +76,21 @@ case class WeekDays(days: List[WeekDay]) extends Periodicity {
     )
 }
 
+sealed abstract class PathType extends EnumEntry with Uncapitalised {
+  def toPathSegment: String = {
+    this match {
+      case PathType.Search => "search"
+      case PathType.PrintSent => "content/print-sent"
+    }
+  }
+}
+
+object PathType extends PlayEnum[PathType] {
+  case object Search extends PathType
+  case object PrintSent extends PathType
+  override def values = findValues
+}
+
 case class CollectionTemplate(
    name: String,
    prefill: Option[CapiPrefillQuery],
@@ -119,6 +134,7 @@ case class EditionsFrontSkeleton(
     metadataParam
   }
 }
+
 
 case class EditionsCollectionSkeleton(
     name: String,

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -48,7 +48,7 @@ object FrontPresentation {
 
 case class CollectionPresentation()
 
-case class CapiPrefillQuery(queryString: String) extends AnyVal {
+case class CapiPrefillQuery(queryString: String, pathType: PathType = PathType.PrintSent) {
   def escapedQueryString(): String =
     queryString
       .replace(",", "%2C")

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -1,13 +1,13 @@
 package model.editions
 
-import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import java.time.temporal.ChronoField
+import java.time.{LocalDate, ZoneId}
 
-import enumeratum.{EnumEntry, PlayEnum}
 import enumeratum.EnumEntry.Uncapitalised
+import enumeratum.{EnumEntry, PlayEnum}
 import model.editions.templates.DailyEdition
 import org.postgresql.util.PGobject
-import play.api.libs.json.{Format, Json, Reads, Writes}
+import play.api.libs.json.Json
 
 object EditionsTemplates {
   val templates: Map[String, EditionTemplate] = Map(
@@ -23,18 +23,26 @@ case object WeekDay extends Enumeration(1) {
 
   type WeekDay = Value
   val Mon, Tues, Wed, Thurs, Fri, Sat, Sun = Value
+
   implicit def WeekDayToInt(weekDay: WeekDay): Int = weekDay.id
 }
 
 sealed abstract class Swatch extends EnumEntry with Uncapitalised
 
 object Swatch extends PlayEnum[Swatch] {
+
   case object Neutral extends Swatch
+
   case object News extends Swatch
+
   case object Opinion extends Swatch
+
   case object Culture extends Swatch
+
   case object Lifestyle extends Swatch
+
   case object Sport extends Swatch
+
   override def values = findValues
 }
 
@@ -48,7 +56,7 @@ object FrontPresentation {
 
 case class CollectionPresentation()
 
-case class CapiPrefillQuery(queryString: String, pathType: PathType = PathType.PrintSent) {
+case class CapiPrefillQuery(queryString: String, pathType: PathType) {
   def escapedQueryString(): String =
     queryString
       .replace(",", "%2C")
@@ -61,10 +69,12 @@ object CapiPrefillQuery {
   implicit def format = Json.format[CapiPrefillQuery]
 }
 
-import WeekDay._
+import model.editions.WeekDay._
+
 trait Periodicity {
   def isValid(date: LocalDate): Boolean
 }
+
 case class Daily() extends Periodicity {
   def isValid(date: LocalDate) = true
 }
@@ -86,46 +96,49 @@ sealed abstract class PathType extends EnumEntry with Uncapitalised {
 }
 
 object PathType extends PlayEnum[PathType] {
+
   case object Search extends PathType
+
   case object PrintSent extends PathType
+
   override def values = findValues
 }
 
 case class CollectionTemplate(
-   name: String,
-   prefill: Option[CapiPrefillQuery],
-   presentation: CollectionPresentation,
-   hidden: Boolean = false
+  name: String,
+  prefill: Option[CapiPrefillQuery],
+  presentation: CollectionPresentation,
+  hidden: Boolean = false
 )
 
 case class FrontTemplate(
-    name: String,
-    collections: List[CollectionTemplate],
-    presentation: FrontPresentation,
-    isSpecial: Boolean = false,
-    hidden: Boolean = false
+  name: String,
+  collections: List[CollectionTemplate],
+  presentation: FrontPresentation,
+  isSpecial: Boolean = false,
+  hidden: Boolean = false
 )
 
 case class EditionTemplate(
-    fronts: List[(FrontTemplate, Periodicity)],
-    zoneId: ZoneId,
-    availability: Periodicity,
+  fronts: List[(FrontTemplate, Periodicity)],
+  zoneId: ZoneId,
+  availability: Periodicity,
 )
 
 // Issue skeletons are what is generated when you create a new issue for a given date
 // (Date + Template) => Skeleton
 case class EditionsIssueSkeleton(
-    issueDate: LocalDate,
-    zoneId: ZoneId,
-    fronts: List[EditionsFrontSkeleton]
+  issueDate: LocalDate,
+  zoneId: ZoneId,
+  fronts: List[EditionsFrontSkeleton]
 )
 
 case class EditionsFrontSkeleton(
-    name: String,
-    collections: List[EditionsCollectionSkeleton],
-    presentation: FrontPresentation,
-    hidden: Boolean,
-    isSpecial: Boolean
+  name: String,
+  collections: List[EditionsCollectionSkeleton],
+  presentation: FrontPresentation,
+  hidden: Boolean,
+  isSpecial: Boolean
 ) {
   def metadata() = {
     val metadataParam = new PGobject()
@@ -137,14 +150,14 @@ case class EditionsFrontSkeleton(
 
 
 case class EditionsCollectionSkeleton(
-    name: String,
-    items: List[EditionsArticleSkeleton],
-    prefill: Option[CapiPrefillQuery],
-    presentation: CollectionPresentation,
-    hidden: Boolean
+  name: String,
+  items: List[EditionsArticleSkeleton],
+  prefill: Option[CapiPrefillQuery],
+  presentation: CollectionPresentation,
+  hidden: Boolean
 )
 
 case class EditionsArticleSkeleton(
-    pageCode: String,
-    metadata: ArticleMetadata
+  pageCode: String,
+  metadata: ArticleMetadata
 )

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -2,8 +2,8 @@ package model.editions.templates
 
 import java.time.ZoneId
 
-import model.editions._
 import model.editions.Swatch._
+import model.editions._
 
 object DailyEdition {
   val template = EditionTemplate(
@@ -55,7 +55,7 @@ object FrontSpecialSpecial1 {
 }
 
 object FrontTopStories {
-   val collectionTopStories = CollectionTemplate(
+  val collectionTopStories = CollectionTemplate(
     name = "Top Stories",
     prefill = None,
     presentation = TemplateDefaults.defaultCollectionPresentation
@@ -69,9 +69,9 @@ object FrontTopStories {
 }
 
 object FrontNewsUkGuardian {
-   val collectionNewsFrontPage = CollectionTemplate(
+  val collectionNewsFrontPage = CollectionTemplate(
     name = "Front Page",
-    prefill =  Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsSpecial1 = CollectionTemplate(
@@ -103,9 +103,9 @@ object FrontNewsUkGuardian {
 }
 
 object FrontNewsUkGuardianSaturday {
-   val collectionNewsFrontPage = CollectionTemplate(
+  val collectionNewsFrontPage = CollectionTemplate(
     name = "Front Page",
-    prefill =  Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsSpecial1 = CollectionTemplate(
@@ -169,7 +169,7 @@ object FrontNewsWorldGuardian {
 object FrontNewsUkObserver {
   val collectionNewsFrontPageObserver = CollectionTemplate(
     name = "Front Page",
-    prefill =  None,
+    prefill = None,
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsUkNewsObserver = CollectionTemplate(
@@ -561,7 +561,7 @@ object FrontFoodObserver {
     prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/life-and-style,food/food")),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
- val collectionFoodMonthly = CollectionTemplate(
+  val collectionFoodMonthly = CollectionTemplate(
     name = "OFM",
     prefill = Some(CapiPrefillQuery("?tag=theobserver/foodmonthly/features|theobserver/foodmonthly")),
     presentation = TemplateDefaults.defaultCollectionPresentation,
@@ -637,7 +637,7 @@ object FrontSpecialSpecial2 {
 object FrontCrosswords {
   val collectionCrosswords = CollectionTemplate(
     name = "Crosswords",
-    prefill = Some(CapiPrefillQuery("?tag=type/crossword")),
+    prefill = Some(CapiPrefillQuery("?tag=type/crossword", PathType.Search)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -71,7 +71,7 @@ object FrontTopStories {
 object FrontNewsUkGuardian {
   val collectionNewsFrontPage = CollectionTemplate(
     name = "Front Page",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsSpecial1 = CollectionTemplate(
@@ -82,17 +82,17 @@ object FrontNewsUkGuardian {
   )
   val collectionNewsUkNewsGuardian = CollectionTemplate(
     name = "UK News",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsUkFinancial = CollectionTemplate(
     name = "UK Financial",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/financial3")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/financial3", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsWeather = CollectionTemplate(
     name = "Weather",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
@@ -105,7 +105,7 @@ object FrontNewsUkGuardian {
 object FrontNewsUkGuardianSaturday {
   val collectionNewsFrontPage = CollectionTemplate(
     name = "Front Page",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsSpecial1 = CollectionTemplate(
@@ -116,22 +116,22 @@ object FrontNewsUkGuardianSaturday {
   )
   val collectionNewsUkNewsGuardian = CollectionTemplate(
     name = "UK News",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsWeekInReviewGuardian = CollectionTemplate(
     name = "Week in Review",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/week-in-review")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/week-in-review", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsUkFinancial = CollectionTemplate(
     name = "UK Financial",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/financial3")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/financial3", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsWeather = CollectionTemplate(
     name = "Weather",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
@@ -145,7 +145,7 @@ object FrontNewsUkGuardianSaturday {
 object FrontNewsWorldGuardian {
   val collectionNewsWorldGuardian = CollectionTemplate(
     name = "World News",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/international")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/international", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsWorldFinancialGuardian = CollectionTemplate(
@@ -174,17 +174,17 @@ object FrontNewsUkObserver {
   )
   val collectionNewsUkNewsObserver = CollectionTemplate(
     name = "UK News",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/uknews")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/uknews", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsUkBusinessObserver = CollectionTemplate(
     name = "Business & Cash",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/business|theobserver/news/cash")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/business|theobserver/news/cash", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsUkFocusObserver = CollectionTemplate(
     name = "Focus",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/focus")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/focus", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation,
     hidden = true
   )
@@ -204,7 +204,7 @@ object FrontNewsUkObserver {
 object FrontNewsWorldObserver {
   val collectionNewsWorldObserver = CollectionTemplate(
     name = "World News",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/worldnews")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/worldnews", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsWorldBusinessObserver = CollectionTemplate(
@@ -228,22 +228,22 @@ object FrontNewsWorldObserver {
 object FrontJournal {
   val collectionJournalFeatures = CollectionTemplate(
     name = "Features",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/the-long-read|theguardian/journal/features")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/the-long-read|theguardian/journal/features", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionJournalComment = CollectionTemplate(
     name = "Comment",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/opinion")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/opinion", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionJournalLetters = CollectionTemplate(
     name = "Letters",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/letters")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/letters", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionJournalObits = CollectionTemplate(
     name = "Obits",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/obituaries")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/journal/obituaries", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionJournalSpecial1 = CollectionTemplate(
@@ -262,7 +262,7 @@ object FrontJournal {
 object FrontComment {
   val collectionOpinionComment = CollectionTemplate(
     name = "Comment",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/comment")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/news/comment", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionOpinionSpecial1 = CollectionTemplate(
@@ -281,12 +281,12 @@ object FrontComment {
 object FrontCulture {
   val collectionCultureArts = CollectionTemplate(
     name = "Arts",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureTVandRadio = CollectionTemplate(
     name = "TV & Radio",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureSpecial1 = CollectionTemplate(
@@ -305,22 +305,22 @@ object FrontCulture {
 object FrontCultureFilmMusic {
   val collectionCultureFilm = CollectionTemplate(
     name = "Film",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/film")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/film", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureMusic = CollectionTemplate(
     name = "Music",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/music")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/music", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureArts = CollectionTemplate(
     name = "Arts",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureTVandRadio = CollectionTemplate(
     name = "TV & Radio",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureSpecial2 = CollectionTemplate(
@@ -338,17 +338,17 @@ object FrontCultureFilmMusic {
 object FrontCultureGuide {
   val collectionCultureFeatures = CollectionTemplate(
     name = "Features",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/theguide/features")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/theguide/features", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCulturePreview = CollectionTemplate(
     name = "Preview",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/theguide/reviews")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/theguide/reviews", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureTVandRadio = CollectionTemplate(
     name = "TV and Radio",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/theguide/tv-radio")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/theguide/tv-radio", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureSpecial3 = CollectionTemplate(
@@ -366,22 +366,22 @@ object FrontCultureGuide {
 object FrontCultureNewReview {
   val collectionCultureFeatures = CollectionTemplate(
     name = "Features",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/features")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/features", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureScience = CollectionTemplate(
     name = "Science & Technology",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/discover")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/discover", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureAgenda = CollectionTemplate(
     name = "Agenda",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/agenda")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/agenda", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureCritics = CollectionTemplate(
     name = "Critics",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/critics")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/new-review/critics", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureSpecial3 = CollectionTemplate(
@@ -400,7 +400,7 @@ object FrontCultureNewReview {
 object FrontLife {
   val collectionLifeFeatures = CollectionTemplate(
     name = "Features",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/features")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/features", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeSpecial1 = CollectionTemplate(
@@ -419,7 +419,7 @@ object FrontLife {
 object FrontLifeFashion {
   val collectionLifeFashion1 = CollectionTemplate(
     name = "Fashion 1",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/the-fashion/the-fashion")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/the-fashion/the-fashion", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeFashion2 = CollectionTemplate(
@@ -446,37 +446,37 @@ object FrontLifeFashion {
 object FrontLifeWeekend {
   val collectionLifeWeekend = CollectionTemplate(
     name = "Weekend",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/starters|theguardian/weekend/features2|theguardian/weekend/back")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/starters|theguardian/weekend/features2|theguardian/weekend/back", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeFamily = CollectionTemplate(
     name = "Family",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/family")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/family", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeSpace = CollectionTemplate(
     name = "Space",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/space2")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/space2", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeFashion = CollectionTemplate(
     name = "Fashion & Beauty",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/fashion-and-beauty")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/fashion-and-beauty", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeBody = CollectionTemplate(
     name = "Body & Mind",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/body-and-mind")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/weekend/body-and-mind", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeTravel = CollectionTemplate(
     name = "Travel",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/travel/travel")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/travel/travel", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeMoney = CollectionTemplate(
     name = "Money",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/money")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/money", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeSpecial2 = CollectionTemplate(
@@ -496,17 +496,17 @@ object FrontLifeWeekend {
 object FrontLifeMagazineObserver {
   val collectionLifeMagazineFeatures = CollectionTemplate(
     name = "Features",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/features2")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/features2", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeLifeStyle = CollectionTemplate(
     name = "Life & Style",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/life-and-style,-food/food")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/life-and-style,-food/food", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionLifeSpecial3 = CollectionTemplate(
     name = "Life Special",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/design/design")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/design/design", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation,
     hidden = true
   )
@@ -520,7 +520,7 @@ object FrontLifeMagazineObserver {
 object FrontBooks {
   val collectionBooks = CollectionTemplate(
     name = "Books",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/guardianreview/saturdayreviewsfeatres|theobserver/new-review/books")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/guardianreview/saturdayreviewsfeatres|theobserver/new-review/books", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionBooksSpecial1 = CollectionTemplate(
@@ -539,7 +539,7 @@ object FrontBooks {
 object FrontFood {
   val collectionFeast = CollectionTemplate(
     name = "Food",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/feast/feast")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/feast/feast", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionFoodSpecial1 = CollectionTemplate(
@@ -558,12 +558,12 @@ object FrontFood {
 object FrontFoodObserver {
   val collectionFood = CollectionTemplate(
     name = "Food",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/life-and-style,food/food")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/magazine/life-and-style,food/food", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionFoodMonthly = CollectionTemplate(
     name = "OFM",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/foodmonthly/features|theobserver/foodmonthly")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/foodmonthly/features|theobserver/foodmonthly", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation,
     hidden = true
   )
@@ -583,7 +583,7 @@ object FrontFoodObserver {
 object FrontSportGuardian {
   val collectionSport = CollectionTemplate(
     name = "Sport",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/sport/news")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/sport/news", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionSportSpecial1 = CollectionTemplate(
@@ -602,7 +602,7 @@ object FrontSportGuardian {
 object FrontSportObserver {
   val collectionObsSport = CollectionTemplate(
     name = "Sport",
-    prefill = Some(CapiPrefillQuery("?tag=theobserver/sport/news")),
+    prefill = Some(CapiPrefillQuery("?tag=theobserver/sport/news", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionSportSpecial2 = CollectionTemplate(
@@ -621,7 +621,7 @@ object FrontSportObserver {
 object FrontSpecialSpecial2 {
   val collectionSpecialSpecial2 = CollectionTemplate(
     name = "Special",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
 

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -120,10 +120,6 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       .showBlocks("main")
       .showAtoms("media")
 
-    import play.api.Logger
-
-    Logger.info(s"prefill query URL generated:\n${query.getUrl(targetUrl)}")
-
     this.getResponse(query).map { response =>
       val filteredResults = response.results.filter { result =>
         (for {

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -1,33 +1,33 @@
 package services
 
 import java.io.IOException
-import java.net.{URI, URLEncoder}
+import java.net.URI
 import java.nio.charset.Charset
-import java.time.{LocalDate, Period, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, ZoneOffset}
 
-import org.apache.http.client.utils.URLEncodedUtils
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Content, SearchResponse, TagType}
-import com.gu.contentapi.client.{GuardianContentClient, IAMEncoder, IAMSigner, Parameter}
+import com.gu.contentapi.client.{GuardianContentClient, IAMSigner, Parameter}
 import com.gu.facia.api.utils.{CardStyle, ResolvedMetaData}
 import com.gu.facia.client.models.TrailMetaData
 import conf.ApplicationConfiguration
 import logging.Logging
-import model.editions.CapiPrefillQuery
+import model.editions.{CapiPrefillQuery, PathType}
 import okhttp3.{Call, Callback, Request, Response}
+import org.apache.http.client.utils.URLEncodedUtils
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
 case class Prefill(
-                    internalPageCode: Int,
-                    showByline: Boolean,
-                    showQuotedHeadline: Boolean,
-                    imageCutoutReplace: Boolean,
-                    cutout: Option[String]
-                  )
+  internalPageCode: Int,
+  showByline: Boolean,
+  showQuotedHeadline: Boolean,
+  imageCutoutReplace: Boolean,
+  cutout: Option[String]
+)
 
 class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionContext) extends GuardianContentClient(config.contentApi.editionsKey) with Capi with Logging {
   override def targetUrl: String = config.contentApi.editionsPrefillHost
@@ -45,6 +45,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
     http.newCall(req.build()).enqueue(new Callback() {
       override def onFailure(call: Call, e: IOException): Unit = promise.failure(e)
+
       override def onResponse(call: Call, response: Response): Unit = {
         promise.success(HttpResponse(response.body().bytes, response.code(), response.message()))
       }
@@ -63,10 +64,10 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
     )
   }
 
-  def getPreviewHeaders(url: String): Seq[(String,String)] = previewSigner.addIAMHeaders(headers = Map.empty, URI.create(url)).toSeq
+  def getPreviewHeaders(url: String): Seq[(String, String)] = previewSigner.addIAMHeaders(headers = Map.empty, URI.create(url)).toSeq
 
   // Prefill
-  def geneneratePrefillQuery(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, fields: List[String]) = {
+  private def geneneratePrefillQuery(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, fields: List[String]) = {
     val params = URLEncodedUtils
       .parse(new URI(capiPrefillQuery.escapedQueryString()), Charset.forName("UTF-8"))
       .asScala
@@ -74,7 +75,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
     // Hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
     val utcMidnightOnDate = issueDate.atStartOfDay().toInstant(ZoneOffset.UTC)
 
-    var query = PrintSentQuery()
+    var query = CapiQueryBuilder(capiPrefillQuery.pathType)
       .page(1)
       .pageSize(200)
       .showFields(fields.mkString(","))
@@ -139,11 +140,12 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
   }
 
   /**
-    * Get a list of article items in the order they exist according to the newspaper page number
-    * @param issueDate
-    * @param capiPrefillQuery
-    * @return
-    */
+   * Get a list of article items in the order they exist according to the newspaper page number
+   *
+   * @param issueDate
+   * @param capiPrefillQuery
+   * @return
+   */
   def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = {
     val fields = List(
       "newspaperEditionDate",
@@ -191,16 +193,18 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 }
 
 // Query generator for the print-sent endpoint
-case class PrintSentQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends SearchQueryBase[PrintSentQuery] {
+case class CapiQueryBuilder(pathType: PathType, parameterHolder: Map[String, Parameter] = Map.empty)
+  extends SearchQueryBase[CapiQueryBuilder] {
 
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(pathType, parameterMap)
 
-  override def pathSegment: String = "content/print-sent"
+  override def pathSegment: String = pathType.toPathSegment
 }
 
 trait Capi {
-  def getPreviewHeaders(url: String): Seq[(String,String)]
+  def getPreviewHeaders(url: String): Seq[(String, String)]
+
   def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]]
+
   def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse]
 }

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -51,7 +51,8 @@ trait CollectionsQueries {
        """.map { rs =>
         val date = rs.localDate("issue_date")
         val zone = ZoneId.of(rs.string("timezone_id"))
-        val pathType = PathType.withName(rs.string("path_type"))
+        val pathTypeStr = rs.string("path_type")
+        val pathType = PathType.withName(pathTypeStr)
 
         (date, zone, CapiPrefillQuery(rs.string("prefill"), pathType), rs.string("page_code"))
       }.list().apply()
@@ -114,6 +115,7 @@ trait CollectionsQueries {
         collections.updated_by,
         collections.updated_email,
         collections.prefill,
+        collections.path_type,
 
         articles.collection_id AS articles_collection_id,
         articles.page_code     AS articles_page_code,

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -3,7 +3,7 @@ package services.editions.db
 import java.time._
 
 import model.editions.internal.PrefillUpdate
-import model.editions.{CapiPrefillQuery, EditionsCollection}
+import model.editions.{CapiPrefillQuery, EditionsCollection, PathType}
 import model.forms.GetCollectionsFilter
 import play.api.libs.json.Json
 import scalikejdbc._
@@ -11,7 +11,7 @@ import services.editions.DbEditionsArticle
 
 trait CollectionsQueries {
 
-  def getCollections(filters : List[GetCollectionsFilter]) = DB readOnly { implicit session =>
+  def getCollections(filters: List[GetCollectionsFilter]) = DB readOnly { implicit session =>
     case class TypedFilters(id: String, updatedAt: Option[OffsetDateTime])
 
     val sqlFilters = filters.map { f =>
@@ -23,7 +23,8 @@ trait CollectionsQueries {
       )
     }
 
-    val rows = fetchCollectionsSql(where = sqls"""
+    val rows = fetchCollectionsSql(where =
+      sqls"""
       EXISTS (
         SELECT *
         FROM (VALUES ${sqlFilters.map(f => sqls"(${f.id}, ${f.updatedAt})")}) AS F(id, updated_on)
@@ -35,8 +36,10 @@ trait CollectionsQueries {
   }
 
   def getCollectionPrefillQueryString(id: String) = DB readOnly { implicit session =>
-    val rows = sql"""
+    val rows =
+      sql"""
           SELECT collections.prefill,
+                 collections.path_type,
                  articles.page_code,
                  edition_issues.issue_date,
                  edition_issues.timezone_id
@@ -46,18 +49,19 @@ trait CollectionsQueries {
           JOIN edition_issues ON (fronts.issue_id = edition_issues.id)
           WHERE collections.id = $id
        """.map { rs =>
-      val date = rs.localDate("issue_date")
-      val zone = ZoneId.of(rs.string("timezone_id"))
+        val date = rs.localDate("issue_date")
+        val zone = ZoneId.of(rs.string("timezone_id"))
+        val pathType = PathType.withName(rs.string("path_type"))
 
-      (date, zone, CapiPrefillQuery(rs.string("prefill")), rs.string("page_code"))
-    }.list().apply()
+        (date, zone, CapiPrefillQuery(rs.string("prefill"), pathType), rs.string("page_code"))
+      }.list().apply()
 
     rows.headOption.map { case (issueDate, zone, prefill, _) =>
       PrefillUpdate(issueDate, zone, prefill, rows.map(_._4))
     }
   }
 
-  def updateCollection(collection: EditionsCollection): EditionsCollection  = DB localTx { implicit session =>
+  def updateCollection(collection: EditionsCollection): EditionsCollection = DB localTx { implicit session =>
     val lastUpdated = collection.lastUpdated.map(EditionsDB.dateTimeFromMillis)
     sql"""
       UPDATE collections
@@ -97,7 +101,8 @@ trait CollectionsQueries {
   }
 
   private def fetchCollectionsSql(where: SQLSyntax): SQLToList[GetCollectionsRow, HasExtractor] = {
-    val sql = sql"""
+    val sql =
+      sql"""
       SELECT
         collections.id,
         collections.front_id,

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -58,7 +58,7 @@ trait IssueQueries {
             updated_on,
             updated_by,
             updated_email
-          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.queryString)}, ${collection.prefill.map(_.pathType.toString)}, $truncatedNow, $userName, ${user.email})
+          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.queryString)}, ${collection.prefill.map(_.pathType.entryName)}, $truncatedNow, $userName, ${user.email})
           RETURNING id;
           """.map(_.string("id")).single().apply().get
 
@@ -151,6 +151,7 @@ trait IssueQueries {
         collections.updated_by    AS collections_updated_by,
         collections.updated_email AS collections_updated_email,
         collections.prefill       AS collections_prefill,
+        collections.path_type     AS collections_path_type,
 
         articles.collection_id AS articles_collection_id,
         articles.page_code     AS articles_page_code,

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -54,10 +54,11 @@ trait IssueQueries {
             is_hidden,
             metadata,
             prefill,
+            path_type,
             updated_on,
             updated_by,
             updated_email
-          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.queryString)}, $truncatedNow, $userName, ${user.email})
+          ) VALUES ($frontId, $cIndex, ${collection.name}, ${collection.hidden}, NULL, ${collection.prefill.map(_.queryString)}, ${collection.prefill.map(_.pathType.toString)}, $truncatedNow, $userName, ${user.email})
           RETURNING id;
           """.map(_.string("id")).single().apply().get
 

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,7 +1,8 @@
 # --- !Ups
 
 ALTER TABLE collections ADD COLUMN path_type TEXT;
-UPDATE  collections  SET path_type = 'print-sent' where prefill IS NOT NULL;
+UPDATE  collections  SET path_type = 'printSent' where prefill IS NOT NULL;
+UPDATE  collections  SET path_type = 'search' where prefill = '?tag=type/crossword';
 
 # --- !Downs
 

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE collections ADD COLUMN path_type TEXT;
+UPDATE  collections  SET path_type = 'print-sent' where prefill IS NOT NULL;
+
+# --- !Downs
+
+ALTER TABLE collections DROP COLUMN path_type;
+

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -14,7 +14,7 @@ class editionTemplateTest extends FreeSpec with Matchers {
 
   // Currently not testing prefills!
   object TestCapi extends Capi {
-    override def getPreviewHeaders(url: String): Seq[(String, String)] = Seq.empty[(String, String)]
+    override def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)] = Seq.empty[(String, String)]
     override def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
     override def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = Future.successful(Nil)
   }

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -2,8 +2,8 @@ package fixtures
 
 import java.time.ZoneId
 
-import model.editions.{CapiPrefillQuery, CollectionTemplate, Daily, EditionTemplate, FrontTemplate, WeekDay, WeekDays}
 import model.editions.templates.TemplateDefaults
+import model.editions._
 
 object TestEdition {
   val template = EditionTemplate(
@@ -38,17 +38,17 @@ object FrontTopStories {
 object FrontNewsUkGuardian {
   val collectionNewsFrontPage = CollectionTemplate(
     name = "Front Page",
-    prefill =  Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsUkNewsGuardian = CollectionTemplate(
     name = "UK News",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsWeather = CollectionTemplate(
     name = "Weather",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
@@ -61,7 +61,7 @@ object FrontNewsUkGuardian {
 object FrontNewsUkGuardianSaturday {
   val collectionNewsFrontPage = CollectionTemplate(
     name = "Front Page",
-    prefill =  Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionNewsSpecial1 = CollectionTemplate(
@@ -72,7 +72,7 @@ object FrontNewsUkGuardianSaturday {
   )
   val collectionNewsWeather = CollectionTemplate(
     name = "Weather",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/mainsection/weather2", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
@@ -85,12 +85,12 @@ object FrontNewsUkGuardianSaturday {
 object FrontCulture {
   val collectionCultureArts = CollectionTemplate(
     name = "Arts",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/arts", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val collectionCultureTVandRadio = CollectionTemplate(
     name = "TV & Radio",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/g2/tvandradio", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
   val front = FrontTemplate(
@@ -103,7 +103,7 @@ object FrontCulture {
 object FrontSpecialSpecial2 {
   val collectionSpecialSpecial2 = CollectionTemplate(
     name = "Special",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement")),
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
 

--- a/test/model/editions/PathTypeTest.scala
+++ b/test/model/editions/PathTypeTest.scala
@@ -1,0 +1,19 @@
+package model.editions
+
+import org.scalatest.{FunSuite, Matchers}
+
+class PathTypeTest extends FunSuite with Matchers {
+
+  test("should construct correct enum types") {
+
+    PathType.withName("printSent") shouldEqual PathType.PrintSent
+    PathType.withName("search") shouldEqual PathType.Search
+  }
+
+  test("should construct correct path segments form enums") {
+
+    PathType.withName("printSent").toPathSegment shouldEqual "content/print-sent"
+    PathType.withName("search").toPathSegment shouldEqual "search"
+  }
+
+}

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -14,7 +14,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
   "Creating a template" - {
     "Sets the prefill metadata from CAPI" in {
       val fakeCapi = new Capi {
-        def getPreviewHeaders(url: String): Seq[(String, String)] = ???
+        def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)] = ???
         def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = {
           capiPrefillQuery.queryString match {
             case "?tag=theguardian/mainsection/topstories" => Future.successful(List(

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -90,7 +90,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should insert fronts, collections and articles" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           ),
@@ -101,7 +101,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
           )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query", PathType.PrintSent)),
             article("54321"),
             article("65432")
           ),
@@ -128,7 +128,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       val newsPoliticsCollection = newsFront.collections.head
       newsPoliticsCollection.displayName shouldBe "politics"
-      newsPoliticsCollection.prefill.value shouldBe CapiPrefillQuery("magic-politics-query")
+      newsPoliticsCollection.prefill.value shouldBe CapiPrefillQuery("magic-politics-query", PathType.PrintSent)
       newsPoliticsCollection.items.length shouldBe 2
 
       val newsInternationalCollection = newsFront.collections.tail.head
@@ -153,7 +153,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow lookup of issue by collection id" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           )
@@ -161,7 +161,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       )
       insertSkeletonIssue(2019, 9, 29,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("54321"),
             article("65432")
           )
@@ -186,17 +186,17 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow a set of collections to be fetched individually" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           ),
-          collection("international", None,article("34567"),
+          collection("international", None, article("34567"),
             article("45678"),
             article("56789")
           )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query", PathType.PrintSent)),
             article("54321"),
             article("65432")
           ),
@@ -229,7 +229,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow collections to be filtered by timestamp" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           ),
@@ -240,7 +240,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
           )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query", PathType.PrintSent)),
             article("54321"),
             article("65432")
           ),
@@ -262,13 +262,13 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       // pretend we are a client asking for updates since a time that is older than the creation time
       val newerCollections = editionsDB.getCollections(
-        collectionIds.map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli-1)))
+        collectionIds.map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
       )
       newerCollections.size shouldBe 5
 
       // pretend we are a client asking for updates since a time that is more recent than the creation time
       val olderCollections = editionsDB.getCollections(
-        collectionIds.map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli+1)))
+        collectionIds.map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli + 1)))
       )
       olderCollections.size shouldBe 0
     }
@@ -276,7 +276,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow updating of a collection" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           ),
@@ -287,7 +287,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
           )
         ),
         front("comment",
-          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query")),
+          collection("opinion", Some(CapiPrefillQuery("magic-opinion-query", PathType.PrintSent)),
             article("54321"),
             article("65432")
           ),
@@ -340,7 +340,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should allow a special front's hidden status to be changed" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           )
@@ -369,7 +369,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     "should now allow a normal front's hidden status to be changed" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
-          collection("politics", Some(CapiPrefillQuery("magic-politics-query")),
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
             article("12345"),
             article("23456")
           )
@@ -388,6 +388,48 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       specialFront2.isHidden shouldBe false
     }
 
+  }
+
+  "should insert path_type and prefill correctly" taggedAs UsesDatabase in {
+
+    val prefillFromPrintSent = CapiPrefillQuery("magic-politics-query", PathType.PrintSent)
+    val prefillFromSearch = CapiPrefillQuery("crossword", PathType.Search)
+
+    val newsUkIssueId = insertSkeletonIssue(2019, 9, 30,
+      front("news/uk",
+        collection("politics", Some(prefillFromPrintSent),
+          article("12345"),
+          article("23456")
+        )
+      )
+    )
+
+    val internationalIssueId = insertSkeletonIssue(2019, 9, 30,
+      front("news/uk",
+        collection("international", Some(prefillFromSearch),
+          article("34567"),
+          article("45678"),
+          article("56789")
+        )
+      )
+    )
+
+    // pretend we are a client asking for updates since a time that is older than the creation time
+    val collectionFromUKIssue = editionsDB.getCollections(
+      editionsDB.getIssue(newsUkIssueId).value
+        .fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+    ).head
+
+    collectionFromUKIssue.prefill should be
+    collectionFromUKIssue.prefill.get shouldEqual prefillFromPrintSent
+
+    val collectionFromInternationalIssue = editionsDB.getCollections(
+      editionsDB.getIssue(internationalIssueId).value
+        .fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+    ).head
+
+    collectionFromInternationalIssue.prefill should be
+    collectionFromInternationalIssue.prefill.get shouldEqual prefillFromSearch
   }
 
 }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -415,18 +415,16 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     )
 
     // pretend we are a client asking for updates since a time that is older than the creation time
-    val collectionFromUKIssue = editionsDB.getCollections(
-      editionsDB.getIssue(newsUkIssueId).value
-        .fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
-    ).head
+    val ukIssue: EditionsIssue = editionsDB.getIssue(newsUkIssueId).value
+    val ukIssueColFilters: List[GetCollectionsFilter] = ukIssue.fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+    val collectionFromUKIssue = editionsDB.getCollections(ukIssueColFilters).head
 
     collectionFromUKIssue.prefill should be
     collectionFromUKIssue.prefill.get shouldEqual prefillFromPrintSent
 
-    val collectionFromInternationalIssue = editionsDB.getCollections(
-      editionsDB.getIssue(internationalIssueId).value
-        .fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
-    ).head
+    val internationalIssue: EditionsIssue = editionsDB.getIssue(internationalIssueId).value
+    val internationalIssueColFilters: List[GetCollectionsFilter] = internationalIssue.fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+    val collectionFromInternationalIssue = editionsDB.getCollections(internationalIssueColFilters).head
 
     collectionFromInternationalIssue.prefill should be
     collectionFromInternationalIssue.prefill.get shouldEqual prefillFromSearch

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -14,6 +14,10 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
   private val user: User = User("Billy", "Bragg", "billy.bragg@justice.example.com", None)
 
+  private val olderThenCreationTime = now.toInstant.toEpochMilli - 1
+
+  private val moreRecentThenCreationTime = now.toInstant.toEpochMilli + 1
+
   private val simpleMetadata = ArticleMetadata(
     customKicker = Some("Kicker"),
     headline = None,
@@ -262,13 +266,13 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       // pretend we are a client asking for updates since a time that is older than the creation time
       val newerCollections = editionsDB.getCollections(
-        collectionIds.map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+        collectionIds.map(GetCollectionsFilter(_, Some(olderThenCreationTime)))
       )
       newerCollections.size shouldBe 5
 
       // pretend we are a client asking for updates since a time that is more recent than the creation time
       val olderCollections = editionsDB.getCollections(
-        collectionIds.map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli + 1)))
+        collectionIds.map(GetCollectionsFilter(_, Some(moreRecentThenCreationTime)))
       )
       olderCollections.size shouldBe 0
     }
@@ -414,16 +418,15 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       )
     )
 
-    // pretend we are a client asking for updates since a time that is older than the creation time
     val ukIssue: EditionsIssue = editionsDB.getIssue(newsUkIssueId).value
-    val ukIssueColFilters: List[GetCollectionsFilter] = ukIssue.fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+    val ukIssueColFilters: List[GetCollectionsFilter] = ukIssue.fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(olderThenCreationTime)))
     val collectionFromUKIssue = editionsDB.getCollections(ukIssueColFilters).head
 
     collectionFromUKIssue.prefill should be
     collectionFromUKIssue.prefill.get shouldEqual prefillFromPrintSent
 
     val internationalIssue: EditionsIssue = editionsDB.getIssue(internationalIssueId).value
-    val internationalIssueColFilters: List[GetCollectionsFilter] = internationalIssue.fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(now.toInstant.toEpochMilli - 1)))
+    val internationalIssueColFilters: List[GetCollectionsFilter] = internationalIssue.fronts.flatMap(_.collections.map(_.id)).map(GetCollectionsFilter(_, Some(olderThenCreationTime)))
     val collectionFromInternationalIssue = editionsDB.getCollections(internationalIssueColFilters).head
 
     collectionFromInternationalIssue.prefill should be


### PR DESCRIPTION
## What's changed?
Introducing PathType enum and prop in Postgres that will enable us to switch between different paths for prefill queries
This PR includes switching to `/search` from `/content/print-sent` path while getting prefill for crosswords

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

