### PR TITLE
Limit textarea auto-expansion to a given height, but allow users to expand beyond it

### DIFF
--- a/client-v2/src/shared/components/input/CreateResizeableTextInput.tsx
+++ b/client-v2/src/shared/components/input/CreateResizeableTextInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { WrappedFieldProps } from 'redux-form';
 import { StyledProps } from 'styled-components';
+import clamp from 'lodash/clamp';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
@@ -57,7 +58,8 @@ const createResizeableTextInput = (
   Component: new (props: any) => React.Component<
     React.HTMLAttributes<HTMLInputElement> & StyledProps<any>
   >,
-  type?: string
+  type?: string,
+  maxAutoResizeHeight: number = 120
 ) => {
   return class ResizeableTextInput extends React.Component<Props, State> {
     private inputElement: React.RefObject<HTMLInputElement>;
@@ -82,7 +84,13 @@ const createResizeableTextInput = (
         this.inputElement.current &&
         this.inputElement.current.type === 'textarea'
       ) {
-        this.setState({ inputHeight: this.inputElement.current.scrollHeight });
+        this.setState({
+          inputHeight: clamp(
+            this.inputElement.current.scrollHeight,
+            0,
+            maxAutoResizeHeight
+          )
+        });
       }
     }
 

--- a/client-v2/src/shared/components/input/InputTextArea.ts
+++ b/client-v2/src/shared/components/input/InputTextArea.ts
@@ -7,7 +7,6 @@ const InputTextAreaBase = InputBase.withComponent('textarea').extend<{
 }>`
   resize: vertical;
   min-height: ${({ minHeight = 40 }) => minHeight}px;
-  max-height: ${({ maxHeight = 120 }) => maxHeight}px;
 `;
 
 export default createResizeableTextInput(InputTextAreaBase);


### PR DESCRIPTION
## What's changed?

This PR limits  the textarea auto-expansion to a given height, but allow users to expand beyond it if they'd like.

![textarea](https://user-images.githubusercontent.com/7767575/63873183-0c0eb780-c9b7-11e9-8002-5c02f8748de2.gif)

At the moment, users can't expand the textarea for trail text beyond its max height. This is useful when inspecting lots of content for e.g. e-mail fronts, but we'd still like to keep the old behaviour of auto-expansion as users type, with a limit so the area doesn't grow too large. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
