### PR TITLE
Hide Cover Card overrides in fronts mode

### DIFF
--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -486,6 +486,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 </InputGroup>
                 <InputGroup>
                   <ConditionalField
+                    permittedFields={editableFields}
                     name="coverCardImageReplace"
                     id={getInputId(articleFragmentId, 'coverCardImageReplace')}
                     component={InputCheckboxToggleInline}


### PR DESCRIPTION
## What's changed?

In moving where the toggle for cover cards is it was no longer being guarded by `isEditionsMode` and hence relied on the `ConditionalField` logic. Turns out `permittedFields` isn't a require prop and the component "fails open" in this regard.

It would be good to understand if this field being optional is required. If it isn't then we can require it in the type system.