### PR TITLE
Remove empty collections and fronts during export process

### DIFF
--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -35,7 +35,10 @@ case class EditionsFront(
     PublishedFront(
       id,
       name,
-      collections.filterNot(_.isHidden).map(_.toPublishedCollection),
+      collections
+        .filterNot(_.isHidden) // drop hidden collections
+        .map(_.toPublishedCollection) // convert
+        .filterNot(_.items.isEmpty), // drop collections that contain no items
       swatch
     )
   }

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import java.time.{Instant, LocalDate, OffsetDateTime, ZoneId}
+import java.time.LocalDate
 
 import play.api.libs.json.Json
 import scalikejdbc.WrappedResultSet
@@ -23,7 +23,10 @@ case class EditionsIssue(
     displayName,
     issueDate,
     version,
-    fronts.filterNot(_.isHidden).map(_.toPublishedFront)
+    fronts
+      .filterNot(_.isHidden) // drop hidden fronts
+      .map(_.toPublishedFront) // convert
+      .filterNot(_.collections.isEmpty) // drop fronts that contain no collections
   )
 }
 

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -173,15 +173,15 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     "fronts should be filtered out when hidden" in {
       val testIssue = issue(2019, 9, 30,
         front("uk-news",
-          collection("london", None),
-          collection("financial", None)
+          collection("london", None, article("123")),
+          collection("financial", None, article("123"))
         ),
         front("culture",
-          collection("art", None),
-          collection("theatre", None)
+          collection("art", None, article("123")),
+          collection("theatre", None, article("123"))
         ),
         front("special",
-          collection("magic", None)
+          collection("magic", None, article("123"))
         ).hide
       )
       testIssue.fronts.size shouldBe 3
@@ -189,15 +189,48 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       publishedIssue.fronts.size shouldBe 2
       publishedIssue.fronts.find(_.name == "special") shouldBe None
     }
+
+    "fronts should be filtered out when empty" in {
+      val testIssue = issue(2019, 9, 30,
+        front("uk-news"),
+        front("culture",
+          collection("art", None, article("123")),
+          collection("theatre", None, article("123"))
+        ),
+        front("empty")
+      )
+      testIssue.fronts.size shouldBe 3
+      val publishedIssue = testIssue.toPublishedIssue(None)
+      publishedIssue.fronts.size shouldBe 1
+      publishedIssue.fronts.find(_.name == "culture").value.collections.size shouldBe 2
+    }
+
+    "fronts should be filtered out when it only contains empty collections" in {
+      val testIssue = issue(2019, 9, 30,
+        front("uk-news",
+          collection("london", None),
+          collection("financial", None)
+        ),
+        front("culture",
+          collection("art", None, article("123")),
+          collection("theatre", None, article("123"))
+        ),
+        front("empty")
+      )
+      testIssue.fronts.size shouldBe 3
+      val publishedIssue = testIssue.toPublishedIssue(None)
+      publishedIssue.fronts.size shouldBe 1
+      publishedIssue.fronts.find(_.name == "culture").value.collections.size shouldBe 2
+    }
   }
 
   "PublishedFront" - {
     "collections should be filtered out when hidden" in {
       val testFront = front("uk-news",
-        collection("london", None),
-        collection("financial", None),
-        collection("special", None).hide,
-        collection("weather", None)
+        collection("london", None, article("123")),
+        collection("financial", None, article("123")),
+        collection("special", None, article("123")).hide,
+        collection("weather", None, article("123"))
       )
 
       testFront.collections.size shouldBe 4
@@ -206,6 +239,21 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val publishedFront = testFront.toPublishedFront
       publishedFront.collections.size shouldBe 3
       publishedFront.collections.find(_.id == "special") shouldBe None
+    }
+
+    "collections should be filtered out when empty" in {
+      val testFront = front("uk-news",
+        collection("london", None, article("123")),
+        collection("financial", None, article("123")),
+        collection("weather", None)
+      )
+
+      testFront.collections.size shouldBe 3
+      testFront.collections.find(_.id == "weather").value
+
+      val publishedFront = testFront.toPublishedFront
+      publishedFront.collections.size shouldBe 2
+      publishedFront.collections.find(_.id == "weather") shouldBe None
     }
 
     "collection displayName should be provided" in {
@@ -217,10 +265,10 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         None,
         None,
         None,
-        Nil
+        List(article("123"))
       )
       val testFront = front("uk-news",
-        collection("london", None),
+        collection("london", None, article("123")),
         test
       )
 


### PR DESCRIPTION
## What's changed?
When exporting an issue we have for a long time dropped any fronts or collections that are hidden. This goes further and drops any collections without any articles and any fronts that don't have any collections (by extension this will drop any fronts that only has emtpy collections).

## Checklist

### General
- [X] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
