### PR TITLE
Add swatch and fronts for 'Big Serious Things'

### DIFF
--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -42,6 +42,8 @@ object Swatch extends PlayEnum[Swatch] {
   case object Lifestyle extends Swatch
 
   case object Sport extends Swatch
+  
+  case object Special extends Swatch
 
   override def values = findValues
 }

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -10,6 +10,7 @@ object DailyEdition {
     List(
       FrontSpecialSpecial1.front -> Daily(),
       FrontTopStories.front -> Daily(),
+      FrontSpecialSpecial2.front -> Daily(),
       FrontNewsUkGuardian.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri)),
       FrontNewsUkGuardianSaturday.front -> WeekDays(List(WeekDay.Sat)),
       FrontNewsWorldGuardian.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
@@ -28,9 +29,10 @@ object DailyEdition {
       FrontFood.front -> WeekDays(List(WeekDay.Sat)),
       FrontFoodObserver.front -> WeekDays(List(WeekDay.Sun)),
       FrontLifeFashion.front -> WeekDays(List(WeekDay.Sat)),
+      FrontSpecialSpecial3.front -> Daily(),
       FrontSportGuardian.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
       FrontSportObserver.front -> WeekDays(List(WeekDay.Sun)),
-      FrontSpecialSpecial2.front -> Daily(),
+      FrontSpecialSpecial4.front -> Daily(),
       FrontCrosswords.front -> Daily(),
     ),
     zoneId = ZoneId.of("Europe/London"),
@@ -65,6 +67,22 @@ object FrontTopStories {
     name = "Top Stories",
     collections = List(collectionTopStories),
     presentation = FrontPresentation(Neutral),
+  )
+}
+
+object FrontSpecialSpecial2 {
+  val collectionSpecialSpecial2 = CollectionTemplate(
+    name = "Special",
+    prefill = None,
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+
+  val front = FrontTemplate(
+    name = "Special 2",
+    collections = List(collectionSpecialSpecial2),
+    presentation = TemplateDefaults.defaultFrontPresentation,
+    hidden = true,
+    isSpecial = true
   )
 }
 
@@ -580,6 +598,22 @@ object FrontFoodObserver {
   )
 }
 
+object FrontSpecialSpecial3 {
+  val collectionSpecialSpecial3 = CollectionTemplate(
+    name = "Special",
+    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent)),
+    presentation = TemplateDefaults.defaultCollectionPresentation
+  )
+
+  val front = FrontTemplate(
+    name = "Special 3",
+    collections = List(collectionSpecialSpecial3),
+    presentation = TemplateDefaults.defaultFrontPresentation,
+    hidden = true,
+    isSpecial = true
+  )
+}
+
 object FrontSportGuardian {
   val collectionSport = CollectionTemplate(
     name = "Sport",
@@ -618,16 +652,16 @@ object FrontSportObserver {
   )
 }
 
-object FrontSpecialSpecial2 {
-  val collectionSpecialSpecial2 = CollectionTemplate(
+object FrontSpecialSpecial4 {
+  val collectionSpecialSpecial4 = CollectionTemplate(
     name = "Special",
     prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent)),
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
 
   val front = FrontTemplate(
-    name = "Special 2",
-    collections = List(collectionSpecialSpecial2),
+    name = "Special 4",
+    collections = List(collectionSpecialSpecial4),
     presentation = TemplateDefaults.defaultFrontPresentation,
     hidden = true,
     isSpecial = true

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -50,7 +50,7 @@ object FrontSpecialSpecial1 {
   val front = FrontTemplate(
     name = "Special 1",
     collections = List(collectionSpecialSpecial1),
-    presentation = TemplateDefaults.defaultFrontPresentation,
+    presentation = FrontPresentation(Special),
     hidden = true,
     isSpecial = true
   )
@@ -80,7 +80,7 @@ object FrontSpecialSpecial2 {
   val front = FrontTemplate(
     name = "Special 2",
     collections = List(collectionSpecialSpecial2),
-    presentation = TemplateDefaults.defaultFrontPresentation,
+    presentation = FrontPresentation(Special),
     hidden = true,
     isSpecial = true
   )

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -601,7 +601,7 @@ object FrontFoodObserver {
 object FrontSpecialSpecial3 {
   val collectionSpecialSpecial3 = CollectionTemplate(
     name = "Special",
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent)),
+    prefill = None,
     presentation = TemplateDefaults.defaultCollectionPresentation
   )
 


### PR DESCRIPTION
## What's changed?
https://trello.com/c/S5azk9Il/452-front-tool-support-for-big-news

This PR extends swatches to introduce "Special" as a swatch. This is a new palette of colours that will be introduced in the app for BIG SERIOUS THINGS.

In addition it adds two new special fronts, and reconfigures the special fronts that straddle "Top Stories" to use the "Special" swatch.

## Implementation notes
To be honest I thought we defined both the pillar value and the swatch for the fronts, but it seems like I was wrong about that. I don't think this is problematic, but I will check in with Alex W & Co.
