### PR TITLE
Create snap links with gu- params that don't have paths

### DIFF
--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -13,7 +13,7 @@ import {
   MaybeAddFrontPublicationDate
 } from 'shared/types/Action';
 import { createFragment } from 'shared/util/articleFragment';
-import { createLinkSnap, createLatestSnap } from 'shared/util/snap';
+import { createSnap, createLatestSnap } from 'shared/util/snap';
 import { getIdFromURL } from 'util/CAPIUtils';
 import { isValidURL } from 'shared/util/url';
 import { MappableDropType } from 'util/collectionUtils';
@@ -176,16 +176,16 @@ const getArticleEntitiesFromDrop = async (
   const resourceIdOrUrl = drop.data;
   const isURL = isValidURL(resourceIdOrUrl);
   const id = isURL ? getIdFromURL(resourceIdOrUrl) : resourceIdOrUrl;
-  const isNonGuLink = isURL && !id;
   const meta = getArticleFragmentMetaFromUrlParams(resourceIdOrUrl);
-  if (isNonGuLink && !meta) {
-    const fragment = await createLinkSnap(resourceIdOrUrl);
+  const isPlainUrl = isURL && !id && !meta;
+  if (isPlainUrl) {
+    const fragment = await createSnap(resourceIdOrUrl);
     return [fragment];
   }
   try {
     if (meta) {
       // If we have gu params in the url, create a snap with the meta we extract.
-      const fragment = await createLinkSnap(id, meta);
+      const fragment = await createSnap(id, meta);
       return [fragment];
     }
     if (!id) {
@@ -209,7 +209,7 @@ const getArticleEntitiesFromDrop = async (
       // If there was an error getting content for CAPI, assume the link is valid
       // and create a link snap as a fallback. This catches cases like non-tag or
       // section guardian.co.uk URLs, which aren't in CAPI and are sometimes linked.
-      const fragment = await createLinkSnap(resourceIdOrUrl);
+      const fragment = await createSnap(resourceIdOrUrl);
       return [fragment];
     }
   }
@@ -277,7 +277,7 @@ const getArticleEntitiesFromGuardianPath = async (
   );
   const fragment = await (createLatest
     ? createLatestSnap(resourceId, title || 'Unknown title')
-    : createLinkSnap(resourceId));
+    : createSnap(resourceId));
   return [fragment];
 };
 

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -177,19 +177,19 @@ const getArticleEntitiesFromDrop = async (
   const isURL = isValidURL(resourceIdOrUrl);
   const id = isURL ? getIdFromURL(resourceIdOrUrl) : resourceIdOrUrl;
   const isNonGuLink = isURL && !id;
-  if (isNonGuLink) {
+  const meta = getArticleFragmentMetaFromUrlParams(resourceIdOrUrl);
+  if (isNonGuLink && !meta) {
     const fragment = await createLinkSnap(resourceIdOrUrl);
     return [fragment];
   }
-  if (!id) {
-    return [];
-  }
   try {
-    const meta = getArticleFragmentMetaFromUrlParams(resourceIdOrUrl);
     if (meta) {
       // If we have gu params in the url, create a snap with the meta we extract.
       const fragment = await createLinkSnap(id, meta);
       return [fragment];
+    }
+    if (!id) {
+      return [];
     }
     const {
       articles: [article, ...rest],

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -8,7 +8,7 @@ import thunk from 'redux-thunk';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'shared/bundles/externalArticlesBundle';
 import { createFragment } from 'shared/util/articleFragment';
-import { createLinkSnap, createLatestSnap } from 'shared/util/snap';
+import { createSnap, createLatestSnap } from 'shared/util/snap';
 import guardianTagPage from 'shared/fixtures/guardianTagPage';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
 import { RefDrop } from 'util/collectionUtils';
@@ -66,7 +66,7 @@ describe('articleFragments actions', () => {
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createLinkSnap('https://bbc.co.uk/some/page')
+          uuid: await createSnap('https://bbc.co.uk/some/page')
         })
       );
     });
@@ -115,9 +115,7 @@ describe('articleFragments actions', () => {
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createLinkSnap(
-            'https://www.theguardian.com/example/tag/page'
-          )
+          uuid: await createSnap('https://www.theguardian.com/example/tag/page')
         })
       );
     });
@@ -139,7 +137,7 @@ describe('articleFragments actions', () => {
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createLinkSnap(
+          uuid: await createSnap(
             'https://www.theguardian.com/example/non/tag/page'
           )
         })

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -145,35 +145,65 @@ describe('articleFragments actions', () => {
         })
       );
     });
-    it('should create a snap from url params prefixed with gu- if they are provided in the resource id', async () => {
-      const store = mockStore({});
-      const snapUrl =
-        'https://www.theguardian.com/football/live?gu-snapType=json.html&gu-snapCss=football&gu-snapUri=https%3A%2F%2Fapi.nextgen.guardianapps.co.uk%2Ffootball%2Flive.json&gu-headline=Live+matches&gu-trailText=Today%27s+matches';
-      fetchMock.mock(snapUrl, JSON.stringify({}));
-      await store.dispatch(createArticleEntitiesFromDrop(
-        idDrop(snapUrl)
-      ) as any);
-      const actions = store.getActions();
-      expect(actions[0]).toEqual(
-        articleFragmentsReceived({
-          uuid: {
-            frontPublicationDate: 1487076708000,
-            id: 'snap/1487076708000',
-            meta: {
-              byline: undefined,
-              headline: 'Live matches',
-              href: 'football/live',
-              showByline: false,
-              snapCss: 'football',
-              snapType: 'json.html',
-              snapUri:
-                'https://api.nextgen.guardianapps.co.uk/football/live.json',
-              trailText: "Today's matches"
-            },
-            uuid: 'uuid'
-          }
-        })
-      );
-    });
+    describe('snaps created from url params prefixed with gu- ', () => {
+      it('should be created if they are provided in the resource id', async () => {
+        const store = mockStore({});
+        const snapUrl =
+          'https://www.theguardian.com/football/live?gu-snapType=json.html&gu-snapCss=football&gu-snapUri=https%3A%2F%2Fapi.nextgen.guardianapps.co.uk%2Ffootball%2Flive.json&gu-headline=Live+matches&gu-trailText=Today%27s+matches';
+        fetchMock.mock(snapUrl, JSON.stringify({}));
+        await store.dispatch(createArticleEntitiesFromDrop(
+          idDrop(snapUrl)
+        ) as any);
+        const actions = store.getActions();
+        expect(actions[0]).toEqual(
+          articleFragmentsReceived({
+            uuid: {
+              frontPublicationDate: 1487076708000,
+              id: 'snap/1487076708000',
+              meta: {
+                byline: undefined,
+                headline: 'Live matches',
+                href: 'football/live',
+                showByline: false,
+                snapCss: 'football',
+                snapType: 'json.html',
+                snapUri:
+                  'https://api.nextgen.guardianapps.co.uk/football/live.json',
+                trailText: "Today's matches"
+              },
+              uuid: 'uuid'
+            }
+          })
+        );
+      });
+      it('should be created if they are provided on the root path', async () => {
+        const store = mockStore({});
+        const snapUrl =
+          'https://gu.com?gu-snapType=json.html&gu-snapUri=https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json';
+        fetchMock.mock(snapUrl, JSON.stringify({}));
+        await store.dispatch(createArticleEntitiesFromDrop(
+          idDrop(snapUrl)
+        ) as any);
+        const actions = store.getActions();
+        expect(actions[0]).toEqual(
+          articleFragmentsReceived({
+            uuid: {
+              frontPublicationDate: 1487076708000,
+              id: 'snap/1487076708000',
+              meta: {
+                byline: undefined,
+                showByline: false,
+                snapType: 'json.html',
+                snapUri:
+                  'https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json',
+              },
+              uuid: 'uuid'
+            }
+          })
+        );
+      });
+    })
+
+
   });
 });

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -192,18 +192,17 @@ describe('articleFragments actions', () => {
               id: 'snap/1487076708000',
               meta: {
                 byline: undefined,
+                trailText: undefined,
                 showByline: false,
                 snapType: 'json.html',
                 snapUri:
-                  'https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json',
+                  'https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json'
               },
               uuid: 'uuid'
             }
           })
         );
       });
-    })
-
-
+    });
   });
 });

--- a/client-v2/src/shared/util/__tests__/snap.spec.ts
+++ b/client-v2/src/shared/util/__tests__/snap.spec.ts
@@ -1,9 +1,4 @@
-import {
-  validateId,
-  generateId,
-  createLatestSnap,
-  createLinkSnap
-} from '../snap';
+import { validateId, generateId, createLatestSnap, createSnap } from '../snap';
 import tagPageHtml from '../../fixtures/guardianTagPage';
 import fetchMock from 'fetch-mock';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
@@ -58,9 +53,7 @@ describe('utils/snap', () => {
         '/http/proxy/https://www.theguardian.com/world/eu?view=mobile',
         tagPageHtml
       );
-      const linkSnap = await createLinkSnap(
-        'https://www.theguardian.com/world/eu'
-      );
+      const linkSnap = await createSnap('https://www.theguardian.com/world/eu');
       expect(linkSnap).toEqual({
         frontPublicationDate: 1487076708000,
         id: 'snap/1487076708000',
@@ -77,7 +70,7 @@ describe('utils/snap', () => {
     });
     it("should create a snap of type 'link' given an external link", async () => {
       fetchMock.once('/http/proxy/https:/www.bbc.co.uk/news', bbcSectionPage);
-      const linkSnap = await createLinkSnap('https:/www.bbc.co.uk/news');
+      const linkSnap = await createSnap('https:/www.bbc.co.uk/news');
       expect(linkSnap).toEqual({
         frontPublicationDate: 1487076708000,
         id: 'snap/1487076708000',

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -34,7 +34,7 @@ function convertToSnap({
   return set(['meta', 'href'], href, fragment);
 }
 
-async function createLinkSnap(
+async function createSnap(
   url?: string,
   meta?: ArticleFragmentMeta
 ): Promise<ArticleFragment> {
@@ -82,4 +82,4 @@ function createLatestSnap(url: string, kicker: string) {
   });
 }
 
-export { generateId, validateId, createLatestSnap, createLinkSnap };
+export { generateId, validateId, createLatestSnap, createSnap };

--- a/client-v2/src/types/Util.ts
+++ b/client-v2/src/types/Util.ts
@@ -1,0 +1,2 @@
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -7,7 +7,7 @@ import startCase from 'lodash/startCase';
 const getIdFromURL = (url: string): string | undefined => {
   const [, id = null] =
     url.match(
-      /^https:\/\/(?:www.theguardian.com\/|viewer.gutools.co.uk(?:\/(?:preview|live))?\/)([^?]*)/
+      /^https:\/\/(?:www.theguardian.com\/|gu.com\/|viewer.gutools.co.uk(?:\/(?:preview|live))?\/)([^?]*)/
     ) || [];
   return typeof id === 'string' ? id : undefined;
 };

--- a/client-v2/src/util/__tests__/CAPIUtils.spec.ts
+++ b/client-v2/src/util/__tests__/CAPIUtils.spec.ts
@@ -38,6 +38,10 @@ describe('CAPIUtils', () => {
         'https://viewer.gutools.co.uk/live/live/business/2015/example';
       expect(getIdFromURL(url)).toEqual('live/business/2015/example');
     });
+    it('should return correct path if url is for gu.com', () => {
+      const url = 'https://gu.com/business/2015/example';
+      expect(getIdFromURL(url)).toEqual('business/2015/example');
+    });
   });
 
   describe('getContributorImage', () => {


### PR DESCRIPTION
## What's changed?

At the moment we require an id -- a URL path -- to create a non-link Snaplink. But we've just come across a case where there isn't one:

`https://gu.com?gu-snapType=json.html&gu-snapUri=https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json`

I've added code and tests to handle this case.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
