### PR TITLE
Stop sending "special" as a swatch

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -41,14 +41,14 @@ object DailyEdition {
     availability = Daily()
   )
 
-  def FrontSpecial1 = specialFront("Special 1", Special)
+  def FrontSpecial1 = specialFront("Special 1", Neutral)
 
   def FrontTopStories = front(
     "Top stories",
     collection("Top stories")
   )
 
-  def FrontSpecial2 = specialFront("Special 2", Special)
+  def FrontSpecial2 = specialFront("Special 2", Neutral)
 
   def FrontNewsUkGuardian = front(
     "National",


### PR DESCRIPTION
## What's changed?
The editions backend wasn't expecting these yet. Reverting to neutral.
My first edit under the new schema, so appreciate a sense check from Simon
