### PR TITLE
Correct IS_INTEGRATION flag

### DIFF
--- a/client-v2/integration/server/index.html
+++ b/client-v2/integration/server/index.html
@@ -45,6 +45,11 @@
     </div>
     <div id="config"></div>
     <script>
+      // There are certain things that we don't want to interfere with
+      // the timeliness of our integration tests, e.g. polling. We set a flag
+      // here to allow our application code to modify its behaviour.
+      window.IS_INTEGRATION = true;
+
       const config = document.getElementById('config');
 
       config.dataset.value = JSON.stringify({

--- a/client-v2/integration/tests/edit-item-metadata.spec.js
+++ b/client-v2/integration/tests/edit-item-metadata.spec.js
@@ -16,7 +16,6 @@ import {
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
   .before(setup)
-  .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
   .after(teardown);
 
 test('Metadata edits are persisted in collections- headline', async t => {

--- a/client-v2/integration/tests/editions.spec.js
+++ b/client-v2/integration/tests/editions.spec.js
@@ -15,7 +15,6 @@ import {
 fixture`Fronts edit`
   .page`http://localhost:3456/v2/issues/fake-edition-isssue-id`
   .before(setup)
-  .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
   .after(teardown);
 
 test('Only show prefill button when prefill query is defined', async t => {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -28,7 +28,6 @@ import {
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
   .before(setup)
-  .beforeEach(async t => await t.eval(() => (window.IS_INTEGRATION = true)))
   .after(teardown);
 
 // quick and dirty check to see if there are any console errors on page load


### PR DESCRIPTION
## What's changed?

At the moment, the IS_INTEGRATION flag that looks like it's being added in our integration tests ... isn't. This code runs asynchronously after some application code has already been run, so there's no guarantee that every part of the application sees this value. (pollingConfig.ts, for example, does not behave as expected).

This PR moves the flag setting into the test index.html, which guarantees that it evaluates before application code is run.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
