### PR TITLE
Add edition field to published issue in preparation to switch from name

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.{JsObject, Json}
 import services.editions.EditionsTemplating
 import java.time.{LocalDate, OffsetDateTime}
 
-import model.editions.{EditionsFrontMetadata, EditionsFrontendCollectionWrapper, EditionsTemplates}
+import model.editions.{Edition, EditionsFrontMetadata, EditionsFrontendCollectionWrapper, EditionsTemplates}
 import services.Capi
 import services.editions.db.EditionsDB
 import services.editions.publishing.EditionsPublishing
@@ -20,6 +20,8 @@ import play.api.Logger
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.collection.JavaConverters._
+import cats.syntax.either._
+import play.api.mvc.Result
 
 class EditionsController(db: EditionsDB,
                          templating: EditionsTemplating,
@@ -30,15 +32,14 @@ class EditionsController(db: EditionsDB,
   def createIssue(name: String) = EditEditionsAuthAction(parse.json[CreateIssue]) { req =>
     val form = req.body
 
-    templating.generateEditionTemplate(name, form.issueDate).map { skeleton =>
-      val issueId = db.insertIssue(name, skeleton, req.user, OffsetDateTime.now())
+    val result = for {
+      edition <- Either.fromOption[Result, Edition](Edition.withNameOption(name), NotFound(s"Edition $name not found"))
+      skeleton <- templating.generateEditionTemplate(edition, form.issueDate)
+      issueId = db.insertIssue(edition, skeleton, req.user, OffsetDateTime.now())
+      issue <- Either.fromOption(db.getIssue(issueId), NotFound("Issue created but could not retrieve it from the database"))
+    } yield issue
 
-      db.getIssue(issueId).map { issue =>
-        Created(Json.toJson(issue))
-      }.getOrElse(NotFound("Issue created but could not retrieve it from the database"))
-    }.getOrElse {
-      NotFound(s"Edition $name not found")
-    }
+    result.fold(identity, issue => Created(Json.toJson(issue)))
   }
 
   def getIssue(id: String)= EditEditionsAuthAction { _ =>
@@ -77,14 +78,14 @@ class EditionsController(db: EditionsDB,
     Ok(Json.toJson(EditionsTemplates.getAvailableEditions))
   }
 
-  def listIssues(name: String) = EditEditionsAuthAction { req =>
+  def listIssues(edition: Edition) = EditEditionsAuthAction { req =>
     Try {
       val dateFrom = req.queryString.get("dateFrom").map(_.head).get
       val dateTo = req.queryString.get("dateTo").map(_.head).get
       (LocalDate.parse(dateFrom), LocalDate.parse(dateTo))
     }.map {
       case (localDateFrom, localDateTo) => {
-        Ok(Json.toJson(db.listIssues(name, localDateFrom, localDateTo)))
+        Ok(Json.toJson(db.listIssues(edition, localDateFrom, localDateTo)))
       }
     }.getOrElse(BadRequest("Invalid or missing date"))
   }

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -7,7 +7,7 @@ import scalikejdbc.WrappedResultSet
 
 case class EditionsIssue(
     id: String,
-    displayName: String,
+    name: String,
     timezoneId: String,
     issueDate: LocalDate,
     createdOn: Long,
@@ -22,8 +22,8 @@ case class EditionsIssue(
 
   def toPublishedIssue(version: String): PublishedIssue = PublishedIssue(
     id,
-    id,
-    displayName,
+    name,
+    name,
     issueDate,
     version,
     fronts

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -22,6 +22,7 @@ case class EditionsIssue(
 
   def toPublishedIssue(version: String): PublishedIssue = PublishedIssue(
     id,
+    id,
     displayName,
     issueDate,
     version,

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -7,7 +7,7 @@ import scalikejdbc.WrappedResultSet
 
 case class EditionsIssue(
     id: String,
-    name: String,
+    edition: Edition,
     timezoneId: String,
     issueDate: LocalDate,
     createdOn: Long,
@@ -22,8 +22,8 @@ case class EditionsIssue(
 
   def toPublishedIssue(version: String): PublishedIssue = PublishedIssue(
     id,
-    name,
-    name,
+    edition,
+    edition,
     issueDate,
     version,
     fronts
@@ -39,7 +39,7 @@ object EditionsIssue {
   def fromRow(rs: WrappedResultSet, prefix: String = ""): EditionsIssue = {
     EditionsIssue(
       rs.string(prefix + "id"),
-      rs.string(prefix + "name"),
+      Edition.withName(rs.string(prefix + "name")),
       rs.string(prefix + "timezone_id"),
       rs.localDate(prefix + "issue_date"),
       rs.zonedDateTime(prefix + "created_on").toInstant.toEpochMilli,

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -3,7 +3,7 @@ package model.editions
 import java.time.temporal.ChronoField
 import java.time.{LocalDate, ZoneId}
 
-import enumeratum.EnumEntry.Uncapitalised
+import enumeratum.EnumEntry.{Hyphencase, Uncapitalised}
 import enumeratum.{EnumEntry, PlayEnum}
 import model.editions.PathType.{PrintSent, Search}
 import model.editions.templates.{DailyEdition, AmericanEdition, AustralianEdition, TrainingEdition}
@@ -11,15 +11,14 @@ import org.postgresql.util.PGobject
 import play.api.libs.json.Json
 
 object EditionsTemplates {
-  val templates: Map[String, EditionTemplate] = Map(
-    "daily-edition" -> DailyEdition.template,
-    "american-edition" -> AmericanEdition.template,
-    "australian-edition" -> AustralianEdition.template,
-    "training-edition" -> TrainingEdition.template
+  val templates: Map[Edition, EditionTemplate] = Map(
+    Edition.DailyEdition -> DailyEdition.template,
+    Edition.AmericanEdition -> AmericanEdition.template,
+    Edition.AustralianEdition -> AustralianEdition.template,
+    Edition.TrainingEdition -> TrainingEdition.template
   )
 
-  val getAvailableEditions: List[String] = templates.keys.toList
-
+  val getAvailableEditions: List[Edition] = templates.keys.toList
 }
 
 case object WeekDay extends Enumeration(1) {
@@ -51,6 +50,18 @@ object Swatch extends PlayEnum[Swatch] {
 
   override def values = findValues
 }
+
+sealed abstract class Edition extends EnumEntry with Hyphencase
+
+object Edition extends PlayEnum[Edition] {
+  case object DailyEdition extends Edition
+  case object AmericanEdition extends Edition
+  case object AustralianEdition extends Edition
+  case object TrainingEdition extends Edition
+
+  override def values = findValues
+}
+
 
 case class FrontPresentation(swatch: Swatch) {
   implicit def frontPresentationFormat = Json.format[FrontPresentation]

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -50,8 +50,8 @@ case class PublishedFront(id: String, name: String, collections: List[PublishedC
 
 case class PublishedIssue(
   id: String, // TODO: Not sure we should be leaking our internal ID here...
-  name: String, // TODO: remove this once downstream is consuming 'edition'
-  edition: String,
+  name: Edition, // TODO: remove this once downstream is consuming 'edition'
+  edition: Edition,
   issueDate: LocalDate,
   version: String,
   fronts: List[PublishedFront]

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -49,9 +49,9 @@ case class PublishedCollection(id: String, name: String, items: List[PublishedAr
 case class PublishedFront(id: String, name: String, collections: List[PublishedCollection], swatch: Swatch)
 
 case class PublishedIssue(
-  id: String, // TODO: remove this downstream is consuming 'edition'
+  id: String, // TODO: Not sure we should be leaking our internal ID here...
+  name: String, // TODO: remove this once downstream is consuming 'edition'
   edition: String,
-  name: String,
   issueDate: LocalDate,
   version: String,
   fronts: List[PublishedFront]

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -49,7 +49,8 @@ case class PublishedCollection(id: String, name: String, items: List[PublishedAr
 case class PublishedFront(id: String, name: String, collections: List[PublishedCollection], swatch: Swatch)
 
 case class PublishedIssue(
-  id: String,
+  id: String, // TODO: remove this downstream is consuming 'edition'
+  edition: String,
   name: String,
   issueDate: LocalDate,
   version: String,

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -4,6 +4,7 @@ import java.time.{LocalDate, LocalTime, ZonedDateTime}
 
 import logging.Logging
 import model.editions._
+import play.api.mvc.{Result, Results}
 import services.{Capi, Prefill}
 
 import scala.concurrent.Await
@@ -11,13 +12,12 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 
-class EditionsTemplating(templates: Map[String, EditionTemplate], capi: Capi) extends Logging {
-  def generateEditionTemplate(name: String, localDate: LocalDate): Option[EditionsIssueSkeleton] = {
-   templates
-      .get(name)
-      .flatMap { template =>
+class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], capi: Capi) extends Logging {
+  def generateEditionTemplate(edition: Edition, localDate: LocalDate): Either[Result, EditionsIssueSkeleton] = {
+    templates.lift(edition) match {
+      case Some(template) =>
         if (template.availability.isValid(localDate)) {
-          Some(EditionsIssueSkeleton(
+          Right(EditionsIssueSkeleton(
             localDate,
             template.zoneId,
             template.fronts
@@ -40,11 +40,12 @@ class EditionsTemplating(templates: Map[String, EditionTemplate], capi: Capi) ex
                   frontTemplate.hidden,
                   frontTemplate.isSpecial
                 )
-            }))
+              }))
         } else {
-          None
+          Left(Results.UnprocessableEntity(s"$localDate is not a valid date to create an issue of $edition"))
         }
-      }
+      case None => Left(Results.NotFound(s"No template registered for $edition"))
+    }
   }
 
   // this function fetches articles from CAPI with enough data to resolve the defaults

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable
 trait IssueQueries {
 
   def insertIssue(
-                   name: String,
+                   edition: Edition,
                    skeleton: EditionsIssueSkeleton,
                    user: User,
                    now: OffsetDateTime
@@ -31,7 +31,7 @@ trait IssueQueries {
             created_on,
             created_by,
             created_email
-          ) VALUES ($name, ${skeleton.issueDate}, ${skeleton.zoneId.toString}, $truncatedNow, $userName, ${user.email})
+          ) VALUES (${edition.entryName}, ${skeleton.issueDate}, ${skeleton.zoneId.toString}, $truncatedNow, $userName, ${user.email})
           RETURNING id;
        """.map(_.string("id")).single().apply().get
 
@@ -82,7 +82,7 @@ trait IssueQueries {
     issueId
   }
 
-  def listIssues(editionName: String, dateFrom: LocalDate, dateTo: LocalDate) = DB readOnly { implicit session =>
+  def listIssues(edition: Edition, dateFrom: LocalDate, dateTo: LocalDate) = DB readOnly { implicit session =>
     sql"""
     SELECT
       id,
@@ -96,7 +96,7 @@ trait IssueQueries {
       launched_by,
       launched_email
     FROM edition_issues
-    WHERE issue_date BETWEEN $dateFrom AND $dateTo AND name = $editionName
+    WHERE issue_date BETWEEN $dateFrom AND $dateTo AND name = ${edition.entryName}
     """.map(EditionsIssue.fromRow(_)).list().apply()
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,9 @@ TwirlKeys.templateImports ++= Seq(
     "play.api.Play.current"
 )
 
+// include the enum path bindables
+routesImport += "model.editions._"
+
 val awsVersion = "1.11.293"
 val capiModelsVersion = "14.1"
 val capiClientVersion = "14.3"

--- a/conf/routes
+++ b/conf/routes
@@ -99,7 +99,7 @@ POST        /api/usage                               controllers.GridProxy.addUs
 
 # Editions
 GET         /editions-api/editions                               controllers.EditionsController.getAvailableEditions
-GET         /editions-api/editions/:name/issues                  controllers.EditionsController.listIssues(name)
+GET         /editions-api/editions/:edition/issues               controllers.EditionsController.listIssues(edition: Edition)
 POST        /editions-api/editions/:name/issues                  controllers.EditionsController.createIssue(name)
 GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
 DELETE      /editions-api/issues/:id                             controllers.EditionsController.deleteIssue(id)

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -18,7 +18,7 @@ object TestEdition {
     availability = Daily()
   )
 
-  val templates: Map[String, EditionTemplate] = Map("test-edition" -> template)
+  val templates: Map[Edition, EditionTemplate] = Map(Edition.TrainingEdition -> template)
 }
 
 object FrontTopStories {

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -13,7 +13,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
 
     val issue: EditionsIssue = EditionsIssue(
       id = "4290573248905743296789524389623",
-      name = "test-edition",
+      edition = Edition.DailyEdition,
       timezoneId = "Europe/London",
       issueDate = issueDate,
       createdOn = 0,
@@ -29,8 +29,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       val expectedJson =
         """{
           |  "id" : "4290573248905743296789524389623",
-          |  "name" : "test-edition",
-          |  "edition" : "test-edition",
+          |  "name" : "daily-edition",
+          |  "edition" : "daily-edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "preview",
           |  "fronts" : [ ]
@@ -46,8 +46,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       val expectedJson =
         """{
           |  "id" : "4290573248905743296789524389623",
-          |  "name" : "test-edition",
-          |  "edition" : "test-edition",
+          |  "name" : "daily-edition",
+          |  "edition" : "daily-edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "foo",
           |  "fronts" : [ ]

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -29,6 +29,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       val expectedJson =
         """{
           |  "id" : "4290573248905743296789524389623",
+          |  "edition" : "4290573248905743296789524389623",
           |  "name" : "Daily Edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "preview",
@@ -45,6 +46,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       val expectedJson =
         """{
           |  "id" : "4290573248905743296789524389623",
+          |  "edition" : "4290573248905743296789524389623",
           |  "name" : "Daily Edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "foo",

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -13,7 +13,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
 
     val issue: EditionsIssue = EditionsIssue(
       id = "4290573248905743296789524389623",
-      displayName = "Daily Edition",
+      name = "test-edition",
       timezoneId = "Europe/London",
       issueDate = issueDate,
       createdOn = 0,
@@ -29,8 +29,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       val expectedJson =
         """{
           |  "id" : "4290573248905743296789524389623",
-          |  "edition" : "4290573248905743296789524389623",
-          |  "name" : "Daily Edition",
+          |  "name" : "test-edition",
+          |  "edition" : "test-edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "preview",
           |  "fronts" : [ ]
@@ -46,8 +46,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       val expectedJson =
         """{
           |  "id" : "4290573248905743296789524389623",
-          |  "edition" : "4290573248905743296789524389623",
-          |  "name" : "Daily Edition",
+          |  "name" : "test-edition",
+          |  "edition" : "test-edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "foo",
           |  "fronts" : [ ]

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -16,7 +16,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     val dateTimeMilli = dateTime.toInstant.toEpochMilli
     EditionsIssue(
       "test-edition",
-      "Test Edition",
+      Edition.DailyEdition,
       LondonZone.toString,
       date,
       dateTimeMilli,

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -5,13 +5,13 @@ import java.time.{LocalDate, ZonedDateTime}
 import com.gu.contentapi.client.model.v1.SearchResponse
 import com.gu.facia.api.utils.ResolvedMetaData
 import fixtures.TestEdition
-import model.editions.{ArticleMetadata, CapiPrefillQuery, Image, MediaType}
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import model.editions.{ArticleMetadata, CapiPrefillQuery, Edition, Image, MediaType}
+import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
 import services.{Capi, Prefill}
 
 import scala.concurrent.Future
 
-class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
+class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues with EitherValues {
 
   val allFalseMetadata = ResolvedMetaData(false, false, false, false, false, false, false, false, false, false, false, false, false, false)
   val imageUrl = "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif"
@@ -65,7 +65,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
   "Creating a template" - {
     "Sets the prefill metadata from CAPI for Culture 1" in {
       val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
-      val issue = templating.generateEditionTemplate("test-edition", LocalDate.of(2019, 9, 30)).value
+      val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
       issue.fronts.size shouldBe 4
       val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
       arts.items.size shouldBe 2
@@ -89,7 +89,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
     }
     "Sets the prefill metadata from CAPI for Culture 2" in {
       val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
-      val issue = templating.generateEditionTemplate("test-edition", LocalDate.of(2019, 9, 30)).value
+      val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
       issue.fronts.size shouldBe 4
       val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
       arts.items.size shouldBe 2
@@ -112,7 +112,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues {
 
     "Sets the prefill metadata from CAPI for UK News" in {
       val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
-      val issue = templating.generateEditionTemplate("test-edition", LocalDate.of(2019, 9, 30)).value
+      val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
       issue.fronts.size shouldBe 4
       val frontPage = issue.fronts.find(_.name == "UK News").value.collections.find(_.name == "Front Page").value
       frontPage.items.size shouldBe 1

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -40,7 +40,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       ZoneId.of("Europe/London"),
       fronts.toList
     )
-    editionsDB.insertIssue("daily-edition",
+    editionsDB.insertIssue(Edition.DailyEdition,
       skeleton,
       user,
       now
@@ -64,7 +64,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       val id = insertSkeletonIssue(2019, 9, 30)
 
       val retrievedIssue = editionsDB.getIssue(id).value
-      retrievedIssue.name shouldBe "daily-edition"
+      retrievedIssue.edition shouldBe Edition.DailyEdition
       retrievedIssue.createdEmail shouldBe "billy.bragg@justice.example.com"
       retrievedIssue.createdOn shouldBe now.toInstant.toEpochMilli
       retrievedIssue.createdBy shouldBe "Billy Bragg"
@@ -81,14 +81,14 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       insertSkeletonIssue(2019, 9, 30)
       insertSkeletonIssue(2019, 10, 10)
 
-      val allIssues = editionsDB.listIssues("daily-edition", LocalDate.of(2019, 9, 28), LocalDate.of(2019, 10, 10))
+      val allIssues = editionsDB.listIssues(Edition.DailyEdition, LocalDate.of(2019, 9, 28), LocalDate.of(2019, 10, 10))
       allIssues.length shouldBe 4
       allIssues.head.createdEmail shouldBe "billy.bragg@justice.example.com"
 
-      val someIssues = editionsDB.listIssues("daily-edition", LocalDate.of(2019, 9, 28), LocalDate.of(2019, 10, 3))
+      val someIssues = editionsDB.listIssues(Edition.DailyEdition, LocalDate.of(2019, 9, 28), LocalDate.of(2019, 10, 3))
       someIssues.length shouldBe 3
 
-      val singleIssue = editionsDB.listIssues("daily-edition", LocalDate.of(2019, 9, 29), LocalDate.of(2019, 9, 29))
+      val singleIssue = editionsDB.listIssues(Edition.DailyEdition, LocalDate.of(2019, 9, 29), LocalDate.of(2019, 9, 29))
       singleIssue.length shouldBe 1
       singleIssue.head.issueDate.getDayOfMonth shouldBe 29
     }
@@ -123,7 +123,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       )
 
       val retrievedIssue = editionsDB.getIssue(id).value
-      retrievedIssue.name shouldBe "daily-edition"
+      retrievedIssue.edition shouldBe Edition.DailyEdition
       retrievedIssue.fronts.length shouldBe 2
 
       val newsFront = retrievedIssue.fronts.head

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -64,7 +64,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       val id = insertSkeletonIssue(2019, 9, 30)
 
       val retrievedIssue = editionsDB.getIssue(id).value
-      retrievedIssue.displayName shouldBe "daily-edition"
+      retrievedIssue.name shouldBe "daily-edition"
       retrievedIssue.createdEmail shouldBe "billy.bragg@justice.example.com"
       retrievedIssue.createdOn shouldBe now.toInstant.toEpochMilli
       retrievedIssue.createdBy shouldBe "Billy Bragg"
@@ -123,7 +123,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       )
 
       val retrievedIssue = editionsDB.getIssue(id).value
-      retrievedIssue.displayName shouldBe "daily-edition"
+      retrievedIssue.name shouldBe "daily-edition"
       retrievedIssue.fronts.length shouldBe 2
 
       val newsFront = retrievedIssue.fronts.head

--- a/test/services/editions/publishing/EditionsBucketTest.scala
+++ b/test/services/editions/publishing/EditionsBucketTest.scala
@@ -1,0 +1,67 @@
+package services.editions.publishing
+
+import java.time.LocalDate
+
+import model.editions.{Edition, EditionsIssue}
+import services.editions.publishing.PublishedIssueFormatters._
+import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
+import play.api.libs.json.Json
+
+import scala.io.Source
+
+class EditionsBucketTest extends FreeSpec with Matchers with OptionValues with EitherValues {
+  "Saving a publication to a bucket" - {
+    val issueDate = LocalDate.of(2019, 9, 30)
+    val issue: EditionsIssue = EditionsIssue(
+      id = "4290573248905743296789524389623",
+      edition = Edition.DailyEdition,
+      timezoneId = "Europe/London",
+      issueDate = issueDate,
+      createdOn = 0,
+      createdBy = "",
+      createdEmail = "",
+      launchedOn = None,
+      launchedBy = None,
+      launchedEmail = None,
+      fronts = Nil
+    )
+
+    "publication is preview" - {
+      val previewIssue = issue.toPreviewIssue
+      val putObjectRequest = EditionsBucket.createPutObjectRequest("test-bucket", previewIssue)
+
+      "key is correct" in {
+        putObjectRequest.getKey shouldBe "daily-edition/2019-09-30/preview.json"
+      }
+
+      "bucket is correct" in {
+        putObjectRequest.getBucketName shouldBe "test-bucket"
+      }
+
+      "data is correct" in {
+        val actual = Source.fromInputStream(putObjectRequest.getInputStream).mkString
+        val expectedJson = Json.stringify(Json.toJson(previewIssue))
+        actual shouldBe expectedJson
+      }
+    }
+
+    "publication is version called banana" - {
+      val publishedIssue = issue.toPublishedIssue("banana")
+      val putObjectRequest = EditionsBucket.createPutObjectRequest("test-bucket", publishedIssue)
+
+      "key is correct" in {
+        putObjectRequest.getKey shouldBe "daily-edition/2019-09-30/banana.json"
+      }
+
+      "bucket is correct" in {
+        putObjectRequest.getBucketName shouldBe "test-bucket"
+      }
+
+      "data is correct" in {
+        val actual = Source.fromInputStream(putObjectRequest.getInputStream).mkString
+        val expectedJson = Json.stringify(Json.toJson(publishedIssue))
+        actual shouldBe expectedJson
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
The field `name` is not very descriptive so lets make it better. (This previously said `id` which just goes to prove the point as that was completely the wrong field).

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
This also introduces an edition enum to make it slightly typier to work with. Finally a regression test was introduced as the enum change modified the behaviour of the location to which the file was written in S3. Unfortunately the editions code relies on the path layout.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
