### PR TITLE
add issue deletion endpoint

### DIFF
--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -38,26 +38,6 @@ trait FrontsQueries extends Logging {
     Json.fromJson[EditionsFrontMetadata](Json.parse(rawJson)).get
   }
 
-  def getFrontFromIssueId(issueId: String): Option[EditionsFront] = DB localTx { implicit session =>
-    sql"""
-      SELECT id
-        , issue_id
-        , index
-        , name
-        , is_special
-        , is_hidden
-        , metadata
-        , updated_on
-        , updated_by
-        , updated_email
-      FROM fronts
-      WHERE issue_id = $issueId
-    """
-    .map(result => EditionsFront.fromRow(result))
-    .single()
-    .apply()
-  }
-
   // TODO: sihil this should really escalate an error if this is attempted when is_special is false but we don't
   // have a clean way of doing that right now.
   def updateFrontHiddenState(id: String, isHidden: Boolean): Option[Boolean] = DB localTx { implicit session =>

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -1,7 +1,7 @@
 package services.editions.db
 
 import logging.Logging
-import model.editions.EditionsFrontMetadata
+import model.editions.{EditionsFront, EditionsFrontMetadata}
 import scalikejdbc._
 import play.api.libs.json._
 
@@ -36,6 +36,26 @@ trait FrontsQueries extends Logging {
         }
       }).single().apply().get
     Json.fromJson[EditionsFrontMetadata](Json.parse(rawJson)).get
+  }
+
+  def getFrontFromIssueId(issueId: String): Option[EditionsFront] = DB localTx { implicit session =>
+    sql"""
+      SELECT id
+        , issue_id
+        , index
+        , name
+        , is_special
+        , is_hidden
+        , metadata
+        , updated_on
+        , updated_by
+        , updated_email
+      FROM fronts
+      WHERE issue_id = $issueId
+    """
+    .map(result => EditionsFront.fromRow(result))
+    .single()
+    .apply()
   }
 
   // TODO: sihil this should really escalate an error if this is attempted when is_special is false but we don't

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -235,4 +235,11 @@ trait IssueQueries {
     WHERE id = $issueId
     """.execute().apply()
   }
+
+  def deleteIssue(issueId: String) = DB localTx { implicit session =>
+    sql"""
+      DELETE FROM edition_issues
+      WHERE id = $issueId
+    """.execute().apply()
+  }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -103,6 +103,7 @@ GET         /editions-api/editions                               controllers.Edi
 GET         /editions-api/editions/:name/issues                  controllers.EditionsController.listIssues(name)
 POST        /editions-api/editions/:name/issues                  controllers.EditionsController.createIssue(name)
 GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
+DELETE      /editions-api/issues/:id                             controllers.EditionsController.deleteIssue(id)
 GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)
 POST        /editions-api/issues/:id/publish                     controllers.EditionsController.publishIssue(id)
 GET         /editions-api/issues/:id/preview                     controllers.EditionsController.getPreviewEdition(id)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -393,6 +393,21 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       specialFront2.isHidden shouldBe false
     }
 
+    "should delete an issue" taggedAs UsesDatabase in {
+      val issue = insertSkeletonIssue(2019, 9, 1,
+        front("news/uk",
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
+            article("12345"),
+            article("23456")
+          )
+        )
+      )
+
+      val dbIssue: EditionsIssue = editionsDB.getIssue(issue).value
+
+      editionsDB.deleteIssue(dbIssue.id)
+      editionsDB.getIssue(issue) should be
+    }
   }
 
   "should insert path_type and prefill correctly" taggedAs UsesDatabase in {


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
When an issue is deleted, we'll log the issue id, creation date and who is performing the deletion.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
There's no UI... unless you count `fetch`:

```javascript
await fetch("/editions-api/issues/<ID>", {"credentials": "include", "method": "DELETE"});
```

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
