### PR TITLE
Add persist logic when pasting content into clipboard

### DIFF
--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -87,6 +87,14 @@ const insertClipboardArticleFragment = (
   }
 });
 
+const insertClipboardArticleFragmentWithPersist = addPersistMetaToAction(
+  insertClipboardArticleFragment,
+  {
+    persistTo: 'clipboard',
+    key: 'articleFragmentId'
+  }
+);
+
 const removeClipboardArticleFragment = (
   id: string,
   articleFragmentId: string
@@ -114,6 +122,7 @@ export {
   updateClipboard,
   updateClipboardContent,
   insertClipboardArticleFragment,
+  insertClipboardArticleFragmentWithPersist,
   removeClipboardArticleFragment,
   clearClipboard,
   clearClipboardWithPersist

--- a/client-v2/src/keyboard/index.ts
+++ b/client-v2/src/keyboard/index.ts
@@ -14,7 +14,7 @@ import { RefDrop } from 'util/collectionUtils';
 import { createArticleEntitiesFromDrop } from 'shared/actions/ArticleFragments';
 import { moveUp, moveDown } from './keyboardActionMaps/move';
 import { ArticleFragment } from '../shared/types/Collection';
-import { insertClipboardArticleFragment } from 'actions/Clipboard';
+import { insertClipboardArticleFragmentWithPersist } from 'actions/Clipboard';
 
 type FocusableTypes =
   | 'clipboard'
@@ -85,7 +85,11 @@ export const createKeyboardActionMap = (store: Store): KeyboardBindingMap => ({
           return;
         }
         dispatch(
-          insertClipboardArticleFragment('clipboard', 0, articleFragment.uuid)
+          insertClipboardArticleFragmentWithPersist(
+            'clipboard',
+            0,
+            articleFragment.uuid
+          )
         );
       } catch (e) {
         Raven.captureMessage(`Paste to clipboard failed: ${e.message}`);


### PR DESCRIPTION
## What's changed?

The paste action wasn't triggering a persistence call in the clipboard. This PR corrects that mistake.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
