### PR TITLE
Aa mk pulling messages from sqs about publish events

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -229,6 +229,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
   object faciatool {
     lazy val breakingNewsFront = "breaking-news"
     lazy val frontPressToolQueue = getString("frontpress.sqs.tool_queue_url")
+    lazy val issuePublishedEventsSQSUrl ="https://sqs.eu-west-1.amazonaws.com/163592447864/issue-published-events-CODE"
     lazy val showTestContainers = getBoolean("faciatool.show_test_containers").getOrElse(false)
     lazy val stsRoleToAssume = getString("faciatool.sts.role.to.assume").getOrElse(stsRoleToAssumeFromProperties)
     lazy val frontPressUpdateTable = frontPressedDynamoTable

--- a/app/services/editions/SQSRepository.scala
+++ b/app/services/editions/SQSRepository.scala
@@ -1,0 +1,39 @@
+package services.editions
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
+import com.amazonaws.services.sqs.model.{Message, ReceiveMessageRequest}
+import conf.ApplicationConfiguration
+
+import scala.collection.JavaConverters._
+
+object QueueConnectorsFactory {
+
+  def buildSQSConnector(config: ApplicationConfiguration, queueURL: String) = new SQSConnector(config, queueURL)
+
+  def buildInMemoQueueConnector(records: List[Message]) = new InMemoQueueConnector(records)
+}
+
+trait QueueConnector {
+  def receiveMessages: List[Message]
+}
+
+class SQSConnector(val config: ApplicationConfiguration, val queueURL: String) extends QueueConnector {
+
+  private lazy val SQS = AmazonSQSAsyncClientBuilder.standard()
+    .withCredentials(config.aws.cmsFrontsAccountCredentials)
+    .withRegion(Regions.EU_WEST_1).build()
+
+  override def receiveMessages: List[Message] = {
+    val receiveRequest = new ReceiveMessageRequest()
+      .withQueueUrl(queueURL)
+      .withWaitTimeSeconds(20)
+    SQS.receiveMessage(receiveRequest)
+      .getMessages.asScala.toList
+  }
+
+}
+
+class InMemoQueueConnector(queue: List[Message]) extends QueueConnector {
+  override def receiveMessages: List[Message] = queue
+}

--- a/app/services/editions/publishing/IssuePublishEventsListener.scala
+++ b/app/services/editions/publishing/IssuePublishEventsListener.scala
@@ -1,0 +1,46 @@
+package services.editions.publishing
+
+import akka.actor.Scheduler
+import logging.Logging
+import services.editions.QueueConnector
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+object IssuePublishEventsListener {
+  def apply(queueConnector: QueueConnector, scheduler: Scheduler, intervalInSec: Int = 60): IssuePublishEventsListener =
+    new IssuePublishEventsListener(queueConnector, scheduler, intervalInSec)
+}
+
+private[publishing] class IssuePublishEventsListener(val queueConnector: QueueConnector, val scheduler: Scheduler, intervalInSec: Int) extends Logging {
+
+  private val sqsReader = IssuePublishEventsReader(queueConnector)
+
+  logger.info("Starting to listen issue publish events")
+  scheduler.schedule(0.seconds, intervalInSec.seconds) {
+    processPublishEvents
+  }
+
+  def processPublishEvents: Unit = {
+    logger.info("process new publish events")
+
+    val event = getPublishEventsFromSQS
+
+    event.foreach(println(_))
+
+  }
+
+  private def getPublishEventsFromSQS: List[IssuePublishedEvent] = {
+    sqsReader.readPublishEvents match {
+      case Success(messages) =>
+        logger.info("publish events read from SQS successfully")
+        messages.map(_.event)
+      case Failure(e) =>
+        logger.error(s"There was an exception while reading events: ${e.getMessage} from SQS")
+        e.printStackTrace()
+        Nil
+    }
+  }
+}
+

--- a/app/services/editions/publishing/IssuePublishEventsReader.scala
+++ b/app/services/editions/publishing/IssuePublishEventsReader.scala
@@ -1,0 +1,33 @@
+package services.editions.publishing
+
+import logging.Logging
+import play.api.libs.json.Json
+import services.editions.QueueConnector
+
+import scala.util.Try
+
+object IssuePublishEventsReader {
+  def apply(queueConnector: QueueConnector): IssuePublishEventsReader =
+    new IssuePublishEventsReader(queueConnector)
+}
+
+class IssuePublishEventsReader(private val queueConnector: QueueConnector) extends Logging {
+
+  import IssuePublishedSQSMsgFormatter._
+
+  def readPublishEvents: Try[List[IssuePublishedEventWrapper]] = {
+    logger.info("read new publish events")
+    import Json.{fromJson, parse}
+    Try {
+      queueConnector.receiveMessages.map(msg => {
+        /**
+         * .get is used here on option to indicate parse error
+         * otherwise it can failed silently
+         * see more in IssuePublishEventsReaderTest
+         */
+        val sqsMSG = fromJson[SQSMessageBody](parse(msg.getBody)).get
+        fromJson[IssuePublishedEventWrapper](parse(sqsMSG.Message)).get
+      })
+    }
+  }
+}

--- a/app/services/editions/publishing/package.scala
+++ b/app/services/editions/publishing/package.scala
@@ -1,0 +1,19 @@
+package services.editions
+
+import play.api.libs.json.{Format, Json}
+
+package object publishing {
+
+  case class IssuePublishedEvent(status: String, message: String)
+
+  case class IssuePublishedEventWrapper(event: IssuePublishedEvent)
+
+  case class SQSMessageBody(Type: String, MessageId: String, TopicArn: String, Message: String, Timestamp: String, SignatureVersion: String, Signature: String, SigningCertURL: String, UnsubscribeURL: String)
+
+  object IssuePublishedSQSMsgFormatter {
+    implicit val issuePublishedEventFormat: Format[IssuePublishedEvent] = Json.format[IssuePublishedEvent]
+    implicit val issuePublishedEventWrapperFormat: Format[IssuePublishedEventWrapper] = Json.format[IssuePublishedEventWrapper]
+    implicit val sqsMsgBody: Format[SQSMessageBody] = Json.format[SQSMessageBody]
+  }
+
+}

--- a/test/services/editions/publishing/IssuePublishEventsReaderTest.scala
+++ b/test/services/editions/publishing/IssuePublishEventsReaderTest.scala
@@ -1,0 +1,65 @@
+package services.editions.publishing
+
+import org.scalatest.{FunSuite, Matchers, TryValues}
+import services.editions.QueueConnectorsFactory
+
+import scala.util.Success
+
+class IssuePublishEventsReaderTest extends FunSuite with Matchers with TryValues {
+
+  import QueueConnectorsFactory._
+
+  test("read and serialise events from queue") {
+
+    def expectedCorrectSQSMessage = {
+      val msg =
+        """
+          |{
+          |  "Type" : "Notification",
+          |  "MessageId" : "123",
+          |  "TopicArn" : "topic-arn",
+          |  "Message" : "{\"event\":{\"status\":\"Published\",\"message\":\"123\"}}",
+          |  "Timestamp" : "2019-09-13T11:41:29.543Z",
+          |  "SignatureVersion" : "1",
+          |  "Signature" : "",
+          |  "SigningCertURL" : "",
+          |  "UnsubscribeURL" : ""
+          |}
+          |""".stripMargin
+
+      new com.amazonaws.services.sqs.model.Message()
+        .withBody(msg)
+    }
+
+    IssuePublishEventsReader(buildInMemoQueueConnector(List(expectedCorrectSQSMessage))).readPublishEvents shouldEqual Success(List(
+      IssuePublishedEventWrapper(IssuePublishedEvent("Published", "123"))))
+
+    IssuePublishEventsReader(buildInMemoQueueConnector(Nil)).readPublishEvents shouldEqual Success(Nil)
+  }
+
+  test("read events from queue adn indicate if message format was incorrect") {
+
+    def expectedCorrectSQSMessage = {
+      val msg =
+        """
+          |{
+          |  "Type" : "Notification",
+          |  "MessageId" : "123",
+          |  "TopicArn" : "topic-arn",
+          |  "Message" : "{\"event\":{\"statusss\":\"Published\",\"messageee\":\"123\"}}",
+          |  "Timestamp" : "2019-09-13T11:41:29.543Z",
+          |  "SignatureVersion" : "1",
+          |  "Signature" : "",
+          |  "SigningCertURL" : "",
+          |  "UnsubscribeURL" : ""
+          |}
+          |""".stripMargin
+
+      new com.amazonaws.services.sqs.model.Message()
+        .withBody(msg)
+    }
+
+    IssuePublishEventsReader(buildInMemoQueueConnector(List(expectedCorrectSQSMessage))).readPublishEvents.isFailure shouldEqual true
+  }
+
+}


### PR DESCRIPTION
## What's changed?
pulling messages from SQS about publish events
with test coverage for SQS message parsing 

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE
