### PR TITLE
Fix handling of drag over for images

### DIFF
--- a/client-v2/src/components/util/DropDisabler.tsx
+++ b/client-v2/src/components/util/DropDisabler.tsx
@@ -13,7 +13,12 @@ const DisablerWrapper = styled.div`
 // or its child nodes. When dropping links (perhaps when missing a drop
 // zone), the default behaviour is navigating to the linked document
 const DropDisabler = ({ children }: DropDisablerChildren) => (
-  <DisablerWrapper onDrop={e => e.preventDefault()}>{children}</DisablerWrapper>
+  <DisablerWrapper
+    onDrop={e => e.preventDefault()}
+    onDragOver={e => e.preventDefault()}
+  >
+    {children}
+  </DisablerWrapper>
 );
 
 export default DropDisabler;


### PR DESCRIPTION
## What's changed?
Users were unable to drag and drop images from Grid into the Fronts tool. This PR reverts a small change to the DisableWrapper, made in #1005, to fix this.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
