### PR TITLE
Change default of overrideMainMedia to false

### DIFF
--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -90,7 +90,7 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
         mediaType = mediaType.map(_.toPublishedMediaType).getOrElse(PublishedMediaType.UseArticleTrail),
         imageSrcOverride = imageSrcOverride,
         sportScore = metadata.flatMap(_.sportScore),
-        overrideArticleMainMedia = metadata.flatMap(_.overrideArticleMainMedia).getOrElse(true),
+        overrideArticleMainMedia = metadata.flatMap(_.overrideArticleMainMedia).getOrElse(false),
         coverCardImages = coverCardImages
       )
     )

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -85,12 +85,12 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
         headlineOverride = metadata.flatMap(_.headline),
         trailTextOverride = metadata.flatMap(_.trailText),
         bylineOverride = metadata.flatMap(_.byline),
-        showByline = metadata.flatMap(_.showByline).getOrElse(false),
-        showQuotedHeadline = metadata.flatMap(_.showQuotedHeadline).getOrElse(false),
+        showByline = metadata.flatMap(_.showByline).getOrElse(PublishedArticle.SHOW_BYLINE_DEFAULT),
+        showQuotedHeadline = metadata.flatMap(_.showQuotedHeadline).getOrElse(PublishedArticle.SHOW_QUOTED_HEADLINE_DEFAULT),
         mediaType = mediaType.map(_.toPublishedMediaType).getOrElse(PublishedMediaType.UseArticleTrail),
         imageSrcOverride = imageSrcOverride,
         sportScore = metadata.flatMap(_.sportScore),
-        overrideArticleMainMedia = metadata.flatMap(_.overrideArticleMainMedia).getOrElse(false),
+        overrideArticleMainMedia = metadata.flatMap(_.overrideArticleMainMedia).getOrElse(PublishedArticle.OVERRIDE_ARTICLE_MAIN_MEDIA_DEFAULT),
         coverCardImages = coverCardImages
       )
     )

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -38,6 +38,12 @@ case class PublishedFurniture(
 
 case class PublishedArticle(internalPageCode: Long, furniture: PublishedFurniture)
 
+object PublishedArticle {
+  val SHOW_BYLINE_DEFAULT = false
+  val SHOW_QUOTED_HEADLINE_DEFAULT = false
+  val OVERRIDE_ARTICLE_MAIN_MEDIA_DEFAULT = false
+}
+
 case class PublishedCollection(id: String, name: String, items: List[PublishedArticle])
 
 case class PublishedFront(id: String, name: String, collections: List[PublishedCollection], swatch: Swatch)

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -76,7 +76,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val article = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
       val publishedArticle = article.toPublishedArticle
       publishedArticle.internalPageCode shouldBe 1234456
-      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true, None)
+      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
     }
 
     "furniture defaults should be populated correctly" in {
@@ -84,7 +84,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val article = EditionsArticle("123456", 0, Some(furniture))
       val published = article.toPublishedArticle
 
-      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, true, None)
+      published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
     }
 
     val cardImage = Some(Image(Some(100), Some(100), "file://origin.jpg", "file://src.jpg", Some("file://thumb.jpg")))


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Override main media used to default to `true`. It is more correct to default to `false`. Which is what this PR does.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
