### PR TITLE
move hover actions

### DIFF
--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -275,6 +275,25 @@ const articleBodyDefault = React.memo(
             </CollectionItemHeading>
             {displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
           </CollectionItemHeadingContainer>
+          <HoverActionsAreaOverlay disabled={isUneditable}>
+            <HoverActionsButtonWrapper
+              buttons={[
+                { text: 'View', component: HoverViewButton },
+                { text: 'Ophan', component: HoverOphanButton },
+                { text: 'Clipboard', component: HoverAddToClipboardButton },
+                { text: 'Delete', component: HoverDeleteButton }
+              ]}
+              buttonProps={{
+                isLive,
+                urlPath,
+                onDelete,
+                onAddToClipboard
+              }}
+              size={size}
+              toolTipPosition={'top'}
+              toolTipAlign={'left'}
+            />
+          </HoverActionsAreaOverlay>
         </CollectionItemContent>
         <ImageAndGraphWrapper size={size}>
           {featureFlagPageViewData && canShowPageViewData && (
@@ -311,25 +330,6 @@ const articleBodyDefault = React.memo(
               </DraggableArticleImageContainer>
             ))}
         </ImageAndGraphWrapper>
-        <HoverActionsAreaOverlay disabled={isUneditable}>
-          <HoverActionsButtonWrapper
-            buttons={[
-              { text: 'View', component: HoverViewButton },
-              { text: 'Ophan', component: HoverOphanButton },
-              { text: 'Clipboard', component: HoverAddToClipboardButton },
-              { text: 'Delete', component: HoverDeleteButton }
-            ]}
-            buttonProps={{
-              isLive,
-              urlPath,
-              onDelete,
-              onAddToClipboard
-            }}
-            size={size}
-            toolTipPosition={'top'}
-            toolTipAlign={'left'}
-          />
-        </HoverActionsAreaOverlay>
       </>
     );
   }

--- a/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
@@ -17,6 +17,9 @@ export default styled.div<{
   opacity: ${({ fade }) => (fade ? 0.5 : 1)};
 
   ${HoverActionsAreaOverlay} {
+    bottom: 0px;
+    right: 0px;
+    position: absolute;
     visibility: hidden;
   }
 

--- a/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
+++ b/client-v2/src/shared/components/collectionItem/CollectionItemBody.tsx
@@ -17,9 +17,6 @@ export default styled.div<{
   opacity: ${({ fade }) => (fade ? 0.5 : 1)};
 
   ${HoverActionsAreaOverlay} {
-    bottom: 4px;
-    left: 8px;
-    position: absolute;
     visibility: hidden;
   }
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Make `HoverActionsAreaOverlay` a child of `CollectionItemContent`, that is push them into the the middle column of an item. This is to unobscure the content change details at all times.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

**Before**
![image](https://user-images.githubusercontent.com/836140/65034300-acb12100-d93e-11e9-88e8-86766b50113d.png)

**After**
![image](https://user-images.githubusercontent.com/836140/65034968-01a16700-d940-11e9-8e29-3f1d505bb9df.png)


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
