### PR TITLE
Update incoming CAPI articles more efficiently

### DIFF
--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -320,12 +320,12 @@ const DEFAULT_PARAMS = {
   'show-tags': 'all',
   'show-atoms': 'media',
   'show-fields':
-    'internalPageCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,secureThumbnail,liveBloggingNow,membershipAccess,shortUrl,newspaperPageNumber'
+    'internalPageCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,secureThumbnail,liveBloggingNow,membershipAccess,shortUrl,newspaperPageNumber,lastModified'
 };
 
-/**
+/*
  * Get a CAPI query string for the given content ids. This could be a single article
- * or tag/section, or a list of articles.
+ * or tag/section, or a list of articles
  */
 const getCapiUriForContentIds = (contentIds: string[]) => {
   const contentIdsStr = contentIds.join(',');

--- a/client-v2/src/shared/bundles/__tests__/externalArticlesBundle.spec.ts
+++ b/client-v2/src/shared/bundles/__tests__/externalArticlesBundle.spec.ts
@@ -1,0 +1,106 @@
+import set from 'lodash/set';
+import { selectIsExternalArticleStale } from '../externalArticlesBundle';
+import { initialState } from '../../fixtures/shared';
+import { capiArticleWithElementsThumbnail } from 'fixtures/capiArticle';
+
+const exampleArticleWithoutLastModified = capiArticleWithElementsThumbnail;
+
+const exampleArticleWithInvalidLastModified = {
+  ...capiArticleWithElementsThumbnail,
+  fields: {
+    ...capiArticleWithElementsThumbnail.fields,
+    lastModified: 'Not a valid date!'
+  }
+}
+
+const exampleArticleWithLastModified = {
+  ...capiArticleWithElementsThumbnail,
+  fields: {
+    ...capiArticleWithElementsThumbnail.fields,
+    lastModified: '2018-10-10T10:10:10Z'
+  }
+}
+
+describe('selectors', () => {
+  describe('selectIsExternalArticleModifiedOlderThanDate', () => {
+    it('should return true if the article is not present', () => {
+      expect(
+        selectIsExternalArticleStale(
+          initialState,
+          'external-article-does-not-exist',
+          '2018-10-10T17:44:11Z'
+        )
+      ).toBe(true);
+    });
+    it('should return true if the article lastmodified field is not present', () => {
+      const state = set(
+        initialState,
+        ['externalArticles', 'data', 'external-article-1'],
+        exampleArticleWithoutLastModified
+      );
+      expect(
+        selectIsExternalArticleStale(
+          state,
+          'external-article-1',
+          '2018-10-10T17:44:11Z'
+        )
+      ).toBe(true);
+    });
+    it('should return true if the article lastmodified date is invalid', () => {
+      const state = set(
+        initialState,
+        ['externalArticles', 'data', 'external-article-1'],
+        exampleArticleWithInvalidLastModified
+      );
+      expect(
+        selectIsExternalArticleStale(
+          state,
+          'external-article-1',
+          '2018-10-10T17:44:11Z'
+        )
+      ).toBe(true);
+    });
+    it('should return true if the incoming lastmodified date is invalid', () => {
+      const state = set(
+        initialState,
+        ['externalArticles', 'data', 'external-article-1'],
+        exampleArticleWithLastModified
+      );
+      expect(
+        selectIsExternalArticleStale(
+          state,
+          'external-article-1',
+          'Not a date!'
+        )
+      ).toBe(true);
+    });
+    it('should return true if the incoming lastmodified date is later than the article lastmodified date', () => {
+      const state = set(
+        initialState,
+        ['externalArticles', 'data', 'external-article-1'],
+        exampleArticleWithLastModified
+      );
+      expect(
+        selectIsExternalArticleStale(
+          state,
+          'external-article-1',
+          '2018-10-10T10:10:09Z'
+        )
+      ).toBe(true);
+    });
+    it('should return false if the incoming lastmodified date is earlier than the article lastmodified date', () => {
+      const state = set(
+        initialState,
+        ['externalArticles', 'data', 'external-article-1'],
+        exampleArticleWithLastModified
+      );
+      expect(
+        selectIsExternalArticleStale(
+          state,
+          'external-article-1',
+          '2018-10-10T10:10:11Z'
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/client-v2/src/shared/bundles/__tests__/externalArticlesBundle.spec.ts
+++ b/client-v2/src/shared/bundles/__tests__/externalArticlesBundle.spec.ts
@@ -1,4 +1,4 @@
-import set from 'lodash/set';
+import set from 'lodash/fp/set';
 import { selectIsExternalArticleStale } from '../externalArticlesBundle';
 import { initialState } from '../../fixtures/shared';
 import { capiArticleWithElementsThumbnail } from 'fixtures/capiArticle';
@@ -11,7 +11,7 @@ const exampleArticleWithInvalidLastModified = {
     ...capiArticleWithElementsThumbnail.fields,
     lastModified: 'Not a valid date!'
   }
-}
+};
 
 const exampleArticleWithLastModified = {
   ...capiArticleWithElementsThumbnail,
@@ -19,7 +19,7 @@ const exampleArticleWithLastModified = {
     ...capiArticleWithElementsThumbnail.fields,
     lastModified: '2018-10-10T10:10:10Z'
   }
-}
+};
 
 describe('selectors', () => {
   describe('selectIsExternalArticleModifiedOlderThanDate', () => {
@@ -34,9 +34,9 @@ describe('selectors', () => {
     });
     it('should return true if the article lastmodified field is not present', () => {
       const state = set(
-        initialState,
         ['externalArticles', 'data', 'external-article-1'],
-        exampleArticleWithoutLastModified
+        exampleArticleWithoutLastModified,
+        initialState
       );
       expect(
         selectIsExternalArticleStale(
@@ -48,9 +48,9 @@ describe('selectors', () => {
     });
     it('should return true if the article lastmodified date is invalid', () => {
       const state = set(
-        initialState,
         ['externalArticles', 'data', 'external-article-1'],
-        exampleArticleWithInvalidLastModified
+        exampleArticleWithInvalidLastModified,
+        initialState
       );
       expect(
         selectIsExternalArticleStale(
@@ -62,43 +62,39 @@ describe('selectors', () => {
     });
     it('should return true if the incoming lastmodified date is invalid', () => {
       const state = set(
-        initialState,
         ['externalArticles', 'data', 'external-article-1'],
-        exampleArticleWithLastModified
+        exampleArticleWithLastModified,
+        initialState
       );
       expect(
-        selectIsExternalArticleStale(
-          state,
-          'external-article-1',
-          'Not a date!'
-        )
+        selectIsExternalArticleStale(state, 'external-article-1', 'Not a date!')
       ).toBe(true);
     });
     it('should return true if the incoming lastmodified date is later than the article lastmodified date', () => {
       const state = set(
-        initialState,
         ['externalArticles', 'data', 'external-article-1'],
-        exampleArticleWithLastModified
-      );
-      expect(
-        selectIsExternalArticleStale(
-          state,
-          'external-article-1',
-          '2018-10-10T10:10:09Z'
-        )
-      ).toBe(true);
-    });
-    it('should return false if the incoming lastmodified date is earlier than the article lastmodified date', () => {
-      const state = set(
-        initialState,
-        ['externalArticles', 'data', 'external-article-1'],
-        exampleArticleWithLastModified
+        exampleArticleWithLastModified,
+        initialState
       );
       expect(
         selectIsExternalArticleStale(
           state,
           'external-article-1',
           '2018-10-10T10:10:11Z'
+        )
+      ).toBe(true);
+    });
+    it('should return false if the incoming lastmodified date is earlier than the article lastmodified date', () => {
+      const state = set(
+        ['externalArticles', 'data', 'external-article-1'],
+        exampleArticleWithLastModified,
+        initialState
+      );
+      expect(
+        selectIsExternalArticleStale(
+          state,
+          'external-article-1',
+          '2018-10-10T10:10:09Z'
         )
       ).toBe(false);
     });

--- a/client-v2/src/shared/bundles/externalArticlesBundle.ts
+++ b/client-v2/src/shared/bundles/externalArticlesBundle.ts
@@ -1,5 +1,9 @@
+import isAfter from 'date-fns/is_after'
+import isValid from 'date-fns/is_valid';
 import createAsyncResourceBundle from 'lib/createAsyncResourceBundle';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
+import { State } from 'shared/reducers/sharedReducer';
+
 
 export const {
   actions,
@@ -10,3 +14,20 @@ export const {
 } = createAsyncResourceBundle<ExternalArticle>('externalArticles', {
   indexById: true
 });
+
+/**
+ * Is the external article last modified field older than the given date?
+ * This function is conservative -- if either date is invalid/missing, it returns `true`.
+ */
+export const selectIsExternalArticleStale = (state: State, id: string, dateStr: string) => {
+  const article = selectors.selectById(state, id);
+  if (!article || !article.fields.lastModified) {
+    return true;
+  }
+  const articleDate = new Date(article.fields.lastModified);
+  const incomingDate = new Date(dateStr);
+  if (!isValid(articleDate) || !isValid(incomingDate)) {
+    return true;
+  }
+  return isAfter(articleDate, incomingDate);
+}

--- a/client-v2/src/shared/bundles/externalArticlesBundle.ts
+++ b/client-v2/src/shared/bundles/externalArticlesBundle.ts
@@ -1,9 +1,8 @@
-import isAfter from 'date-fns/is_after'
+import isAfter from 'date-fns/is_after';
 import isValid from 'date-fns/is_valid';
 import createAsyncResourceBundle from 'lib/createAsyncResourceBundle';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import { State } from 'shared/reducers/sharedReducer';
-
 
 export const {
   actions,
@@ -17,11 +16,15 @@ export const {
 
 /**
  * Is the external article last modified field older than the given date?
- * This function is conservative -- if either date is invalid/missing, it returns `true`.
+ * This function is liberal in what it accepts -- if either date is invalid/missing, it returns `true`.
  */
-export const selectIsExternalArticleStale = (state: State, id: string, dateStr: string) => {
+export const selectIsExternalArticleStale = (
+  state: State,
+  id: string,
+  dateStr: string | undefined
+) => {
   const article = selectors.selectById(state, id);
-  if (!article || !article.fields.lastModified) {
+  if (!article || !article.fields.lastModified || !dateStr) {
     return true;
   }
   const articleDate = new Date(article.fields.lastModified);
@@ -29,5 +32,5 @@ export const selectIsExternalArticleStale = (state: State, id: string, dateStr: 
   if (!isValid(articleDate) || !isValid(incomingDate)) {
     return true;
   }
-  return isAfter(articleDate, incomingDate);
-}
+  return isAfter(incomingDate, articleDate);
+};

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -724,6 +724,15 @@ const stateWithCollection: any = {
         meta: {},
         uuid: '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d'
       }
+    },
+    externalArticles: {
+      data: {},
+      lastError: null,
+      error: null,
+      lastFetch: null,
+      loading: false,
+      loadingIds: [],
+      updatingIds: []
     }
   },
   feed: {}
@@ -787,6 +796,15 @@ const stateWithCollectionAndSupporting: any = {
         },
         uuid: '322f0527-cf14-43c1-8520-e6732ab01297'
       }
+    },
+    externalArticles: {
+      data: {},
+      lastError: null,
+      error: null,
+      lastFetch: null,
+      loading: false,
+      loadingIds: [],
+      updatingIds: []
     }
   }
 };

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -93,6 +93,7 @@ interface CapiArticleFields {
   isLive?: CapiBool;
   firstPublicationDate?: string;
   scheduledPublicationDate?: CapiDate;
+  lastModified?: string;
   secureThumbnail?: string;
   thumbnail?: string | void;
   liveBloggingNow?: CapiBool;

--- a/client-v2/src/types/Capi.ts
+++ b/client-v2/src/types/Capi.ts
@@ -91,9 +91,9 @@ interface CapiArticleFields {
   byline?: string;
   internalPageCode?: string;
   isLive?: CapiBool;
-  firstPublicationDate?: string;
+  firstPublicationDate?: CapiDate;
   scheduledPublicationDate?: CapiDate;
-  lastModified?: string;
+  lastModified?: CapiDate;
   secureThumbnail?: string;
   thumbnail?: string | void;
   liveBloggingNow?: CapiBool;


### PR DESCRIPTION
## What's changed?

We ask for lots of CAPI articles in the Fronts tool. Opening collections, polling for collections, fetching the feed -- etc.

This PR changes the tool's behaviour: only update articles in the application state if the incoming article has a `lastModified` date that's more recent than the one in the store.

This should make polling in particular much more efficient, but will also be handy wherever else we're fetching articles.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
