### PR TITLE
Fix: external links on snap links should be allowed query params

### DIFF
--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -176,6 +176,7 @@ const getArticleEntitiesFromDrop = async (
   const resourceIdOrUrl = drop.data;
   const isURL = isValidURL(resourceIdOrUrl);
   const id = isURL ? getIdFromURL(resourceIdOrUrl) : resourceIdOrUrl;
+  console.log("here resource id is =====>", resourceIdOrUrl)
   const guMeta = isGuardianUrl(resourceIdOrUrl) ? getArticleFragmentMetaFromUrlParams(resourceIdOrUrl) : false;
   const isPlainUrl = isURL && !id && !guMeta;
   if (isPlainUrl) {

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -56,8 +56,8 @@ function updateArticleFragmentMeta(
 function articleFragmentsReceived(
   articleFragments:
     | {
-      [uuid: string]: ArticleFragment;
-    }
+        [uuid: string]: ArticleFragment;
+      }
     | ArticleFragment[]
 ): ArticleFragmentsReceived {
   const payload = Array.isArray(articleFragments)
@@ -176,7 +176,9 @@ const getArticleEntitiesFromDrop = async (
   const resourceIdOrUrl = drop.data;
   const isURL = isValidURL(resourceIdOrUrl);
   const id = isURL ? getIdFromURL(resourceIdOrUrl) : resourceIdOrUrl;
-  const guMeta = isGuardianUrl(resourceIdOrUrl) ? getArticleFragmentMetaFromUrlParams(resourceIdOrUrl) : false;
+  const guMeta = isGuardianUrl(resourceIdOrUrl)
+    ? getArticleFragmentMetaFromUrlParams(resourceIdOrUrl)
+    : false;
   const isPlainUrl = isURL && !id && !guMeta;
   if (isPlainUrl) {
     const fragment = await createSnap(resourceIdOrUrl);
@@ -262,9 +264,9 @@ const getArticleFragmentMetaFromUrlParams = (
   );
   return guParams.length
     ? guParams.reduce(
-      (acc, [key, value]) => ({ ...acc, [key.replace('gu-', '')]: value }),
-      {}
-    )
+        (acc, [key, value]) => ({ ...acc, [key.replace('gu-', '')]: value }),
+        {}
+      )
     : undefined;
 };
 

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -176,7 +176,6 @@ const getArticleEntitiesFromDrop = async (
   const resourceIdOrUrl = drop.data;
   const isURL = isValidURL(resourceIdOrUrl);
   const id = isURL ? getIdFromURL(resourceIdOrUrl) : resourceIdOrUrl;
-  console.log("here resource id is =====>", resourceIdOrUrl)
   const guMeta = isGuardianUrl(resourceIdOrUrl) ? getArticleFragmentMetaFromUrlParams(resourceIdOrUrl) : false;
   const isPlainUrl = isURL && !id && !guMeta;
   if (isPlainUrl) {

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -70,6 +70,24 @@ describe('articleFragments actions', () => {
         })
       );
     });
+    it('should fetch a link and create a corresponding collection item representing a snap link - query params in external urls should be preserved', async () => {
+      fetchMock.once('begin:/api/preview', {
+        response: {
+          results: []
+        }
+      });
+      fetchMock.mock('/http/proxy/https://bbc.co.uk/some/page?great=true', bbcSectionPage);
+      const store = mockStore({});
+      await store.dispatch(createArticleEntitiesFromDrop(
+        idDrop('https://bbc.co.uk/some/page?great=true')
+      ) as any);
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(
+        articleFragmentsReceived({
+          uuid: await createSnap('https://bbc.co.uk/some/page?great=true')
+        })
+      );
+    });
     it("should fetch tag articles and create a corresponding collection item representing a snap of type 'latest' given user input", async () => {
       fetchMock.once('begin:/api/preview', {
         response: {

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -76,7 +76,10 @@ describe('articleFragments actions', () => {
           results: []
         }
       });
-      fetchMock.mock('/http/proxy/https://bbc.co.uk/some/page?great=true', bbcSectionPage);
+      fetchMock.mock(
+        '/http/proxy/https://bbc.co.uk/some/page?great=true',
+        bbcSectionPage
+      );
       const store = mockStore({});
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('https://bbc.co.uk/some/page?great=true')

--- a/client-v2/src/shared/constants/url.ts
+++ b/client-v2/src/shared/constants/url.ts
@@ -5,7 +5,7 @@ export default {
     mainDomainShort: 'theguardian.com',
     frontendDomain: 'frontend.gutools.co.uk',
     previewDomain: 'preview.gutools.co.uk',
-    shortDomain: 'gu.com',
+    shortDomain: 'gu.com'
   },
   media: {
     apiBaseUrl: pageConfig.apiBaseUrl,

--- a/client-v2/src/shared/constants/url.ts
+++ b/client-v2/src/shared/constants/url.ts
@@ -4,7 +4,8 @@ export default {
     mainDomain: 'www.theguardian.com',
     mainDomainShort: 'theguardian.com',
     frontendDomain: 'frontend.gutools.co.uk',
-    previewDomain: 'preview.gutools.co.uk'
+    previewDomain: 'preview.gutools.co.uk',
+    shortDomain: 'gu.com',
   },
   media: {
     apiBaseUrl: pageConfig.apiBaseUrl,

--- a/client-v2/src/shared/util/url.ts
+++ b/client-v2/src/shared/util/url.ts
@@ -44,7 +44,8 @@ function isGuardianUrl(url: string) {
     urlConstants.base.mainDomain,
     urlConstants.base.mainDomainShort,
     urlConstants.base.previewDomain,
-    urlConstants.base.frontendDomain
+    urlConstants.base.frontendDomain,
+    urlConstants.base.shortDomain
   ]);
 }
 


### PR DESCRIPTION
## What's changed?
Celine couldn't add external links that had query params eg: 
https://www.salesforce.org/events/higher-ed-summit-horizons-2019/?utm_source=the-guardian&utm_medium=banner

This only checks out query params if they are guardian links otherwise lets the url through as normal 

Have added a test to check that the query params are preserved on external urls. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
