### PR TITLE
Reduce length of Ophan calls to under 2048 chars

### DIFF
--- a/client-v2/src/fixtures/pageViewData.ts
+++ b/client-v2/src/fixtures/pageViewData.ts
@@ -1,0 +1,35 @@
+const shortOphanQuery =
+  '?referring-path=/au/business&path=/film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones' +
+  '&path=/commentisfree/2015/aug/13/intern-tent-david-hyde-un-internship-geneva' +
+  '&path=/uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship&hours=1&interval=10';
+
+const longOphanQuery =
+  '?referring-path=/uk' +
+  '&path=/uk-news/2019/sep/19/fastest-growing-uk-terrorist-threat-is-from-far-right-say-police' +
+  '&path=/media/video/2019/sep/19/john-humphrys-signs-off-today-programme-32-years-video' +
+  '&path=/business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live' +
+  '&path=/food/2019/sep/18/cant-i-just-say-its-tasty-why-food-critics-go-too-far' +
+  '&path=/sport/live/2019/sep/18/county-cricket-hampshire-v-somerset-essex-v-surrey-and-more-live' +
+  '&path=/business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live' +
+  '&path=/film/2019/sep/18/draft-piece-005' +
+  '&path=/sport/2019/sep/16/scotland-strive-to-avoid-rugby-world-cup-slip-ups-with-shampoo-soaked-balls' +
+  '&path=/us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates' +
+  '&path=/world/2019/sep/18/israel-election-lengthy-coalition-talks-loom-exit-polls-early-results-deadlock' +
+  '&path=/us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates' +
+  '&path=/business/live/2019/sep/16/oil-price-saudi-arabia-iran-drone-markets-ftse-pound-brexit-business-live' +
+  '&path=/commentisfree/2019/sep/04/boris-johnson-electoral-gamble-wreck-tory-party' +
+  '&path=/politics/live/2019/sep/10/anger-abounds-after-parliament-suspended-in-night-of-high-drama-politics-live' +
+  '&path=/politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news' +
+  '&path=/politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news' +
+  '&path=/world/2021/apr/01/the-week-that-was' +
+  '&path=/commentisfree/2019/sep/04/food-banks-and-an-early-grave-austerity-britain' +
+  '&path=/football/live/2019/aug/30/lucy-bronze-wins-uefa-award-premier-league-previews-and-europa-league-draw-live' +
+  '&path=/world/2019/aug/23/emmanuel-macron-handle-donald-trump-g7-test' +
+  '&path=/business/2019/aug/28/thomas-cook-agrees-terms-of-900m-rescue-deal-with-fosun&';
+const addendumToLongOphanQuery =
+  '?referring-path=/uk' +
+  '&path=/business/live/2019/aug/28/recession-fears-us-yield-curve-inverts-brexit-stock-market-bonds-looms-business-live' +
+  '&path=/commentisfree/2019/aug/22/why-planned-parenthood-was-right-to-refuse-federal-funding' +
+  '&path=/business/live/2019/aug/20/investors-stimulus-recession-fears-markets-ftse-trump-uk-factories-business-live&';
+
+export { longOphanQuery, addendumToLongOphanQuery, shortOphanQuery };

--- a/client-v2/src/redux/modules/pageViewData/__tests__/actions.spec.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/actions.spec.ts
@@ -1,30 +1,105 @@
-import { buildRequestUrl } from '..';
-import { DerivedArticle } from 'shared/types/Article';
+import fetchMock from 'fetch-mock';
+import { fetchPageViewData } from '../actions';
+import { PageViewDataFromOphan } from 'shared/types/PageViewData';
 
-describe('buildRequestUrl', () => {
-  const correctOphanCall =
-    '?referring-path=/au/business&path=/film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones&path=/commentisfree/2015/aug/13/intern-tent-david-hyde-un-internship-geneva&path=/uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship&hours=1&interval=10';
+describe('fetchPageViewData', () => {
+  it('should make a request to ophan to get ophan data', async () => {
+    const ophanQuery =
+      '?referring-path=/au/business&path=/film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones' +
+      '&path=/commentisfree/2015/aug/13/intern-tent-david-hyde-un-internship-geneva' +
+      '&path=/uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship&hours=1&interval=10';
 
-  const frontIds = 'au/business';
-  const articleIds: DerivedArticle[] = [
-    {
-      urlPath:
-        'film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones',
-      id: ''
-    },
-    {
-      urlPath:
-        'commentisfree/2015/aug/13/intern-tent-david-hyde-un-internship-geneva',
-      id: ''
-    },
-    {
-      urlPath:
-        'uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship',
-      id: ''
-    }
-  ] as any;
+    const frontIds = 'au/business';
+    const articleIds: string[] = [
+      'film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones',
+      'commentisfree/2015/aug/13/intern-tent-david-hyde-un-internship-geneva',
+      'uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship'
+    ];
 
-  it('generates a url for ophan which lists all fronts and articles requested in correct format', () => {
-    expect(buildRequestUrl(frontIds, articleIds)).toBe(correctOphanCall);
+    fetchMock.once(`/ophan/histogram${ophanQuery}`, []);
+
+    const result = await fetchPageViewData(frontIds, articleIds);
+    expect(result).toEqual([]);
+  });
+  it('should make multiple requests to ophan when given a number of articles that would exceed ophans request length', async () => {
+    const ophanQuery =
+      '?referring-path=/uk' +
+      '&path=/uk-news/2019/sep/19/fastest-growing-uk-terrorist-threat-is-from-far-right-say-police' +
+      '&path=/media/video/2019/sep/19/john-humphrys-signs-off-today-programme-32-years-video' +
+      '&path=/business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live' +
+      '&path=/food/2019/sep/18/cant-i-just-say-its-tasty-why-food-critics-go-too-far' +
+      '&path=/sport/live/2019/sep/18/county-cricket-hampshire-v-somerset-essex-v-surrey-and-more-live' +
+      '&path=/business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live' +
+      '&path=/film/2019/sep/18/draft-piece-005' +
+      '&path=/sport/2019/sep/16/scotland-strive-to-avoid-rugby-world-cup-slip-ups-with-shampoo-soaked-balls' +
+      '&path=/us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates' +
+      '&path=/world/2019/sep/18/israel-election-lengthy-coalition-talks-loom-exit-polls-early-results-deadlock' +
+      '&path=/us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates' +
+      '&path=/business/live/2019/sep/16/oil-price-saudi-arabia-iran-drone-markets-ftse-pound-brexit-business-live' +
+      '&path=/commentisfree/2019/sep/04/boris-johnson-electoral-gamble-wreck-tory-party' +
+      '&path=/politics/live/2019/sep/10/anger-abounds-after-parliament-suspended-in-night-of-high-drama-politics-live' +
+      '&path=/politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news' +
+      '&path=/politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news' +
+      '&path=/world/2021/apr/01/the-week-that-was' +
+      '&path=/commentisfree/2019/sep/04/food-banks-and-an-early-grave-austerity-britain' +
+      '&path=/football/live/2019/aug/30/lucy-bronze-wins-uefa-award-premier-league-previews-and-europa-league-draw-live' +
+      '&path=/world/2019/aug/23/emmanuel-macron-handle-donald-trump-g7-test' +
+      '&path=/business/2019/aug/28/thomas-cook-agrees-terms-of-900m-rescue-deal-with-fosun&';
+    const additionalOphanQuery =
+      '?referring-path=/uk' +
+      '&path=/business/live/2019/aug/28/recession-fears-us-yield-curve-inverts-brexit-stock-market-bonds-looms-business-live' +
+      '&path=/commentisfree/2019/aug/22/why-planned-parenthood-was-right-to-refuse-federal-funding' +
+      '&path=/business/live/2019/aug/20/investors-stimulus-recession-fears-markets-ftse-trump-uk-factories-business-live&';
+
+    const time = 'hours=1&interval=10';
+
+    const articleIds = [
+      'uk-news/2019/sep/19/fastest-growing-uk-terrorist-threat-is-from-far-right-say-police',
+      'media/video/2019/sep/19/john-humphrys-signs-off-today-programme-32-years-video',
+      'business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live',
+      'food/2019/sep/18/cant-i-just-say-its-tasty-why-food-critics-go-too-far',
+      'sport/live/2019/sep/18/county-cricket-hampshire-v-somerset-essex-v-surrey-and-more-live',
+      'business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live',
+      'film/2019/sep/18/draft-piece-005',
+      'sport/2019/sep/16/scotland-strive-to-avoid-rugby-world-cup-slip-ups-with-shampoo-soaked-balls',
+      'us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates',
+      'world/2019/sep/18/israel-election-lengthy-coalition-talks-loom-exit-polls-early-results-deadlock',
+      'us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates',
+      'business/live/2019/sep/16/oil-price-saudi-arabia-iran-drone-markets-ftse-pound-brexit-business-live',
+      'commentisfree/2019/sep/04/boris-johnson-electoral-gamble-wreck-tory-party',
+      'politics/live/2019/sep/10/anger-abounds-after-parliament-suspended-in-night-of-high-drama-politics-live',
+      'politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news',
+      'politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news',
+      'world/2021/apr/01/the-week-that-was',
+      'commentisfree/2019/sep/04/food-banks-and-an-early-grave-austerity-britain',
+      'football/live/2019/aug/30/lucy-bronze-wins-uefa-award-premier-league-previews-and-europa-league-draw-live',
+      'world/2019/aug/23/emmanuel-macron-handle-donald-trump-g7-test',
+      'business/2019/aug/28/thomas-cook-agrees-terms-of-900m-rescue-deal-with-fosun',
+      'business/live/2019/aug/28/recession-fears-us-yield-curve-inverts-brexit-stock-market-bonds-looms-business-live',
+      'commentisfree/2019/aug/22/why-planned-parenthood-was-right-to-refuse-federal-funding',
+      'business/live/2019/aug/20/investors-stimulus-recession-fears-markets-ftse-trump-uk-factories-business-live'
+    ];
+
+    const frontIds = 'uk';
+
+    const dataFromOphan1: PageViewDataFromOphan = {
+      totalHits: 100,
+      series: [],
+      path: ''
+    };
+
+    const dataFromOphan2: PageViewDataFromOphan = {
+      totalHits: 200,
+      series: [],
+      path: ''
+    };
+
+    fetchMock.once(`/ophan/histogram${ophanQuery}${time}`, [dataFromOphan1]);
+    fetchMock.once(`/ophan/histogram${additionalOphanQuery}${time}`, [
+      dataFromOphan2
+    ]);
+
+    const result = await fetchPageViewData(frontIds, articleIds);
+    expect(result).toEqual([dataFromOphan1, dataFromOphan2]);
   });
 });

--- a/client-v2/src/redux/modules/pageViewData/__tests__/actions.spec.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/actions.spec.ts
@@ -1,14 +1,14 @@
 import fetchMock from 'fetch-mock';
 import { fetchPageViewData } from '../actions';
 import { PageViewDataFromOphan } from 'shared/types/PageViewData';
+import {
+  longOphanQuery,
+  addendumToLongOphanQuery,
+  shortOphanQuery
+} from '../../../../fixtures/pageViewData';
 
 describe('fetchPageViewData', () => {
   it('should make a request to ophan to get ophan data', async () => {
-    const ophanQuery =
-      '?referring-path=/au/business&path=/film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones' +
-      '&path=/commentisfree/2015/aug/13/intern-tent-david-hyde-un-internship-geneva' +
-      '&path=/uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship&hours=1&interval=10';
-
     const frontIds = 'au/business';
     const articleIds: string[] = [
       'film/2015/aug/13/dads-army-film-first-trailer-bill-nighy-toby-jones-catherine-zeta-jones',
@@ -16,43 +16,13 @@ describe('fetchPageViewData', () => {
       'uk-news/2018/mar/14/sharp-rise-in-number-of-eu-nationals-applying-for-uk-citizenship'
     ];
 
-    fetchMock.once(`/ophan/histogram${ophanQuery}`, []);
+    fetchMock.once(`/ophan/histogram${shortOphanQuery}`, []);
 
     const result = await fetchPageViewData(frontIds, articleIds);
     expect(result).toEqual([]);
   });
   it('should make multiple requests to ophan when given a number of articles that would exceed ophans request length', async () => {
-    const ophanQuery =
-      '?referring-path=/uk' +
-      '&path=/uk-news/2019/sep/19/fastest-growing-uk-terrorist-threat-is-from-far-right-say-police' +
-      '&path=/media/video/2019/sep/19/john-humphrys-signs-off-today-programme-32-years-video' +
-      '&path=/business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live' +
-      '&path=/food/2019/sep/18/cant-i-just-say-its-tasty-why-food-critics-go-too-far' +
-      '&path=/sport/live/2019/sep/18/county-cricket-hampshire-v-somerset-essex-v-surrey-and-more-live' +
-      '&path=/business/live/2019/sep/18/markets-uk-inflation-house-prices-brexit-fed-rate-decision-business-live' +
-      '&path=/film/2019/sep/18/draft-piece-005' +
-      '&path=/sport/2019/sep/16/scotland-strive-to-avoid-rugby-world-cup-slip-ups-with-shampoo-soaked-balls' +
-      '&path=/us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates' +
-      '&path=/world/2019/sep/18/israel-election-lengthy-coalition-talks-loom-exit-polls-early-results-deadlock' +
-      '&path=/us-news/live/2019/sep/18/trump-greta-thunberg-news-today-live-latest-climate-change-testimony-updates' +
-      '&path=/business/live/2019/sep/16/oil-price-saudi-arabia-iran-drone-markets-ftse-pound-brexit-business-live' +
-      '&path=/commentisfree/2019/sep/04/boris-johnson-electoral-gamble-wreck-tory-party' +
-      '&path=/politics/live/2019/sep/10/anger-abounds-after-parliament-suspended-in-night-of-high-drama-politics-live' +
-      '&path=/politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news' +
-      '&path=/politics/live/2019/aug/30/politics-brexit-mps-lawyers-and-campaigners-battle-prorogation-live-news' +
-      '&path=/world/2021/apr/01/the-week-that-was' +
-      '&path=/commentisfree/2019/sep/04/food-banks-and-an-early-grave-austerity-britain' +
-      '&path=/football/live/2019/aug/30/lucy-bronze-wins-uefa-award-premier-league-previews-and-europa-league-draw-live' +
-      '&path=/world/2019/aug/23/emmanuel-macron-handle-donald-trump-g7-test' +
-      '&path=/business/2019/aug/28/thomas-cook-agrees-terms-of-900m-rescue-deal-with-fosun&';
-    const additionalOphanQuery =
-      '?referring-path=/uk' +
-      '&path=/business/live/2019/aug/28/recession-fears-us-yield-curve-inverts-brexit-stock-market-bonds-looms-business-live' +
-      '&path=/commentisfree/2019/aug/22/why-planned-parenthood-was-right-to-refuse-federal-funding' +
-      '&path=/business/live/2019/aug/20/investors-stimulus-recession-fears-markets-ftse-trump-uk-factories-business-live&';
-
-    const time = 'hours=1&interval=10';
-
+    const frontIds = 'uk';
     const articleIds = [
       'uk-news/2019/sep/19/fastest-growing-uk-terrorist-threat-is-from-far-right-say-police',
       'media/video/2019/sep/19/john-humphrys-signs-off-today-programme-32-years-video',
@@ -80,8 +50,6 @@ describe('fetchPageViewData', () => {
       'business/live/2019/aug/20/investors-stimulus-recession-fears-markets-ftse-trump-uk-factories-business-live'
     ];
 
-    const frontIds = 'uk';
-
     const dataFromOphan1: PageViewDataFromOphan = {
       totalHits: 100,
       series: [],
@@ -94,8 +62,12 @@ describe('fetchPageViewData', () => {
       path: ''
     };
 
-    fetchMock.once(`/ophan/histogram${ophanQuery}${time}`, [dataFromOphan1]);
-    fetchMock.once(`/ophan/histogram${additionalOphanQuery}${time}`, [
+    const interval = 'hours=1&interval=10';
+
+    fetchMock.once(`/ophan/histogram${longOphanQuery}${interval}`, [
+      dataFromOphan1
+    ]);
+    fetchMock.once(`/ophan/histogram${addendumToLongOphanQuery}${interval}`, [
       dataFromOphan2
     ]);
 

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -126,12 +126,10 @@ const fetchPageViewData = async (
 
   const urls: string[] = articlePaths.reduce(
     (acc, path) => {
-      if (acc.length) {
-        const latestUrl = acc[acc.length - 1];
-        if (latestUrl.length + path.length < maxLength) {
-          acc.splice(acc.length - 1, 1, latestUrl + path);
-          return acc;
-        }
+      const latestUrl = acc[acc.length - 1];
+      if (acc.length && latestUrl.length + path.length < maxLength) {
+        acc.splice(acc.length - 1, 1, latestUrl + path);
+        return acc;
       }
       return acc.concat(referringPath + path);
     },
@@ -146,9 +144,7 @@ const fetchPageViewData = async (
   );
 
   const response = await Promise.all(ophanCalls);
-  const parsedResponse = await Promise.all(
-    response.map(r => r.json().then((data: PageViewDataFromOphan) => data))
-  );
+  const parsedResponse = await Promise.all(response.map(r => r.json()));
 
   return ([] as PageViewDataFromOphan[]).concat(...parsedResponse);
 };

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -3,7 +3,6 @@ import {
   PageViewDataRequested,
   PageViewDataReceived
 } from '../../../shared/types/Action';
-import { getPageViewDataFromOphan } from '../../../services/faciaApi';
 import {
   PageViewDataFromOphan,
   PageViewStory
@@ -15,6 +14,7 @@ import {
   createSelectArticleFromArticleFragment
 } from 'shared/selectors/shared';
 import { CollectionItemSets } from 'shared/types/Collection';
+import pandaFetch from 'services/pandaFetch';
 
 const totalPeriodInHours = 1;
 const intervalInMinutes = 10;
@@ -34,20 +34,21 @@ const getPageViewData = (
     dispatch(pageViewDataRequestedAction(frontId));
     try {
       const state = selectSharedState(getState());
-      const articleIds = selectArticlesInCollection(state, {
+      const articleIds: string[] = selectArticlesInCollection(state, {
         collectionId,
         collectionSet
       });
       const articles = articleIds
         .map(_ => selectArticleFromArticleFragment(state, _))
         .filter(_ => _) as DerivedArticle[];
-      const result = await fetchPageViewData(frontId, articles);
-      result.json().then((data: PageViewDataFromOphan[]) => {
-        const dataWithArticleIds = convertToStoriesData(data, articles);
-        dispatch(
-          pageViewDataReceivedAction(dataWithArticleIds, frontId, collectionId)
-        );
-      });
+      const urlPaths: string[] = articles
+        .map(article => article.urlPath)
+        .filter(_ => _) as string[];
+      const data = await fetchPageViewData(frontId, urlPaths);
+      const dataWithArticleIds = convertToStoriesData(data, articles);
+      dispatch(
+        pageViewDataReceivedAction(dataWithArticleIds, frontId, collectionId)
+      );
     } catch (e) {
       throw new Error(`API request to Ophan for page view data failed: ${e}`);
     }
@@ -112,28 +113,44 @@ const pageViewDataRequestedAction = (
   };
 };
 
-const fetchPageViewData = (
-  front: string,
-  articlesInFront: DerivedArticle[]
-): Promise<any> => {
-  return getPageViewDataFromOphan(buildRequestUrl(front, articlesInFront));
-};
-
-const buildRequestUrl = (
+const fetchPageViewData = async (
   frontId: string,
-  articles: DerivedArticle[]
-): string => {
-  const referringPath = `?referring-path=/${frontId}&`;
-  const articlePaths = articles
-    .map(article => `path=/${article.urlPath}&`)
-    .join('');
+  articlesInFront: string[]
+): Promise<PageViewDataFromOphan[]> => {
+  const base = 'https://fronts.local.dev-gutools.co.uk';
+  const referringPath = `/ophan/histogram?referring-path=/${frontId}&`;
   const timePeriod = `hours=${totalPeriodInHours}&interval=${intervalInMinutes}`;
-  return `${referringPath}${articlePaths}${timePeriod}`;
+  const maxLength = 2048 - timePeriod.length - base.length;
+
+  const articlePaths = articlesInFront.map(article => `path=/${article}&`);
+
+  const urls: string[] = articlePaths.reduce(
+    (acc, path) => {
+      if (acc.length) {
+        const latestUrl = acc[acc.length - 1];
+        if (latestUrl.length + path.length < maxLength) {
+          acc.splice(acc.length - 1, 1, latestUrl + path);
+          return acc;
+        }
+      }
+      return acc.concat(referringPath + path);
+    },
+    [] as string[]
+  );
+
+  const ophanCalls = urls.map(url =>
+    pandaFetch(`${url}${timePeriod}`, {
+      method: 'get',
+      credentials: 'same-origin'
+    })
+  );
+
+  const response = await Promise.all(ophanCalls);
+  const parsedResponse = await Promise.all(
+    response.map(r => r.json().then((data: PageViewDataFromOphan) => data))
+  );
+
+  return ([] as PageViewDataFromOphan[]).concat(...parsedResponse);
 };
 
-export {
-  fetchPageViewData,
-  buildRequestUrl,
-  getPageViewData,
-  pageViewDataReceivedAction
-};
+export { fetchPageViewData, getPageViewData, pageViewDataReceivedAction };

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -424,13 +424,6 @@ async function getArticlesBatched(
   }
 }
 
-async function getPageViewDataFromOphan(query: string): Promise<any> {
-  return await pandaFetch(`/ophan/histogram${query}`, {
-    method: 'get',
-    credentials: 'same-origin'
-  });
-}
-
 export {
   fetchFrontsConfig,
   fetchEditionsIssueAsConfig,
@@ -452,6 +445,5 @@ export {
   fetchVisibleArticles,
   discardDraftChangesToCollection,
   transformExternalArticle,
-  getPageViewDataFromOphan,
   DEFAULT_PARAMS
 };


### PR DESCRIPTION
## What's changed?
When we make a call to Ophan for page view data, the length of the request might - for fronts with large collections - exceed the maximum number of characters (2048) that the request URI can contain. To avoid receiving a 414 from Ophan, we can split the request into multiple calls and combine the resulting responses together. 

## Implementation notes
This PR merges the `buildRequestUrl` and `getPageViewDataFromOphan` functions into the existing `fetchPageViewData` function: a single function that prepares, sends, and evaluates the Ophan query. As a result, the test on `buildRequestUrl` is no longer relevant.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
