### PR TITLE
Add order information to createAsyncBundleResource

### DIFF
--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -58,7 +58,7 @@ const fetchResourceOrResults = async (
   return {
     results: checkIsContent(response) ? [response.content] : response.results,
     pagination: checkIsContent(response)
-      ? null
+      ? undefined
       : {
           totalPages: response.pages,
           currentPage: response.currentPage,
@@ -84,7 +84,9 @@ export const fetchLive = (
       isNonCommercialArticle
     );
     dispatch(
-      liveActions.fetchSuccess(nonCommercialResults, resultData.pagination)
+      liveActions.fetchSuccess(nonCommercialResults, {
+        pagination: resultData.pagination
+      })
     );
   }
 };
@@ -110,7 +112,9 @@ export const fetchPreview = (
       isNonCommercialArticle
     );
     dispatch(
-      previewActions.fetchSuccess(nonCommercialResults, resultData.pagination)
+      previewActions.fetchSuccess(nonCommercialResults, {
+        pagination: resultData.pagination
+      })
     );
   }
 };


### PR DESCRIPTION
## What's changed?

Adds the ability to add order information to an async bundle, even when objects are keyed by id. This lets us use an indexed store for the CAPI feeds, which will allow us to make incremental updates to them in future.

## Implementation notes

I've added a few by-value comparisons to incoming state to avoid updating object references where we can help it. This might be a bottleneck if the incoming state included tens of thousands of objects; absent that use case I've made a judgement, but happy to discuss 👍 

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
