### PR TITLE
Treats link in config should point to v1

### DIFF
--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -135,7 +135,7 @@
                         &middot;
                         <a class='tool--content' data-bind="attr: {href: '/' + $root.fullPriority + '?layout=latest,front:' + id()}">edit content</a>
                         &middot;
-                        <a class='tool--content' data-bind="attr: {href: '/' + $root.fullPriority + '?treats=please&amp;front=' + id()}">edit treats</a>
+                        <a class='tool--content' data-bind="attr: {href: '/' + $root.fullPriority + '?redirect=false&amp;treats=please&amp;front=' + id()}">edit treats</a>
                         &middot;
                         <a class='tool--live' data-bind="attr: {href: $root.liveFrontend + id()}" target="_blank">view live</a>
                         &middot;


### PR DESCRIPTION
## What's changed?

Add the redirect param to the treats link in collection config to point it at v1.

Which link? This link!

<img width="244" alt="Screenshot 2019-09-25 at 17 49 10" src="https://user-images.githubusercontent.com/7767575/65622044-cc8ab980-dfbc-11e9-8c24-384295468229.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
