### PR TITLE
Allow updates to ophan on a per-article basis

### DIFF
--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -175,6 +175,7 @@ class CollectionContext extends React.Component<
                     >
                       <CollectionItem
                         frontId={frontId}
+                        collectionId={id}
                         uuid={articleFragment.uuid}
                         parentId={group.uuid}
                         isUneditable={isUneditable}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -70,6 +70,7 @@ const CollectionItemContainer = styled('div')<{
 interface ContainerProps {
   uuid: string;
   frontId: string;
+  collectionId?: string;
   children?: React.ReactNode;
   getNodeProps: () => object;
   onSelect: (uuid: string) => void;
@@ -129,6 +130,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
       parentId,
       showMeta,
       frontId,
+      collectionId,
       canDragImage,
       canShowPageViewData = false,
       isLive,
@@ -150,6 +152,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
           return (
             <Article
               frontId={frontId}
+              collectionId={collectionId}
               id={uuid}
               isUneditable={isUneditable}
               {...getNodeProps()}

--- a/client-v2/src/fixtures/clipboard.ts
+++ b/client-v2/src/fixtures/clipboard.ts
@@ -31,7 +31,7 @@ const stateWithClipboard = {
         uuid: 'article3'
       }
     },
-    pageViewData: [{ frontId: '', collections: [] }]
+    pageViewData: {}
   }
 };
 

--- a/client-v2/src/fixtures/initialState.ts
+++ b/client-v2/src/fixtures/initialState.ts
@@ -662,7 +662,7 @@ const shared = {
     loadingIds: [],
     updatingIds: []
   },
-  pageViewData: [{ frontId: '', collections: [] }]
+  pageViewData: {}
 };
 
 const emptyFeedBundle = {

--- a/client-v2/src/redux/modules/pageViewData/__tests__/fixtures.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/fixtures.ts
@@ -1,0 +1,29 @@
+export const data = {
+  articleId: 'articleId',
+  articlePath: 'uk/news/a-story',
+  totalHits: 2002,
+  data: [
+    {
+      dateTime: 1238984989,
+      count: 345
+    },
+    {
+      dateTime: 1238985490,
+      count: 895
+    }
+  ]
+};
+
+export const state = {
+  frontId: {
+    frontId: 'frontId',
+    collections: {
+      collectionId: {
+        collectionId: 'collectionId',
+        stories: {
+          articleId: data
+        }
+      }
+    }
+  }
+};

--- a/client-v2/src/redux/modules/pageViewData/__tests__/reducer.spec.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/reducer.spec.ts
@@ -1,41 +1,64 @@
+import set from 'lodash/fp/set';
 import { reducer } from '../reducer';
 import { pageViewDataReceivedAction } from '../actions';
 import { PageViewStory } from '../../../../shared/types/PageViewData';
 
+const data = {
+  articleId: 'articleId',
+  articlePath: 'uk/news/a-story',
+  totalHits: 2002,
+  data: [
+    {
+      dateTime: 1238984989,
+      count: 345
+    },
+    {
+      dateTime: 1238985490,
+      count: 895
+    }
+  ]
+};
+
+const state = {
+  frontId: {
+    frontId: 'frontId',
+    collections: {
+      collectionId: {
+        collectionId: 'collectionId',
+        stories: {
+          articleId: data
+        }
+      }
+    }
+  }
+};
+
 describe('Page view data reducer', () => {
-  it('when data is received, it adds it to the store', () => {
-    const data: PageViewStory[] = [
-      {
-        articleId: '123',
-        articlePath: 'uk/news/a-story',
-        totalHits: 2002,
-        data: [
-          {
-            dateTime: 1238984989,
-            count: 345
-          },
-          {
-            dateTime: 1238985490,
-            count: 895
-          }
-        ]
-      }
-    ];
-
-    const expectedState = [
-      {
-        frontId: 'frontId',
-        collections: [
-          {
-            collectionId: 'collectionId',
-            stories: data
-          }
-        ]
-      }
-    ];
-
-    const action = pageViewDataReceivedAction(data, 'frontId', 'collectionId');
+  it('adds data to the store when it is received', () => {
+    const action = pageViewDataReceivedAction(
+      [data],
+      'frontId',
+      'collectionId'
+    );
     const newState = reducer(undefined, action);
+    expect(newState).toEqual(state);
+  });
+  it('clears out previous data when `clearPreviousData` is true', () => {
+    const newData = set(['articleId'], 'articleId2', data);
+    const action = pageViewDataReceivedAction(
+      [newData],
+      'frontId',
+      'collectionId',
+      true
+    );
+    const expectedState = set(
+      ['frontId', 'collections', 'collectionId', 'stories'],
+      {
+        articleId2: newData
+      },
+      state
+    );
+    const newState = reducer(state, action);
     expect(newState).toEqual(expectedState);
   });
 });

--- a/client-v2/src/redux/modules/pageViewData/__tests__/reducer.spec.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/reducer.spec.ts
@@ -1,37 +1,7 @@
 import set from 'lodash/fp/set';
+import { state, data } from './fixtures';
 import { reducer } from '../reducer';
 import { pageViewDataReceivedAction } from '../actions';
-import { PageViewStory } from '../../../../shared/types/PageViewData';
-
-const data = {
-  articleId: 'articleId',
-  articlePath: 'uk/news/a-story',
-  totalHits: 2002,
-  data: [
-    {
-      dateTime: 1238984989,
-      count: 345
-    },
-    {
-      dateTime: 1238985490,
-      count: 895
-    }
-  ]
-};
-
-const state = {
-  frontId: {
-    frontId: 'frontId',
-    collections: {
-      collectionId: {
-        collectionId: 'collectionId',
-        stories: {
-          articleId: data
-        }
-      }
-    }
-  }
-};
 
 describe('Page view data reducer', () => {
   it('adds data to the store when it is received', () => {

--- a/client-v2/src/redux/modules/pageViewData/__tests__/selectors.spec.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/selectors.spec.ts
@@ -16,36 +16,36 @@ describe('selectors', () => {
     it('should select page view data for an article', () => {
       const result = selectDataForArticle(
         state,
-        'frontId',
+        'articleId',
         'collectionId',
-        'articleId'
+        'frontId'
       );
       expect(result).toBe(data);
     });
     it('should handle missing article data', () => {
       const result = selectDataForArticle(
         state,
-        'frontId',
+        'invalidArticleId',
         'collectionId',
-        'invalidArticleId'
+        'frontId'
       );
       expect(result).toBe(undefined);
     });
     it('should handle missing collection data', () => {
       const result = selectDataForArticle(
         state,
-        'frontId',
+        'invalidArticleId',
         'invalidCollectionId',
-        'invalidArticleId'
+        'frontId'
       );
       expect(result).toBe(undefined);
     });
     it('should handle missing front data', () => {
       const result = selectDataForArticle(
         state,
-        'invalidFrontId',
+        'invalidArticleId',
         'invalidCollectionId',
-        'invalidArticleId'
+        'invalidFrontId'
       );
       expect(result).toBe(undefined);
     });

--- a/client-v2/src/redux/modules/pageViewData/__tests__/selectors.spec.ts
+++ b/client-v2/src/redux/modules/pageViewData/__tests__/selectors.spec.ts
@@ -1,0 +1,53 @@
+import { selectDataForArticle } from '../selectors';
+import { state as pageViewData, data } from './fixtures';
+import globalState from '../../../../fixtures/initialState';
+import { State } from 'types/State';
+
+const state = {
+  ...globalState,
+  shared: {
+    ...globalState.shared,
+    pageViewData
+  }
+} as State;
+
+describe('selectors', () => {
+  describe('selectDataForArticle', () => {
+    it('should select page view data for an article', () => {
+      const result = selectDataForArticle(
+        state,
+        'frontId',
+        'collectionId',
+        'articleId'
+      );
+      expect(result).toBe(data);
+    });
+    it('should handle missing article data', () => {
+      const result = selectDataForArticle(
+        state,
+        'frontId',
+        'collectionId',
+        'invalidArticleId'
+      );
+      expect(result).toBe(undefined);
+    });
+    it('should handle missing collection data', () => {
+      const result = selectDataForArticle(
+        state,
+        'frontId',
+        'invalidCollectionId',
+        'invalidArticleId'
+      );
+      expect(result).toBe(undefined);
+    });
+    it('should handle missing front data', () => {
+      const result = selectDataForArticle(
+        state,
+        'invalidFrontId',
+        'invalidCollectionId',
+        'invalidArticleId'
+      );
+      expect(result).toBe(undefined);
+    });
+  });
+});

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -47,7 +47,12 @@ const getPageViewData = (
       const data = await fetchPageViewData(frontId, urlPaths);
       const dataWithArticleIds = convertToStoriesData(data, articles);
       dispatch(
-        pageViewDataReceivedAction(dataWithArticleIds, frontId, collectionId)
+        pageViewDataReceivedAction(
+          dataWithArticleIds,
+          frontId,
+          collectionId,
+          true
+        )
       );
     } catch (e) {
       throw new Error(`API request to Ophan for page view data failed: ${e}`);

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -90,14 +90,18 @@ const getArticleIdFromOphanData = (
 const pageViewDataReceivedAction = (
   data: PageViewStory[],
   frontId: string,
-  collectionId: string
+  collectionId: string,
+  // Clear out the previous data for this collection. Useful when polling
+  // to prevent an endless accumulation of page view data.
+  clearPreviousData = false
 ): PageViewDataReceived => {
   return {
     type: PAGE_VIEW_DATA_RECEIVED,
     payload: {
       data,
       frontId,
-      collectionId
+      collectionId,
+      clearPreviousData
     }
   };
 };

--- a/client-v2/src/redux/modules/pageViewData/reducer.ts
+++ b/client-v2/src/redux/modules/pageViewData/reducer.ts
@@ -3,7 +3,7 @@ import { PAGE_VIEW_DATA_RECEIVED } from './actions';
 import { Action } from 'types/Action';
 import { PageViewDataPerFront, PageViewStory } from 'shared/types/PageViewData';
 
-interface State {
+export interface State {
   [id: string]: PageViewDataPerFront;
 }
 

--- a/client-v2/src/redux/modules/pageViewData/reducer.ts
+++ b/client-v2/src/redux/modules/pageViewData/reducer.ts
@@ -1,53 +1,48 @@
+import set from 'lodash/fp/set';
 import { PAGE_VIEW_DATA_RECEIVED } from './actions';
 import { Action } from 'types/Action';
-import {
-  PageViewDataPerFront,
-  PageViewDataPerCollection
-} from 'shared/types/PageViewData';
+import { PageViewDataPerFront, PageViewStory } from 'shared/types/PageViewData';
 
-type State = PageViewDataPerFront[];
+interface State {
+  [id: string]: PageViewDataPerFront;
+}
 
-const reducer = (state: State = [], action: Action): State => {
+const reducer = (state: State = {}, action: Action): State => {
   switch (action.type) {
     case PAGE_VIEW_DATA_RECEIVED: {
-      const frontsNotBeingChanged: PageViewDataPerFront[] = state.filter(
-        front => front.frontId !== action.payload.frontId
+      const { frontId, collectionId, data, clearPreviousData } = action.payload;
+
+      // Ensure the front and collection objects are there.
+      let newState = set([frontId, 'frontId'], frontId, state);
+      newState = set(
+        [frontId, 'collections', collectionId, 'collectionId'],
+        collectionId,
+        newState
       );
-      const frontBeingChanged: PageViewDataPerFront | undefined = state.find(
-        front => front.frontId === action.payload.frontId
-      );
-      const getCollectionsNotBeingChanged = (
-        front: PageViewDataPerFront
-      ): PageViewDataPerCollection[] | [] => {
-        return front.collections.filter(
-          collection => collection.collectionId !== action.payload.collectionId
+
+      if (clearPreviousData) {
+        const stories = data.reduce(
+          (acc, pageViewStory) => {
+            acc[pageViewStory.articleId] = pageViewStory;
+            return acc;
+          },
+          {} as { [id: string]: PageViewStory }
         );
-      };
-
-      const collectionBeingChanged = {
-        collectionId: action.payload.collectionId,
-        stories: action.payload.data
-      };
-
-      const frontToBeChanged = (): PageViewDataPerFront => {
-        if (frontBeingChanged) {
-          // if front exists in state, remove the old version and create new one
-          return {
-            frontId: action.payload.frontId,
-            collections: [
-              ...getCollectionsNotBeingChanged(frontBeingChanged),
-              collectionBeingChanged
-            ]
-          };
-        }
-        // if data for the front does not exist, create it
-        return {
-          frontId: action.payload.frontId,
-          collections: [collectionBeingChanged]
-        };
-      };
-
-      return [...frontsNotBeingChanged, frontToBeChanged()];
+        return set(
+          [frontId, 'collections', collectionId],
+          { collectionId, stories },
+          newState
+        );
+      }
+      return data.reduce(
+        (currentState, story) =>
+          set(
+            [frontId, 'collections', collectionId, 'stories', story.articleId],
+            story,
+            currentState
+          ),
+        newState
+      );
     }
     default: {
       return state;

--- a/client-v2/src/redux/modules/pageViewData/selectors.ts
+++ b/client-v2/src/redux/modules/pageViewData/selectors.ts
@@ -1,21 +1,8 @@
-import { createSelector } from 'reselect';
+import { oc } from 'ts-optchain';
 import { State } from '../../../types/State';
-import {
-  PageViewDataPerFront,
-  PageViewDataPerCollection,
-  PageViewArticlesOnFront
-} from 'shared/types/PageViewData';
+import { PageViewStory } from 'shared/types/PageViewData';
 
-const selectArticleId = (state: State, articleId: string, frontId: string) => {
-  return articleId;
-};
-
-const selectFrontId = (state: State, articleId: string, frontId: string) => {
-  return frontId;
-};
-
-const selectPageViewData = (state: State): PageViewDataPerFront[] =>
-  state.shared.pageViewData;
+const selectPageViewData = (state: State) => state.shared.pageViewData;
 
 const selectOpenCollectionsForFront = (
   allCollectionsInAFront: string[],
@@ -26,37 +13,18 @@ const selectOpenCollectionsForFront = (
   );
 };
 
-const createSelectDataForArticle = () =>
-  createSelector(
-    [selectPageViewData, selectArticleId, selectFrontId],
-    (pageViewData, articleId, frontId) => {
-      const dataForFront: PageViewDataPerFront | undefined = pageViewData.find(
-        front => front.frontId === frontId
-      );
-
-      const allArticlesOnFront =
-        dataForFront &&
-        dataForFront.collections.reduce(
-          (acc: PageViewArticlesOnFront, curr: PageViewDataPerCollection) => {
-            return {
-              frontId,
-              stories: acc.stories.concat(curr.stories)
-            } as PageViewArticlesOnFront;
-          },
-          { frontId, stories: [] }
-        );
-
-      return (
-        allArticlesOnFront &&
-        allArticlesOnFront.stories.find(article => {
-          return article.articleId === articleId;
-        })
-      );
-    }
-  );
+const selectDataForArticle = (
+  state: State,
+  frontId: string,
+  collectionId: string,
+  articleId: string
+): PageViewStory | undefined =>
+  oc(state).shared.pageViewData[frontId].collections[collectionId].stories[
+    articleId
+  ]();
 
 export {
   selectPageViewData,
   selectOpenCollectionsForFront,
-  createSelectDataForArticle
+  selectDataForArticle
 };

--- a/client-v2/src/redux/modules/pageViewData/selectors.ts
+++ b/client-v2/src/redux/modules/pageViewData/selectors.ts
@@ -15,9 +15,9 @@ const selectOpenCollectionsForFront = (
 
 const selectDataForArticle = (
   state: State,
-  frontId: string,
+  articleId: string,
   collectionId: string,
-  articleId: string
+  frontId: string
 ): PageViewStory | undefined =>
   oc(state).shared.pageViewData[frontId].collections[collectionId].stories[
     articleId

--- a/client-v2/src/shared/components/article/Article.tsx
+++ b/client-v2/src/shared/components/article/Article.tsx
@@ -56,6 +56,7 @@ interface ArticleComponentProps {
   canShowPageViewData: boolean;
   featureFlagPageViewData?: boolean;
   frontId: string;
+  collectionId?: string;
 }
 
 interface ContainerProps extends ArticleComponentProps {
@@ -111,7 +112,8 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
       canDragImage,
       featureFlagPageViewData,
       canShowPageViewData = false,
-      frontId
+      frontId,
+      collectionId
     } = this.props;
 
     const dragEventHasImageData = (e: React.DragEvent) =>
@@ -166,6 +168,7 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
               <ArticleBody
                 {...getArticleData()}
                 frontId={frontId}
+                collectionId={collectionId}
                 size={size}
                 textSize={textSize}
                 isUneditable={!!article && isUneditable}

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -137,6 +137,7 @@ interface ArticleBodyProps {
   featureFlagPageViewData?: boolean;
   canShowPageViewData: boolean;
   frontId: string;
+  collectionId?: string;
 }
 
 const articleBodyDefault = React.memo(
@@ -179,6 +180,7 @@ const articleBodyDefault = React.memo(
     hasMainVideo,
     showMainVideo,
     frontId,
+    collectionId,
     newspaperPageNumber
   }: ArticleBodyProps) => {
     const displayByline = size === 'default' && showByline && byline;
@@ -277,9 +279,13 @@ const articleBodyDefault = React.memo(
           </CollectionItemHeadingContainer>
         </CollectionItemContent>
         <ImageAndGraphWrapper size={size}>
-          {featureFlagPageViewData && canShowPageViewData && (
+          {featureFlagPageViewData && canShowPageViewData && collectionId && (
             <PageViewDataWrapper data-testid="page-view-graph">
-              <ArticleGraph articleId={uuid} frontId={frontId} />
+              <ArticleGraph
+                articleId={uuid}
+                collectionId={collectionId}
+                frontId={frontId}
+              />
             </PageViewDataWrapper>
           )}
 

--- a/client-v2/src/shared/components/article/ArticleGraph.tsx
+++ b/client-v2/src/shared/components/article/ArticleGraph.tsx
@@ -4,15 +4,19 @@ import { PageViewStory } from 'shared/types/PageViewData';
 import { theme } from '../../../constants/theme';
 import { State } from 'types/State';
 import { connect } from 'react-redux';
-import { createSelectDataForArticle } from '../../../redux/modules/pageViewData/selectors';
+import { selectDataForArticle } from '../../../redux/modules/pageViewData/selectors';
 
-interface ArticleGraphProps {
+interface ArticleGraphContainerProps {
   articleId: string;
+  collectionId: string;
   frontId: string;
+}
+
+interface ArticleGraphComponentProps extends ArticleGraphContainerProps {
   data?: PageViewStory;
 }
 
-class ArticleGraph extends React.Component<ArticleGraphProps> {
+class ArticleGraph extends React.Component<ArticleGraphComponentProps> {
   public render() {
     const { data } = this.props;
 
@@ -43,9 +47,13 @@ class ArticleGraph extends React.Component<ArticleGraphProps> {
 }
 
 const mapStateToProps = () => {
-  const selectPageViewDataForArticleId = createSelectDataForArticle();
-  return (state: State, props: ArticleGraphProps) => ({
-    data: selectPageViewDataForArticleId(state, props.articleId, props.frontId)
+  return (state: State, props: ArticleGraphContainerProps) => ({
+    data: selectDataForArticle(
+      state,
+      props.articleId,
+      props.collectionId,
+      props.frontId
+    )
   });
 };
 

--- a/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
+++ b/client-v2/src/shared/components/article/__tests__/Article.spec.tsx
@@ -166,6 +166,7 @@ it('should show the page view data graph if 3 conditions are true: canShowPageVi
       <ThemeProvider theme={theme}>
         <ArticleComponent
           frontId={'uk'}
+          collectionId={'collectionId'}
           children={<React.Fragment />}
           article={derivedArticle}
           id="ea1"
@@ -184,6 +185,7 @@ it('should NOT show the page view data graph if any of these conditions are fals
       <ThemeProvider theme={theme}>
         <ArticleComponent
           frontId={'uk'}
+          collectionId={'collectionId'}
           children={<React.Fragment />}
           article={undefined}
           id="ea1"

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -872,7 +872,7 @@ const initialState = {
   groups: {},
   articleFragments: {},
   featureSwitches: {},
-  pageViewData: [{ frontId: '', collections: [] }]
+  pageViewData: {}
 } as State;
 
 export {

--- a/client-v2/src/shared/reducers/sharedReducer.ts
+++ b/client-v2/src/shared/reducers/sharedReducer.ts
@@ -5,7 +5,6 @@ import { reducer as externalArticles } from '../bundles/externalArticlesBundle';
 import { reducer as featureSwitches } from '../redux/modules/featureSwitches';
 import { reducer as pageViewData } from '../../redux/modules/pageViewData';
 import { ArticleFragment, Group } from 'shared/types/Collection';
-import { PageViewDataPerFront } from 'shared/types/PageViewData';
 
 interface State {
   articleFragments: {
@@ -17,7 +16,7 @@ interface State {
   collections: ReturnType<typeof collections>;
   externalArticles: ReturnType<typeof externalArticles>;
   featureSwitches: ReturnType<typeof featureSwitches>;
-  pageViewData: PageViewDataPerFront[];
+  pageViewData: ReturnType<typeof pageViewData>;
 }
 
 const rootReducer = (state: any = {}, action: any): State => ({

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -96,6 +96,7 @@ interface PageViewDataReceived {
     data: PageViewStory[];
     frontId: string;
     collectionId: string;
+    clearPreviousData: boolean;
   };
 }
 

--- a/client-v2/src/shared/types/PageViewData.ts
+++ b/client-v2/src/shared/types/PageViewData.ts
@@ -23,12 +23,16 @@ interface PageViewStory {
 
 interface PageViewDataPerFront {
   frontId: string;
-  collections: PageViewDataPerCollection[];
+  collections: {
+    [id: string]: PageViewDataPerCollection;
+  };
 }
 
 interface PageViewDataPerCollection {
   collectionId: string;
-  stories: PageViewStory[];
+  stories: {
+    [id: string]: PageViewStory;
+  };
 }
 
 interface PageViewArticlesOnFront {


### PR DESCRIPTION
## What's changed?

This PR refactors the internal state of the page view module to make it easier to update page view data on a per-article basis. This is important when we're trying to make the tool more performant -- when we first drag an article into a collection and make a request to ophan for its analytics, we don't want to have to update an entire collection's worth of data in the state.

## Implementation notes

I've done this by indexing front, collection and article data by id, which has the additional benefit of reducing the amount of work our selectors have to do to fetch page view data. This does, however, mean threading a collection id all the way through from `CollectionItem` to `ArticleBody`, which is less elegant than I'd like. If there's another solution I'd be really keen to hear 👍 

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
