### PR TITLE
More efficient Ophan updates

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -74,7 +74,7 @@ import { events } from 'services/GA';
 import { selectCollectionParams } from 'selectors/collectionSelectors';
 import { fetchCollectionsStrategy } from 'strategies/fetch-collection';
 import { updateCollectionStrategy } from 'strategies/update-collection';
-import { getPageViewData } from 'redux/modules/pageViewData';
+import { getPageViewDataForCollection } from 'redux/modules/pageViewData';
 
 const articlesInCollection = createSelectAllArticlesInCollection();
 
@@ -366,7 +366,9 @@ const getOphanDataForCollections = (
   itemSet: CollectionItemSets
 ): ThunkResult<Promise<void[]>> => async dispatch => {
   const ophanRequests = collectionIds.map(collectionId => {
-    return dispatch(getPageViewData(frontId, collectionId, itemSet));
+    return dispatch(
+      getPageViewDataForCollection(frontId, collectionId, itemSet)
+    );
   });
   return Promise.all(ophanRequests);
 };

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -31,7 +31,8 @@ import {
   defaultState,
   editorCloseFormsForCollection,
   createSelectCollectionsInOpenFronts,
-  selectOpenFrontsCollectionsAndArticles
+  selectOpenFrontsCollectionsAndArticles,
+  selectOpenParentFrontOfArticleFragment
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import initialStateForOpenFronts from './fixtures/initialStateForOpenFronts';
@@ -61,6 +62,51 @@ const reducer = (
 
 describe('frontsUIBundle', () => {
   describe('selectors', () => {
+    describe('selectOpenParentFrontOfArticleFragment', () => {
+      const state = set(
+        ['editor', 'collectionIds'],
+        ['collection1', 'collection6'],
+        initialStateForOpenFronts
+      );
+      it('should select the parent front of an article fragment', () => {
+        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+          state,
+          'articleFragment1'
+        );
+        expect(parentFrontId).toEqual('editorialFront');
+      });
+      it("should return undefined if it does't find anything", () => {
+        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+          state,
+          'not-a-thing'
+        );
+        expect(parentFrontId).toEqual(undefined);
+      });
+      it('should not select from fronts that are not open', () => {
+        const stateWithClosedFronts = set(
+          ['editor', 'frontIdsByPriority', 'editorial'],
+          [],
+          state
+        );
+        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+          stateWithClosedFronts,
+          'articleFragment1'
+        );
+        expect(parentFrontId).toEqual(undefined);
+      });
+      it('should not select from collections that are not open', () => {
+        const stateWithClosedCollections = set(
+          ['editor', 'collectionIds'],
+          [],
+          state
+        );
+        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+          stateWithClosedCollections,
+          'articleFragment1'
+        );
+        expect(parentFrontId).toEqual(undefined);
+      });
+    });
     describe('selectEditorFrontIdsByPriority', () => {
       it('should handle empty priorities', () => {
         expect(

--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -35,7 +35,7 @@ import {
   selectOpenParentFrontOfArticleFragment
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
-import initialStateForOpenFronts from './fixtures/initialStateForOpenFronts';
+import initialStateForOpenFronts from '../../fixtures/initialStateForOpenFronts';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { Action } from 'types/Action';
 import {
@@ -69,18 +69,18 @@ describe('frontsUIBundle', () => {
         initialStateForOpenFronts
       );
       it('should select the parent front of an article fragment', () => {
-        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+        const result = selectOpenParentFrontOfArticleFragment(
           state,
           'articleFragment1'
         );
-        expect(parentFrontId).toEqual('editorialFront');
+        expect(result).toEqual(['editorialFront', 'collection1']);
       });
       it("should return undefined if it does't find anything", () => {
-        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+        const result = selectOpenParentFrontOfArticleFragment(
           state,
           'not-a-thing'
         );
-        expect(parentFrontId).toEqual(undefined);
+        expect(result).toEqual([]);
       });
       it('should not select from fronts that are not open', () => {
         const stateWithClosedFronts = set(
@@ -88,11 +88,11 @@ describe('frontsUIBundle', () => {
           [],
           state
         );
-        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+        const result = selectOpenParentFrontOfArticleFragment(
           stateWithClosedFronts,
           'articleFragment1'
         );
-        expect(parentFrontId).toEqual(undefined);
+        expect(result).toEqual([]);
       });
       it('should not select from collections that are not open', () => {
         const stateWithClosedCollections = set(
@@ -100,11 +100,11 @@ describe('frontsUIBundle', () => {
           [],
           state
         );
-        const parentFrontId = selectOpenParentFrontOfArticleFragment(
+        const result = selectOpenParentFrontOfArticleFragment(
           stateWithClosedCollections,
           'articleFragment1'
         );
-        expect(parentFrontId).toEqual(undefined);
+        expect(result).toEqual([]);
       });
     });
     describe('selectEditorFrontIdsByPriority', () => {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -363,16 +363,27 @@ const createSelectCurrentlyOpenCollectionsByFront = () => {
 const selectOpenParentFrontOfArticleFragment = (
   state: GlobalState,
   articleFragmentId: string
-) => {
+): [string, string] | [] => {
   const openFrontsCollectionsAndArticles = selectOpenFrontsCollectionsAndArticles(
     state
   );
-  const front = openFrontsCollectionsAndArticles.find(frontAndCollections =>
-    frontAndCollections.collections.some(collection =>
-      collection.articleIds.some(articleId => articleId === articleFragmentId)
-    )
-  );
-  return front ? front.frontId : undefined;
+  let frontId;
+  let collectionId;
+
+  // I've used an imperative loop for efficiency's sake here, as it lets us break.
+  for (const front of openFrontsCollectionsAndArticles) {
+    for (const collection of front.collections) {
+      if (collection.articleIds.includes(articleFragmentId)) {
+        frontId = front.frontId;
+        collectionId = collection.id;
+        break;
+      }
+    }
+    if (frontId && collectionId) {
+      break;
+    }
+  }
+  return frontId && collectionId ? [frontId, collectionId] : [];
 };
 
 const selectOpenArticleFragmentIds = (state: GlobalState): string[] => {

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -356,6 +356,25 @@ const createSelectCurrentlyOpenCollectionsByFront = () => {
   );
 };
 
+/**
+ * Select the parent front of an article fragment.
+ * For performance reasons, only considers open fronts and collections.
+ */
+const selectOpenParentFrontOfArticleFragment = (
+  state: GlobalState,
+  articleFragmentId: string
+) => {
+  const openFrontsCollectionsAndArticles = selectOpenFrontsCollectionsAndArticles(
+    state
+  );
+  const front = openFrontsCollectionsAndArticles.find(frontAndCollections =>
+    frontAndCollections.collections.some(collection =>
+      collection.articleIds.some(articleId => articleId === articleFragmentId)
+    )
+  );
+  return front ? front.frontId : undefined;
+};
+
 const selectOpenArticleFragmentIds = (state: GlobalState): string[] => {
   const frontsCollectionsAndArticles = selectOpenFrontsCollectionsAndArticles(
     state
@@ -801,6 +820,7 @@ export {
   selectIsCurrentFrontsMenuOpen,
   selectIsArticleFragmentFormOpen,
   selectOpenArticleFragmentForms,
+  selectOpenParentFrontOfArticleFragment,
   createSelectEditorFrontsByPriority,
   createSelectFrontIdWithOpenAndStarredStatesByPriority,
   selectEditorFrontIds,

--- a/client-v2/src/constants/polling.ts
+++ b/client-v2/src/constants/polling.ts
@@ -1,4 +1,5 @@
 export const collectionsPollInterval = 10000;
 export const collectionArticlesPollInterval = 30000;
 export const feedArticlesPollInterval = 30000;
-export const ophanPollInterval = 30000;
+export const articlesPollInterval = 30000;
+export const ophanPollInterval = 300000;

--- a/client-v2/src/fixtures/initialStateForOpenFronts.ts
+++ b/client-v2/src/fixtures/initialStateForOpenFronts.ts
@@ -1,9 +1,16 @@
 import { defaultState } from 'bundles/frontsUIBundle';
 import { frontsConfig } from 'fixtures/frontsConfig';
+import initialState from './initialState';
+import { State } from 'types/State';
 
-const initialState = {
+const state = {
+  ...initialState,
   fronts: {
-    frontsConfig
+    ...initialState.fronts,
+    frontsConfig: {
+      ...initialState.fronts.frontsConfig,
+      ...frontsConfig
+    }
   },
   editor: {
     ...defaultState,
@@ -14,7 +21,9 @@ const initialState = {
     frontIdsByBrowsingStage: {}
   },
   shared: {
+    ...initialState.shared,
     collections: {
+      ...initialState.shared.collections,
       data: {
         collection1: {
           id: 'collection1',
@@ -29,8 +38,11 @@ const initialState = {
       }
     },
     groups: {
+      ...initialState.shared.groups,
       group1: {
         uuid: 'group1',
+        id: 'group1',
+        name: 'Group 1',
         articleFragments: [
           'articleFragment1',
           'articleFragment2',
@@ -39,23 +51,28 @@ const initialState = {
       }
     },
     articleFragments: {
+      ...initialState.shared.articleFragments,
       articleFragment1: {
         uuid: 'articleFragment1',
         id: 'capiArticle1',
+        frontPublicationDate: 0,
         meta: {}
       },
       articleFragment2: {
         uuid: 'articleFragment2',
         id: 'capiArticle2',
+        frontPublicationDate: 0,
         meta: {}
       },
       articleFragment3: {
         uuid: 'articleFragment3',
+        frontPublicationDate: 0,
         id: 'capiArticle3',
         meta: {}
       }
     },
     externalArticles: {
+      ...initialState.shared.externalArticles,
       data: {
         capiArticle1: {
           id: 'capiArticle1',
@@ -79,5 +96,6 @@ const initialState = {
     }
   },
   path: '/v2/editorial'
-} as any;
-export default initialState;
+} as State;
+
+export default state;

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -25,7 +25,7 @@ export const PAGE_VIEW_DATA_REQUESTED = 'PAGE_VIEW_DATA_REQUESTED';
 const selectArticlesInCollection = createSelectArticlesInCollection();
 const selectArticleFromArticleFragment = createSelectArticleFromArticleFragment();
 
-const getPageViewData = (
+const getPageViewDataForCollection = (
   frontId: string,
   collectionId: string,
   collectionSet: CollectionItemSets
@@ -38,26 +38,30 @@ const getPageViewData = (
         collectionId,
         collectionSet
       });
-      const articles = articleIds
-        .map(_ => selectArticleFromArticleFragment(state, _))
-        .filter(_ => _) as DerivedArticle[];
-      const urlPaths: string[] = articles
-        .map(article => article.urlPath)
-        .filter(_ => _) as string[];
-      const data = await fetchPageViewData(frontId, urlPaths);
-      const dataWithArticleIds = convertToStoriesData(data, articles);
-      dispatch(
-        pageViewDataReceivedAction(
-          dataWithArticleIds,
-          frontId,
-          collectionId,
-          true
-        )
-      );
+      dispatch(getPageViewData(frontId, collectionId, articleIds));
     } catch (e) {
       throw new Error(`API request to Ophan for page view data failed: ${e}`);
     }
   };
+};
+
+const getPageViewData = (
+  frontId: string,
+  collectionId: string,
+  articleIds: string[]
+): ThunkResult<void> => async (dispatch, getState) => {
+  const state = selectSharedState(getState());
+  const articles = articleIds
+    .map(_ => selectArticleFromArticleFragment(state, _))
+    .filter(_ => _) as DerivedArticle[];
+  const urlPaths: string[] = articles
+    .map(article => article.urlPath)
+    .filter(_ => _) as string[];
+  const data = await fetchPageViewData(frontId, urlPaths);
+  const dataWithArticleIds = convertToStoriesData(data, articles);
+  dispatch(
+    pageViewDataReceivedAction(dataWithArticleIds, frontId, collectionId)
+  );
 };
 
 const convertToStoriesData = (
@@ -158,4 +162,9 @@ const fetchPageViewData = async (
   return ([] as PageViewDataFromOphan[]).concat(...parsedResponse);
 };
 
-export { fetchPageViewData, getPageViewData, pageViewDataReceivedAction };
+export {
+  fetchPageViewData,
+  getPageViewData,
+  getPageViewDataForCollection,
+  pageViewDataReceivedAction
+};

--- a/client-v2/src/shared/actions/ArticleFragments.ts
+++ b/client-v2/src/shared/actions/ArticleFragments.ts
@@ -20,8 +20,6 @@ import { MappableDropType } from 'util/collectionUtils';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import { CapiArticle } from 'types/Capi';
 import { ArticleFragment, ArticleFragmentMeta } from '../types/Collection';
-import { selectOpenParentFrontOfArticleFragment } from 'bundles/frontsUIBundle';
-import { getPageViewData } from 'redux/modules/pageViewData';
 
 export const UPDATE_ARTICLE_FRAGMENT_META =
   'SHARED/UPDATE_ARTICLE_FRAGMENT_META';
@@ -148,7 +146,7 @@ type TArticleEntities = [ArticleFragment?, ExternalArticle?];
 const createArticleEntitiesFromDrop = (
   drop: MappableDropType
 ): ThunkResult<Promise<ArticleFragment | undefined>> => {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     const [
       maybeArticleFragment,
       maybeExternalArticle
@@ -158,16 +156,6 @@ const createArticleEntitiesFromDrop = (
     }
     if (maybeArticleFragment) {
       dispatch(articleFragmentsReceived([maybeArticleFragment]));
-
-      const [frontId, collectionId] = selectOpenParentFrontOfArticleFragment(
-        getState(),
-        maybeArticleFragment.uuid
-      );
-      if (frontId && collectionId) {
-        await dispatch(
-          getPageViewData(frontId, collectionId, [maybeArticleFragment.uuid])
-        );
-      }
     }
     return maybeArticleFragment;
   };

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -1,7 +1,6 @@
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
-import set from 'lodash/fp/set';
 import {
   createArticleEntitiesFromDrop,
   articleFragmentsReceived

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -1,21 +1,27 @@
+import configureMockStore from 'redux-mock-store';
+import fetchMock from 'fetch-mock';
+import thunk from 'redux-thunk';
+import set from 'lodash/fp/set';
 import {
   createArticleEntitiesFromDrop,
   articleFragmentsReceived
 } from '../ArticleFragments';
-import configureStore from 'redux-mock-store';
-import fetchMock from 'fetch-mock';
-import thunk from 'redux-thunk';
+import initialState from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'shared/bundles/externalArticlesBundle';
 import { createFragment } from 'shared/util/articleFragment';
 import { createSnap, createLatestSnap } from 'shared/util/snap';
 import guardianTagPage from 'shared/fixtures/guardianTagPage';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
+import initialStateForOpenFronts from 'fixtures/initialStateForOpenFronts';
 import { RefDrop } from 'util/collectionUtils';
+import configureStore from 'util/configureStore';
+import { selectPageViewData } from 'redux/modules/pageViewData/selectors';
+import { PageViewDataFromOphan } from 'shared/types/PageViewData';
 
-jest.mock('uuid/v4', () => () => 'uuid');
+jest.mock('uuid/v4', () => () => 'articleFragment1');
 const middlewares = [thunk];
-const mockStore = configureStore(middlewares);
+const mockStore = configureMockStore(middlewares);
 const idDrop = (id: string): RefDrop => ({ type: 'REF', data: id });
 
 describe('articleFragments actions', () => {
@@ -40,17 +46,42 @@ describe('articleFragments actions', () => {
           results: [capiArticle]
         }
       });
-      const store = mockStore({});
+      const store = mockStore(initialState);
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('internal-code/page/5029528')
       ) as any);
       const actions = store.getActions();
-      expect(actions[0]).toEqual(
+      expect(actions[0].type).toEqual(externalArticleActionNames.fetchSuccess);
+      expect(actions[1]).toEqual(
         articleFragmentsReceived({
-          uuid: createFragment('internal-code/page/5029528')
+          articleFragment1: createFragment('internal-code/page/5029528')
         })
       );
-      expect(actions[1].type).toEqual(externalArticleActionNames.fetchSuccess);
+    });
+    it('should fetch ophan data if the parent collection and front can be found', async () => {
+      fetchMock.once('begin:/api/preview', {
+        response: {
+          results: [capiArticle]
+        }
+      });
+      const emptyOphanData = [] as PageViewDataFromOphan[];
+      fetchMock.once('begin:/ophan/histogram', emptyOphanData);
+      const state = set(
+        ['editor', 'collectionIds'],
+        ['collection1', 'collection6'],
+        initialStateForOpenFronts
+      );
+
+      const store = configureStore(state, '/v2/editorial');
+      await store.dispatch(createArticleEntitiesFromDrop(
+        idDrop('internal-code/page/5029528')
+      ) as any);
+
+      // Expect the page data to have been added to the state.
+      expect(selectPageViewData(store.getState())).toContainEqual({
+        collections: [{ collectionId: 'collection1', stories: [] }],
+        frontId: 'editorialFront'
+      });
     });
     it('should fetch a link and create a corresponding collection item representing a snap link', async () => {
       fetchMock.once('begin:/api/preview', {
@@ -59,14 +90,14 @@ describe('articleFragments actions', () => {
         }
       });
       fetchMock.mock('/http/proxy/https://bbc.co.uk/some/page', bbcSectionPage);
-      const store = mockStore({});
+      const store = mockStore(initialState);
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('https://bbc.co.uk/some/page')
       ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createSnap('https://bbc.co.uk/some/page')
+          articleFragment1: await createSnap('https://bbc.co.uk/some/page')
         })
       );
     });
@@ -80,14 +111,16 @@ describe('articleFragments actions', () => {
         '/http/proxy/https://bbc.co.uk/some/page?great=true',
         bbcSectionPage
       );
-      const store = mockStore({});
+      const store = mockStore(initialState);
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('https://bbc.co.uk/some/page?great=true')
       ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createSnap('https://bbc.co.uk/some/page?great=true')
+          articleFragment1: await createSnap(
+            'https://bbc.co.uk/some/page?great=true'
+          )
         })
       );
     });
@@ -103,14 +136,14 @@ describe('articleFragments actions', () => {
         guardianTagPage
       );
       (window as any).confirm = jest.fn(() => true);
-      const store = mockStore({});
+      const store = mockStore(initialState);
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('https://www.theguardian.com/example/tag/page')
       ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createLatestSnap(
+          articleFragment1: await createLatestSnap(
             'https://www.theguardian.com/example/tag/page',
             'Example title'
           )
@@ -129,14 +162,16 @@ describe('articleFragments actions', () => {
         guardianTagPage
       );
       (window as any).confirm = jest.fn(() => false);
-      const store = mockStore({});
+      const store = mockStore(initialState);
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('https://www.theguardian.com/example/tag/page')
       ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createSnap('https://www.theguardian.com/example/tag/page')
+          articleFragment1: await createSnap(
+            'https://www.theguardian.com/example/tag/page'
+          )
         })
       );
     });
@@ -151,14 +186,14 @@ describe('articleFragments actions', () => {
         '/http/proxy/https://www.theguardian.com/example/non/tag/page?view=mobile',
         guardianTagPage
       );
-      const store = mockStore({});
+      const store = mockStore(initialState);
       await store.dispatch(createArticleEntitiesFromDrop(
         idDrop('https://www.theguardian.com/example/non/tag/page')
       ) as any);
       const actions = store.getActions();
       expect(actions[0]).toEqual(
         articleFragmentsReceived({
-          uuid: await createSnap(
+          articleFragment1: await createSnap(
             'https://www.theguardian.com/example/non/tag/page'
           )
         })
@@ -166,7 +201,7 @@ describe('articleFragments actions', () => {
     });
     describe('snaps created from url params prefixed with gu- ', () => {
       it('should be created if they are provided in the resource id', async () => {
-        const store = mockStore({});
+        const store = mockStore(initialState);
         const snapUrl =
           'https://www.theguardian.com/football/live?gu-snapType=json.html&gu-snapCss=football&gu-snapUri=https%3A%2F%2Fapi.nextgen.guardianapps.co.uk%2Ffootball%2Flive.json&gu-headline=Live+matches&gu-trailText=Today%27s+matches';
         fetchMock.mock(snapUrl, JSON.stringify({}));
@@ -176,7 +211,7 @@ describe('articleFragments actions', () => {
         const actions = store.getActions();
         expect(actions[0]).toEqual(
           articleFragmentsReceived({
-            uuid: {
+            articleFragment1: {
               frontPublicationDate: 1487076708000,
               id: 'snap/1487076708000',
               meta: {
@@ -190,13 +225,13 @@ describe('articleFragments actions', () => {
                   'https://api.nextgen.guardianapps.co.uk/football/live.json',
                 trailText: "Today's matches"
               },
-              uuid: 'uuid'
+              uuid: 'articleFragment1'
             }
           })
         );
       });
       it('should be created if they are provided on the root path', async () => {
-        const store = mockStore({});
+        const store = mockStore(initialState);
         const snapUrl =
           'https://gu.com?gu-snapType=json.html&gu-snapUri=https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json';
         fetchMock.mock(snapUrl, JSON.stringify({}));
@@ -206,7 +241,7 @@ describe('articleFragments actions', () => {
         const actions = store.getActions();
         expect(actions[0]).toEqual(
           articleFragmentsReceived({
-            uuid: {
+            articleFragment1: {
               frontPublicationDate: 1487076708000,
               id: 'snap/1487076708000',
               meta: {
@@ -217,7 +252,7 @@ describe('articleFragments actions', () => {
                 snapUri:
                   'https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json'
               },
-              uuid: 'uuid'
+              uuid: 'articleFragment1'
             }
           })
         );

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -13,11 +13,7 @@ import { createFragment } from 'shared/util/articleFragment';
 import { createSnap, createLatestSnap } from 'shared/util/snap';
 import guardianTagPage from 'shared/fixtures/guardianTagPage';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
-import initialStateForOpenFronts from 'fixtures/initialStateForOpenFronts';
 import { RefDrop } from 'util/collectionUtils';
-import configureStore from 'util/configureStore';
-import { selectPageViewData } from 'redux/modules/pageViewData/selectors';
-import { PageViewDataFromOphan } from 'shared/types/PageViewData';
 
 jest.mock('uuid/v4', () => () => 'articleFragment1');
 const middlewares = [thunk];

--- a/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/articleFragments.spec.ts
@@ -58,31 +58,6 @@ describe('articleFragments actions', () => {
         })
       );
     });
-    it('should fetch ophan data if the parent collection and front can be found', async () => {
-      fetchMock.once('begin:/api/preview', {
-        response: {
-          results: [capiArticle]
-        }
-      });
-      const emptyOphanData = [] as PageViewDataFromOphan[];
-      fetchMock.once('begin:/ophan/histogram', emptyOphanData);
-      const state = set(
-        ['editor', 'collectionIds'],
-        ['collection1', 'collection6'],
-        initialStateForOpenFronts
-      );
-
-      const store = configureStore(state, '/v2/editorial');
-      await store.dispatch(createArticleEntitiesFromDrop(
-        idDrop('internal-code/page/5029528')
-      ) as any);
-
-      // Expect the page data to have been added to the state.
-      expect(selectPageViewData(store.getState())).toContainEqual({
-        collections: [{ collectionId: 'collection1', stories: [] }],
-        frontId: 'editorialFront'
-      });
-    });
     it('should fetch a link and create a corresponding collection item representing a snap link', async () => {
       fetchMock.once('begin:/api/preview', {
         response: {

--- a/client-v2/src/util/pollingConfig.ts
+++ b/client-v2/src/util/pollingConfig.ts
@@ -7,7 +7,7 @@ import {
   collectionArticlesPollInterval
 } from 'constants/polling';
 import { selectPriority } from 'selectors/pathSelectors';
-import { getPageViewData } from '../redux/modules/pageViewData/actions';
+import { getPageViewDataForCollection } from '../redux/modules/pageViewData/actions';
 import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
 import {
   selectSharedState,
@@ -75,7 +75,7 @@ const createRefreshOphanData = (store: Store) => () => {
     front.collections.forEach(collection => {
       if (collection.articleIds.length > 0) {
         (store.dispatch as Dispatch)(
-          getPageViewData(front.frontId, collection.id, 'draft')
+          getPageViewDataForCollection(front.frontId, collection.id, 'draft')
         );
       }
     });


### PR DESCRIPTION
Welcome, traveller! This PR depends on #1029 -- please review that first 💜 

## What's changed?

This PR makes updating ophan less of a burden for our client:

- ophan data is fetched when articles are added to a front, which means we don't have to wait for our polling window to see a graph
- as a result, we can expand the polling window from 30s to 300s (as it was in V1), which makes it much less likely that users experience a delay as ophan data is updated.

Tada! 🎉 

![ophan-now](https://user-images.githubusercontent.com/7767575/65682124-3c974f00-e052-11e9-8f12-b780d23197cd.gif)

## Implementation notes

This relies on #1028 to allow us to ask for ophan data on a per-article basis.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
