### PR TITLE
Bug with Launch button: Failure in publish function caused weird behaviour

### DIFF
--- a/client-v2/src/actions/Collections.ts
+++ b/client-v2/src/actions/Collections.ts
@@ -471,6 +471,7 @@ function publishCollection(
         return;
       })
       .catch(e => {
+        // tslint:disable-next-line
         console.error('Error during publishing collection:', e);
       });
   };

--- a/client-v2/src/actions/Fronts.ts
+++ b/client-v2/src/actions/Fronts.ts
@@ -18,15 +18,6 @@ function fetchLastPressedSuccess(frontId: string, datePressed: string): Action {
   };
 }
 
-function publishCollectionSuccess(collectionId: string): Action {
-  return {
-    type: 'PUBLISH_COLLECTION_SUCCESS',
-    payload: {
-      collectionId
-    }
-  };
-}
-
 function recordStaleFronts(frontId: string, frontIsStale: boolean): Action {
   return {
     type: 'RECORD_STALE_FRONTS',
@@ -66,7 +57,6 @@ export {
   fetchLastPressed,
   fetchLastPressedSuccess,
   recordVisibleArticles,
-  publishCollectionSuccess,
   recordStaleFronts
 };
 

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -1,6 +1,10 @@
 import uniq from 'lodash/uniq';
 import { createSelector } from 'reselect';
-import { FrontConfig, CollectionConfig } from 'types/FaciaApi';
+import {
+  FrontConfig,
+  CollectionConfig,
+  VisibleArticlesResponse
+} from 'types/FaciaApi';
 import { State } from 'types/State';
 import { AlsoOnDetail } from 'types/Collection';
 import { breakingNewsFrontId } from 'constants/fronts';
@@ -303,7 +307,10 @@ const selectClipboard = (state: State) => state.clipboard;
 
 const selectVisibleArticles = createSelector(
   [selectCollectionVisibilities, selectCollectionIdAndStage],
-  (collectionVisibilities, { collectionId, stage }) => {
+  (
+    collectionVisibilities,
+    { collectionId, stage }
+  ): VisibleArticlesResponse | undefined => {
     return collectionVisibilities[stage][collectionId];
   }
 );

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -242,11 +242,6 @@ interface RecordUnpublishedChanges {
   payload: { [id: string]: boolean };
 }
 
-interface PublishCollectionSuccess {
-  type: 'PUBLISH_COLLECTION_SUCCESS';
-  payload: { collectionId: string };
-}
-
 interface UpdateClipboardContent {
   type: 'UPDATE_CLIPBOARD_CONTENT';
   payload: string[];
@@ -323,7 +318,6 @@ type Action =
   | FrontsUpdateLastPressedAction
   | SharedActions
   | RecordUnpublishedChanges
-  | PublishCollectionSuccess
   | InsertGroupArticleFragment
   | InsertSupportingArticleFragment
   | InsertClipboardArticleFragment
@@ -381,7 +375,6 @@ export {
   FrontsUpdateLastPressedAction,
   SharedActions,
   RecordUnpublishedChanges,
-  PublishCollectionSuccess,
   InsertGroupArticleFragment,
   InsertSupportingArticleFragment,
   InsertClipboardArticleFragment,


### PR DESCRIPTION
## What's changed?
A failure in the `publishCollection` function (triggered when the Launch button was hit on a collection) caused the function to exit early.

This resulted in weird behaviour where the launching state and the visibility of the button flickered on and off. A confusing UI experience. 

The cause was that the action `recordVisibleArticles()` failed for certain types of collections*.  This caused the publish action to exit early, meaning several other actions further down were not dispatched. This disrupted the flow of events causing the weird UI behaviour.

So now we only dispatch this action when visibleArticles is present and true. 

Also the catch statement now returns a clearer error 

Additionally the `publishCollectionSuccess` action never seemed to trigger any state change so this has been removed. 

-------
*(those with a "fast" layout. Fast articles don't have a visible articles line - ie something that shows what articles are visible on a mobile/desktop layout). 


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
