### PR TITLE
Fix refresh button in feed

### DIFF
--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -76,32 +76,35 @@ export const createFetch = (
   getState
 ) => {
   dispatch(actions.fetchStart());
-  let resultData;
   try {
-    resultData = await fetchResourceOrResults(
+    const resultData = await fetchResourceOrResults(
       isPreview ? previewCapi : liveCapi,
       params,
       isResource,
       isPreview
     );
+    if (resultData) {
+      const nonCommercialResults = resultData.results.filter(article =>
+        isNonCommercialArticle(article)
+      );
+      const updatedResults = nonCommercialResults.filter(article =>
+        selectIsArticleStale(
+          getState(),
+          article.id,
+          article.fields.lastModified
+        )
+      );
+      dispatch(
+        actions.fetchSuccess(updatedResults, {
+          pagination: resultData.pagination || undefined,
+          order: nonCommercialResults.map(_ => _.id)
+        })
+      );
+    } else {
+      dispatch(actions.fetchSuccessIgnore([]));
+    }
   } catch (e) {
     dispatch(actions.fetchError(e.message));
-  }
-  if (resultData) {
-    const nonCommercialResults = resultData.results.filter(article =>
-      isNonCommercialArticle(article)
-    );
-    const updatedResults = nonCommercialResults.filter(article =>
-      selectIsArticleStale(getState(), article.id, article.fields.lastModified)
-    );
-    dispatch(
-      actions.fetchSuccess(updatedResults, {
-        pagination: resultData.pagination || undefined,
-        order: nonCommercialResults.map(_ => _.id)
-      })
-    );
-  } else {
-    dispatch(actions.fetchSuccessIgnore([]));
   }
 };
 

--- a/client-v2/src/bundles/capiFeedBundle.ts
+++ b/client-v2/src/bundles/capiFeedBundle.ts
@@ -100,6 +100,8 @@ export const createFetch = (
         order: nonCommercialResults.map(_ => _.id)
       })
     );
+  } else {
+    dispatch(actions.fetchSuccessIgnore([]));
   }
 };
 

--- a/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
@@ -1,4 +1,4 @@
-import createAsyncResourceBundle from '../';
+import createAsyncResourceBundle, { globalLoadingIndicator } from '../';
 
 const { actions, reducer, selectors, initialState } = createAsyncResourceBundle(
   'books'
@@ -204,7 +204,7 @@ describe('createAsyncResourceBundle', () => {
       describe('Success action handler', () => {
         it('should merge data and mark the state as not loading when a success action is dispatched', () => {
           const newState = reducer(
-            { ...initialState },
+            { ...initialState, loadingIds: ['@@ALL@@'] },
             actions.fetchSuccess({ uuid: { id: 'uuid', author: 'Mark Twain' } })
           );
           expect(newState.loadingIds).toEqual([]);
@@ -240,6 +240,22 @@ describe('createAsyncResourceBundle', () => {
           expect(newState.data).toEqual({
             uuid: { id: 'uuid', author: 'Mark Twain' },
             uuid2: { id: 'uuid2', author: 'Elizabeth Gaskell' }
+          });
+        });
+        it('should remove global loading indicators when merging arrays', () => {
+          const { reducer: indexedReducer } = createAsyncResourceBundle(
+            'books',
+            {
+              indexById: true
+            }
+          );
+          const newState = indexedReducer(
+            { ...initialState, loadingIds: [globalLoadingIndicator] },
+            actions.fetchSuccess([{ id: 'uuid', author: 'Mark Twain' }])
+          );
+          expect(newState.loadingIds).toEqual([]);
+          expect(newState.data).toEqual({
+            uuid: { id: 'uuid', author: 'Mark Twain' }
           });
         });
         it('should keep order information when merging arrays', () => {

--- a/client-v2/src/lib/createAsyncResourceBundle/index.ts
+++ b/client-v2/src/lib/createAsyncResourceBundle/index.ts
@@ -82,6 +82,7 @@ type Actions<Resource> =
   | UpdateErrorAction;
 
 const defaultArray = [] as string[];
+const globalLoadingIndicator = '@@ALL';
 
 const getStatusIdsFromData = (
   data: BaseResource | BaseResource[] | any
@@ -93,14 +94,14 @@ const getStatusIdsFromData = (
 const applyStatusIds = (
   currentIds: string[],
   incomingIds?: string | string[]
-) => currentIds.concat(incomingIds || '@@ALL');
+) => currentIds.concat(incomingIds || globalLoadingIndicator);
 
 const removeStatusIds = (
   currentIds: string[],
   incomingIds: string[] | string = ''
 ): string[] =>
   incomingIds instanceof Array
-    ? without(currentIds, ...incomingIds)
+    ? without(currentIds, ...incomingIds, globalLoadingIndicator)
     : without<string>(currentIds, incomingIds);
 
 function formatIncomingResourceData<Resource extends BaseResource>(
@@ -484,5 +485,5 @@ function createAsyncResourceBundle<Resource>(
   };
 }
 
-export { Actions, State, IPagination };
+export { Actions, State, IPagination, globalLoadingIndicator };
 export default createAsyncResourceBundle;


### PR DESCRIPTION
## What's changed?

A previous PR, #1016, broke the refresh button in the feed. This PR restores it.

## Implementation notes

This works by removing the global loading indicator for feed state when incomplete updates are returned. Previously it stayed, cluttering up the state and causing misleading behaviour.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
