### PR TITLE
Shrink vertical height of inline form

### DIFF
--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -97,7 +97,6 @@ test('Snap Links - Guardian', async t => {
   const frontDropsCount = await frontDropZone().count;
   const tagSnap = await guardianSnapLink();
   await t
-    // .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => false)
     .dragToElement(tagSnap, frontDropZone(1)) //drag tag into parent position (not a sublink)
     .expect(frontDropZone().count)
@@ -112,7 +111,6 @@ test('Snap Links - Guardian Latest', async t => {
   const frontDropsCount = await frontDropZone().count;
   const tagSnap = await guardianSnapLink();
   await t
-    // .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => true)
     .dragToElement(tagSnap, frontDropZone(1))
     .expect(frontDropZone().count)
@@ -127,7 +125,6 @@ test('Snap Links - External', async t => {
   const frontDropsCount = await frontDropZone().count;
   const externalSnap = await externalSnapLink();
   await t
-    // .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => false)
     .dragToElement(externalSnap, frontDropZone(1))
     .expect(frontDropZone().count)
@@ -161,7 +158,6 @@ test('Previously', async t => {
 test('Clipboard - drop depth', async t => {
   const prevCount = await clipboardItem().count;
   await t
-    // .maximizeWindow()
     // drag to a position in the UI wrapper - NOT the clipboard itself
     // this checks that the clipboard drop area extends to the bottom of the visual clipboard wrapper
     .dragToElement(feedItem(0), clipboardWrapper(), {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -97,7 +97,7 @@ test('Snap Links - Guardian', async t => {
   const frontDropsCount = await frontDropZone().count;
   const tagSnap = await guardianSnapLink();
   await t
-    .maximizeWindow() // needed to find DOM elements in headless mode
+    // .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => false)
     .dragToElement(tagSnap, frontDropZone(1)) //drag tag into parent position (not a sublink)
     .expect(frontDropZone().count)
@@ -112,7 +112,7 @@ test('Snap Links - Guardian Latest', async t => {
   const frontDropsCount = await frontDropZone().count;
   const tagSnap = await guardianSnapLink();
   await t
-    .maximizeWindow() // needed to find DOM elements in headless mode
+    // .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => true)
     .dragToElement(tagSnap, frontDropZone(1))
     .expect(frontDropZone().count)
@@ -127,7 +127,7 @@ test('Snap Links - External', async t => {
   const frontDropsCount = await frontDropZone().count;
   const externalSnap = await externalSnapLink();
   await t
-    .maximizeWindow() // needed to find DOM elements in headless mode
+    // .maximizeWindow() // needed to find DOM elements in headless mode
     .setNativeDialogHandler(() => false)
     .dragToElement(externalSnap, frontDropZone(1))
     .expect(frontDropZone().count)
@@ -161,7 +161,7 @@ test('Previously', async t => {
 test('Clipboard - drop depth', async t => {
   const prevCount = await clipboardItem().count;
   await t
-    .maximizeWindow()
+    // .maximizeWindow()
     // drag to a position in the UI wrapper - NOT the clipboard itself
     // this checks that the clipboard drop area extends to the bottom of the visual clipboard wrapper
     .dragToElement(feedItem(0), clipboardWrapper(), {

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -89,32 +89,41 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
 `;
 
 const FormContent = styled.div`
-  flex: 1;
+  flex: 3;
   display: flex;
   flex-direction: ${(props: { size?: string }) =>
-    props.size === 'medium' ? 'column' : 'row'};
+    props.size !== 'wide' ? 'column' : 'row'};
 `;
 
 const RowContainer = styled.div`
   overflow: hidden;
 `;
 
+const TextOptionsContainer = styled(InputGroup)`
+  flex: 2;
+`;
+
 const ImageOptionsContainer = styled.div`
   display: flex;
-  flex-direction: ${(props: { size?: string }) =>
-    props.size === 'medium' ? 'row' : 'column'};
+  height: fit-content;
+  flex-wrap: wrap;
+  flex: 1;
+  flex-direction: column;
+  margin-top: ${(props: { size?: string }) =>
+    props.size !== 'wide' ? 0 : '10px'};
 `;
 
 const SlideshowRowContainer = styled(RowContainer)`
   flex: 1 1 auto;
+  overflow: visible;
   margin-left: ${(props: { size?: string }) =>
-    props.size === 'medium' ? 0 : '10px'};
+    props.size !== 'wide' ? 0 : '10px'};
 `;
 
 const ImageRowContainer = styled(RowContainer)`
   flex: 1 1 auto;
   margin-left: ${(props: { size?: string }) =>
-    props.size === 'medium' ? 0 : '10px'};
+    props.size !== 'wide' ? 0 : '10px'};
 `;
 
 const ButtonContainer = styled.div`
@@ -334,7 +343,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           </CollectionEditedError>
         )}
         <FormContent size={this.props.size}>
-          <InputGroup>
+          <TextOptionsContainer>
             <ConditionalField
               name="customKicker"
               label="Kicker"
@@ -454,11 +463,13 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               placeholder=""
               originalValue={''}
             />
-          </InputGroup>
+          </TextOptionsContainer>
           <ImageOptionsContainer size={this.props.size}>
             <ImageRowContainer size={this.props.size}>
               <Row>
                 <ImageCol faded={imageHide || !!coverCardImageReplace}>
+                  {/* TODO: Use existing or create new component to style this text... */}
+                  <span>Trail image</span>
                   <ConditionalField
                     permittedFields={editableFields}
                     name={this.getImageFieldName()}

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -52,6 +52,7 @@ import { getContributorImage } from 'util/CAPIUtils';
 import { EditMode } from 'types/EditMode';
 import { selectEditMode } from 'selectors/pathSelectors';
 import { ValidationResponse } from 'shared/util/validateImageSrc';
+import InputLabel from 'shared/components/input/InputLabel';
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -468,8 +469,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             <ImageRowContainer size={this.props.size}>
               <Row>
                 <ImageCol faded={imageHide || !!coverCardImageReplace}>
-                  {/* TODO: Use existing or create new component to style this text... */}
-                  <span>Trail image</span>
+                  <InputLabel for={this.getImageFieldName()}>
+                    Trail image
+                  </InputLabel>
                   <ConditionalField
                     permittedFields={editableFields}
                     name={this.getImageFieldName()}

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -112,7 +112,7 @@ const ImageOptionsContainer = styled.div`
   flex-direction: column;
   min-width: 300px;
   margin-top: ${(props: { size?: string }) =>
-    props.size !== 'wide' ? 0 : '10px'};
+    props.size !== 'wide' ? 0 : '6px'};
 `;
 
 const SlideshowRowContainer = styled(RowContainer)`

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -110,6 +110,7 @@ const ImageOptionsContainer = styled.div`
   flex-wrap: wrap;
   flex: 1;
   flex-direction: column;
+  min-width: 300px;
   margin-top: ${(props: { size?: string }) =>
     props.size !== 'wide' ? 0 : '10px'};
 `;
@@ -168,6 +169,10 @@ const SlideshowCol = styled(Col)`
   min-width: 0;
 `;
 
+const ToggleCol = styled(Col)`
+  margin-top: 24px;
+`;
+
 const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
   <>
     {fields.map((name, index) => (
@@ -187,23 +192,33 @@ const RenderSlideshow = ({ fields, frontId }: RenderSlideshowProps) => (
 const CheckboxFieldsContainer: React.SFC<{
   children: Array<React.ReactElement<{ name: string }>>;
   editableFields: string[];
-}> = ({ children, editableFields }) => {
+  size?: string;
+}> = ({ children, editableFields, size }) => {
   const childrenToRender = children.filter(child =>
     shouldRenderField(child.props.name, editableFields)
   );
   return (
     <FieldsContainerWrap>
       {childrenToRender.map(child => {
-        return <FieldContainer key={child.props.name}>{child}</FieldContainer>;
+        return (
+          <FieldContainer key={child.props.name} size={size}>
+            {child}
+          </FieldContainer>
+        );
       })}
     </FieldsContainerWrap>
   );
 };
 
 const FieldContainer = styled(Col)`
-  flex-basis: calc(100% / 4);
-  min-width: 125px; /* Prevents labels breaking across lines */
+  flex: ${(props: { size?: string }) =>
+    props.size === 'wide' ? '0 0 auto' : 1};
   margin-bottom: 8px;
+  white-space: nowrap;
+  & label {
+    padding-left: 3px;
+    padding-right: 5px;
+  }
 `;
 
 const KickerSuggestionsContainer = styled.div`
@@ -392,7 +407,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                 data-testid="edit-form-headline-field"
               />
             )}
-            <CheckboxFieldsContainer editableFields={editableFields}>
+            <CheckboxFieldsContainer
+              editableFields={editableFields}
+              size={this.props.size}
+            >
               <Field
                 name="isBoosted"
                 component={InputCheckboxToggleInline}
@@ -469,7 +487,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             <ImageRowContainer size={this.props.size}>
               <Row>
                 <ImageCol faded={imageHide || !!coverCardImageReplace}>
-                  <InputLabel for={this.getImageFieldName()}>
+                  <InputLabel htmlFor={this.getImageFieldName()}>
                     Trail image
                   </InputLabel>
                   <ConditionalField
@@ -496,7 +514,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                     onChange={this.handleImageChange}
                   />
                 </ImageCol>
-                <Col flex={2}>
+                <ToggleCol flex={2}>
                   <InputGroup>
                     <ConditionalField
                       permittedFields={editableFields}
@@ -578,7 +596,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                       />
                     </InputGroup>
                   )}
-                </Col>
+                </ToggleCol>
               </Row>
               <ConditionalComponent
                 permittedNames={editableFields}

--- a/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/ArticleFragmentFormInline.tsx
@@ -66,6 +66,7 @@ interface ComponentProps extends ContainerProps {
   coverCardImageReplace?: boolean;
   coverCardMobileImage?: ImageData;
   coverCardTabletImage?: ImageData;
+  size?: string;
 }
 
 type Props = ComponentProps &
@@ -89,10 +90,31 @@ const FormContainer = styled(ContentContainer.withComponent('form'))`
 
 const FormContent = styled.div`
   flex: 1;
+  display: flex;
+  flex-direction: ${(props: { size?: string }) =>
+    props.size === 'medium' ? 'column' : 'row'};
 `;
 
 const RowContainer = styled.div`
   overflow: hidden;
+`;
+
+const ImageOptionsContainer = styled.div`
+  display: flex;
+  flex-direction: ${(props: { size?: string }) =>
+    props.size === 'medium' ? 'row' : 'column'};
+`;
+
+const SlideshowRowContainer = styled(RowContainer)`
+  flex: 1 1 auto;
+  margin-left: ${(props: { size?: string }) =>
+    props.size === 'medium' ? 0 : '10px'};
+`;
+
+const ImageRowContainer = styled(RowContainer)`
+  flex: 1 1 auto;
+  margin-left: ${(props: { size?: string }) =>
+    props.size === 'medium' ? 0 : '10px'};
 `;
 
 const ButtonContainer = styled.div`
@@ -311,7 +333,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               )} since you started editing this article. Your changes have not been saved.`}
           </CollectionEditedError>
         )}
-        <FormContent>
+        <FormContent size={this.props.size}>
           <InputGroup>
             <ConditionalField
               name="customKicker"
@@ -433,127 +455,136 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               originalValue={''}
             />
           </InputGroup>
-          <RowContainer>
-            <Row>
-              <ImageCol faded={imageHide || !!coverCardImageReplace}>
-                <ConditionalField
-                  permittedFields={editableFields}
-                  name={this.getImageFieldName()}
-                  component={InputImage}
-                  disabled={imageHide || coverCardImageReplace}
-                  criteria={
-                    isEditionsMode
-                      ? editionsArticleFragmentImageCriteria
-                      : articleFragmentImageCriteria
-                  }
-                  frontId={frontId}
-                  defaultImageUrl={
-                    imageCutoutReplace
-                      ? cutoutImage
-                      : articleCapiFieldValues.thumbnail
-                  }
-                  useDefault={!imageCutoutReplace && !imageReplace}
-                  message={imageCutoutReplace ? 'Add cutout' : 'Replace image'}
-                  hasVideo={hasMainVideo}
-                  onChange={this.handleImageChange}
-                />
-              </ImageCol>
-              <Col flex={2}>
-                <InputGroup>
+          <ImageOptionsContainer size={this.props.size}>
+            <ImageRowContainer size={this.props.size}>
+              <Row>
+                <ImageCol faded={imageHide || !!coverCardImageReplace}>
                   <ConditionalField
                     permittedFields={editableFields}
-                    name="imageHide"
-                    component={InputCheckboxToggleInline}
-                    label="Hide media"
-                    id={getInputId(articleFragmentId, 'hide-media')}
-                    type="checkbox"
-                    default={false}
-                    onChange={_ => this.changeImageField('imageHide')}
-                  />
-                </InputGroup>
-                <InputGroup>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name="imageCutoutReplace"
-                    component={InputCheckboxToggleInline}
-                    label="Use cutout"
-                    id={getInputId(articleFragmentId, 'use-cutout')}
-                    type="checkbox"
-                    default={false}
-                    onChange={_ => this.changeImageField('imageCutoutReplace')}
-                  />
-                </InputGroup>
-                <InputGroup>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name="coverCardImageReplace"
-                    id={getInputId(articleFragmentId, 'coverCardImageReplace')}
-                    component={InputCheckboxToggleInline}
-                    label="Replace Cover Card Image"
-                    type="checkbox"
-                    default={false}
-                    onChange={_ =>
-                      this.changeImageField('coverCardImageReplace')
+                    name={this.getImageFieldName()}
+                    component={InputImage}
+                    disabled={imageHide || coverCardImageReplace}
+                    criteria={
+                      isEditionsMode
+                        ? editionsArticleFragmentImageCriteria
+                        : articleFragmentImageCriteria
                     }
-                  />
-                </InputGroup>
-                <InputGroup>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name="showMainVideo"
-                    component={InputCheckboxToggleInline}
-                    label="Show video"
-                    id={getInputId(articleFragmentId, 'show-video')}
-                    type="checkbox"
-                    onChange={_ => this.changeImageField('showMainVideo')}
-                  />
-                </InputGroup>
-                <InputGroup>
-                  <ConditionalField
-                    permittedFields={editableFields}
-                    name="imageSlideshowReplace"
-                    component={InputCheckboxToggleInline}
-                    label="Slideshow"
-                    id={getInputId(articleFragmentId, 'slideshow')}
-                    type="checkbox"
-                    onChange={_ =>
-                      this.changeImageField('imageSlideshowReplace')
+                    frontId={frontId}
+                    defaultImageUrl={
+                      imageCutoutReplace
+                        ? cutoutImage
+                        : articleCapiFieldValues.thumbnail
                     }
+                    useDefault={!imageCutoutReplace && !imageReplace}
+                    message={
+                      imageCutoutReplace ? 'Add cutout' : 'Replace image'
+                    }
+                    hasVideo={hasMainVideo}
+                    onChange={this.handleImageChange}
                   />
-                </InputGroup>
-                {primaryImage && !!primaryImage.src && (
+                </ImageCol>
+                <Col flex={2}>
                   <InputGroup>
                     <ConditionalField
                       permittedFields={editableFields}
-                      name="imageReplace"
+                      name="imageHide"
                       component={InputCheckboxToggleInline}
-                      label="Use replacement image"
-                      id={getInputId(articleFragmentId, 'image-replace')}
+                      label="Hide media"
+                      id={getInputId(articleFragmentId, 'hide-media')}
                       type="checkbox"
                       default={false}
-                      onChange={_ => this.changeImageField('imageReplace')}
+                      onChange={_ => this.changeImageField('imageHide')}
                     />
                   </InputGroup>
-                )}
-              </Col>
-            </Row>
-            <ConditionalComponent
-              permittedNames={editableFields}
-              name={['primaryImage', 'imageHide']}
-            />
-          </RowContainer>
-          {imageSlideshowReplace && (
-            <RowContainer>
-              <SlideshowRow>
-                <FieldArray
-                  name="slideshow"
-                  frontId={frontId}
-                  component={RenderSlideshow}
-                />
-              </SlideshowRow>
-              <SlideshowLabel>Drag and drop up to five images</SlideshowLabel>
-            </RowContainer>
-          )}
+                  <InputGroup>
+                    <ConditionalField
+                      permittedFields={editableFields}
+                      name="imageCutoutReplace"
+                      component={InputCheckboxToggleInline}
+                      label="Use cutout"
+                      id={getInputId(articleFragmentId, 'use-cutout')}
+                      type="checkbox"
+                      default={false}
+                      onChange={_ =>
+                        this.changeImageField('imageCutoutReplace')
+                      }
+                    />
+                  </InputGroup>
+                  <InputGroup>
+                    <ConditionalField
+                      permittedFields={editableFields}
+                      name="coverCardImageReplace"
+                      id={getInputId(
+                        articleFragmentId,
+                        'coverCardImageReplace'
+                      )}
+                      component={InputCheckboxToggleInline}
+                      label="Replace Cover Card Image"
+                      type="checkbox"
+                      default={false}
+                      onChange={_ =>
+                        this.changeImageField('coverCardImageReplace')
+                      }
+                    />
+                  </InputGroup>
+                  <InputGroup>
+                    <ConditionalField
+                      permittedFields={editableFields}
+                      name="showMainVideo"
+                      component={InputCheckboxToggleInline}
+                      label="Show video"
+                      id={getInputId(articleFragmentId, 'show-video')}
+                      type="checkbox"
+                      onChange={_ => this.changeImageField('showMainVideo')}
+                    />
+                  </InputGroup>
+                  <InputGroup>
+                    <ConditionalField
+                      permittedFields={editableFields}
+                      name="imageSlideshowReplace"
+                      component={InputCheckboxToggleInline}
+                      label="Slideshow"
+                      id={getInputId(articleFragmentId, 'slideshow')}
+                      type="checkbox"
+                      onChange={_ =>
+                        this.changeImageField('imageSlideshowReplace')
+                      }
+                    />
+                  </InputGroup>
+                  {primaryImage && !!primaryImage.src && (
+                    <InputGroup>
+                      <ConditionalField
+                        permittedFields={editableFields}
+                        name="imageReplace"
+                        component={InputCheckboxToggleInline}
+                        label="Use replacement image"
+                        id={getInputId(articleFragmentId, 'image-replace')}
+                        type="checkbox"
+                        default={false}
+                        onChange={_ => this.changeImageField('imageReplace')}
+                      />
+                    </InputGroup>
+                  )}
+                </Col>
+              </Row>
+              <ConditionalComponent
+                permittedNames={editableFields}
+                name={['primaryImage', 'imageHide']}
+              />
+            </ImageRowContainer>
+            {imageSlideshowReplace && (
+              <SlideshowRowContainer size={this.props.size}>
+                <SlideshowRow>
+                  <FieldArray
+                    name="slideshow"
+                    frontId={frontId}
+                    component={RenderSlideshow}
+                  />
+                </SlideshowRow>
+                <SlideshowLabel>Drag and drop up to five images</SlideshowLabel>
+              </SlideshowRowContainer>
+            )}
+          </ImageOptionsContainer>
           {isEditionsMode && coverCardImageReplace && (
             <RowContainer>
               <Row>
@@ -706,6 +737,7 @@ interface InterfaceProps {
   onCancel: () => void;
   onSave: (meta: ArticleFragmentMeta) => void;
   frontId: string;
+  size?: string;
 }
 
 const formContainer: React.SFC<ContainerProps & InterfaceProps> = props => (

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -91,7 +91,7 @@ interface CollectionContextProps {
     [id: string]: AlsoOnDetail;
   };
   browsingStage: CollectionItemSets;
-  size?: 'medium' | 'default';
+  size?: 'medium' | 'default' | 'wide';
   handleMove: (move: Move<TArticleFragment>) => void;
   handleInsert: (e: React.DragEvent, to: PosSpec) => void;
   selectArticleFragment: (id: string, isSupporting: boolean) => void;

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -220,6 +220,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 clearArticleFragmentSelection(uuid);
               }}
               onCancel={() => clearArticleFragmentSelection(uuid)}
+              size={size}
             />
             {getSublinks}
             {numSupportingArticles === 0

--- a/client-v2/src/components/FrontsEdit/Front.tsx
+++ b/client-v2/src/components/FrontsEdit/Front.tsx
@@ -320,7 +320,13 @@ class FrontComponent extends React.Component<FrontProps, FrontState> {
                           alsoOn={this.props.alsoOn}
                           handleInsert={this.handleInsert}
                           handleMove={this.handleMove}
-                          size={width && width > 500 ? 'default' : 'medium'}
+                          size={
+                            width && width > 750
+                              ? 'wide'
+                              : width && width > 500
+                              ? 'default'
+                              : 'medium'
+                          }
                           selectArticleFragment={(
                             articleFragmentId,
                             isSupporting

--- a/client-v2/src/shared/components/input/InputGroup.ts
+++ b/client-v2/src/shared/components/input/InputGroup.ts
@@ -3,7 +3,6 @@ import InputContainer from './InputContainer';
 
 export default styled.div`
   & > ${InputContainer} {
-    margin: 6px 0;
+    margin: 6px 0 10px 0;
   }
-  padding-bottom: 4px;
 `;

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -14,7 +14,7 @@ type CollectionItemSets = 'draft' | 'live' | 'previously';
 type Stages = 'draft' | 'live';
 
 type CollectionItemTypes = 'SNAP_LINK' | 'ARTICLE';
-type CollectionItemSizes = 'default' | 'medium' | 'small';
+type CollectionItemSizes = 'wide' | 'default' | 'medium' | 'small';
 
 interface NestedArticleFragmentRootFields {
   id: string;


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This PR adds a new layout to the Fronts inline form. In an attempt to make more efficient use of space in the browser, when the form has a width of more than 700px the image toggles and inputs will display to the right of the other inputs and toggles. 

An example of the new layout:
![Screenshot 2019-09-27 at 17 06 33](https://user-images.githubusercontent.com/12645938/65784083-38019200-e149-11e9-9a3c-0f1161a5d97f.png)

([Trello card](https://trello.com/c/RJFjyDvc/836-shrink-vertical-height-of-inline-form-akemi-designs))

## Implementation notes

This PR also makes a small change to the integration tests, removing a call to `maximizeWindow` from a number of tests. Previously, this call was necessary to allow the headless browser to find certain elements in the DOM. It's not clear when this stopped being necessary, but without removing this call, the tests now _would_ fail. This is because at the point the window is maximised, our collection items are re-rendered, due to the fact that they are moving from 'default' size to 'wide' size.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
