### PR TITLE
Style tidy up on 'Recently removed' section

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -80,9 +80,11 @@ const PreviouslyCollectionContainer = styled.div``;
 
 const PreviouslyCollectionToggle = styled(CollectionMetaContainer)`
   align-items: center;
-  font-size: 16px;
-  font-weight: bold;
+  font-size: 14px;
+  font-weight: normal;
   padding-top: 0.25em;
+  justify-content: unset;
+  border-top: 1px solid ${theme.shared.colors.greyMediumLight};
 `;
 
 const PreviouslyGroupsWrapper = styled.div`
@@ -99,6 +101,17 @@ const PreviouslyCollectionInfo = styled.div`
 
 const LoadingImageBox = styled.div`
   min-width: 50px;
+`;
+
+const PreviouslyCircularCaret = styled(ButtonCircularCaret)`
+  height: 15px;
+  width: 15px;
+  background-color: ${theme.shared.colors.greyMediumLight};
+  margin-left: 6px;
+  svg {
+    height: 15px;
+    width: 15px;
+  }
 `;
 
 class Collection extends React.Component<CollectionProps> {
@@ -256,7 +269,7 @@ class Collection extends React.Component<CollectionProps> {
                 data-testid="previously-toggle"
               >
                 Recently removed from launched front
-                <ButtonCircularCaret active={isPreviouslyOpen} />
+                <PreviouslyCircularCaret active={isPreviouslyOpen} />
               </PreviouslyCollectionToggle>
               {isPreviouslyOpen && (
                 <>

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -69,6 +69,7 @@ const CollectionContainer = styled(ContentContainer)<{
     border-top: none;
     outline: none;
   }
+  padding-bottom: 0;
 `;
 
 const HeadlineContentContainer = styled.span`


### PR DESCRIPTION
## What's changed?
The 'recently removed' section is... smaller!

Before:
![Screenshot 2019-09-30 at 13 31 56](https://user-images.githubusercontent.com/12645938/65879032-2a395000-e387-11e9-84c8-eb0ef0bbe3fa.png)

After:
![Screenshot 2019-09-30 at 13 31 29](https://user-images.githubusercontent.com/12645938/65879030-29a0b980-e387-11e9-9801-722deb1cc01c.png)

([Trello card](https://trello.com/c/CKeSejX8/789-style-tidy-up-on-recently-removed))

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
