### PR TITLE
make version property of PublishedIssue non-optional

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -110,7 +110,7 @@ class EditionsController(db: EditionsDB,
 
   def getPreviewEdition(id: String) = EditEditionsAuthAction { _ =>
     db.getIssue(id).map { issue =>
-      Ok(Json.toJson(issue.toPublishedIssue()))
+      Ok(Json.toJson(issue.toPreviewIssue))
     }.getOrElse(NotFound(s"Issue $id not found"))
   }
 

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -18,7 +18,9 @@ case class EditionsIssue(
     launchedEmail: Option[String],
     fronts: List[EditionsFront]
 ) {
-  def toPublishedIssue(version: Option[String] = None): PublishedIssue = PublishedIssue(
+  def toPreviewIssue: PublishedIssue = toPublishedIssue("preview")
+
+  def toPublishedIssue(version: String): PublishedIssue = PublishedIssue(
     id,
     displayName,
     issueDate,

--- a/app/model/editions/PublishedIssue.scala
+++ b/app/model/editions/PublishedIssue.scala
@@ -52,6 +52,6 @@ case class PublishedIssue(
   id: String,
   name: String,
   issueDate: LocalDate,
-  version: Option[String],
+  version: String,
   fronts: List[PublishedFront]
 )

--- a/app/services/editions/publishing/EditionsBucket.scala
+++ b/app/services/editions/publishing/EditionsBucket.scala
@@ -10,10 +10,7 @@ import PublishedIssueFormatters._
 class EditionsBucket(s3Client: AmazonS3, bucketName: String) {
   def createIssuePrefix(issue: PublishedIssue): String = s"${issue.name}/${issue.issueDate.toString}"
 
-  def createIssueFilename(issue: PublishedIssue): String = {
-    val keyname = issue.version.getOrElse("preview")
-    s"$keyname.json"
-  }
+  def createIssueFilename(issue: PublishedIssue): String = s"${issue.version}.json"
 
   def putIssue(issue: PublishedIssue) = {
     val issueJson = Json.stringify(Json.toJson(issue))

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -10,12 +10,12 @@ import services.editions.db.EditionsDB
 class EditionsPublishing(publishedBucket: EditionsBucket, previewBucket: EditionsBucket, db: EditionsDB) {
 
   def updatePreview(issue: EditionsIssue) = {
-    val previewIssue = issue.toPublishedIssue()
+    val previewIssue = issue.toPreviewIssue
     previewBucket.putIssue(previewIssue)
   }
 
   def publish(issue: EditionsIssue, user: User, now: OffsetDateTime) = {
-    val publishedIssue = issue.toPublishedIssue(Some(now.format(DateTimeFormatter.ISO_DATE_TIME)))
+    val publishedIssue = issue.toPublishedIssue(now.format(DateTimeFormatter.ISO_DATE_TIME))
 
     // Archive a copy
     publishedBucket.putIssue(publishedIssue)

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -31,10 +31,11 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           |  "id" : "4290573248905743296789524389623",
           |  "name" : "Daily Edition",
           |  "issueDate" : "2019-09-30",
+          |  "version" : "preview",
           |  "fronts" : [ ]
           |}""".stripMargin
 
-      val previewIssue = issue.toPublishedIssue()
+      val previewIssue = issue.toPreviewIssue
       val json = Json.prettyPrint(Json.toJson(previewIssue))
 
       json shouldBe expectedJson
@@ -50,7 +51,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           |  "fronts" : [ ]
           |}""".stripMargin
 
-      val publishedIssue = issue.toPublishedIssue(Some("foo"))
+      val publishedIssue = issue.toPublishedIssue("foo")
       val json = Json.prettyPrint(Json.toJson(publishedIssue))
 
       json shouldBe expectedJson

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -185,7 +185,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         ).hide
       )
       testIssue.fronts.size shouldBe 3
-      val publishedIssue = testIssue.toPublishedIssue(None)
+      val publishedIssue = testIssue.toPublishedIssue("foo")
       publishedIssue.fronts.size shouldBe 2
       publishedIssue.fronts.find(_.name == "special") shouldBe None
     }
@@ -200,7 +200,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         front("empty")
       )
       testIssue.fronts.size shouldBe 3
-      val publishedIssue = testIssue.toPublishedIssue(None)
+      val publishedIssue = testIssue.toPublishedIssue("foo")
       publishedIssue.fronts.size shouldBe 1
       publishedIssue.fronts.find(_.name == "culture").value.collections.size shouldBe 2
     }
@@ -218,7 +218,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         front("empty")
       )
       testIssue.fronts.size shouldBe 3
-      val publishedIssue = testIssue.toPublishedIssue(None)
+      val publishedIssue = testIssue.toPublishedIssue("foo")
       publishedIssue.fronts.size shouldBe 1
       publishedIssue.fronts.find(_.name == "culture").value.collections.size shouldBe 2
     }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Update `version` on `PublishedIssue` to a `String` rather than `Option[String]` and when we're talking about preview, `version` is set to `"preview"` via a helper method, which keeps things DRY. This makes for a cleaner interface.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
This is part of my effort to split https://github.com/guardian/facia-tool/pull/1011 into smaller pieces of work.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
