### PR TITLE
new table to track publication status of an issue version

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -67,6 +67,12 @@ class EditionsController(db: EditionsDB,
     }.getOrElse(NotFound(s"Issue $id not found"))
   }
 
+  def getVersions(id: String) = AccessAPIAuthAction { _ =>
+    db.getIssue(id)
+      .map(_ => Ok(Json.toJson(db.getIssueVersions(id))))
+      .getOrElse(NotFound(s"Issue $id not found"))
+  }
+
   def getAvailableEditions = EditEditionsAuthAction { _ =>
     Ok(Json.toJson(EditionsTemplates.getAvailableEditions))
   }

--- a/app/model/editions/IssueVersion.scala
+++ b/app/model/editions/IssueVersion.scala
@@ -1,0 +1,57 @@
+package model.editions
+
+import play.api.libs.json.Json
+import scalikejdbc.WrappedResultSet
+import enumeratum.{EnumEntry, PlayEnum}
+
+sealed abstract class IssueVersionStatus extends EnumEntry
+
+object IssueVersionStatus extends PlayEnum[IssueVersionStatus] {
+  case object Started extends IssueVersionStatus
+
+  // The values below should match the `Status` provided by the Editions Archiver lambda
+  // See https://github.com/guardian/editions/blob/34ed6cdacc9bc7a2c5b2067f58a6635704b8e425/projects/archiver/src/tasks/notification/helpers/pub-status-notifier.ts#L7
+  case object Processing extends IssueVersionStatus
+  case object Published extends IssueVersionStatus
+  case object Failed extends IssueVersionStatus
+
+  override def values = findValues
+}
+
+case class IssueVersionEvent(
+  eventTime: Long,
+  status: IssueVersionStatus,
+  message: Option[String]
+)
+
+object IssueVersionEvent {
+  implicit val reads = Json.reads[IssueVersionEvent]
+  implicit val writes = Json.writes[IssueVersionEvent]
+
+  def fromRow(rs: WrappedResultSet): IssueVersionEvent = IssueVersionEvent(
+    rs.zonedDateTime("event_time").toInstant.toEpochMilli,
+    IssueVersionStatus.withName(rs.string("event_status")),
+    rs.stringOpt("event_message")
+  )
+}
+
+case class IssueVersion(
+  id: String,
+  launchedOn: Long,
+  launchedBy: String,
+  launchedEmail: String,
+  events: List[IssueVersionEvent]
+)
+
+object IssueVersion {
+  implicit val reads = Json.reads[IssueVersion]
+  implicit val writes = Json.writes[IssueVersion]
+
+  def fromRow(rs: WrappedResultSet): IssueVersion = IssueVersion(
+    rs.string("version_id"),
+    rs.zonedDateTime("version_launched_on").toInstant.toEpochMilli,
+    rs.string("version_launched_by"),
+    rs.string("version_launched_email"),
+    events = List.empty
+  )
+}

--- a/app/model/editions/IssueVersion.scala
+++ b/app/model/editions/IssueVersion.scala
@@ -36,7 +36,7 @@ object IssueVersionEvent {
 }
 
 case class IssueVersion(
-  id: String,
+  id: EditionIssueVersionId,
   launchedOn: Long,
   launchedBy: String,
   launchedEmail: String,

--- a/app/model/editions/package.scala
+++ b/app/model/editions/package.scala
@@ -1,0 +1,5 @@
+package model
+
+package object editions {
+  type EditionIssueVersionId = String
+}

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -226,7 +226,7 @@ trait IssueQueries {
       .apply()
   }
 
-  def publishIssue(issueId: String, user: User, now: OffsetDateTime): String = DB localTx { implicit session =>
+  def createIssueVersion(issueId: String, user: User, now: OffsetDateTime): EditionIssueVersionId = DB localTx { implicit session =>
     val userName = user.firstName + " " + user.lastName
     val truncatedNow = EditionsDB.truncateDateTime(now)
 

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -1,5 +1,6 @@
 package services.editions.db
 
+import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, OffsetDateTime}
 
 import com.gu.pandomainauth.model.User
@@ -8,6 +9,8 @@ import play.api.libs.json.Json
 import scalikejdbc._
 import services.editions.{DbEditionsArticle, DbEditionsCollection, DbEditionsFront}
 import services.editions.CollectionsHelpers._
+
+import scala.collection.immutable
 
 trait IssueQueries {
 
@@ -223,9 +226,13 @@ trait IssueQueries {
       .apply()
   }
 
-  def publishIssue(issueId: String, user: User, now: OffsetDateTime) = DB localTx { implicit session =>
+  def publishIssue(issueId: String, user: User, now: OffsetDateTime): String = DB localTx { implicit session =>
     val userName = user.firstName + " " + user.lastName
     val truncatedNow = EditionsDB.truncateDateTime(now)
+
+    // versionId is a date string as the downstream Archiver lambda assumes it is a date
+    // TODO move to a GUID
+    val versionId = now.format(DateTimeFormatter.ISO_DATE_TIME)
 
     sql"""
     UPDATE edition_issues
@@ -234,6 +241,35 @@ trait IssueQueries {
         launched_email = ${user.email}
     WHERE id = $issueId
     """.execute().apply()
+
+    sql"""
+    INSERT INTO issue_versions (
+      id
+      , issue_id
+      , launched_on
+      , launched_by
+      , launched_email
+    ) VALUES (
+      $versionId
+      , $issueId
+      , $truncatedNow
+      , $userName
+      , ${user.email}
+    );
+    """.execute().apply()
+
+    sql"""
+    INSERT INTO issue_versions_events (
+      version_id
+      , event_time
+      , status
+    ) VALUES (
+      $versionId
+      , $truncatedNow
+      , ${IssueVersionStatus.Started.toString}
+    )
+    RETURNING version_id;
+    """.map(_.string("version_id")).single.apply.get
   }
 
   def deleteIssue(issueId: String) = DB localTx { implicit session =>
@@ -241,5 +277,31 @@ trait IssueQueries {
       DELETE FROM edition_issues
       WHERE id = $issueId
     """.execute().apply()
+  }
+
+  def getIssueVersions(issueId: String): List[IssueVersion] = DB localTx { implicit session =>
+    case class Row(version: IssueVersion, event: IssueVersionEvent)
+
+    val rows: List[Row] = sql"""
+      SELECT
+        v.id                AS version_id
+        , v.launched_on     AS version_launched_on
+        , v.launched_by     AS version_launched_by
+        , v.launched_email  AS version_launched_email
+        , e.event_time      AS event_time
+        , e.status          AS event_status
+        , e.message         AS event_message
+      FROM issue_versions v
+      LEFT JOIN issue_versions_events e
+        ON v.id = e.version_id
+      WHERE v.issue_id = $issueId
+      ORDER BY launched_on DESC
+    """.map(rs => Row(IssueVersion.fromRow(rs), IssueVersionEvent.fromRow(rs)))
+      .list()
+      .apply()
+
+    (rows.groupBy(_.version) map {
+      case (version, rows) => version.copy(events = rows.map(_.event))
+    }).toList
   }
 }

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -1,11 +1,14 @@
 package services.editions.publishing
 
 import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
 
 import com.gu.pandomainauth.model.User
 import model.editions.EditionsIssue
+import net.logstash.logback.marker.Markers
+import play.api.Logger
 import services.editions.db.EditionsDB
+
+import scala.collection.JavaConverters._
 
 class EditionsPublishing(publishedBucket: EditionsBucket, previewBucket: EditionsBucket, db: EditionsDB) {
 
@@ -15,13 +18,23 @@ class EditionsPublishing(publishedBucket: EditionsBucket, previewBucket: Edition
   }
 
   def publish(issue: EditionsIssue, user: User, now: OffsetDateTime) = {
-    val publishedIssue = issue.toPublishedIssue(now.format(DateTimeFormatter.ISO_DATE_TIME))
+    // Bump the recently published counters
+    val versionId = db.publishIssue(issue.id, user, now)
+
+    val markers = Markers.appendEntries(
+      Map (
+        "issue-id" -> issue.id,
+        "issue-date" -> issue.issueDate,
+        "version" -> versionId,
+        "user" -> user.email
+      ).asJava
+    )
+
+    Logger.info(s"Publishing issue ${issue.id}")(markers)
+
+    val publishedIssue = issue.toPublishedIssue(versionId)
 
     // Archive a copy
     publishedBucket.putIssue(publishedIssue)
-
-    // Bump the recently published counters
-    db.publishIssue(issue.id, user, now)
   }
 }
-

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -19,7 +19,7 @@ class EditionsPublishing(publishedBucket: EditionsBucket, previewBucket: Edition
 
   def publish(issue: EditionsIssue, user: User, now: OffsetDateTime) = {
     // Bump the recently published counters
-    val versionId = db.publishIssue(issue.id, user, now)
+    val versionId = db.createIssueVersion(issue.id, user, now)
 
     val markers = Markers.appendEntries(
       Map (

--- a/app/services/editions/publishing/events/package.scala
+++ b/app/services/editions/publishing/events/package.scala
@@ -1,10 +1,11 @@
 package services.editions.publishing
 
+import model.editions.IssueVersionStatus
 import play.api.libs.json.{Format, Json}
 
 package object events {
 
-  case class PublishEvent(status: String, message: String)
+  case class PublishEvent(status: IssueVersionStatus, message: String)
 
   case class PublishEventMessage(receiptHandle: String, event: PublishEvent)
 

--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -1,0 +1,21 @@
+# --- !Ups
+
+CREATE TABLE issue_versions (
+  id               TEXT PRIMARY KEY
+  , issue_id       TEXT REFERENCES edition_issues(id) ON DELETE CASCADE NOT NULL
+  , launched_on    TIMESTAMPTZ NOT NULL
+  , launched_by    TEXT NOT NULL
+  , launched_email TEXT NOT NULL
+);
+
+CREATE TABLE issue_versions_events (
+  version_id   TEXT REFERENCES issue_versions(id) ON DELETE CASCADE NOT NULL
+  , event_time TIMESTAMPTZ NOT NULL
+  , status     TEXT NOT NULL
+  , message    TEXT
+  , PRIMARY KEY (version_id, event_time)
+);
+
+# --- !Downs
+DROP TABLE issue_versions_events;
+DROP TABLE issue_versions;

--- a/conf/routes
+++ b/conf/routes
@@ -104,6 +104,7 @@ POST        /editions-api/editions/:name/issues                  controllers.Edi
 GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
 DELETE      /editions-api/issues/:id                             controllers.EditionsController.deleteIssue(id)
 GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)
+GET         /editions-api/issues/:id/versions                    controllers.EditionsController.getVersions(id)
 POST        /editions-api/issues/:id/publish                     controllers.EditionsController.publishIssue(id)
 GET         /editions-api/issues/:id/preview                     controllers.EditionsController.getPreviewEdition(id)
 

--- a/test/services/editions/publishing/events/PublishEventSNSMessageParserTest.scala
+++ b/test/services/editions/publishing/events/PublishEventSNSMessageParserTest.scala
@@ -1,5 +1,6 @@
 package services.editions.publishing.events
 
+import model.editions.IssueVersionStatus
 import org.scalatest.{FunSuite, Matchers}
 
 class PublishEventSNSMessageParserTest extends FunSuite with Matchers {
@@ -28,7 +29,7 @@ class PublishEventSNSMessageParserTest extends FunSuite with Matchers {
     }
 
     PublishEventSNSMessageParser.parseToEvent(correctSQSMessagefromSNS) shouldEqual Some(
-      PublishEventMessage("ReceiptHandle1", PublishEvent("Published", "123")))
+      PublishEventMessage("ReceiptHandle1", PublishEvent(IssueVersionStatus.Published, "123")))
   }
 
   test("indicate if message format was incorrect") {

--- a/test/services/editions/publishing/events/PublishEventsProcessorTest.scala
+++ b/test/services/editions/publishing/events/PublishEventsProcessorTest.scala
@@ -1,12 +1,13 @@
 package services.editions.publishing.events
 
+import model.editions.IssueVersionStatus
 import org.scalatest.{FunSuite, Matchers}
 
 class PublishEventsProcessorTest extends FunSuite with Matchers {
 
   private val initialMessagesInQueue = List(
-    PublishEventMessage(receiptHandle = "123", event = PublishEvent("Published", "issue 123")),
-    PublishEventMessage(receiptHandle = "456", event = PublishEvent("Published", "issue 456"))
+    PublishEventMessage(receiptHandle = "123", event = PublishEvent(IssueVersionStatus.Published, "issue 123")),
+    PublishEventMessage(receiptHandle = "456", event = PublishEvent(IssueVersionStatus.Published, "issue 456"))
   )
 
   test("queue messages were deleted after updating events in DB was successful") {


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
When publishing, insert a row into `issue_versions` and `issue_versions_events`. This will allow us to record events fired by the Archiver lambda, providing the ability to see the progress of publication.

We can then render this on the client to provide confidence that the publishing action is doing something.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
