### PR TITLE
Add three containers to every special front

### DIFF
--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -1,6 +1,5 @@
 package model.editions.templates
 
-import model.editions.Swatch.Neutral
 import model.editions.{CapiPrefillQuery, CollectionPresentation, CollectionTemplate, FrontPresentation, FrontTemplate, Swatch}
 
 object TemplateHelpers {
@@ -17,7 +16,9 @@ object TemplateHelpers {
 
   def specialFront(name: String, swatch: Swatch, prefill: Option[CapiPrefillQuery] = None) = front(
     name,
-    collection("Special").copy(prefill = prefill)
+    collection("Special Container 1").special.copy(prefill = prefill),
+    collection("Special Container 2").special,
+    collection("Special Container 3").special
   ).special
    .swatch(swatch)
 }


### PR DESCRIPTION
To allow production to organise content within special fronts, we are adding three generic containers to each special front that was previously a single container.

## What's changed?
Sadly the single line descriptions for special sections now more resemble other fronts, since they now specify containers.

## Implementation notes
Written in github, treat with caution.

