### PR TITLE
DND UI: hide desktop/mobile line when collection is hovered over

### DIFF
--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -76,7 +76,7 @@ const VisibilityDividerEl = styled.div`
 
 const VisibilityDivider = ({ notifications }: { notifications: string[] }) =>
   notifications.length ? (
-    <VisibilityDividerEl>
+    <VisibilityDividerEl className="visibility-divider">
       {notifications.map(notification => (
         <Notification key={notification}>{notification}</Notification>
       ))}

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -48,7 +48,7 @@ const Notification = styled.span`
 const selectGrey = ({ theme }: { theme: Theme }) =>
   theme.shared.colors.greyMediumLight;
 
-const VisibilityDividerEl = styled.div`
+export const VisibilityDividerEl = styled.div`
   display: flex;
   font-weight: bold;
   font-size: 12px;
@@ -76,7 +76,7 @@ const VisibilityDividerEl = styled.div`
 
 const VisibilityDivider = ({ notifications }: { notifications: string[] }) =>
   notifications.length ? (
-    <VisibilityDividerEl className="visibility-divider">
+    <VisibilityDividerEl>
       {notifications.map(notification => (
         <Notification key={notification}>{notification}</Notification>
       ))}

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -4,6 +4,7 @@ import createStore, { Store } from './store';
 import DragIntentContainer from 'shared/components/DragIntentContainer';
 import styled from 'styled-components';
 import { DropZoneContainer } from './DropZone';
+import { VisibilityDividerEl } from 'components/FrontsEdit/Collection';
 
 const { Provider: StoreProvider, Consumer: StoreConsumer } = createContext(
   null as Store | null
@@ -27,7 +28,7 @@ const RootContainer = styled.div`
     ${DropZoneContainer} {
       pointer-events: initial;
     }
-    .visibility-divider {
+    ${VisibilityDividerEl} {
       opacity: 0;
     }
   }

--- a/client-v2/src/lib/dnd/Root.tsx
+++ b/client-v2/src/lib/dnd/Root.tsx
@@ -27,6 +27,9 @@ const RootContainer = styled.div`
     ${DropZoneContainer} {
       pointer-events: initial;
     }
+    .visibility-divider {
+      opacity: 0;
+    }
   }
 `;
 


### PR DESCRIPTION
## What's changed?

PROBLEM
 - People want to add a story that should go in the top 4... but it appears like it won't be in the top 4 when they drop it. But after they add it, it turns out it is.

While they are dragging it is giving them (in certain cases where there are less than the maximum stories) the wrong information.

![jumping-desktop-mobile-boundary](https://user-images.githubusercontent.com/10324129/66197071-8c4cca80-e691-11e9-844c-fef866dfa45f.gif)

SUGGESTED SOLUTION 
- remove the divider line when hovering over a collection, since it's not in the right place. It's not that helpful to see it. It reappears once the story has been dropped. 

![ezgif-desktop-line-2](https://user-images.githubusercontent.com/10324129/66203870-53b4ed00-e6a1-11e9-9bf5-3096aa38f3ab.gif)

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
