### PR TITLE
Display feed filtering options during search

### DIFF
--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -291,64 +291,71 @@ class FeedsContainer extends React.Component<
           showReviewSearch={false}
           rightHandContainer={<ClipboardHeader />}
         />
-        {!displaySearchFilters && (
-          <FixedContentContainer>
-            <ResultsHeadingContainer>
-              <div>
+        <FixedContentContainer>
+          <ResultsHeadingContainer>
+            <div>
+              {displaySearchFilters ? (
                 <Title>
-                  Latest
+                  {'Results'}
                   <ShortVerticalPinline />
                 </Title>
-                <RefreshButton
-                  disabled={this.isLoading}
-                  onClick={() => this.runSearchAndRestartPolling()}
-                >
-                  {this.isLoading ? 'Loading' : 'Refresh'}
-                </RefreshButton>
-              </div>
-              <Sorters>
-                <TopOptions>
-                  <RadioGroup>
-                    <RadioButton
-                      checked={this.state.capiFeedIndex === 0}
-                      onChange={() => this.handleFeedClick(0)}
-                      label="Live"
-                      inline
-                      name="capiFeed"
-                    />
-                    <RadioButton
-                      checked={this.state.capiFeedIndex === 1}
-                      onChange={() => this.handleFeedClick(1)}
-                      label="Draft"
-                      inline
-                      name="capiFeed"
-                    />
-                  </RadioGroup>
-                  {pagination && hasPages && (
-                    <PaginationContainer>
-                      <Pagination
-                        pageChange={this.handlePageChange}
-                        currentPage={pagination.currentPage}
-                        totalPages={pagination.totalPages}
-                      />
-                    </PaginationContainer>
-                  )}
-                </TopOptions>
-                <SortByContainer>
-                  <label htmlFor="sort-results">Sort by:</label>
-                  <select
-                    id="sort-results"
-                    onChange={this.sortResultsBy}
-                    value={this.state.sortByParam}
+              ) : (
+                <>
+                  <Title>
+                    {'Latest'}
+                    <ShortVerticalPinline />
+                  </Title>
+                  <RefreshButton
+                    disabled={this.isLoading}
+                    onClick={() => this.runSearchAndRestartPolling()}
                   >
-                    <option value="first-publication">First published</option>
-                    <option value="published">Latest published</option>
-                  </select>
-                </SortByContainer>
-              </Sorters>
-            </ResultsHeadingContainer>
-          </FixedContentContainer>
-        )}
+                    {this.isLoading ? 'Loading' : 'Refresh'}
+                  </RefreshButton>
+                </>
+              )}
+            </div>
+            <Sorters>
+              <TopOptions>
+                <RadioGroup>
+                  <RadioButton
+                    checked={this.state.capiFeedIndex === 0}
+                    onChange={() => this.handleFeedClick(0)}
+                    label="Live"
+                    inline
+                    name="capiFeed"
+                  />
+                  <RadioButton
+                    checked={this.state.capiFeedIndex === 1}
+                    onChange={() => this.handleFeedClick(1)}
+                    label="Draft"
+                    inline
+                    name="capiFeed"
+                  />
+                </RadioGroup>
+                {pagination && hasPages && (
+                  <PaginationContainer>
+                    <Pagination
+                      pageChange={this.handlePageChange}
+                      currentPage={pagination.currentPage}
+                      totalPages={pagination.totalPages}
+                    />
+                  </PaginationContainer>
+                )}
+              </TopOptions>
+              <SortByContainer>
+                <label htmlFor="sort-results">Sort by:</label>
+                <select
+                  id="sort-results"
+                  onChange={this.sortResultsBy}
+                  value={this.state.sortByParam}
+                >
+                  <option value="first-publication">First published</option>
+                  <option value="published">Latest published</option>
+                </select>
+              </SortByContainer>
+            </Sorters>
+          </ResultsHeadingContainer>
+        </FixedContentContainer>
       </React.Fragment>
     );
   };


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
When searching the feed, the feed filtering controls (e.g. Draft and Live toggles, 'Sort by' menu) were previously hidden. Now, they display whether the search form is closed or open.

Before:
<img width="409" alt="Screen_Shot_2019-08-21_at_17 39 21" src="https://user-images.githubusercontent.com/12645938/66201599-9ffd2e80-e69b-11e9-8d5d-2e11e8fc6f18.png">

After:
![Screenshot 2019-10-04 at 11 39 01](https://user-images.githubusercontent.com/12645938/66201634-b5725880-e69b-11e9-90e6-39c67059b997.png)

([Trello](https://trello.com/c/Susp9OJJ/591-search-draft-and-live-toggle-hidden-during-search))

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
