### PR TITLE
Pre-populate custom kicker with picked kicker when an issue is created

### DIFF
--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -59,12 +59,13 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
         logger.warn(s"Failed to successfully execute CAPI prefill query $prefillQuery", t)
         Nil
     }
-    items.map { case Prefill(pageCode, metaData, cutoutImage, tone, mediaType, customKicker) =>
+    items.map { case Prefill(pageCode, metaData, cutoutImage, _, mediaType, pickedKicker) =>
       val articleMetadata = ArticleMetadata.default.copy(
         showByline = if (metaData.showByline) Some(true) else None,
         showQuotedHeadline = if (metaData.showQuotedHeadline) Some(true) else None,
         mediaType = mediaType,
-        cutoutImage = cutoutImage
+        cutoutImage = cutoutImage,
+        customKicker = pickedKicker
       )
       EditionsArticleSkeleton(pageCode.toString, articleMetadata)
     }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
When a new issue is created we should populate the custom kicker with the picked kicker.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
