### PR TITLE
Display page view data for snaplinks

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -180,6 +180,8 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
           return (
             <>
               <SnapLink
+                frontId={frontId}
+                collectionId={collectionId}
                 id={uuid}
                 isUneditable={isUneditable}
                 {...getNodeProps()}
@@ -189,6 +191,7 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
                 size={size}
                 textSize={textSize}
                 showMeta={showMeta}
+                canShowPageViewData={canShowPageViewData}
               />
               {getSublinks}
               {numSupportingArticles === 0

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -54,8 +54,11 @@ const getPageViewData = (
   const articles = articleIds
     .map(_ => selectArticleFromArticleFragment(state, _))
     .filter(_ => _) as DerivedArticle[];
+  // the url path is either the urlPath value, for articles, or the href for snaplink
   const urlPaths: string[] = articles
-    .map(article => article.urlPath)
+    .map(article =>
+      article.urlPath ? article.urlPath : article.href && article.href.substr(1)
+    )
     .filter(_ => _) as string[];
   const data = await fetchPageViewData(frontId, urlPaths);
   const dataWithArticleIds = convertToStoriesData(data, articles);
@@ -90,9 +93,11 @@ const getArticleIdFromOphanData = (
   ophanData: PageViewDataFromOphan,
   articles: DerivedArticle[]
 ): string | undefined => {
-  // the path from ophan has a slash at the front, removing below
-  const ophanPathClean = ophanData.path.substr(1);
-  const matchingArticle = articles.find(a => a.urlPath === ophanPathClean);
+  // if we have a urlPath, we need to trim the Ophan data path to make the comparison
+  // if we have an href - because the article is a snap link - we don't need to trim
+  const matchingArticle = articles.find(
+    a => a.urlPath === ophanData.path.substr(1) || a.href === ophanData.path
+  );
   return matchingArticle ? matchingArticle.uuid : undefined;
 };
 

--- a/client-v2/src/redux/modules/pageViewData/actions.ts
+++ b/client-v2/src/redux/modules/pageViewData/actions.ts
@@ -15,6 +15,7 @@ import {
 } from 'shared/selectors/shared';
 import { CollectionItemSets } from 'shared/types/Collection';
 import pandaFetch from 'services/pandaFetch';
+import { isValidURL } from 'shared/util/url';
 
 const totalPeriodInHours = 1;
 const intervalInMinutes = 10;
@@ -54,10 +55,12 @@ const getPageViewData = (
   const articles = articleIds
     .map(_ => selectArticleFromArticleFragment(state, _))
     .filter(_ => _) as DerivedArticle[];
-  // the url path is either the urlPath value, for articles, or the href for snaplink
   const urlPaths: string[] = articles
-    .map(article =>
-      article.urlPath ? article.urlPath : article.href && article.href.substr(1)
+    .map(
+      article =>
+        article.urlPath
+          ? article.urlPath // it's an article
+          : article.href && !isValidURL(article.href) && article.href.substr(1) // it's a snaplink
     )
     .filter(_ => _) as string[];
   const data = await fetchPageViewData(frontId, urlPaths);

--- a/client-v2/src/shared/components/PageViewDataWrapper.tsx
+++ b/client-v2/src/shared/components/PageViewDataWrapper.tsx
@@ -1,0 +1,12 @@
+import { styled } from 'shared/constants/theme';
+
+export default styled.div`
+  width: 45px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding-right: 5px;
+  font-size: 12px;
+  height: 35px;
+  padding-bottom: 3px;
+`;

--- a/client-v2/src/shared/components/article/ArticleBody.tsx
+++ b/client-v2/src/shared/components/article/ArticleBody.tsx
@@ -32,6 +32,8 @@ import CollectionItemSettingsDisplay from '../collectionItem/CollectionItemSetti
 import CircularIconContainer from '../icons/CircularIconContainer';
 import { ImageMetadataContainer } from '../image/ImageMetaDataContainer';
 import EditModeVisibility from 'components/util/EditModeVisibility';
+import PageViewDataWrapper from '../PageViewDataWrapper';
+import ImageAndGraphWrapper from '../image/ImageAndGraphWrapper';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -66,28 +68,8 @@ const FirstPublicationDate = styled(CollectionItemMetaContent)`
   color: ${theme.shared.colors.green};
 `;
 
-const PageViewDataWrapper = styled.div`
-  width: 45px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  padding-right: 5px;
-  font-size: 12px;
-  height: 35px;
-  padding-bottom: 3px;
-`;
-
 const Tone = styled.span`
   font-weight: normal;
-`;
-
-const ImageAndGraphWrapper = styled.div<{ size: CollectionItemSizes }>`
-  display: flex;
-  flex-direction: row;
-  ${props =>
-    props.size === 'medium' &&
-    `flex-wrap: wrap-reverse;
-    justify-content: flex-end;`}
 `;
 
 const VideoIconContainer = styled(CircularIconContainer)`

--- a/client-v2/src/shared/components/image/ImageAndGraphWrapper.tsx
+++ b/client-v2/src/shared/components/image/ImageAndGraphWrapper.tsx
@@ -1,0 +1,11 @@
+import { styled } from '../../constants/theme';
+import { CollectionItemSizes } from '../../types/Collection';
+
+export default styled.div<{ size: CollectionItemSizes }>`
+  display: flex;
+  flex-direction: row;
+  ${props =>
+    props.size === 'medium' &&
+    `flex-wrap: wrap-reverse;
+  justify-content: flex-end;`}
+`;

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -35,6 +35,8 @@ import { ImageMetadataContainer } from '../image/ImageMetaDataContainer';
 import { theme } from 'constants/theme';
 import ArticleGraph from '../article/ArticleGraph';
 import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
+import PageViewDataWrapper from '../PageViewDataWrapper';
+import ImageAndGraphWrapper from '../image/ImageAndGraphWrapper';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
   justify-content: space-between;
@@ -47,26 +49,6 @@ const SnapLinkURL = styled.p`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-`;
-
-const PageViewDataWrapper = styled.div`
-  width: 45px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  padding-right: 5px;
-  font-size: 12px;
-  height: 35px;
-  padding-bottom: 3px;
-`;
-
-const ImageAndGraphWrapper = styled.div<{ size: CollectionItemSizes }>`
-  display: flex;
-  flex-direction: row;
-  ${props =>
-    props.size === 'medium' &&
-    `flex-wrap: wrap-reverse;
-    justify-content: flex-end;`}
 `;
 
 interface ContainerProps {
@@ -190,7 +172,6 @@ const SnapLink = ({
               />
             </PageViewDataWrapper>
           )}
-          {/* )} */}
           <ThumbnailSmall
             imageHide={article && article.imageHide}
             url={article && article.imageReplace ? article.thumbnail : ''}

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -33,6 +33,8 @@ import { distanceInWordsStrict } from 'date-fns';
 import { DerivedArticle } from 'shared/types/Article';
 import { ImageMetadataContainer } from '../image/ImageMetaDataContainer';
 import { theme } from 'constants/theme';
+import ArticleGraph from '../article/ArticleGraph';
+import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
 
 const SnapLinkBodyContainer = styled(CollectionItemBody)`
   justify-content: space-between;
@@ -47,7 +49,25 @@ const SnapLinkURL = styled.p`
   overflow: hidden;
 `;
 
-const ImageWrapper = styled.div``;
+const PageViewDataWrapper = styled.div`
+  width: 45px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding-right: 5px;
+  font-size: 12px;
+  height: 35px;
+  padding-bottom: 3px;
+`;
+
+const ImageAndGraphWrapper = styled.div<{ size: CollectionItemSizes }>`
+  display: flex;
+  flex-direction: row;
+  ${props =>
+    props.size === 'medium' &&
+    `flex-wrap: wrap-reverse;
+    justify-content: flex-end;`}
+`;
 
 interface ContainerProps {
   selectSharedState?: (state: any) => State;
@@ -57,6 +77,8 @@ interface ContainerProps {
   onAddToClipboard?: (uuid: string) => void;
   onClick?: () => void;
   id: string;
+  collectionId?: string;
+  frontId: string;
   draggable?: boolean;
   size?: CollectionItemSizes;
   textSize?: CollectionItemSizes;
@@ -64,11 +86,13 @@ interface ContainerProps {
   fade?: boolean;
   children?: React.ReactNode;
   isUneditable?: boolean;
+  canShowPageViewData: boolean;
 }
 
 interface SnapLinkProps extends ContainerProps {
   articleFragment: ArticleFragment;
   article: DerivedArticle | undefined;
+  featureFlagPageViewData: boolean;
 }
 
 const SnapLink = ({
@@ -83,6 +107,10 @@ const SnapLink = ({
   articleFragment,
   isUneditable,
   article,
+  collectionId,
+  frontId,
+  canShowPageViewData = true,
+  featureFlagPageViewData,
   ...rest
 }: SnapLinkProps) => {
   const headline =
@@ -152,7 +180,17 @@ const SnapLink = ({
             </SnapLinkURL>
           </CollectionItemHeadingContainer>
         </CollectionItemContent>
-        <ImageWrapper>
+        <ImageAndGraphWrapper size={size}>
+          {featureFlagPageViewData && canShowPageViewData && collectionId && (
+            <PageViewDataWrapper data-testid="page-view-graph">
+              <ArticleGraph
+                articleId={id}
+                collectionId={collectionId}
+                frontId={frontId}
+              />
+            </PageViewDataWrapper>
+          )}
+          {/* )} */}
           <ThumbnailSmall
             imageHide={article && article.imageHide}
             url={article && article.imageReplace ? article.thumbnail : ''}
@@ -162,7 +200,7 @@ const SnapLink = ({
             imageReplace={article && article.imageReplace}
             imageCutoutReplace={article && article.imageCutoutReplace}
           />
-        </ImageWrapper>
+        </ImageAndGraphWrapper>
         <HoverActionsAreaOverlay
           disabled={isUneditable}
           justify={'space-between'}
@@ -201,7 +239,11 @@ const mapStateToProps = () => {
     const article = selectArticle(sharedState, props.id);
     return {
       articleFragment: selectArticleFragment(sharedState, props.id),
-      article
+      article,
+      featureFlagPageViewData: selectFeatureValue(
+        selectSharedState(state),
+        'page-view-data-visualisation'
+      )
     };
   };
 };


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
We can now show page view data for snaplinks. This is only applicable for non-article snaplinks, e.g. https://www.theguardian.com/news/series/todayinfocus.

![Screenshot 2019-10-04 at 12 49 42](https://user-images.githubusercontent.com/12645938/66205500-76490500-e6a5-11e9-8925-63a2bbee6039.png)

([Trello](https://trello.com/c/peQqzxZC/833-we-send-snaplinks-and-duplicate-articles-to-ophan-we-should-not-do-that))

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
As snaplinks don't have the `urlPath` that is used to look up article data, this PR instead uses the `href` of the snaplink to populate the Ophan request. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
