### PR TITLE
CAPI REQUESTS: add api key for tracking

### DIFF
--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -32,7 +32,7 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
     else
       config.contentApi.contentApiLiveHost
 
-    val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+    val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("&api-key=fronts-tool")}"
 
     wsClient.url(url).withHttpHeaders(capi.getPreviewHeaders(Map.empty, url): _*).get().map { response =>
 
@@ -54,9 +54,9 @@ class FaciaContentApiProxy(capi: Capi, val deps: BaseFaciaControllerComponents)(
     val contentApiHost = config.contentApi.contentApiLiveHost
 
     // In the CODE and PROD environments, an api key is not required because we are using an AWS private link endpoint to connect to CAPI.
-    // Private Link endpoints are inside the AWS account and allow other services in the account access to the API.
-    // In DEV environments - we use a standard external API for which a key is required, and is passed in via the config.
-    val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+    // However, we're adding a descriptive one "fronts-tool" so CAPI can track traffic from different consumers.
+    // In DEV environments - we use a standard external API for which a key is required, this key is passed in via the config.
+    val url = s"$contentApiHost/$path?$queryString${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("&api-key=fronts-tool")}"
 
     wsClient.url(url).get().map { response =>
 


### PR DESCRIPTION
## What's changed?
Calls to CAPI in the CODE and PROD environments do not require api-keys because they go through AWS Private Link, not a key auth service. 

However, J-Dev team have requested that we add a descriptive api key  `fronts-tool` to our calls from the fronts tool so it's easier for them to track consumers of the API. 

Tested by deploying to CODE - works ✅ 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
