### PR TITLE
Show unsaved forms before launch

### DIFF
--- a/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/client-v2/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -32,7 +32,8 @@ import {
   editorCloseFormsForCollection,
   createSelectCollectionsInOpenFronts,
   selectOpenFrontsCollectionsAndArticles,
-  selectOpenParentFrontOfArticleFragment
+  selectOpenParentFrontOfArticleFragment,
+  createSelectDoesCollectionHaveOpenForms
 } from '../frontsUIBundle';
 import initialState from 'fixtures/initialState';
 import initialStateForOpenFronts from '../../fixtures/initialStateForOpenFronts';
@@ -286,6 +287,129 @@ describe('frontsUIBundle', () => {
             'index'
           ).map(_ => _.index)
         ).toEqual([0, 1, 2, 3]);
+      });
+    });
+    describe('selectOpenFrontsCollectionsAndArticles', () => {
+      it('should return just fronts if no collections are open', () => {
+        const openEntities = selectOpenFrontsCollectionsAndArticles(
+          initialStateForOpenFronts
+        );
+        expect(openEntities).toEqual([
+          { collections: [], frontId: 'editorialFront' },
+          { collections: [], frontId: 'editorialFront2' }
+        ]);
+      });
+      it('should give an array of fronts, with nested collections and articles, when those fronts and collections are open -- single collection', () => {
+        const state = set(
+          ['editor', 'collectionIds'],
+          ['collection1'],
+          initialStateForOpenFronts
+        );
+        const openEntities = selectOpenFrontsCollectionsAndArticles(state);
+        expect(openEntities.length).toEqual(2); // Two fronts
+        expect(openEntities[0].collections.length).toEqual(1); // First front has one collection
+        expect(openEntities[0].collections[0].articleIds).toEqual([
+          'articleFragment1',
+          'articleFragment2',
+          'articleFragment3'
+        ]); // First collection has three articles
+        expect(openEntities[1].collections.length).toEqual(0); // Second front has no collections
+      });
+      it('should give an array of fronts, with nested collections and articles, when those fronts and collections are open -- multiple collections', () => {
+        const state = set(
+          ['editor', 'collectionIds'],
+          ['collection1', 'collection6'],
+          initialStateForOpenFronts
+        );
+        const openEntities = selectOpenFrontsCollectionsAndArticles(state);
+        expect(openEntities.length).toEqual(2); // Two fronts
+        expect(openEntities[0].collections.length).toEqual(1); // First front has one collection
+        expect(openEntities[1].collections.length).toEqual(1); // Second front has one collection
+      });
+      it('should respect the current browsing stage', () => {
+        let state = set(
+          ['editor', 'collectionIds'],
+          ['collection1'],
+          initialStateForOpenFronts
+        );
+        state = set(
+          ['editor', 'frontIdsByBrowsingStage', 'editorialFront'],
+          'live',
+          state
+        );
+        const openEntities = selectOpenFrontsCollectionsAndArticles(state);
+        expect(openEntities[0].collections.length).toEqual(1); // First front has one collection
+        expect(openEntities[0].collections[0].articleIds.length).toEqual(0); // First collection has no live articles
+      });
+    });
+    describe('Selecting collections on all open Fronts', () => {
+      const selectCollectionsInOpenFronts = createSelectCollectionsInOpenFronts();
+      it('return correct collections for one open Front', () => {
+        expect(
+          selectCollectionsInOpenFronts({
+            fronts: {
+              frontsConfig
+            },
+            editor: {
+              frontIdsByPriority: { editorial: ['editorialFront'] }
+            },
+            path: '/v2/editorial'
+          } as any)
+        ).toEqual(['collection1']);
+      });
+      it('return correct collections for multiple open Fronts', () => {
+        expect(
+          selectCollectionsInOpenFronts({
+            fronts: {
+              frontsConfig
+            },
+            editor: {
+              frontIdsByPriority: {
+                editorial: ['editorialFront', 'editorialFront2']
+              }
+            },
+            path: '/v2/editorial'
+          } as any)
+        ).toEqual(['collection1', 'collection6']);
+      });
+      it('return enpty array for no open Fronts', () => {
+        expect(
+          selectCollectionsInOpenFronts({
+            fronts: {
+              frontsConfig
+            },
+            editor: {
+              frontIdsByPriority: {}
+            },
+            path: '/v2/editorial'
+          } as any)
+        ).toEqual([]);
+      });
+    });
+    describe('selectDoesCollectionHaveOpenForms', () => {
+      it('should return false when the collection has no forms open', () => {
+        const selectDoesCollectionHaveOpenForms = createSelectDoesCollectionHaveOpenForms();
+        const state = initialState;
+        expect(
+          selectDoesCollectionHaveOpenForms(state, {
+            frontId: 'exampleFront',
+            collectionId: 'collection-id'
+          })
+        ).toBe(false);
+      });
+      it('should return true when the collection has a form open', () => {
+        const selectDoesCollectionHaveOpenForms = createSelectDoesCollectionHaveOpenForms();
+        const state = set(
+          ['editor', 'selectedArticleFragments', 'exampleFront'],
+          [{ id: 'id', collectionId: 'collection-id', isSupporting: false }],
+          initialState
+        );
+        expect(
+          selectDoesCollectionHaveOpenForms(state, {
+            frontId: 'exampleFront',
+            collectionId: 'collection-id'
+          })
+        ).toBe(true);
       });
     });
   });
@@ -551,7 +675,9 @@ describe('frontsUIBundle', () => {
             'front1'
           )
         );
-        expect(selectOpenArticleFragmentForms(state, 'front1')).toEqual([
+        expect(
+          selectOpenArticleFragmentForms(state, { frontId: 'front1' })
+        ).toEqual([
           {
             id: 'exampleArticleFragment',
             isSupporting: false,
@@ -579,104 +705,6 @@ describe('frontsUIBundle', () => {
       expect(selectIsClipboardOpen(state)).toBe(false);
       const state2 = reducer(state.editor, editorOpenClipboard());
       expect(selectIsClipboardOpen(state2)).toBe(true);
-    });
-  });
-
-  describe('Selecting collections on all open Fronts', () => {
-    const selectCollectionsInOpenFronts = createSelectCollectionsInOpenFronts();
-    it('return correct collections for one open Front', () => {
-      expect(
-        selectCollectionsInOpenFronts({
-          fronts: {
-            frontsConfig
-          },
-          editor: {
-            frontIdsByPriority: { editorial: ['editorialFront'] }
-          },
-          path: '/v2/editorial'
-        } as any)
-      ).toEqual(['collection1']);
-    });
-    it('return correct collections for multiple open Fronts', () => {
-      expect(
-        selectCollectionsInOpenFronts({
-          fronts: {
-            frontsConfig
-          },
-          editor: {
-            frontIdsByPriority: {
-              editorial: ['editorialFront', 'editorialFront2']
-            }
-          },
-          path: '/v2/editorial'
-        } as any)
-      ).toEqual(['collection1', 'collection6']);
-    });
-    it('return enpty array for no open Fronts', () => {
-      expect(
-        selectCollectionsInOpenFronts({
-          fronts: {
-            frontsConfig
-          },
-          editor: {
-            frontIdsByPriority: {}
-          },
-          path: '/v2/editorial'
-        } as any)
-      ).toEqual([]);
-    });
-  });
-  describe('selectOpenFrontsCollectionsAndArticles', () => {
-    it('should return just fronts if no collections are open', () => {
-      const openEntities = selectOpenFrontsCollectionsAndArticles(
-        initialStateForOpenFronts
-      );
-      expect(openEntities).toEqual([
-        { collections: [], frontId: 'editorialFront' },
-        { collections: [], frontId: 'editorialFront2' }
-      ]);
-    });
-    it('should give an array of fronts, with nested collections and articles, when those fronts and collections are open -- single collection', () => {
-      const state = set(
-        ['editor', 'collectionIds'],
-        ['collection1'],
-        initialStateForOpenFronts
-      );
-      const openEntities = selectOpenFrontsCollectionsAndArticles(state);
-      expect(openEntities.length).toEqual(2); // Two fronts
-      expect(openEntities[0].collections.length).toEqual(1); // First front has one collection
-      expect(openEntities[0].collections[0].articleIds).toEqual([
-        'articleFragment1',
-        'articleFragment2',
-        'articleFragment3'
-      ]); // First collection has three articles
-      expect(openEntities[1].collections.length).toEqual(0); // Second front has no collections
-    });
-    it('should give an array of fronts, with nested collections and articles, when those fronts and collections are open -- multiple collections', () => {
-      const state = set(
-        ['editor', 'collectionIds'],
-        ['collection1', 'collection6'],
-        initialStateForOpenFronts
-      );
-      const openEntities = selectOpenFrontsCollectionsAndArticles(state);
-      expect(openEntities.length).toEqual(2); // Two fronts
-      expect(openEntities[0].collections.length).toEqual(1); // First front has one collection
-      expect(openEntities[1].collections.length).toEqual(1); // Second front has one collection
-    });
-    it('should respect the current browsing stage', () => {
-      let state = set(
-        ['editor', 'collectionIds'],
-        ['collection1'],
-        initialStateForOpenFronts
-      );
-      state = set(
-        ['editor', 'frontIdsByBrowsingStage', 'editorialFront'],
-        'live',
-        state
-      );
-      const openEntities = selectOpenFrontsCollectionsAndArticles(state);
-      expect(openEntities[0].collections.length).toEqual(1); // First front has one collection
-      expect(openEntities[0].collections[0].articleIds.length).toEqual(0); // First collection has no live articles
     });
   });
 });

--- a/client-v2/src/bundles/frontsUIBundle.ts
+++ b/client-v2/src/bundles/frontsUIBundle.ts
@@ -520,7 +520,7 @@ const createSelectOpenCollectionItemTitlesForCollection = () => {
   return (
     state: GlobalState,
     { frontId, collectionId }: { frontId: string; collectionId: string }
-  ): Array<{ uuid: string; title: string }> => {
+  ): Array<{ uuid: string; title: string | undefined }> => {
     const articleFragmentIds = selectOpenArticleFragmentIdsForCollection(
       state,
       { collectionId, frontId }
@@ -533,10 +533,9 @@ const createSelectOpenCollectionItemTitlesForCollection = () => {
         .filter(_ => _)
         .map(
           derivedArticle =>
-            derivedArticle &&
-            derivedArticle.headline && {
+            derivedArticle && {
               uuid: derivedArticle.uuid,
-              title: derivedArticle.headline
+              title: derivedArticle.headline || derivedArticle.customKicker
             }
         )
     );

--- a/client-v2/src/components/App.tsx
+++ b/client-v2/src/components/App.tsx
@@ -118,6 +118,10 @@ const AppFonts = createGlobalStyle`
   input, textarea {
     font-family: TS3TextSans, 'Helvetica Neue', Helvetica, Arial;
   }
+
+  a {
+    color: ${theme.shared.base.colors.text}
+  }
 `;
 
 const AppContainer = styled.div`

--- a/client-v2/src/components/Clipboard.tsx
+++ b/client-v2/src/components/Clipboard.tsx
@@ -261,10 +261,9 @@ const mapStateToProps = () => {
     isClipboardOpen: selectIsClipboardOpen(state),
     isClipboardFocused: selectIsClipboardFocused(state),
     clipboardHasContent: !!selectClipboardArticles(state).length,
-    clipboardHasOpenForms: !!selectCollectionIdsWithOpenForms(
-      state,
-      clipboardId
-    ).length
+    clipboardHasOpenForms: !!selectCollectionIdsWithOpenForms(state, {
+      frontId: clipboardId
+    }).length
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/CollectionItem.tsx
@@ -48,6 +48,8 @@ import { styled } from 'constants/theme';
 import { getPillarColor } from 'shared/util/getPillarColor';
 import { isLive as isArticleLive } from 'util/CAPIUtils';
 
+export const createCollectionItemId = (id: string) => `collection-item-${id}`;
+
 const imageDropTypes = [
   ...gridDropTypes,
   DRAG_DATA_COLLECTION_ITEM_IMAGE_OVERRIDE,
@@ -209,7 +211,12 @@ class CollectionItem extends React.Component<ArticleContainerProps> {
     };
 
     return (
-      <CollectionItemContainer size={size} isLive={isLive} pillarId={pillarId}>
+      <CollectionItemContainer
+        id={createCollectionItemId(uuid)}
+        size={size}
+        isLive={isLive}
+        pillarId={pillarId}
+      >
         {isSelected ? (
           <>
             <ArticleFragmentFormInline

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { State } from 'types/State';
+import FlatUl from 'components/layout/FlatUl';
+import { createSelectOpenCollectionItemTitlesForCollection } from 'bundles/frontsUIBundle';
+import { createCollectionItemId } from './CollectionItem';
+import styled from 'styled-components';
+
+interface ContainerProps {
+  collectionId: string;
+  frontId: string;
+}
+
+interface ComponentProps extends ContainerProps {
+  openArticleTitles: Array<{ uuid: string; title: string }>;
+}
+
+const OpenArticleLi = styled.li`
+  & + & {
+    margin-top: 10px;
+  }
+`;
+
+const OpenFormsWarning = ({ openArticleTitles }: ComponentProps) => (
+  <div>
+    <strong>Launching will discard changes in these unsaved forms:</strong>
+    <FlatUl>
+      {openArticleTitles.map(({ uuid, title }) => (
+        <OpenArticleLi key={title}>
+          <a
+            href={`#${uuid}`}
+            onClick={() => {
+              const id = createCollectionItemId(uuid);
+              const element = document.getElementById(id);
+              if (element) {
+                element.scrollIntoView({
+                  behavior: 'smooth',
+                  inline: 'start',
+                  block: 'start'
+                });
+              }
+            }}
+          >
+            {title}
+          </a>
+        </OpenArticleLi>
+      ))}
+    </FlatUl>
+  </div>
+);
+
+const mapStateToProps = () => {
+  const selectOpenCollectionItemTitlesForCollection = createSelectOpenCollectionItemTitlesForCollection();
+  return (state: State, { collectionId, frontId }: ContainerProps) => ({
+    openArticleTitles: selectOpenCollectionItemTitlesForCollection(state, {
+      collectionId,
+      frontId
+    })
+  });
+};
+
+export default connect(mapStateToProps)(OpenFormsWarning);

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
@@ -12,7 +12,7 @@ interface ContainerProps {
 }
 
 interface ComponentProps extends ContainerProps {
-  openArticleTitles: Array<{ uuid: string; title: string }>;
+  openArticleTitles: Array<{ uuid: string; title?: string }>;
 }
 
 const OpenArticleLi = styled.li`
@@ -41,7 +41,7 @@ const OpenFormsWarning = ({ openArticleTitles }: ComponentProps) => (
               }
             }}
           >
-            {title}
+            {title || 'No title'}
           </a>
         </OpenArticleLi>
       ))}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
@@ -23,7 +23,7 @@ const OpenArticleLi = styled.li`
 
 const OpenFormsWarning = ({ openArticleTitles }: ComponentProps) => (
   <div>
-    <strong>Launching will discard changes in these unsaved forms:</strong>
+    <strong>There are open forms in this collection:</strong>
     <FlatUl>
       {openArticleTitles.map(({ uuid, title }) => (
         <OpenArticleLi key={title}>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
@@ -36,7 +36,7 @@ const OpenFormsWarning = ({ openArticleTitles }: ComponentProps) => (
                 element.scrollIntoView({
                   behavior: 'smooth',
                   inline: 'start',
-                  block: 'start'
+                  block: 'end'
                 });
               }
             }}

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -183,8 +183,9 @@ const mapStateToProps = () => {
       collectionId
     }),
     hasOpenForms:
-      selectCollectionIdsWithOpenForms(state, frontId).indexOf(collectionId) !==
-      -1
+      selectCollectionIdsWithOpenForms(state, { frontId }).indexOf(
+        collectionId
+      ) !== -1
   });
 };
 

--- a/client-v2/src/components/layout/FlatUl.tsx
+++ b/client-v2/src/components/layout/FlatUl.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export default styled.ul`
+  padding-left: 0;
+  list-style: none;
+`;

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -75,7 +75,6 @@ const CollectionContainer = styled(ContentContainer)<{
 const HeadlineContentContainer = styled.span`
   position: relative;
   margin-right: -11px;
-  line-height: 0px;
   display: flex;
 `;
 

--- a/client-v2/src/shared/constants/theme.ts
+++ b/client-v2/src/shared/constants/theme.ts
@@ -27,6 +27,7 @@ const colors = {
   whiteLight: '#F6F6F6',
   white: '#FFF', // lightest
   orange: '#FF7F0F',
+  orangeVeryLight: '#FFE9D6',
   orangeLight: '#FD8A2E',
   orangeDark: '#E05E00',
   orangeFaded: '#D08B5A',
@@ -42,6 +43,8 @@ const base = {
     textMuted: colors.greyMediumLight,
     textLight: colors.white,
     textDark: colors.blackDark,
+    brandColor: colors.orange,
+    brandColorLight: colors.orangeVeryLight,
     highlightColor: colors.orange,
     highlightColorFocused: colors.orangeLight,
     button: colors.blackLight,


### PR DESCRIPTION
## What's changed?

When the user hovers over the launch button, they're shown a list of forms they haven't yet saved. This is important, because launching will remove any unsaved changes in their forms and close them.

Clicking on those articles zooms you down to the form in question.

![show links](https://user-images.githubusercontent.com/7767575/66226787-98f21280-e6d3-11e9-9c79-38150a27bd68.gif)

## Implementation notes

This current shows all forms that are open -- but do we want just the forms with unsaved changes?

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
