### PR TITLE
Show Draft and LIve toggle on Feed during search

### DIFF
--- a/client-v2/src/components/FeedsContainer.tsx
+++ b/client-v2/src/components/FeedsContainer.tsx
@@ -291,64 +291,71 @@ class FeedsContainer extends React.Component<
           showReviewSearch={false}
           rightHandContainer={<ClipboardHeader />}
         />
-        {!displaySearchFilters && (
-          <FixedContentContainer>
-            <ResultsHeadingContainer>
-              <div>
+        <FixedContentContainer>
+          <ResultsHeadingContainer>
+            <div>
+              {displaySearchFilters ? (
                 <Title>
-                  Latest
+                  {'Results'}
                   <ShortVerticalPinline />
                 </Title>
-                <RefreshButton
-                  disabled={this.isLoading}
-                  onClick={() => this.runSearchAndRestartPolling()}
-                >
-                  {this.isLoading ? 'Loading' : 'Refresh'}
-                </RefreshButton>
-              </div>
-              <Sorters>
-                <TopOptions>
-                  <RadioGroup>
-                    <RadioButton
-                      checked={this.state.capiFeedIndex === 0}
-                      onChange={() => this.handleFeedClick(0)}
-                      label="Live"
-                      inline
-                      name="capiFeed"
-                    />
-                    <RadioButton
-                      checked={this.state.capiFeedIndex === 1}
-                      onChange={() => this.handleFeedClick(1)}
-                      label="Draft"
-                      inline
-                      name="capiFeed"
-                    />
-                  </RadioGroup>
-                  {pagination && hasPages && (
-                    <PaginationContainer>
-                      <Pagination
-                        pageChange={this.handlePageChange}
-                        currentPage={pagination.currentPage}
-                        totalPages={pagination.totalPages}
-                      />
-                    </PaginationContainer>
-                  )}
-                </TopOptions>
-                <SortByContainer>
-                  <label htmlFor="sort-results">Sort by:</label>
-                  <select
-                    id="sort-results"
-                    onChange={this.sortResultsBy}
-                    value={this.state.sortByParam}
+              ) : (
+                <>
+                  <Title>
+                    {'Latest'}
+                    <ShortVerticalPinline />
+                  </Title>
+                  <RefreshButton
+                    disabled={this.isLoading}
+                    onClick={() => this.runSearchAndRestartPolling()}
                   >
-                    <option value="first-publication">First published</option>
-                    <option value="published">Latest published</option>
-                  </select>
-                </SortByContainer>
-              </Sorters>
-            </ResultsHeadingContainer>
-          </FixedContentContainer>
-        )}
+                    {this.isLoading ? 'Loading' : 'Refresh'}
+                  </RefreshButton>
+                </>
+              )}
+            </div>
+            <Sorters>
+              <TopOptions>
+                <RadioGroup>
+                  <RadioButton
+                    checked={this.state.capiFeedIndex === 0}
+                    onChange={() => this.handleFeedClick(0)}
+                    label="Live"
+                    inline
+                    name="capiFeed"
+                  />
+                  <RadioButton
+                    checked={this.state.capiFeedIndex === 1}
+                    onChange={() => this.handleFeedClick(1)}
+                    label="Draft"
+                    inline
+                    name="capiFeed"
+                  />
+                </RadioGroup>
+                {pagination && hasPages && (
+                  <PaginationContainer>
+                    <Pagination
+                      pageChange={this.handlePageChange}
+                      currentPage={pagination.currentPage}
+                      totalPages={pagination.totalPages}
+                    />
+                  </PaginationContainer>
+                )}
+              </TopOptions>
+              <SortByContainer>
+                <label htmlFor="sort-results">Sort by:</label>
+                <select
+                  id="sort-results"
+                  onChange={this.sortResultsBy}
+                  value={this.state.sortByParam}
+                >
+                  <option value="first-publication">First published</option>
+                  <option value="published">Latest published</option>
+                </select>
+              </SortByContainer>
+            </Sorters>
+          </ResultsHeadingContainer>
+        </FixedContentContainer>
       </React.Fragment>
     );
   };


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Readding a PR accidetally removed on rebase 

revert: https://github.com/guardian/facia-tool/pull/1046

original: https://github.com/guardian/facia-tool/pull/1043


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
