### PR TITLE
Change styling of Overview toggle

### DIFF
--- a/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontCollectionsOverview.tsx
@@ -35,7 +35,6 @@ const Container = styled(ContentContainer)<ContainerProps>`
   flex-direction: column;
   flex: 1;
   margin-left: 10px;
-  margin-top: 43px;
   max-height: calc(100% - 43px);
   overflow-y: scroll;
   padding: 0;
@@ -48,6 +47,14 @@ const ContainerBody = styled.div`
   padding-bottom: ${theme.front.paddingForAddFrontButton}px;
 `;
 
+const OverviewContainerHeadingPinline = styled(ContainerHeadingPinline)`
+  font-family: TS3TextSans;
+  font-size: 15px;
+  font-weight: bold;
+  line-height: normal;
+  padding-bottom: 5px;
+`;
+
 const FrontCollectionsOverview = ({
   id,
   front,
@@ -55,7 +62,7 @@ const FrontCollectionsOverview = ({
   currentCollection
 }: FrontCollectionOverviewProps) => (
   <Container setBack isClosed={false}>
-    <ContainerHeadingPinline>Overview</ContainerHeadingPinline>
+    <OverviewContainerHeadingPinline>Overview</OverviewContainerHeadingPinline>
     <ContainerBody>
       {front.collections.map(collectionId => (
         <CollectionOverview

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -39,7 +39,7 @@ const SectionContentMetaContainer = styled.div`
   margin-right: 5px;
 `;
 
-const OverviewToggleContainer = styled.div`
+const OverviewToggleContainer = styled.div<{ active: boolean }>`
   font-size: 13px;
   font-weight: bold;
   padding-left: 10px;
@@ -49,7 +49,7 @@ const OverviewToggleContainer = styled.div`
   padding-top: 13px;
   padding-bottom: 10px;
   text-align: right;
-  margin-left: -1px;
+  margin-left: ${props => (props.active ? '0' : '-1px')};
   cursor: pointer;
 `;
 
@@ -189,6 +189,7 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
       <>
         <OverviewToggleContainer
           onClick={() => this.props.toggleOverview(!this.props.overviewIsOpen)}
+          active={this.props.overviewIsOpen}
         >
           <OverviewHeading htmlFor={overviewToggleId}>
             {overviewIsOpen ? 'Hide overview' : 'Overview'}

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -47,6 +47,10 @@ const OverviewToggleContainer = styled.div`
   border-left: ${({ theme }) =>
     `solid 1px  ${theme.shared.colors.greyVeryLight}`};
   padding-top: 13px;
+  padding-bottom: 10px;
+  text-align: right;
+  margin-left: -1px;
+  cursor: pointer;
 `;
 
 const OverviewHeading = styled.label`
@@ -127,7 +131,6 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
 
   public render() {
     const { overviewIsOpen, id, browsingStage } = this.props;
-    const overviewToggleId = `btn-overview-toggle-${this.props.id}`;
     return (
       <React.Fragment>
         <div
@@ -155,24 +158,7 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
                   fill={sharedTheme.base.colors.text}
                 />
               </OverviewHeadingButton>
-              <OverviewToggleContainer>
-                <OverviewHeading htmlFor={overviewToggleId}>
-                  {this.props.overviewIsOpen ? 'Hide overview' : 'Overview'}
-                </OverviewHeading>
-                <ButtonCircularCaret
-                  id={overviewToggleId}
-                  style={{
-                    margin: '0'
-                  }}
-                  openDir="right"
-                  active={this.props.overviewIsOpen}
-                  preActive={false}
-                  onClick={() =>
-                    this.props.toggleOverview(!this.props.overviewIsOpen)
-                  }
-                  small={true}
-                />
-              </OverviewToggleContainer>
+              {!overviewIsOpen && this.overviewToggle(overviewIsOpen)}
             </SectionContentMetaContainer>
             <FrontContent
               id={id}
@@ -183,6 +169,7 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
           </FrontContentContainer>
           {overviewIsOpen && (
             <FrontDetailContainer>
+              {this.overviewToggle(overviewIsOpen)}
               <FrontCollectionsOverview
                 id={this.props.id}
                 browsingStage={this.props.browsingStage}
@@ -194,6 +181,32 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
       </React.Fragment>
     );
   }
+
+  private overviewToggle = (overviewIsOpen: boolean) => {
+    const overviewToggleId = `btn-overview-toggle-${this.props.id}`;
+
+    return (
+      <>
+        <OverviewToggleContainer
+          onClick={() => this.props.toggleOverview(!this.props.overviewIsOpen)}
+        >
+          <OverviewHeading htmlFor={overviewToggleId}>
+            {overviewIsOpen ? 'Hide overview' : 'Overview'}
+          </OverviewHeading>
+          <ButtonCircularCaret
+            id={overviewToggleId}
+            style={{
+              margin: '0'
+            }}
+            openDir="right"
+            active={this.props.overviewIsOpen}
+            preActive={false}
+            small={true}
+          />
+        </OverviewToggleContainer>
+      </>
+    );
+  };
 
   private handleOpenCollections = (e: React.MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
The styling of the 'Overview' / 'HIde overview' toggle. The 'Hide overview' button is now not quite so jumpy, as it stays aligned to the right even when open. The hot spot for clicking the toggle is now also larger.

Before:
![Screenshot 2019-10-07 at 14 14 53](https://user-images.githubusercontent.com/12645938/66315007-dab9cd80-e90c-11e9-80e9-2ec7014f4761.png)

After:
![Screenshot 2019-10-07 at 14 14 16](https://user-images.githubusercontent.com/12645938/66315018-e1484500-e90c-11e9-90b7-a1d2b5b36f66.png)

([Trello](https://trello.com/c/OUttWfqE/791-tidy-up-hide-overview-btn))

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
