### PR TITLE
DROPZONE: bigger dropzone for bottom of collection

### DIFF
--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -35,11 +35,27 @@ export const CollectionDropContainer = styled(DefaultDropContainer)`
   margin: 0 -10px;
 `;
 
-const OffsetDropContainer = styled(CollectionDropContainer)`
+const OffsetDropContainerTop = styled(CollectionDropContainer)`
   height: 32px;
   margin-top: -22px;
   padding-top: 24px;
 `;
+
+const OffsetDropContainerBottom = styled(CollectionDropContainer)`
+  height: 32px;
+  margin-bottom: -22px;
+  padding-bottom: 24px;
+`;
+
+const getDropContainer = (itemIndex: number, numItems: number) => {
+  if (itemIndex === 0) {
+    return OffsetDropContainerTop;
+  } else if (itemIndex === numItems) {
+    return OffsetDropContainerBottom;
+  } else {
+    return CollectionDropContainer;
+  }
+};
 
 const GroupLevel = ({
   children,
@@ -70,11 +86,7 @@ const GroupLevel = ({
               {...props}
               dropColor={theme.base.colors.dropZoneActiveStory}
               doubleHeight={!cards.length || props.index === 0}
-              dropContainer={
-                props.index === 0
-                  ? OffsetDropContainer
-                  : CollectionDropContainer
-              }
+              dropContainer={getDropContainer(props.index, cards.length)}
             />
           )
     }

--- a/client-v2/src/components/clipboard/GroupLevel.tsx
+++ b/client-v2/src/components/clipboard/GroupLevel.tsx
@@ -43,7 +43,7 @@ const OffsetDropContainerTop = styled(CollectionDropContainer)`
 
 const OffsetDropContainerBottom = styled(CollectionDropContainer)`
   height: 32px;
-  margin-bottom: -22px;
+  margin-bottom: -28px;
   padding-bottom: 24px;
 `;
 


### PR DESCRIPTION
## What's changed?
Dropping stories at the bottom of groups/collections was hard. The DropZone was narrow so it was hard to get the story to land. 

**Problem - the blue "Place here" is visible but drops fail.** 

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/10324129/66565444-670d0000-eb5a-11e9-9458-b048e845f0da.gif)


**Solution - allowing a longer dropzones - means that whenever the blue "Place here" sign is visible the drop should land** 

![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/10324129/66565457-755b1c00-eb5a-11e9-9cf4-e9d24cfdf4a6.gif)

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
