### PR TITLE
Be able to define time window rules for prefill queries in templates

### DIFF
--- a/app/logic/CapiPrefiller.scala
+++ b/app/logic/CapiPrefiller.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.{Content, TagType}
 import com.gu.facia.api.utils.{CardStyle, ResolvedMetaData}
 import com.gu.facia.client.models.TrailMetaData
 import model.editions.{Image, MediaType}
-import services.Prefill
+import services.editions.prefills.Prefill
 
 object CapiPrefiller {
 

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -146,7 +146,7 @@ case class FrontTemplate(
   def swatch(swatch: Swatch) = copy(presentation = FrontPresentation(swatch))
 }
 
-case class TimeWindowConfigInDays(startDiff: Int, endDiff: Int)
+case class TimeWindowConfigInDays(startOffset: Int, endOffset: Int)
 case class CapiQueryPrefillParams(timeWindowConfig: TimeWindowConfigInDays)
 
 case class EditionTemplate(

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -146,8 +146,12 @@ case class FrontTemplate(
   def swatch(swatch: Swatch) = copy(presentation = FrontPresentation(swatch))
 }
 
+case class TimeWindowConfigInDays(startDiff: Int, endDiff: Int)
+case class CapiQueryPrefillParams(timeWindowConfig: TimeWindowConfigInDays)
+
 case class EditionTemplate(
   fronts: List[(FrontTemplate, Periodicity)],
+  capiQueryPrefillParams: CapiQueryPrefillParams,
   zoneId: ZoneId,
   availability: Periodicity,
 )

--- a/app/model/editions/internal/PrefillUpdate.scala
+++ b/app/model/editions/internal/PrefillUpdate.scala
@@ -2,8 +2,8 @@ package model.editions.internal
 
 import java.time.{LocalDate, ZoneId}
 
-import model.editions.CapiPrefillQuery
+import model.editions.{CapiPrefillQuery, Edition}
 
 // Small class which is returned by the database to allow fetching new prefilled articles
-case class PrefillUpdate(issueDate: LocalDate, zone: ZoneId, prefill: CapiPrefillQuery, currentPageCodes: List[String])
+case class PrefillUpdate(issueDate: LocalDate, edition: Edition, zone: ZoneId, prefill: CapiPrefillQuery, currentPageCodes: List[String])
 

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -60,8 +60,8 @@ object AmericanEdition {
     availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
-        startDiff = 0,
-        endDiff = 0)
+        startOffset = 0,
+        endOffset = 0)
     )
   )
 

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -8,7 +8,7 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object AmericanEdition {
-  val template = EditionTemplate(
+  lazy val template = EditionTemplate(
     List(
       // Top Stories and Nuclear specials
       FrontSpecial1 -> Daily(),
@@ -57,7 +57,12 @@ object AmericanEdition {
       FrontCrosswords -> Daily(),
     ),
     zoneId = ZoneId.of("Europe/London"),
-    availability = Daily()
+    availability = Daily(),
+    capiQueryPrefillParams = CapiQueryPrefillParams(
+      timeWindowConfig = TimeWindowConfigInDays(
+        startDiff = 0,
+        endDiff = 0)
+    )
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)
@@ -76,7 +81,7 @@ object AmericanEdition {
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
@@ -86,7 +91,7 @@ object AmericanEdition {
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsSpecial = specialFront("News Special", News)
 
@@ -95,7 +100,7 @@ object AmericanEdition {
     collection("World News").printSentAnyTag("theguardian/mainsection/international"),
     collection("World Special").special
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
@@ -104,32 +109,32 @@ object AmericanEdition {
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,
     collection("News Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
     collection("World News").printSentAnyTag("theobserver/news/worldnews"),
     collection("World Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontWorldSpecial = specialFront("World Special", News)
 
   // Financial fronts then special
 
-  def FrontFinancialGuardian = front (
+  def FrontFinancialGuardian = front(
     "Financial",
-    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3","theguardian/mainsection/money"),
+    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
     collection("Financial Special").special,
-    )
-  .swatch(News)
+  )
+    .swatch(News)
 
-  def FrontFinancialObserver = front (
+  def FrontFinancialObserver = front(
     "Financial",
     collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
     collection("Financial Special").special,
-    )
-  .swatch(News)
+  )
+    .swatch(News)
 
   def FrontFinancialSpecial = specialFront("Financial Special", News)
 
@@ -141,14 +146,14 @@ object AmericanEdition {
     collection("Obituaries").printSentAnyTag("theguardian/journal/obituaries"),
     collection("Journal Special").special,
   )
-  .swatch(Opinion)
+    .swatch(Opinion)
 
   def FrontComment = front(
     "Journal",
     collection("Comment").printSentAnyTag("theobserver/news/comment"),
     collection("Comment Special").special,
   )
-  .swatch(Opinion)
+    .swatch(Opinion)
 
   def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
 
@@ -158,7 +163,7 @@ object AmericanEdition {
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureFilmMusic = front(
     "Culture",
@@ -168,7 +173,7 @@ object AmericanEdition {
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture Special"),
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureGuide = front(
     "Culture",
@@ -177,7 +182,7 @@ object AmericanEdition {
     collection("TV and Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
     collection("Culture Special"),
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureNewReview = front(
     "Culture",
@@ -187,14 +192,14 @@ object AmericanEdition {
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
     collection("Books Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureSpecial = specialFront("Culture Special", Culture)
 
@@ -203,7 +208,7 @@ object AmericanEdition {
     collection("Features").printSentAnyTag("theguardian/g2/features"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeFashion = front(
     "The Fashion",
@@ -211,7 +216,7 @@ object AmericanEdition {
     collection("Fashion 2").special,
     collection("Fashion 3").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeWeekend = front(
     "Life",
@@ -222,14 +227,14 @@ object AmericanEdition {
     collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
     collection("Travel Special").special,
-    )
-  .swatch(Lifestyle);
+  )
+    .swatch(Lifestyle);
 
   def FrontLifeMagazineObserver = front(
     "Life",
@@ -237,14 +242,14 @@ object AmericanEdition {
     collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
     collection("Life Special").printSentAnyTag("theobserver/design/design").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontFood = front(
     "Food",
     collection("Food").printSentAnyTag("theguardian/feast/feast"),
     collection("Food Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontFoodObserver = front(
     "Food",
@@ -252,7 +257,7 @@ object AmericanEdition {
     collection("OFM").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").special,
     collection("Food Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeSpecial = specialFront("Life Special", Lifestyle)
 
@@ -261,14 +266,14 @@ object AmericanEdition {
     collection("Sport").printSentAnyTag("theguardian/sport/news"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
+    .swatch(Sport)
 
   def FrontSportObserver = front(
     "Sport",
     collection("Sport").printSentAnyTag("theobserver/sport/news"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
+    .swatch(Sport)
 
   def FrontSportSpecial = specialFront("Sport Special", Sport)
 

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -8,7 +8,7 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object AustralianEdition {
-  val template = EditionTemplate(
+  lazy val template = EditionTemplate(
     List(
       // Top Stories and Nuclear specials
       FrontSpecial1 -> Daily(),
@@ -57,7 +57,13 @@ object AustralianEdition {
       FrontCrosswords -> Daily(),
     ),
     zoneId = ZoneId.of("Europe/London"),
-    availability = Daily()
+    availability = Daily(),
+    capiQueryPrefillParams = CapiQueryPrefillParams(
+      timeWindowConfig = TimeWindowConfigInDays(
+        startDiff = 0,
+        endDiff = 0
+      )
+    )
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)
@@ -76,7 +82,7 @@ object AustralianEdition {
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
@@ -86,7 +92,7 @@ object AustralianEdition {
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsSpecial = specialFront("News Special", News)
 
@@ -95,7 +101,7 @@ object AustralianEdition {
     collection("World News").printSentAnyTag("theguardian/mainsection/international"),
     collection("World Special").special
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
@@ -104,32 +110,32 @@ object AustralianEdition {
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,
     collection("News Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
     collection("World News").printSentAnyTag("theobserver/news/worldnews"),
     collection("World Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontWorldSpecial = specialFront("World Special", News)
 
   // Financial fronts then special
 
-  def FrontFinancialGuardian = front (
+  def FrontFinancialGuardian = front(
     "Financial",
-    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3","theguardian/mainsection/money"),
+    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
     collection("Financial Special").special,
-    )
-  .swatch(News)
+  )
+    .swatch(News)
 
-  def FrontFinancialObserver = front (
+  def FrontFinancialObserver = front(
     "Financial",
     collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
     collection("Financial Special").special,
-    )
-  .swatch(News)
+  )
+    .swatch(News)
 
   def FrontFinancialSpecial = specialFront("Financial Special", News)
 
@@ -141,14 +147,14 @@ object AustralianEdition {
     collection("Obituaries").printSentAnyTag("theguardian/journal/obituaries"),
     collection("Journal Special").special,
   )
-  .swatch(Opinion)
+    .swatch(Opinion)
 
   def FrontComment = front(
     "Journal",
     collection("Comment").printSentAnyTag("theobserver/news/comment"),
     collection("Comment Special").special,
   )
-  .swatch(Opinion)
+    .swatch(Opinion)
 
   def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
 
@@ -158,7 +164,7 @@ object AustralianEdition {
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureFilmMusic = front(
     "Culture",
@@ -168,7 +174,7 @@ object AustralianEdition {
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture Special"),
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureGuide = front(
     "Culture",
@@ -177,7 +183,7 @@ object AustralianEdition {
     collection("TV and Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
     collection("Culture Special"),
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureNewReview = front(
     "Culture",
@@ -187,14 +193,14 @@ object AustralianEdition {
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
     collection("Books Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureSpecial = specialFront("Culture Special", Culture)
 
@@ -203,7 +209,7 @@ object AustralianEdition {
     collection("Features").printSentAnyTag("theguardian/g2/features"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeFashion = front(
     "The Fashion",
@@ -211,7 +217,7 @@ object AustralianEdition {
     collection("Fashion 2").special,
     collection("Fashion 3").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeWeekend = front(
     "Life",
@@ -222,14 +228,14 @@ object AustralianEdition {
     collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
     collection("Travel Special").special,
-    )
-  .swatch(Lifestyle);
+  )
+    .swatch(Lifestyle);
 
   def FrontLifeMagazineObserver = front(
     "Life",
@@ -237,14 +243,14 @@ object AustralianEdition {
     collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
     collection("Life Special").printSentAnyTag("theobserver/design/design").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontFood = front(
     "Food",
     collection("Food").printSentAnyTag("theguardian/feast/feast"),
     collection("Food Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontFoodObserver = front(
     "Food",
@@ -252,7 +258,7 @@ object AustralianEdition {
     collection("OFM").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").special,
     collection("Food Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeSpecial = specialFront("Life Special", Lifestyle)
 
@@ -261,14 +267,14 @@ object AustralianEdition {
     collection("Sport").printSentAnyTag("theguardian/sport/news"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
+    .swatch(Sport)
 
   def FrontSportObserver = front(
     "Sport",
     collection("Sport").printSentAnyTag("theobserver/sport/news"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
+    .swatch(Sport)
 
   def FrontSportSpecial = specialFront("Sport Special", Sport)
 

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -60,8 +60,8 @@ object AustralianEdition {
     availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
-        startDiff = 0,
-        endDiff = 0
+        startOffset = 0,
+        endOffset = 0
       )
     )
   )

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -4,11 +4,11 @@ import java.time.ZoneId
 
 import model.editions.Swatch._
 import model.editions._
-import TemplateHelpers._
+import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object DailyEdition {
-  val template = EditionTemplate(
+  lazy val template = EditionTemplate(
     List(
       // Top Stories and Nuclear specials
       FrontSpecial1 -> Daily(),
@@ -57,7 +57,12 @@ object DailyEdition {
       FrontCrosswords -> Daily(),
     ),
     zoneId = ZoneId.of("Europe/London"),
-    availability = Daily()
+    availability = Daily(),
+    capiQueryPrefillParams = CapiQueryPrefillParams(
+      timeWindowConfig = TimeWindowConfigInDays(
+        startDiff = 0,
+        endDiff = 0)
+    )
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)
@@ -76,8 +81,8 @@ object DailyEdition {
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
-  
+    .swatch(News)
+
   def FrontNewsUkGuardianSaturday = front(
     "National",
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
@@ -86,16 +91,16 @@ object DailyEdition {
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
-  
+    .swatch(News)
+
   def FrontNewsSpecial = specialFront("News Special", News)
-  
+
   def FrontNewsWorldGuardian = front(
     "World",
     collection("World News").printSentAnyTag("theguardian/mainsection/international"),
     collection("World Special").special
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
@@ -104,35 +109,35 @@ object DailyEdition {
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,
     collection("News Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
     collection("World News").printSentAnyTag("theobserver/news/worldnews"),
     collection("World Special").special,
   )
-  .swatch(News)
-  
+    .swatch(News)
+
   def FrontWorldSpecial = specialFront("World Special", News)
-  
+
   // Financial fronts then special
-  
-  def FrontFinancialGuardian = front (
+
+  def FrontFinancialGuardian = front(
     "Financial",
-    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3","theguardian/mainsection/money"),
+    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
     collection("Financial Special").special,
-    )
-  .swatch(News)
-  
-  def FrontFinancialObserver = front (
+  )
+    .swatch(News)
+
+  def FrontFinancialObserver = front(
     "Financial",
     collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
     collection("Financial Special").special,
-    )
-  .swatch(News)
-  
+  )
+    .swatch(News)
+
   def FrontFinancialSpecial = specialFront("Financial Special", News)
-  
+
   def FrontJournal = front(
     "Journal",
     collection("Features").printSentAnyTag("theguardian/journal/the-long-read", "theguardian/journal/features"),
@@ -141,7 +146,7 @@ object DailyEdition {
     collection("Obituaries").printSentAnyTag("theguardian/journal/obituaries"),
     collection("Journal Special").special,
   )
-  .swatch(Opinion)
+    .swatch(Opinion)
 
   def FrontComment = front(
     "Journal",
@@ -150,17 +155,17 @@ object DailyEdition {
     collection("Comment 2"),
     collection("Comment Special").special,
   )
-  .swatch(Opinion)
-  
+    .swatch(Opinion)
+
   def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
-  
+
   def FrontCulture = front(
     "Culture",
     collection("Arts").printSentAnyTag("theguardian/g2/arts"),
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureFilmMusic = front(
     "Culture",
@@ -170,7 +175,7 @@ object DailyEdition {
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture Special"),
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureGuide = front(
     "Culture",
@@ -179,7 +184,7 @@ object DailyEdition {
     collection("TV and Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
     collection("Culture Special"),
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureNewReview = front(
     "Culture",
@@ -189,23 +194,23 @@ object DailyEdition {
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
-  
+    .swatch(Culture)
+
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
     collection("Books Special").special,
   )
-  .swatch(Culture)
-  
-  def FrontCultureSpecial = specialFront("Culture Special", Culture) 
+    .swatch(Culture)
+
+  def FrontCultureSpecial = specialFront("Culture Special", Culture)
 
   def FrontLife = front(
     "Life",
     collection("Features").printSentAnyTag("theguardian/g2/features"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeFashion = front(
     "The Fashion",
@@ -213,8 +218,8 @@ object DailyEdition {
     collection("Fashion 2").special,
     collection("Fashion 3").special,
   )
-  .special
-  .swatch(Lifestyle)
+    .special
+    .swatch(Lifestyle)
 
   def FrontLifeWeekend = front(
     "Life",
@@ -225,29 +230,29 @@ object DailyEdition {
     collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
-  
+    .swatch(Lifestyle)
+
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
     collection("Travel Special").special,
-    )
-  .swatch(Lifestyle);
-  
+  )
+    .swatch(Lifestyle);
+
   def FrontLifeMagazineObserver = front(
     "Life",
     collection("Features").printSentAnyTag("theobserver/magazine/features2"),
     collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
     collection("Life Special").printSentAnyTag("theobserver/design/design").special,
   )
-  .swatch(Lifestyle)
-  
+    .swatch(Lifestyle)
+
   def FrontFood = front(
     "Food",
     collection("Food").printSentAnyTag("theguardian/feast/feast"),
     collection("Food Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontFoodObserver = front(
     "Food",
@@ -255,7 +260,7 @@ object DailyEdition {
     collection("OFM").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").special,
     collection("Food Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontLifeSpecial = specialFront("Life Special", Lifestyle)
 
@@ -267,7 +272,7 @@ object DailyEdition {
     collection("Sport 3"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
+    .swatch(Sport)
 
   def FrontSportObserver = front(
     "Sport",
@@ -277,20 +282,20 @@ object DailyEdition {
     collection("Sport 3"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
-  
+    .swatch(Sport)
+
   def FrontSportSpecial = specialFront("Sport Special", Sport)
-  
+
   def FrontSupplementSpecial1 = specialFront(
     "Special Supplement 1",
     swatch = Neutral,
     prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent))
   )
-  
+
   def FrontSupplementSpecial2 = specialFront("Special Supplement 2", Neutral)
 
   def FrontCrosswords = front(
     "Crosswords",
-    collection("Crosswords").searchPrefill("?tag=type/crossword"),
+    collection("Crosswords").searchPrefill("?tag=type/crossword")
   )
 }

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -60,8 +60,8 @@ object DailyEdition {
     availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
-        startDiff = 0,
-        endDiff = 0)
+        startOffset = 0,
+        endOffset = 0)
     )
   )
 

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -19,8 +19,8 @@ object TrainingEdition {
     availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
-        startDiff = 0,
-        endDiff = 0)
+        startOffset = 0,
+        endOffset = 0)
     )
   )
 

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -8,7 +8,7 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object TrainingEdition {
-  val template = EditionTemplate(
+  lazy val template = EditionTemplate(
     List(
       FrontNewsSpecial -> Daily(),
       FrontWorldSpecial -> Daily(),
@@ -16,7 +16,12 @@ object TrainingEdition {
       FrontCrosswords -> Daily(),
     ),
     zoneId = ZoneId.of("Europe/London"),
-    availability = Daily()
+    availability = Daily(),
+    capiQueryPrefillParams = CapiQueryPrefillParams(
+      timeWindowConfig = TimeWindowConfigInDays(
+        startDiff = 0,
+        endDiff = 0)
+    )
   )
 
   def FrontNewsSpecial = specialFront("News Special", News)

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -2,36 +2,26 @@ package services
 
 import java.io.IOException
 import java.net.URI
-import java.nio.charset.Charset
-import java.time.{LocalDate, ZoneOffset}
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.contentapi.client.model._
-import com.gu.contentapi.client.model.v1.{Content, SearchResponse, TagType}
+import com.gu.contentapi.client.model.v1.{Content, SearchResponse}
 import com.gu.contentapi.client.{GuardianContentClient, IAMSigner, Parameter}
-import com.gu.facia.api.utils.ResolvedMetaData
 import conf.ApplicationConfiguration
 import logging.Logging
 import logic.CapiPrefiller
-import model.editions.{CapiPrefillQuery, Image, MediaType, PathType}
+import model.editions._
 import okhttp3.{Call, Callback, Request, Response}
-import org.apache.http.client.utils.URLEncodedUtils
+import services.editions.prefills.{Prefill, PrefillHelper, PrefillParamsAdapter}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
-
-case class Prefill(
-                    internalPageCode: Int,
-                    metaData: ResolvedMetaData,
-                    cutout: Option[Image],
-                    tone: String,
-                    mediaType: Option[MediaType],
-                    pickedKicker: Option[String] // Note: algorithmically-picked, not human-picked.
-                  )
 
 class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionContext)
   extends GuardianContentClient(apiKey = config.contentApi.editionsKey) with Capi with Logging {
+
+  private def prefillHelper = PrefillHelper(EditionsTemplates.templates)
+
   override def targetUrl: String = config.contentApi.contentApiDraftHost
 
   override def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
@@ -65,40 +55,10 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
   def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)] = previewSigner.addIAMHeaders(headers = headers, URI.create(url)).toSeq
 
-  private def geneneratePrefillQuery(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, fields: List[String]) = {
-    val params = URLEncodedUtils
-      .parse(new URI(capiPrefillQuery.escapedQueryString()), Charset.forName("UTF-8"))
-      .asScala
-
-    // Hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
-    val utcMidnightOnDate = issueDate.atStartOfDay().toInstant(ZoneOffset.UTC)
-
-    var query = CapiQueryGenerator(capiPrefillQuery.pathType)
-      .page(1)
-      .pageSize(200)
-      .showFields(fields.mkString(","))
-      .useDate("newspaper-edition") // deliberately-kebab-case
-      .orderBy("newest")
-      .fromDate(utcMidnightOnDate)
-      .toDate(utcMidnightOnDate)
-
-    params.filter(pair => pair.getName == "section").foreach { sectionPair =>
-      query = query.section(sectionPair.getValue)
-    }
-
-    params.filter(pair => pair.getName == "tag").foreach { tagPair =>
-      query = query.tag(tagPair.getValue)
-    }
-
-    params.find(pair => pair.getName == "q").foreach { queryPair =>
-      query = query.q(queryPair.getValue)
-    }
-
-    query
-  }
 
   // Sadly there's no easy way of converting a CAPI client response into JSON so we'll just proxy - similar to controllers.FaciaContentApiProxy
-  def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = {
+  def getPrefillArticles(getPrefill: PrefillParamsAdapter, currentPageCodes: List[String]): Future[SearchResponse] = {
+
     val fields = List(
       "newspaperEditionDate",
       "newspaperPapeNumber",
@@ -115,7 +75,7 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       "shortUrl"
     )
 
-    val query = geneneratePrefillQuery(issueDate, capiPrefillQuery, fields)
+    val query = prefillHelper.geneneratePrefillQuery(getPrefill, fields)
       .showElements("images")
       .showTags("all")
       .showBlocks("main")
@@ -140,18 +100,18 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
   /**
    * Get a list of article items in the order they exist according to the newspaper page number
    *
-   * @param issueDate
-   * @param capiPrefillQuery
+   * @param prefillParams
    * @return
    */
-  def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = {
+  def getPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = {
+
     val fields = List(
       "newspaperEditionDate",
       "newspaperPageNumber",
       "internalPageCode"
     )
 
-    val query = geneneratePrefillQuery(issueDate, capiPrefillQuery, fields)
+    val query = prefillHelper.geneneratePrefillQuery(prefillParams, fields)
       .showTags("all")
 
     this.getResponse(query) map { response =>
@@ -190,7 +150,7 @@ case class CapiQueryGenerator(pathType: PathType, parameterHolder: Map[String, P
 trait Capi {
   def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)]
 
-  def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]]
+  def getPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]]
 
-  def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse]
+  def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): Future[SearchResponse]
 }

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -81,6 +81,8 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
       .showBlocks("main")
       .showAtoms("media")
 
+    logger.info(s"getPrefillArticles, Prefill Query: $query")
+
     this.getResponse(query).map { response =>
       val filteredResults = response.results.filter { result =>
         (for {
@@ -113,6 +115,8 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit ex: ExecutionConte
 
     val query = prefillHelper.geneneratePrefillQuery(prefillParams, fields)
       .showTags("all")
+
+    logger.info(s"getPrefillArticleItems, Prefill Query: $query")
 
     this.getResponse(query) map { response =>
       response.results

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -51,7 +51,7 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
   }
 
   // this function fetches articles from CAPI with enough data to resolve the defaults
-  def getPrefillArticles(prefillParams: PrefillParamsAdapter): List[EditionsArticleSkeleton] = {
+  private def getPrefillArticles(prefillParams: PrefillParamsAdapter): List[EditionsArticleSkeleton] = {
     // TODO: This being a try will hide a litany of failures, some of which we might want to surface
     val items = try {
       Await.result(capi.getPrefillArticleItems(prefillParams), 10 seconds)

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -3,7 +3,7 @@ package services.editions.db
 import java.time._
 
 import model.editions.internal.PrefillUpdate
-import model.editions.{CapiPrefillQuery, EditionsCollection, PathType}
+import model.editions.{CapiPrefillQuery, Edition, EditionsCollection, PathType}
 import model.forms.GetCollectionsFilter
 import play.api.libs.json.Json
 import scalikejdbc._
@@ -41,6 +41,7 @@ trait CollectionsQueries {
           SELECT collections.prefill,
                  collections.path_type,
                  articles.page_code,
+                 edition_issues.name,
                  edition_issues.issue_date,
                  edition_issues.timezone_id
           FROM collections
@@ -50,15 +51,17 @@ trait CollectionsQueries {
           WHERE collections.id = $id
        """.map { rs =>
         val date = rs.localDate("issue_date")
+        val editionStr = rs.string("name")
+        val edition = Edition.withName(editionStr)
         val zone = ZoneId.of(rs.string("timezone_id"))
         val pathTypeStr = rs.string("path_type")
         val pathType = PathType.withName(pathTypeStr)
 
-        (date, zone, CapiPrefillQuery(rs.string("prefill"), pathType), rs.string("page_code"))
+        (date, edition, zone, CapiPrefillQuery(rs.string("prefill"), pathType), rs.string("page_code"))
       }.list().apply()
 
-    rows.headOption.map { case (issueDate, zone, prefill, _) =>
-      PrefillUpdate(issueDate, zone, prefill, rows.map(_._4))
+    rows.headOption.map { case (issueDate, edition, zone, prefill, _) =>
+      PrefillUpdate(issueDate, edition, zone, prefill, rows.map(_._5))
     }
   }
 

--- a/app/services/editions/prefills/PrefillHelper.scala
+++ b/app/services/editions/prefills/PrefillHelper.scala
@@ -59,8 +59,8 @@ object PrefillHelper {
   private[prefills] def defineTimeWindow(issueDate: LocalDate, timeWindowConfig: TimeWindowConfigInDays): CapiQueryTimeWindow = {
     val issueDateStart = issueDate.atStartOfDay()
     // Regarding UTC Hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
-    val fromDateUTC = issueDateStart.plusDays(timeWindowConfig.startDiff).toInstant(ZoneOffset.UTC)
-    val toDateAsUTC = issueDateStart.plusDays(timeWindowConfig.endDiff).toInstant(ZoneOffset.UTC)
+    val fromDateUTC = issueDateStart.plusDays(timeWindowConfig.startOffset).toInstant(ZoneOffset.UTC)
+    val toDateAsUTC = issueDateStart.plusDays(timeWindowConfig.endOffset).toInstant(ZoneOffset.UTC)
     CapiQueryTimeWindow(fromDateUTC, toDateAsUTC)
   }
 

--- a/app/services/editions/prefills/PrefillHelper.scala
+++ b/app/services/editions/prefills/PrefillHelper.scala
@@ -1,0 +1,67 @@
+package services.editions.prefills
+
+import java.net.URI
+import java.nio.charset.Charset
+import java.time.{LocalDate, ZoneOffset}
+
+import model.editions.{Edition, EditionTemplate, TimeWindowConfigInDays}
+import org.apache.http.client.utils.URLEncodedUtils
+import services.CapiQueryGenerator
+
+import scala.collection.JavaConverters._
+
+class PrefillHelper(val templates: Map[Edition, EditionTemplate]) {
+
+  import PrefillHelper._
+
+  def geneneratePrefillQuery(prefillParams: PrefillParamsAdapter, fields: List[String]): CapiQueryGenerator = {
+
+    import prefillParams._
+
+    val params = URLEncodedUtils
+      .parse(new URI(capiPrefillQuery.escapedQueryString()), Charset.forName("UTF-8"))
+      .asScala
+
+    val timeWindowCfg = templates(edition).capiQueryPrefillParams.timeWindowConfig
+
+    val timeWindow = defineTimeWindow(issueDate, timeWindowCfg)
+
+    var query = CapiQueryGenerator(capiPrefillQuery.pathType)
+      .page(1)
+      .pageSize(200)
+      .showFields(fields.mkString(","))
+      .useDate("newspaper-edition") // deliberately-kebab-case
+      .orderBy("newest")
+      .fromDate(timeWindow.fromDate)
+      .toDate(timeWindow.toDate)
+
+    params.filter(pair => pair.getName == "section").foreach { sectionPair =>
+      query = query.section(sectionPair.getValue)
+    }
+
+    params.filter(pair => pair.getName == "tag").foreach { tagPair =>
+      query = query.tag(tagPair.getValue)
+    }
+
+    params.find(pair => pair.getName == "q").foreach { queryPair =>
+      query = query.q(queryPair.getValue)
+    }
+
+    query
+  }
+
+}
+
+object PrefillHelper {
+
+  def apply(templates: Map[Edition, EditionTemplate]): PrefillHelper = new PrefillHelper(templates)
+
+  private[prefills] def defineTimeWindow(issueDate: LocalDate, timeWindowConfig: TimeWindowConfigInDays): CapiQueryTimeWindow = {
+    val issueDateStart = issueDate.atStartOfDay()
+    // Regarding UTC Hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
+    val fromDateUTC = issueDateStart.plusDays(timeWindowConfig.startDiff).toInstant(ZoneOffset.UTC)
+    val toDateAsUTC = issueDateStart.plusDays(timeWindowConfig.endDiff).toInstant(ZoneOffset.UTC)
+    CapiQueryTimeWindow(fromDateUTC, toDateAsUTC)
+  }
+
+}

--- a/app/services/editions/prefills/package.scala
+++ b/app/services/editions/prefills/package.scala
@@ -1,0 +1,23 @@
+package services.editions
+
+import java.time.{Instant, LocalDate}
+
+import com.gu.facia.api.utils.ResolvedMetaData
+import model.editions.{CapiPrefillQuery, Edition, Image, MediaType}
+
+package object prefills {
+
+  case class Prefill(
+                      internalPageCode: Int,
+                      metaData: ResolvedMetaData,
+                      cutout: Option[Image],
+                      tone: String,
+                      mediaType: Option[MediaType],
+                      pickedKicker: Option[String] // Note: algorithmically-picked, not human-picked.
+                    )
+
+  case class CapiQueryTimeWindow(fromDate: Instant, toDate: Instant)
+
+  case class PrefillParamsAdapter(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, edition: Edition)
+
+}

--- a/test/editions/EditionTemplates.scala
+++ b/test/editions/EditionTemplates.scala
@@ -1,12 +1,10 @@
 package services
 
-import java.time.{LocalDate, ZonedDateTime}
-
 import com.gu.contentapi.client.model.v1.SearchResponse
 import fixtures.TestEdition
 import org.scalatest.{FreeSpec, Matchers}
-import model.editions._
 import services.editions.EditionsTemplating
+import services.editions.prefills.{Prefill, PrefillParamsAdapter}
 
 import scala.concurrent.Future
 
@@ -15,58 +13,61 @@ class editionTemplateTest extends FreeSpec with Matchers {
   // Currently not testing prefills!
   object TestCapi extends Capi {
     override def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)] = Seq.empty[(String, String)]
-    override def getPrefillArticles(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
-    override def getPrefillArticleItems(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery): Future[List[Prefill]] = Future.successful(Nil)
+
+    override def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
+
+    override def getPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = Future.successful(Nil)
   }
+
   val templating = new EditionsTemplating(TestEdition.templates, TestCapi)
 
-//  "createEdition" - {
-//    "should return Monday's content for Monday" in {
-//      val editionTemplateFronts = templating.generateEditionTemplate("daily-edition", LocalDate.parse("2019-03-11")).get.fronts
-//      editionTemplateFronts.length should be (10)
-//      editionTemplateFronts(0) should matchPattern { case EditionsFrontSkeleton("comment/journal", _,  _, _) => }
-//      editionTemplateFronts(1) should matchPattern { case EditionsFrontSkeleton("sport/sport", _, _, _) => }
-//      editionTemplateFronts(2) should matchPattern { case EditionsFrontSkeleton("arts/arts", _, _, _) => }
-//      editionTemplateFronts(3) should matchPattern { case EditionsFrontSkeleton("features/features", _, _, _) => }
-//      editionTemplateFronts(4) should matchPattern { case EditionsFrontSkeleton("news/financial", _, _, _) => }
-//      editionTemplateFronts(5) should matchPattern { case EditionsFrontSkeleton("news/international", _, _, _) => }
-//      editionTemplateFronts(6) should matchPattern { case EditionsFrontSkeleton("frontpage/frontpage", _, _, _) => }
-//      editionTemplateFronts(7) should matchPattern { case EditionsFrontSkeleton("news/national", _, _, _) => }
-//      editionTemplateFronts(8) should matchPattern { case EditionsFrontSkeleton("media/media", _, _, _) => }
-//      editionTemplateFronts(9) should matchPattern { case EditionsFrontSkeleton("special/special", _, _, _) => }
-//    }
-//
-//    "should return Friday's content for Friday" in {
-//      val editionTemplateFronts = templating.generateEditionTemplate("daily-edition", LocalDate.parse("2019-03-15")).get.fronts
-//      editionTemplateFronts.length should be (10)
-//      editionTemplateFronts(0) should matchPattern { case EditionsFrontSkeleton("comment/journal", _, _, _) => }
-//      editionTemplateFronts(1) should matchPattern { case EditionsFrontSkeleton("sport/sport", _, _, _) => }
-//      editionTemplateFronts(2) should matchPattern { case EditionsFrontSkeleton("arts/artsfriday", _, _, _) => }
-//      editionTemplateFronts(3) should matchPattern { case EditionsFrontSkeleton("film/film", _, _, _) => }
-//      editionTemplateFronts(4) should matchPattern { case EditionsFrontSkeleton("music/music", _, _, _) => }
-//      editionTemplateFronts(5) should matchPattern { case EditionsFrontSkeleton("news/financial", _, _, _) => }
-//      editionTemplateFronts(6) should matchPattern { case EditionsFrontSkeleton("news/international", _, _, _) => }
-//      editionTemplateFronts(7) should matchPattern { case EditionsFrontSkeleton("frontpage/frontpage", _, _, _) => }
-//      editionTemplateFronts(8) should matchPattern { case EditionsFrontSkeleton("news/national", _, _, _) => }
-//      editionTemplateFronts(9) should matchPattern { case EditionsFrontSkeleton("special/special", _, _, _) => }
-//    }
-//
-//    "should return Saturday's content for Saturday" in {
-//      val editionTemplateFronts = templating.generateEditionTemplate("daily-edition", LocalDate.parse("2019-03-16")).get.fronts
-//      editionTemplateFronts.length should be (13)
-//      editionTemplateFronts(0) should matchPattern { case EditionsFrontSkeleton("comment/journal", _, _, _) => }
-//      editionTemplateFronts(1) should matchPattern { case EditionsFrontSkeleton("weekend/weekend", _, _, _) => }
-//      editionTemplateFronts(2) should matchPattern { case EditionsFrontSkeleton("theguide/theguide", _, _, _) => }
-//      editionTemplateFronts(3) should matchPattern { case EditionsFrontSkeleton("sport/sport", _, _, _) => }
-//      editionTemplateFronts(4) should matchPattern { case EditionsFrontSkeleton("travel/travel", _, _, _) => }
-//      editionTemplateFronts(5) should matchPattern { case EditionsFrontSkeleton("news/financial", _, _, _) => }
-//      editionTemplateFronts(6) should matchPattern { case EditionsFrontSkeleton("news/international", _, _, _) => }
-//      editionTemplateFronts(7) should matchPattern { case EditionsFrontSkeleton("frontpage/frontpage", _, _, _) => }
-//      editionTemplateFronts(8) should matchPattern { case EditionsFrontSkeleton("news/national", _, _, _) => }
-//      editionTemplateFronts(9) should matchPattern { case EditionsFrontSkeleton("money/money", _, _, _) => }
-//      editionTemplateFronts(10) should matchPattern { case EditionsFrontSkeleton("review/review", _, _, _) => }
-//      editionTemplateFronts(11) should matchPattern { case EditionsFrontSkeleton("feast/feast", _, _, _) => }
-//      editionTemplateFronts(12) should matchPattern { case EditionsFrontSkeleton("special/special", _, _, _) => }
-//    }
-//  }
+  //  "createEdition" - {
+  //    "should return Monday's content for Monday" in {
+  //      val editionTemplateFronts = templating.generateEditionTemplate("daily-edition", LocalDate.parse("2019-03-11")).get.fronts
+  //      editionTemplateFronts.length should be (10)
+  //      editionTemplateFronts(0) should matchPattern { case EditionsFrontSkeleton("comment/journal", _,  _, _) => }
+  //      editionTemplateFronts(1) should matchPattern { case EditionsFrontSkeleton("sport/sport", _, _, _) => }
+  //      editionTemplateFronts(2) should matchPattern { case EditionsFrontSkeleton("arts/arts", _, _, _) => }
+  //      editionTemplateFronts(3) should matchPattern { case EditionsFrontSkeleton("features/features", _, _, _) => }
+  //      editionTemplateFronts(4) should matchPattern { case EditionsFrontSkeleton("news/financial", _, _, _) => }
+  //      editionTemplateFronts(5) should matchPattern { case EditionsFrontSkeleton("news/international", _, _, _) => }
+  //      editionTemplateFronts(6) should matchPattern { case EditionsFrontSkeleton("frontpage/frontpage", _, _, _) => }
+  //      editionTemplateFronts(7) should matchPattern { case EditionsFrontSkeleton("news/national", _, _, _) => }
+  //      editionTemplateFronts(8) should matchPattern { case EditionsFrontSkeleton("media/media", _, _, _) => }
+  //      editionTemplateFronts(9) should matchPattern { case EditionsFrontSkeleton("special/special", _, _, _) => }
+  //    }
+  //
+  //    "should return Friday's content for Friday" in {
+  //      val editionTemplateFronts = templating.generateEditionTemplate("daily-edition", LocalDate.parse("2019-03-15")).get.fronts
+  //      editionTemplateFronts.length should be (10)
+  //      editionTemplateFronts(0) should matchPattern { case EditionsFrontSkeleton("comment/journal", _, _, _) => }
+  //      editionTemplateFronts(1) should matchPattern { case EditionsFrontSkeleton("sport/sport", _, _, _) => }
+  //      editionTemplateFronts(2) should matchPattern { case EditionsFrontSkeleton("arts/artsfriday", _, _, _) => }
+  //      editionTemplateFronts(3) should matchPattern { case EditionsFrontSkeleton("film/film", _, _, _) => }
+  //      editionTemplateFronts(4) should matchPattern { case EditionsFrontSkeleton("music/music", _, _, _) => }
+  //      editionTemplateFronts(5) should matchPattern { case EditionsFrontSkeleton("news/financial", _, _, _) => }
+  //      editionTemplateFronts(6) should matchPattern { case EditionsFrontSkeleton("news/international", _, _, _) => }
+  //      editionTemplateFronts(7) should matchPattern { case EditionsFrontSkeleton("frontpage/frontpage", _, _, _) => }
+  //      editionTemplateFronts(8) should matchPattern { case EditionsFrontSkeleton("news/national", _, _, _) => }
+  //      editionTemplateFronts(9) should matchPattern { case EditionsFrontSkeleton("special/special", _, _, _) => }
+  //    }
+  //
+  //    "should return Saturday's content for Saturday" in {
+  //      val editionTemplateFronts = templating.generateEditionTemplate("daily-edition", LocalDate.parse("2019-03-16")).get.fronts
+  //      editionTemplateFronts.length should be (13)
+  //      editionTemplateFronts(0) should matchPattern { case EditionsFrontSkeleton("comment/journal", _, _, _) => }
+  //      editionTemplateFronts(1) should matchPattern { case EditionsFrontSkeleton("weekend/weekend", _, _, _) => }
+  //      editionTemplateFronts(2) should matchPattern { case EditionsFrontSkeleton("theguide/theguide", _, _, _) => }
+  //      editionTemplateFronts(3) should matchPattern { case EditionsFrontSkeleton("sport/sport", _, _, _) => }
+  //      editionTemplateFronts(4) should matchPattern { case EditionsFrontSkeleton("travel/travel", _, _, _) => }
+  //      editionTemplateFronts(5) should matchPattern { case EditionsFrontSkeleton("news/financial", _, _, _) => }
+  //      editionTemplateFronts(6) should matchPattern { case EditionsFrontSkeleton("news/international", _, _, _) => }
+  //      editionTemplateFronts(7) should matchPattern { case EditionsFrontSkeleton("frontpage/frontpage", _, _, _) => }
+  //      editionTemplateFronts(8) should matchPattern { case EditionsFrontSkeleton("news/national", _, _, _) => }
+  //      editionTemplateFronts(9) should matchPattern { case EditionsFrontSkeleton("money/money", _, _, _) => }
+  //      editionTemplateFronts(10) should matchPattern { case EditionsFrontSkeleton("review/review", _, _, _) => }
+  //      editionTemplateFronts(11) should matchPattern { case EditionsFrontSkeleton("feast/feast", _, _, _) => }
+  //      editionTemplateFronts(12) should matchPattern { case EditionsFrontSkeleton("special/special", _, _, _) => }
+  //    }
+  //  }
 }

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -15,10 +15,15 @@ object TestEdition {
       FrontSpecialSpecial2.front -> Daily(),
     ),
     zoneId = ZoneId.of("Europe/London"),
-    availability = Daily()
+    availability = Daily(),
+    capiQueryPrefillParams = CapiQueryPrefillParams(
+      timeWindowConfig = TimeWindowConfigInDays(
+        startDiff = -1,
+        endDiff= 2)
+    )
   )
 
-  val templates: Map[Edition, EditionTemplate] = Map(Edition.TrainingEdition -> template)
+  lazy val templates: Map[Edition, EditionTemplate] = Map(Edition.TrainingEdition -> template)
 }
 
 object FrontTopStories {

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -18,8 +18,8 @@ object TestEdition {
     availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
-        startDiff = -1,
-        endDiff= 2)
+        startOffset = -1,
+        endOffset= 2)
     )
   )
 

--- a/test/services/editions/prefills/PrefillHelperTest.scala
+++ b/test/services/editions/prefills/PrefillHelperTest.scala
@@ -1,0 +1,42 @@
+package services.editions.prefills
+
+import java.time.{LocalDate, ZoneOffset}
+
+import fixtures.TestEdition
+import model.editions.{CapiPrefillQuery, Edition, PathType, TimeWindowConfigInDays}
+import org.scalatest.{FunSuite, Matchers}
+
+class PrefillHelperTest extends FunSuite with Matchers {
+
+  private val issueDate = LocalDate.of(2019, 10, 5)
+
+  private def prefillHelper = PrefillHelper(TestEdition.templates)
+
+  test("defineTimeWindow should return expected time window") {
+    val timeWindowCfg = TimeWindowConfigInDays(startDiff = -1, endDiff = 2)
+    PrefillHelper.defineTimeWindow(issueDate, timeWindowCfg) shouldEqual CapiQueryTimeWindow(
+      LocalDate.of(2019, 10, 4).atStartOfDay().toInstant(ZoneOffset.UTC),
+      LocalDate.of(2019, 10, 7).atStartOfDay().toInstant(ZoneOffset.UTC)
+    )
+  }
+
+  test("geneneratePrefillQuery") {
+
+    val prefillQuery = CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)
+
+    val prefillParams = PrefillParamsAdapter(issueDate, prefillQuery, Edition.TrainingEdition)
+
+    val fields = List(
+      "newspaperEditionDate",
+      "newspaperPageNumber",
+      "internalPageCode"
+    )
+
+    val actual = prefillHelper.geneneratePrefillQuery(prefillParams, fields).getUrl("")
+
+    val expected = "/content/print-sent?order-by=newest&page-size=200&tag=theguardian%2Fmainsection%2Ftopstories&to-date=2019-10-07T00%3A00%3A00Z&page=1&use-date=newspaper-edition&show-fields=newspaperEditionDate%2CnewspaperPageNumber%2CinternalPageCode&from-date=2019-10-04T00%3A00%3A00Z"
+
+    actual shouldEqual expected
+  }
+
+}

--- a/test/services/editions/prefills/PrefillHelperTest.scala
+++ b/test/services/editions/prefills/PrefillHelperTest.scala
@@ -13,7 +13,7 @@ class PrefillHelperTest extends FunSuite with Matchers {
   private def prefillHelper = PrefillHelper(TestEdition.templates)
 
   test("defineTimeWindow should return expected time window") {
-    val timeWindowCfg = TimeWindowConfigInDays(startDiff = -1, endDiff = 2)
+    val timeWindowCfg = TimeWindowConfigInDays(startOffset = -1, endOffset = 2)
     PrefillHelper.defineTimeWindow(issueDate, timeWindowCfg) shouldEqual CapiQueryTimeWindow(
       LocalDate.of(2019, 10, 4).atStartOfDay().toInstant(ZoneOffset.UTC),
       LocalDate.of(2019, 10, 7).atStartOfDay().toInstant(ZoneOffset.UTC)


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Be able to define time window rules for prefill queries in templates

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

Time window config is specified on Edition Template level

for example lets say for DailyEdition it will be:

```
capiQueryPrefillParams = CapiQueryPrefillParams(
      timeWindowConfig = TimeWindowConfigInDays(
        startDiff = -1,
        endDiff = 3
      )
    )
```

then it means that for issue-date is `2019-OCT-10` for window (-1, 3) the fromDate will be `2019-OCT-9` toDate will be `2019-OCT-13`

those values are propagated to Capi query params:

`to-date=2019-10-07T00%3A00%3A00Z`
`from-date=2019-10-04T00%3A00%3A00Z`

Now all templates have `startDiff = 0` and `endDiff = 0 `so it remain the same as before in runtime

Next steps would be persisting those window settings in DB

And having a new PathType such that those window rules will apply to  specified path type and to not disturb crosswords

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

