### PR TITLE
save Archiver messages into database

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -19,6 +19,7 @@ import router.Routes
 import services._
 import services.editions.EditionsTemplating
 import services.editions.db.EditionsDB
+import services.editions.publishing.events.PublishEventsListener
 import services.editions.publishing.{EditionsBucket, EditionsPublishing}
 import slices.{Containers, FixedContainers}
 import thumbnails.ContainerThumbnails
@@ -49,6 +50,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
   val publishingBucket = new EditionsBucket(s3Client, config.aws.publishedEditionsIssuesBucket)
   val previewBucket = new EditionsBucket(s3Client, config.aws.previewEditionsIssuesBucket)
   val editionsPublishing = new EditionsPublishing(publishingBucket, previewBucket, editionsDb)
+  PublishEventsListener.apply(config, editionsDb).start
 
   // Controllers
   val frontsApi = new FrontsApi(config, awsEndpoints)

--- a/app/Loader.scala
+++ b/app/Loader.scala
@@ -4,7 +4,6 @@ import play.api.ApplicationLoader.Context
 import play.api.{Application, ApplicationLoader, Configuration, LoggerConfigurator, Mode}
 import switchboard.{SwitchboardConfiguration, Lifecycle => SwitchboardLifecycle}
 import conf.ApplicationConfiguration
-import services.editions.publishing.events.PublishEventsListener
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -49,8 +48,6 @@ class Loader extends ApplicationLoader {
       components.isDev
     )
     new LogStashConfig(components.config)
-
-    PublishEventsListener.apply(config).start
 
     components.application
   }

--- a/app/services/editions/db/package.scala
+++ b/app/services/editions/db/package.scala
@@ -1,0 +1,6 @@
+package services.editions
+
+package object db {
+  // see https://www.postgresql.org/docs/current/errcodes-appendix.html
+  final val ForeignKeyViolationSQLState = "23503"
+}

--- a/app/services/editions/publishing/events/PublishEventsProcessor.scala
+++ b/app/services/editions/publishing/events/PublishEventsProcessor.scala
@@ -12,7 +12,7 @@ private[events] class PublishEventsProcessor(sqsFacade: PublishEventsQueueFacade
   def processPublishEvent(updateEventInDB: PublishEvent => Boolean): Unit = {
     sqsFacade.getPublishEventFromQueue.foreach{sqsEvent => {
       val publishEvent = sqsEvent.event
-      logger.info(s"received publish event from SQS: $publishEvent")
+      logger.info(s"received publish event from SQS")(publishEvent.toLogMarker)
       if (updateEventInDB(publishEvent)) {
         sqsFacade.delete(sqsEvent.receiptHandle)
       }

--- a/app/services/editions/publishing/events/package.scala
+++ b/app/services/editions/publishing/events/package.scala
@@ -3,7 +3,9 @@ package services.editions.publishing
 import java.time.{LocalDate, LocalDateTime}
 
 import model.editions.{Edition, EditionIssueVersionId, IssueVersionStatus}
+import net.logstash.logback.marker.{LogstashMarker, Markers}
 import play.api.libs.json.{Format, Json}
+import scala.collection.JavaConverters._
 
 package object events {
   case class PublishEvent(
@@ -13,7 +15,20 @@ package object events {
     status: IssueVersionStatus,
     message: String,
     timestamp: LocalDateTime
-  )
+  ) {
+    def toLogMarker: LogstashMarker = {
+      val markers = Map(
+        "edition" -> edition.toString,
+        "issueVersion" -> version,
+        "issueDate" -> issueDate.toString,
+        "issueVersionStatus" -> status.toString,
+        "issueEventMessage" -> message,
+        "issueEventTimestamp" -> timestamp.toString
+      )
+
+      Markers.appendEntries(markers.asJava)
+    }
+  }
 
   case class PublishEventMessage(receiptHandle: String, event: PublishEvent)
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Save messages read of the SQS queue, originating from Archiver and pertaining to the progress of issue publication, to the database.

This is getting us a step closer to showing this in the UI to provide confidence that publication is happening as currently we say "issue has been submitted to publication, check your device in 5 minutes".

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
If we encounter a foreign key constraint violation, because the `version_id` doesn't exist in the `issue_versions` table, proceed to remove the message from SQS (that is, mark it as successful). This is because we can never recover from this state and it is the only way to progress.

We're only likely to enter this state in DEV and CODE as we share the same Archiver stack. That is, the SQS queue will have messages for DEV and CODE.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
