### PR TITLE
ATOMS: Get an interactive atom from capi & create snap card for it

### DIFF
--- a/client-v2/src/fixtures/capiInteractiveAtomResponse.ts
+++ b/client-v2/src/fixtures/capiInteractiveAtomResponse.ts
@@ -1,0 +1,47 @@
+export default {
+  response: {
+    status: 'ok',
+    userTier: 'internal',
+    total: 1,
+    interactive: {
+      id: 'interactives/2017/06/general-election',
+      atomType: 'interactive',
+      labels: [],
+      defaultHtml: 'default',
+      data: {
+        interactive: {
+          type: 'interactive',
+          title: 'General Election 2017'
+        }
+      },
+      contentChangeDetails: {
+        lastModified: {
+          date: 1561564370000,
+          user: {
+            email: 'graphics@theguardian.com',
+            firstName: 'Visuals',
+            lastName: 'Guardian'
+          }
+        },
+        created: {
+          date: 1561564370000,
+          user: {
+            email: 'graphics@theguardian.com',
+            firstName: 'Visuals',
+            lastName: 'Guardian'
+          }
+        },
+        published: {
+          date: 1561564370000,
+          user: {
+            email: 'graphics@theguardian.com',
+            firstName: 'Visuals',
+            lastName: 'Guardian'
+          }
+        },
+        revision: 1561564370681
+      },
+      commissioningDesks: []
+    }
+  }
+};

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -58,9 +58,32 @@ interface CAPITagQueryReponse {
   };
 }
 
+interface CAPIAtomResponse {
+  response: {
+    status: CAPIStatus;
+    userTier: string;
+    total: number,
+    interactive: CAPIAtomInteractive
+  }
+}
+
+interface CAPIAtomInteractive {
+  id: string;
+  atomType: string;
+  labels: [];
+  defaultHtml: string;
+  data: {
+    interactive: {
+      title: string
+    }
+  };
+  contentChangeDetails: object;
+  commissioningDesks: [];
+};
+
 const getErrorMessageFromResponse = (response: Response) =>
   `Error making a request to CAPI: the server returned ${response.status}, ${
-    response.statusText
+  response.statusText
   }`;
 
 /**
@@ -110,8 +133,8 @@ const capiQuery = (baseURL: string) => {
     return options && options.isResource
       ? `${baseURL}/${q}${qs({ ...rest })}`
       : `${baseURL}/${path}${qs({
-          ...params
-        })}`;
+        ...params
+      })}`;
   };
 
   return {
@@ -164,6 +187,7 @@ export {
   checkIsContent,
   CAPISearchQueryResultsResponse,
   checkIsResults,
-  CAPITagQueryReponse
+  CAPITagQueryReponse,
+  CAPIAtomResponse
 };
 export default capiQuery;

--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -58,13 +58,13 @@ interface CAPITagQueryReponse {
   };
 }
 
-interface CAPIAtomResponse {
+interface CAPIInteractiveAtomResponse {
   response: {
     status: CAPIStatus;
     userTier: string;
-    total: number,
-    interactive: CAPIAtomInteractive
-  }
+    total: number;
+    interactive: CAPIAtomInteractive;
+  };
 }
 
 interface CAPIAtomInteractive {
@@ -74,16 +74,16 @@ interface CAPIAtomInteractive {
   defaultHtml: string;
   data: {
     interactive: {
-      title: string
-    }
+      title: string;
+    };
   };
   contentChangeDetails: object;
   commissioningDesks: [];
-};
+}
 
 const getErrorMessageFromResponse = (response: Response) =>
   `Error making a request to CAPI: the server returned ${response.status}, ${
-  response.statusText
+    response.statusText
   }`;
 
 /**
@@ -133,8 +133,8 @@ const capiQuery = (baseURL: string) => {
     return options && options.isResource
       ? `${baseURL}/${q}${qs({ ...rest })}`
       : `${baseURL}/${path}${qs({
-        ...params
-      })}`;
+          ...params
+        })}`;
   };
 
   return {
@@ -188,6 +188,6 @@ export {
   CAPISearchQueryResultsResponse,
   checkIsResults,
   CAPITagQueryReponse,
-  CAPIAtomResponse
+  CAPIInteractiveAtomResponse
 };
 export default capiQuery;

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -18,11 +18,7 @@ import {
 import pandaFetch from './pandaFetch';
 import { CapiArticle } from 'types/Capi';
 import chunk from 'lodash/chunk';
-import {
-  CAPISearchQueryResponse,
-  checkIsResults,
-  CAPIInteractiveAtomResponse
-} from './capiQuery';
+import { CAPISearchQueryResponse, checkIsResults } from './capiQuery';
 import flatMap from 'lodash/flatMap';
 import { EditionsIssue, EditionsCollection } from 'types/Edition';
 import { EditionsRoutes } from 'routes/routes';

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -348,8 +348,7 @@ const getAtomFromCapi = async (path: string) => {
     method: 'get',
     credentials: 'same-origin'
   });
-  const parsedResponse: CAPIInteractiveAtomResponse = await response.json();
-  return parsedResponse;
+  return await response.json();
 };
 
 const getTagOrSectionTitle = (queryResponse: CAPISearchQueryResponse) => {

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -18,7 +18,11 @@ import {
 import pandaFetch from './pandaFetch';
 import { CapiArticle } from 'types/Capi';
 import chunk from 'lodash/chunk';
-import { CAPISearchQueryResponse, checkIsResults, CAPIAtomResponse } from './capiQuery';
+import {
+  CAPISearchQueryResponse,
+  checkIsResults,
+  CAPIInteractiveAtomResponse
+} from './capiQuery';
 import flatMap from 'lodash/flatMap';
 import { EditionsIssue, EditionsCollection } from 'types/Edition';
 import { EditionsRoutes } from 'routes/routes';
@@ -338,16 +342,14 @@ const getCapiUriForContentIds = (contentIds: string[]) => {
     .join('&')}`;
 };
 
-
-// getting interactive atoms from CAPI 
+// getting interactive atoms from CAPI
 const getAtomFromCapi = async (path: string) => {
-  const response = await pandaFetch(`/api/live${path}`, {
+  const response = await pandaFetch(`/api/live/${path}`, {
     method: 'get',
     credentials: 'same-origin'
   });
-  const parsedResponse: CAPIAtomResponse = await response.json();
-  console.log(parsedResponse)
-  return parsedResponse
+  const parsedResponse: CAPIInteractiveAtomResponse = await response.json();
+  return parsedResponse;
 };
 
 const getTagOrSectionTitle = (queryResponse: CAPISearchQueryResponse) => {

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -354,9 +354,6 @@ const getAtomFromCapi = async (path: string) => {
 
 const getTagOrSectionTitle = (queryResponse: CAPISearchQueryResponse) => {
   const { response } = queryResponse;
-
-  //  getAtomFromCapi('/atom/interactive/interactives/2017/06/general-election');
-
   return response
     ? (response.tag && response.tag.webTitle) ||
         (response.section && response.section.webTitle)

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -18,7 +18,7 @@ import {
 import pandaFetch from './pandaFetch';
 import { CapiArticle } from 'types/Capi';
 import chunk from 'lodash/chunk';
-import { CAPISearchQueryResponse, checkIsResults } from './capiQuery';
+import { CAPISearchQueryResponse, checkIsResults, CAPIAtomResponse } from './capiQuery';
 import flatMap from 'lodash/flatMap';
 import { EditionsIssue, EditionsCollection } from 'types/Edition';
 import { EditionsRoutes } from 'routes/routes';
@@ -338,8 +338,22 @@ const getCapiUriForContentIds = (contentIds: string[]) => {
     .join('&')}`;
 };
 
+
+// getting interactive atoms from CAPI 
+const getAtomFromCapi = async (path: string) => {
+  const response = await pandaFetch(`/api/live${path}`, {
+    method: 'get',
+    credentials: 'same-origin'
+  });
+  const parsedResponse: CAPIAtomResponse = await response.json();
+  console.log(parsedResponse)
+  return parsedResponse
+};
+
 const getTagOrSectionTitle = (queryResponse: CAPISearchQueryResponse) => {
   const { response } = queryResponse;
+
+  //  getAtomFromCapi('/atom/interactive/interactives/2017/06/general-election');
 
   return response
     ? (response.tag && response.tag.webTitle) ||
@@ -445,5 +459,6 @@ export {
   fetchVisibleArticles,
   discardDraftChangesToCollection,
   transformExternalArticle,
+  getAtomFromCapi,
   DEFAULT_PARAMS
 };

--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -13,9 +13,9 @@ import {
   MaybeAddFrontPublicationDate
 } from 'shared/types/Action';
 import { createCard } from 'shared/util/card';
-import { createSnap, createLatestSnap } from 'shared/util/snap';
+import { createSnap, createLatestSnap, createAtomSnap } from 'shared/util/snap';
 import { getIdFromURL } from 'util/CAPIUtils';
-import { isValidURL, isGuardianUrl } from 'shared/util/url';
+import { isValidURL, isGuardianUrl, isCapiUrl } from 'shared/util/url';
 import { MappableDropType } from 'util/collectionUtils';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import { CapiArticle } from 'types/Capi';
@@ -177,6 +177,11 @@ const getArticleEntitiesFromDrop = async (
     ? getCardMetaFromUrlParams(resourceIdOrUrl)
     : false;
   const isPlainUrl = isURL && !id && !guMeta;
+  const isCAPIUrl = isCapiUrl(resourceIdOrUrl);
+  if (isCAPIUrl) {
+    const card = await createAtomSnap(resourceIdOrUrl);
+    return [card];
+  }
   if (isPlainUrl) {
     const card = await createSnap(resourceIdOrUrl);
     return [card];

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -240,7 +240,6 @@ describe('Snap cards actions', () => {
             meta: {
               headline: 'General Election 2017',
               byline: 'Guardian Visuals',
-              trailText: '',
               showByline: false,
               snapType: 'interactive',
               snapUri:

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -11,6 +11,7 @@ import { RefDrop } from 'util/collectionUtils';
 import configureStore from 'util/configureStore';
 import { selectOptionsModalOptions } from 'selectors/modalSelectors';
 import { selectCard, selectSharedState } from 'shared/selectors/shared';
+import capiInteractiveAtomResponse from 'fixtures/capiInteractiveAtomResponse';
 
 jest.mock('uuid/v4', () => () => 'card1');
 const middlewares = [thunk];
@@ -215,6 +216,76 @@ describe('Snap cards actions', () => {
           })
         );
       });
+    });
+  });
+  describe('snaps can be created based on interactive atoms stored in CAPI', () => {
+    it('takes a content.guardianapis.com URL and retrieves an interactive atom', async () => {
+      const store = mockStore(initialState);
+      const snapUrl =
+        'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election';
+      const CapiResponse = capiInteractiveAtomResponse;
+      fetchMock.mock(
+        '/api/live/atom/interactive/interactives/2017/06/general-election',
+        CapiResponse
+      );
+      await store.dispatch(createArticleEntitiesFromDrop(
+        idDrop(snapUrl)
+      ) as any);
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(
+        cardsReceived({
+          card1: {
+            frontPublicationDate: 1487076708000,
+            id: 'snap/1487076708000',
+            meta: {
+              headline: 'General Election 2017',
+              byline: 'Guardian Visuals',
+              trailText: '',
+              showByline: false,
+              snapType: 'interactive',
+              snapUri:
+                'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election',
+              href:
+                'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election'
+            },
+            uuid: 'card1'
+          }
+        })
+      );
+    });
+    it('takes a content.guardianapis.com URL and returns an invalid atom card if there is no atom', async () => {
+      const store = mockStore(initialState);
+      const snapUrl =
+        'https://content.guardianapis.com/atom/interactive/interactives/2017/06/not-an-atom';
+      const CapiErrorResponse = {
+        response: {
+          status: 'error',
+          message: 'atom id not found: interactives/2017/06/not-an-atom'
+        }
+      };
+      fetchMock.mock(
+        '/api/live/atom/interactive/interactives/2017/06/not-an-atom',
+        CapiErrorResponse
+      );
+      await store.dispatch(createArticleEntitiesFromDrop(
+        idDrop(snapUrl)
+      ) as any);
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(
+        cardsReceived({
+          card1: {
+            frontPublicationDate: 1487076708000,
+            id: 'snap/1487076708000',
+            meta: {
+              headline: 'Invalid atom',
+              snapType: 'interactive',
+              href:
+                'https://content.guardianapis.com/atom/interactive/interactives/2017/06/not-an-atom'
+            },
+            uuid: 'card1'
+          }
+        })
+      );
     });
   });
 });

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -141,17 +141,17 @@ const SnapLink = ({
             {!showMeta && <CardMetaHeading>Snap link </CardMetaHeading>}
             <CardHeading html>{headline}</CardHeading>
             <SnapLinkURL>
-              {card.meta.snapUri && (
-                <>
-                  <strong>snap uri:&nbsp;</strong>
-                  {card.meta.snapUri}
-                  &nbsp;
-                </>
-              )}
               <strong>url:&nbsp;</strong>
               <a href={urlPath} target="_blank">
                 {card.meta.href}
               </a>
+              &nbsp;
+              {card.meta.snapUri && (
+                <>
+                  <strong>snap uri:&nbsp;</strong>
+                  {card.meta.snapUri}
+                </>
+              )}
             </SnapLinkURL>
           </CardHeadingContainer>
         </CardContent>

--- a/client-v2/src/shared/constants/url.ts
+++ b/client-v2/src/shared/constants/url.ts
@@ -5,7 +5,8 @@ export default {
     mainDomainShort: 'theguardian.com',
     frontendDomain: 'frontend.gutools.co.uk',
     previewDomain: 'preview.gutools.co.uk',
-    shortDomain: 'gu.com'
+    shortDomain: 'gu.com',
+    capi: 'content.guardianapis.com'
   },
   media: {
     apiBaseUrl: pageConfig.apiBaseUrl,

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -1,11 +1,11 @@
-import { getAbsolutePath, isGuardianUrl, isCapiUrl } from './url';
+import { getAbsolutePath, isGuardianUrl } from './url';
 import fetchOpenGraphData from './openGraph';
 import { Card, CardMeta } from '../types/Collection';
 import v4 from 'uuid/v4';
 import set from 'lodash/fp/set';
 import { PartialBy } from 'types/Util';
 import { getAtomFromCapi } from 'services/faciaApi';
-import { CAPIAtomResponse } from 'services/capiQuery';
+import { CAPIAtomResponse as CAPIInteractiveAtomResponse } from 'services/capiQuery';
 
 function generateId() {
   return 'snap/' + new Date().getTime();
@@ -67,8 +67,9 @@ async function createSnap(url?: string, meta?: CardMeta): Promise<Card> {
 async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
   const uuid = v4();
   try {
-
-    const atom: CAPIAtomResponse = await getAtomFromCapi(url);
+    const atom: CAPIInteractiveAtomResponse = await getAtomFromCapi(
+      getAbsolutePath(url, false)
+    );
     const { title } = atom.response.interactive.data.interactive;
 
     return convertToSnap({
@@ -96,7 +97,6 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
     });
   }
 }
-
 
 function createLatestSnap(url: string, kicker: string) {
   return convertToSnap({

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -82,7 +82,7 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
         byline: 'Guardian Visuals',
         showByline: false,
         snapType: 'interactive',
-        ...meta
+        snapUri: url
       }
     });
   } catch (e) {

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -78,7 +78,6 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
       frontPublicationDate: Date.now(),
       meta: {
         headline: title,
-        trailText: '',
         byline: 'Guardian Visuals',
         showByline: false,
         snapType: 'interactive',

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -5,7 +5,7 @@ import v4 from 'uuid/v4';
 import set from 'lodash/fp/set';
 import { PartialBy } from 'types/Util';
 import { getAtomFromCapi } from 'services/faciaApi';
-import { CAPIAtomResponse as CAPIInteractiveAtomResponse } from 'services/capiQuery';
+import { CAPIInteractiveAtomResponse } from 'services/capiQuery';
 
 function generateId() {
   return 'snap/' + new Date().getTime();

--- a/client-v2/src/shared/util/url.ts
+++ b/client-v2/src/shared/util/url.ts
@@ -51,7 +51,7 @@ function isGuardianUrl(url: string) {
 
 // eg: hits a capi endpoint https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election
 function isCapiUrl(url: string) {
-  return matchHostname(url, [urlConstants.base.capi])
+  return matchHostname(url, [urlConstants.base.capi]);
 }
 
 export {

--- a/client-v2/src/shared/util/url.ts
+++ b/client-v2/src/shared/util/url.ts
@@ -49,10 +49,16 @@ function isGuardianUrl(url: string) {
   ]);
 }
 
+// eg: hits a capi endpoint https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election
+function isCapiUrl(url: string) {
+  return matchHostname(url, [urlConstants.base.capi])
+}
+
 export {
   getAbsolutePath,
   getHostname,
   isGuardianWebsiteUrl,
   isGuardianUrl,
-  isValidURL
+  isValidURL,
+  isCapiUrl
 };


### PR DESCRIPTION
## What's changed?

This is a change to make adding snaps easier for the Interactives team. It makes use of an existing workflow to add interactives to CAPI as interactive atoms. 

**The old way:**
Users have to hand-craft a url like this, adding certain query params to make sure it does the right thing

```
https://gu.com?gu-snapType=json.html&gu-snapUri=https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json
```

**The new way:** 
Users get a CAPI url for their interactive atom and drop that in, this pulls the title from the url

```
https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election
```
![Screenshot 2019-10-16 at 17 13 39](https://user-images.githubusercontent.com/10324129/66938006-523bdb00-f038-11e9-9004-58953b1956b2.png)


CAPI links that are invalid or point to atoms of the wrong type will return invalid atom cards. 
```
https://content.guardianapis.com/atom/guide/166615a1-ed30-43e9-9201-083a41ce7713
```
![Screenshot 2019-10-16 at 17 12 25](https://user-images.githubusercontent.com/10324129/66937913-2ae50e00-f038-11e9-8e9f-9a64822c2216.png)

## Implementation notes
* Using the interactive atom as the canonical format for interactives - whether on articles, live blogs or the front gives us consistency of data structures. 

* The old method is still supported. Nothing is broken

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
