### PR TITLE
Order by Ophan promotion metric

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -38,6 +38,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
   // Services
   val awsEndpoints = new AwsEndpoints(config)
   val capi = new GuardianCapi(config)
+  val ophan = new GuardianOphan(config)
   val awsCredentials: AWSCredentialsProvider = config.aws.cmsFrontsAccountCredentials
   val dynamo: AmazonDynamoDB = Dynamo.client(awsCredentials, config.aws.region)
   val s3Client = S3.client(awsCredentials, config.aws.region)
@@ -45,7 +46,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
 
   // Editions services
   val editionsDb = new EditionsDB(config.postgres.url, config.postgres.user, config.postgres.password)
-  val templating = new EditionsTemplating(EditionsTemplates.templates, capi)
+  val templating = new EditionsTemplating(EditionsTemplates.templates, capi, ophan)
   val publishingBucket = new EditionsBucket(s3Client, config.aws.publishedEditionsIssuesBucket)
   val previewBucket = new EditionsBucket(s3Client, config.aws.previewEditionsIssuesBucket)
   val editionsPublishing = new EditionsPublishing(publishingBucket, previewBucket, editionsDb)

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -132,7 +132,7 @@ class EditionsController(db: EditionsDB,
   def getPrefillForCollection(id: String) = EditEditionsAuthAction.async { req =>
     db.getCollectionPrefillQueryString(id).map { prefillUpdate =>
       import prefillUpdate._
-      val prefillParams = PrefillParamsAdapter(issueDate, prefill, None, 0, edition)
+      val prefillParams = PrefillParamsAdapter(issueDate, prefill, None, None, edition)
       capi.getPrefillArticles(prefillParams, prefillUpdate.currentPageCodes).map { body =>
         // Need to wrap this in a "response" object because the CAPI client and CAPI API return different JSON
         val json = "{\"response\":" + body.asJson.noSpaces + "}"

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -132,7 +132,7 @@ class EditionsController(db: EditionsDB,
   def getPrefillForCollection(id: String) = EditEditionsAuthAction.async { req =>
     db.getCollectionPrefillQueryString(id).map { prefillUpdate =>
       import prefillUpdate._
-      val prefillParams = PrefillParamsAdapter(issueDate, prefill, edition)
+      val prefillParams = PrefillParamsAdapter(issueDate, prefill, None, 0, edition)
       capi.getPrefillArticles(prefillParams, prefillUpdate.currentPageCodes).map { body =>
         // Need to wrap this in a "response" object because the CAPI client and CAPI API return different JSON
         val json = "{\"response\":" + body.asJson.noSpaces + "}"

--- a/app/logic/CapiPrefiller.scala
+++ b/app/logic/CapiPrefiller.scala
@@ -25,6 +25,9 @@ object CapiPrefiller {
 
   def prefill(content: Content): Prefill = {
     val internalPageCode = content.fields.flatMap(_.internalPageCode).getOrElse(-1)
+    val newspaperPageNumber = content.fields.flatMap(_.newspaperPageNumber)
+    val webUrl = content.webUrl
+
     val cardStyle = CardStyle(content, TrailMetaData.empty)
     val metadata = ResolvedMetaData.fromContent(content, cardStyle)
 
@@ -48,6 +51,8 @@ object CapiPrefiller {
 
     Prefill(
       internalPageCode,
+      newspaperPageNumber,
+      webUrl,
       newMetadata,
       cutoutImage,
       cardStyle.toneString,

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -139,6 +139,7 @@ case class FrontTemplate(
   name: String,
   collections: List[CollectionTemplate],
   presentation: FrontPresentation,
+  ophanUrl: Option[String],
   isSpecial: Boolean = false,
   hidden: Boolean = false
 ) {
@@ -154,6 +155,7 @@ case class EditionTemplate(
   capiQueryPrefillParams: CapiQueryPrefillParams,
   zoneId: ZoneId,
   availability: Periodicity,
+  ophanRangeSearchDays: Long
 )
 
 // Issue skeletons are what is generated when you create a new issue for a given date

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -136,12 +136,12 @@ case class CollectionTemplate(
 }
 
 case class FrontTemplate(
-  name: String,
-  collections: List[CollectionTemplate],
-  presentation: FrontPresentation,
-  ophanUrl: Option[String],
-  isSpecial: Boolean = false,
-  hidden: Boolean = false
+                          name: String,
+                          collections: List[CollectionTemplate],
+                          presentation: FrontPresentation,
+                          maybeOphanPath: Option[String],
+                          isSpecial: Boolean = false,
+                          hidden: Boolean = false
 ) {
   def special = copy(isSpecial = true, hidden = true)
   def swatch(swatch: Swatch) = copy(presentation = FrontPresentation(swatch))

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -149,13 +149,14 @@ case class FrontTemplate(
 
 case class TimeWindowConfigInDays(startOffset: Int, endOffset: Int)
 case class CapiQueryPrefillParams(timeWindowConfig: TimeWindowConfigInDays)
+case class OphanQueryPrefillParams(apiKey: String, timeWindowConfig: TimeWindowConfigInDays)
 
 case class EditionTemplate(
   fronts: List[(FrontTemplate, Periodicity)],
   capiQueryPrefillParams: CapiQueryPrefillParams,
   zoneId: ZoneId,
   availability: Periodicity,
-  ophanRangeSearchDays: Long
+  ophanQueryPrefillParams: Option[OphanQueryPrefillParams]
 )
 
 // Issue skeletons are what is generated when you create a new issue for a given date

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -56,13 +56,14 @@ object AmericanEdition {
       // Crosswords
       FrontCrosswords -> Daily(),
     ),
-    zoneId = ZoneId.of("Europe/London"),
-    availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = 0,
         endOffset = 0)
-    )
+    ),
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily(),
+    7
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -64,7 +64,7 @@ object AmericanEdition {
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
     ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
-      apiKey = s"fronts-editions-${this.getClass.toString}",
+      apiKey = s"fronts-editions-us",
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = 0,
         endOffset = -7

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -63,7 +63,13 @@ object AmericanEdition {
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
-    7
+    ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
+      apiKey = s"fronts-editions-${this.getClass.toString}",
+      timeWindowConfig = TimeWindowConfigInDays(
+        startOffset = 0,
+        endOffset = -7
+      ))
+    )
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -56,14 +56,15 @@ object AustralianEdition {
       // Crosswords
       FrontCrosswords -> Daily(),
     ),
-    zoneId = ZoneId.of("Europe/London"),
-    availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = 0,
         endOffset = 0
       )
-    )
+    ),
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily(),
+    7
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -64,7 +64,13 @@ object AustralianEdition {
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
-    7
+    ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
+      apiKey = s"fronts-editions-${this.getClass.toString}",
+      timeWindowConfig = TimeWindowConfigInDays(
+        startOffset = 0,
+        endOffset = -7
+      ))
+    )
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral)

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -11,50 +11,10 @@ object AustralianEdition {
   lazy val template = EditionTemplate(
     List(
       // Top Stories and Nuclear specials
-      FrontSpecial1 -> Daily(),
-      FrontTopStories -> Daily(),
-      FrontSpecial2 -> Daily(),
       // News fronts then special
-      FrontNewsUkGuardian -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri)),
-      FrontNewsUkGuardianSaturday -> WeekDays(List(WeekDay.Sat)),
-      FrontNewsUkObserver -> WeekDays(List(WeekDay.Sun)),
-      FrontNewsSpecial -> Daily(),
-      // World News fronts and special
-      FrontNewsWorldGuardian -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
-      FrontNewsWorldObserver -> WeekDays(List(WeekDay.Sun)),
-      FrontWorldSpecial -> Daily(),
-      // Financial fronts and special
-      FrontFinancialGuardian -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
-      FrontFinancialObserver -> WeekDays(List(WeekDay.Sun)),
-      // Journal, Comment and special
-      FrontJournal -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
-      FrontComment -> WeekDays(List(WeekDay.Sun)),
-      FrontOpinionSpecial -> Daily(),
-      // Culture fronts and special
-      FrontCulture -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs)),
-      FrontCultureFilmMusic -> WeekDays(List(WeekDay.Fri)),
-      FrontCultureGuide -> WeekDays(List(WeekDay.Sat)),
-      FrontCultureNewReview -> WeekDays(List(WeekDay.Sun)),
-      FrontBooks -> WeekDays(List(WeekDay.Sat, WeekDay.Sun)),
-      FrontCultureSpecial -> Daily(),
-      // Life fronts and special
-      FrontLife -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs)),
-      FrontLifeWeekend -> WeekDays(List(WeekDay.Sat)),
-      FrontTravelGuardian -> WeekDays(List(WeekDay.Sat)),
-      FrontLifeMagazineObserver -> WeekDays(List(WeekDay.Sun)),
-      FrontFood -> WeekDays(List(WeekDay.Sat)),
-      FrontFoodObserver -> WeekDays(List(WeekDay.Sun)),
-      FrontLifeFashion -> WeekDays(List(WeekDay.Sat)),
-      FrontLifeSpecial -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Sat, WeekDay.Sun)),
-      // Sport fronts and special
-      FrontSportGuardian -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
-      FrontSportObserver -> WeekDays(List(WeekDay.Sun)),
-      FrontSportSpecial -> Daily(),
-      // Special Supplements
-      FrontSupplementSpecial1 -> Daily(),
-      FrontSupplementSpecial2 -> Daily(),
-      // Crosswords
-      FrontCrosswords -> Daily(),
+      FrontNewsAuGuardian -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri)),
+      FrontNewsAuGuardianSaturday -> WeekDays(List(WeekDay.Sat)),
+      FrontNewsAuObserver -> WeekDays(List(WeekDay.Sun)),
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
@@ -65,236 +25,41 @@ object AustralianEdition {
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
     ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
-      apiKey = s"fronts-editions-${this.getClass.toString}",
+      apiKey = s"fronts-editions-au",
       timeWindowConfig = TimeWindowConfigInDays(
-        startOffset = 0,
-        endOffset = -7
+        startOffset = -6,
+        endOffset = 0
       ))
     )
   )
 
-  def FrontSpecial1 = specialFront("Top Special 1", Neutral)
-
-  def FrontTopStories = front(
-    "Top stories",
-    collection("Top stories")
-  )
-
-  def FrontSpecial2 = specialFront("Top Special 2", Neutral)
-
-  def FrontNewsUkGuardian = front(
+  def FrontNewsAuGuardian = front(
     "National",
+    Some("au"),
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("News Special").special,
-    collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
+    collection("Australian News").printSentAnyTag("theguardian/mainsection/au", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
-  )
-    .swatch(News)
 
-  def FrontNewsUkGuardianSaturday = front(
+  )
+  .swatch(News)
+
+  def FrontNewsAuGuardianSaturday = front(
     "National",
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("News Special").special,
-    collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
+    collection("Au News").printSentAnyTag("theguardian/mainsection/au", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-    .swatch(News)
+  .swatch(News)
 
-  def FrontNewsSpecial = specialFront("News Special", News)
-
-  def FrontNewsWorldGuardian = front(
-    "World",
-    collection("World News").printSentAnyTag("theguardian/mainsection/international"),
-    collection("World Special").special
-  )
-    .swatch(News)
-
-  def FrontNewsUkObserver = front(
+  def FrontNewsAuObserver = front(
     "National",
     collection("Front Page"),
-    collection("UK News").printSentAnyTag("theobserver/news/uknews"),
+    collection("Au News").printSentAnyTag("theobserver/news/au"),
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,
     collection("News Special").special,
   )
-    .swatch(News)
-
-  def FrontNewsWorldObserver = front(
-    "World",
-    collection("World News").printSentAnyTag("theobserver/news/worldnews"),
-    collection("World Special").special,
-  )
-    .swatch(News)
-
-  def FrontWorldSpecial = specialFront("World Special", News)
-
-  // Financial fronts then special
-
-  def FrontFinancialGuardian = front(
-    "Financial",
-    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
-    collection("Financial Special").special,
-  )
-    .swatch(News)
-
-  def FrontFinancialObserver = front(
-    "Financial",
-    collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
-    collection("Financial Special").special,
-  )
-    .swatch(News)
-
-  def FrontFinancialSpecial = specialFront("Financial Special", News)
-
-  def FrontJournal = front(
-    "Journal",
-    collection("Features").printSentAnyTag("theguardian/journal/the-long-read", "theguardian/journal/features"),
-    collection("Comment").printSentAnyTag("theguardian/journal/opinion"),
-    collection("Letters").printSentAnyTag("theguardian/journal/letters"),
-    collection("Obituaries").printSentAnyTag("theguardian/journal/obituaries"),
-    collection("Journal Special").special,
-  )
-    .swatch(Opinion)
-
-  def FrontComment = front(
-    "Journal",
-    collection("Comment").printSentAnyTag("theobserver/news/comment"),
-    collection("Comment Special").special,
-  )
-    .swatch(Opinion)
-
-  def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
-
-  def FrontCulture = front(
-    "Culture",
-    collection("Arts").printSentAnyTag("theguardian/g2/arts"),
-    collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
-    collection("Culture Special").special,
-  )
-    .swatch(Culture)
-
-  def FrontCultureFilmMusic = front(
-    "Culture",
-    collection("Film").printSentAnyTag("theguardian/g2/film"),
-    collection("Music").printSentAnyTag("theguardian/g2/music"),
-    collection("Arts").printSentAnyTag("theguardian/g2/arts"),
-    collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
-    collection("Culture Special"),
-  )
-    .swatch(Culture)
-
-  def FrontCultureGuide = front(
-    "Culture",
-    collection("Features").printSentAnyTag("theguardian/theguide/features"),
-    collection("Preview").printSentAnyTag("theguardian/theguide/reviews"),
-    collection("TV and Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
-    collection("Culture Special"),
-  )
-    .swatch(Culture)
-
-  def FrontCultureNewReview = front(
-    "Culture",
-    collection("Features").printSentAnyTag("theobserver/new-review/features"),
-    collection("Agenda").printSentAnyTag("theobserver/new-review/agenda"),
-    collection("Science & Technology").printSentAnyTag("theobserver/new-review/discover"),
-    collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
-    collection("Culture Special").special,
-  )
-    .swatch(Culture)
-
-  def FrontBooks = front(
-    "Books",
-    collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
-    collection("Books Special").special,
-  )
-    .swatch(Culture)
-
-  def FrontCultureSpecial = specialFront("Culture Special", Culture)
-
-  def FrontLife = front(
-    "Life",
-    collection("Features").printSentAnyTag("theguardian/g2/features"),
-    collection("Life Special").special,
-  )
-    .swatch(Lifestyle)
-
-  def FrontLifeFashion = front(
-    "The Fashion",
-    collection("Fashion 1").printSentAnyTag("theguardian/the-fashion/the-fashion"),
-    collection("Fashion 2").special,
-    collection("Fashion 3").special,
-  )
-    .swatch(Lifestyle)
-
-  def FrontLifeWeekend = front(
-    "Life",
-    collection("Weekend").printSentAnyTag("theguardian/weekend/starters", "theguardian/weekend/features2", "theguardian/weekend/back"),
-    collection("Family").printSentAnyTag("theguardian/weekend/family"),
-    collection("Space").printSentAnyTag("theguardian/weekend/space2"),
-    collection("Fashion & Beauty").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
-    collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
-    collection("Life Special").special,
-  )
-    .swatch(Lifestyle)
-
-  def FrontTravelGuardian = front(
-    "Travel",
-    collection("Travel").printSentAnyTag("theguardian/travel/travel"),
-    collection("Travel Special").special,
-  )
-    .swatch(Lifestyle);
-
-  def FrontLifeMagazineObserver = front(
-    "Life",
-    collection("Features").printSentAnyTag("theobserver/magazine/features2"),
-    collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
-    collection("Life Special").printSentAnyTag("theobserver/design/design").special,
-  )
-    .swatch(Lifestyle)
-
-  def FrontFood = front(
-    "Food",
-    collection("Food").printSentAnyTag("theguardian/feast/feast"),
-    collection("Food Special").special,
-  )
-    .swatch(Lifestyle)
-
-  def FrontFoodObserver = front(
-    "Food",
-    collection("Food").printSentAllTags("theobserver/magazine/life-and-style", "food/food"),
-    collection("OFM").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").special,
-    collection("Food Special").special,
-  )
-    .swatch(Lifestyle)
-
-  def FrontLifeSpecial = specialFront("Life Special", Lifestyle)
-
-  def FrontSportGuardian = front(
-    "Sport",
-    collection("Sport").printSentAnyTag("theguardian/sport/news"),
-    collection("Sport Special").special,
-  )
-    .swatch(Sport)
-
-  def FrontSportObserver = front(
-    "Sport",
-    collection("Sport").printSentAnyTag("theobserver/sport/news"),
-    collection("Sport Special").special,
-  )
-    .swatch(Sport)
-
-  def FrontSportSpecial = specialFront("Sport Special", Sport)
-
-  def FrontSupplementSpecial1 = specialFront(
-    "Special Supplement 1",
-    swatch = Neutral,
-    prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent))
-  )
-
-  def FrontSupplementSpecial2 = specialFront("Special Supplement 2", Neutral)
-
-  def FrontCrosswords = front(
-    "Crosswords",
-    collection("Crosswords").searchPrefill("?tag=type/crossword"),
-  )
+  .swatch(News)
 }

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -63,7 +63,13 @@ object DailyEdition {
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
-    1
+    ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
+      apiKey = s"fronts-editions-${this.getClass.toString}",
+      timeWindowConfig = TimeWindowConfigInDays(
+        startOffset = 0,
+        endOffset = -1
+      ))
+    )
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral, None)

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -63,13 +63,7 @@ object DailyEdition {
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
-    ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
-      apiKey = s"fronts-editions-${this.getClass.toString}",
-      timeWindowConfig = TimeWindowConfigInDays(
-        startOffset = 0,
-        endOffset = -1
-      ))
-    )
+    ophanQueryPrefillParams = None
   )
 
   def FrontSpecial1 = specialFront("Top Special 1", Neutral, None)
@@ -83,7 +77,7 @@ object DailyEdition {
 
   def FrontNewsUkGuardian = front(
     "National",
-    Some("https://api.ophan.co.uk/api/promotion/front/uk"),
+    Some("uk"),
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("News Special").special,
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
@@ -93,7 +87,7 @@ object DailyEdition {
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
-    Some("https://api.ophan.co.uk/api/promotion/front/uk"),
+    Some("uk"),
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("News Special").special,
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
@@ -113,7 +107,7 @@ object DailyEdition {
 
   def FrontNewsUkObserver = front(
     "National",
-    Some("https://api.ophan.co.uk/api/promotion/front/uk"),
+    Some("uk"),
     collection("Front Page"),
     collection("UK News").printSentAnyTag("theobserver/news/uknews"),
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -56,60 +56,64 @@ object DailyEdition {
       // Crosswords
       FrontCrosswords -> Daily(),
     ),
-    zoneId = ZoneId.of("Europe/London"),
-    availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = 0,
         endOffset = 0)
-    )
+    ),
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily(),
+    1
   )
 
-  def FrontSpecial1 = specialFront("Top Special 1", Neutral)
+  def FrontSpecial1 = specialFront("Top Special 1", Neutral, None)
 
   def FrontTopStories = front(
     "Top stories",
     collection("Top stories")
   )
 
-  def FrontSpecial2 = specialFront("Top Special 2", Neutral)
+  def FrontSpecial2 = specialFront("Top Special 2", Neutral, None)
 
   def FrontNewsUkGuardian = front(
     "National",
+    Some("https://api.ophan.co.uk/api/promotion/front/uk"),
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("News Special").special,
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-    .swatch(News)
+  .swatch(News)
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
+    Some("https://api.ophan.co.uk/api/promotion/front/uk"),
     collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("News Special").special,
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-    .swatch(News)
+  .swatch(News)
 
-  def FrontNewsSpecial = specialFront("News Special", News)
+  def FrontNewsSpecial = specialFront("News Special", News).swatch(News)
 
   def FrontNewsWorldGuardian = front(
     "World",
     collection("World News").printSentAnyTag("theguardian/mainsection/international"),
     collection("World Special").special
   )
-    .swatch(News)
+  .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
+    Some("https://api.ophan.co.uk/api/promotion/front/uk"),
     collection("Front Page"),
     collection("UK News").printSentAnyTag("theobserver/news/uknews"),
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,
     collection("News Special").special,
   )
-    .swatch(News)
+  .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
@@ -127,16 +131,16 @@ object DailyEdition {
     collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
     collection("Financial Special").special,
   )
-    .swatch(News)
+  .swatch(News)
 
   def FrontFinancialObserver = front(
     "Financial",
     collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
-    collection("Financial Special").special,
+    collection("Financial Special").special
   )
     .swatch(News)
 
-  def FrontFinancialSpecial = specialFront("Financial Special", News)
+  def FrontFinancialSpecial = specialFront("Financial Special", News, None)
 
   def FrontJournal = front(
     "Journal",
@@ -155,7 +159,7 @@ object DailyEdition {
     collection("Comment 2"),
     collection("Comment Special").special,
   )
-    .swatch(Opinion)
+  .swatch(Opinion)
 
   def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
 
@@ -194,14 +198,14 @@ object DailyEdition {
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
     collection("Culture Special").special,
   )
-    .swatch(Culture)
+  .swatch(Culture)
 
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
     collection("Books Special").special,
   )
-    .swatch(Culture)
+  .swatch(Culture)
 
   def FrontCultureSpecial = specialFront("Culture Special", Culture)
 
@@ -230,14 +234,14 @@ object DailyEdition {
     collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life Special").special,
   )
-    .swatch(Lifestyle)
+  .swatch(Lifestyle)
 
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
     collection("Travel Special").special,
-  )
-    .swatch(Lifestyle);
+    )
+  .swatch(Lifestyle);
 
   def FrontLifeMagazineObserver = front(
     "Life",
@@ -245,7 +249,7 @@ object DailyEdition {
     collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
     collection("Life Special").printSentAnyTag("theobserver/design/design").special,
   )
-    .swatch(Lifestyle)
+  .swatch(Lifestyle)
 
   def FrontFood = front(
     "Food",
@@ -282,7 +286,7 @@ object DailyEdition {
     collection("Sport 3"),
     collection("Sport Special").special,
   )
-    .swatch(Sport)
+  .swatch(Sport)
 
   def FrontSportSpecial = specialFront("Sport Special", Sport)
 

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -11,15 +11,15 @@ object TemplateHelpers {
   def collection(name: String): CollectionTemplate =
     CollectionTemplate(name, None, Defaults.defaultCollectionPresentation, hidden = false)
 
-  def front(name: String, ophanUrl: Option[String], collections: CollectionTemplate*): FrontTemplate =
-    FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation, ophanUrl)
+  def front(name: String, ophanPath: Option[String], collections: CollectionTemplate*): FrontTemplate =
+    FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation, ophanPath)
 
   def front(name: String, collections: CollectionTemplate*): FrontTemplate =
     FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation, None)
 
-  def specialFront(name: String, swatch: Swatch, ophanUrl: Option[String] = None, prefill: Option[CapiPrefillQuery] = None) = front(
+  def specialFront(name: String, swatch: Swatch, ophanPath: Option[String] = None, prefill: Option[CapiPrefillQuery] = None) = front(
     name,
-    ophanUrl,
+    ophanPath,
     collection("Special Container 1").special.copy(prefill = prefill),
     collection("Special Container 2").special,
     collection("Special Container 3").special

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -11,15 +11,20 @@ object TemplateHelpers {
   def collection(name: String): CollectionTemplate =
     CollectionTemplate(name, None, Defaults.defaultCollectionPresentation, hidden = false)
 
-  def front(name: String, collections: CollectionTemplate*): FrontTemplate =
-    FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation)
+  def front(name: String, ophanUrl: Option[String], collections: CollectionTemplate*): FrontTemplate =
+    FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation, ophanUrl)
 
-  def specialFront(name: String, swatch: Swatch, prefill: Option[CapiPrefillQuery] = None) = front(
+  def front(name: String, collections: CollectionTemplate*): FrontTemplate =
+    FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation, None)
+
+  def specialFront(name: String, swatch: Swatch, ophanUrl: Option[String] = None, prefill: Option[CapiPrefillQuery] = None) = front(
     name,
+    ophanUrl,
     collection("Special Container 1").special.copy(prefill = prefill),
     collection("Special Container 2").special,
     collection("Special Container 3").special
   ).special
-   .swatch(swatch)
+    .swatch(swatch)
+
 }
 

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -15,13 +15,14 @@ object TrainingEdition {
       FrontOpinionSpecial -> Daily(),
       FrontCrosswords -> Daily(),
     ),
-    zoneId = ZoneId.of("Europe/London"),
-    availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = 0,
         endOffset = 0)
-    )
+    ),
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily(),
+    3
   )
 
   def FrontNewsSpecial = specialFront("News Special", News)

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -22,7 +22,13 @@ object TrainingEdition {
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
-    3
+    ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
+      apiKey = s"fronts-editions-${this.getClass.toString}",
+      timeWindowConfig = TimeWindowConfigInDays(
+        startOffset = 0,
+        endOffset = -3
+      ))
+    )
   )
 
   def FrontNewsSpecial = specialFront("News Special", News)

--- a/app/services/Ophan.scala
+++ b/app/services/Ophan.scala
@@ -1,0 +1,63 @@
+package services
+
+import java.io.IOException
+import java.time.LocalDate
+
+import conf.ApplicationConfiguration
+import logging.Logging
+import java.util.concurrent.TimeUnit
+
+import com.gu.contentapi.client.model.HttpResponse
+import okhttp3.{Call, Callback, ConnectionPool, OkHttpClient, Request, Response}
+import okhttp3.Request.Builder
+import play.api.libs.json.Json
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+case class OphanScore(val webUrl: String, val promotionScore: Double)
+
+class GuardianOphan(config: ApplicationConfiguration)(implicit ex: ExecutionContext) extends Ophan with Logging {
+
+  private val ophanApiKey = "fronts-editions"
+
+  // NEEDS CACHING!
+
+  implicit val ophanScoreReads = Json.format[OphanScore]
+  def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = {
+    maybeUrl match {
+      case Some(url) => get(url, startDate, endDate).map(response => Json.parse(new String(response.body)).validate[Array[OphanScore]].asOpt)
+      case _ => Future.successful(None)
+    }
+  }
+
+  protected def httpClientBuilder = new OkHttpClient.Builder()
+    .connectTimeout(1, TimeUnit.SECONDS)
+    .readTimeout(2, TimeUnit.SECONDS)
+    .followRedirects(true)
+    .connectionPool(new ConnectionPool(10, 60, TimeUnit.SECONDS))
+
+  protected val http = httpClientBuilder.build
+
+  def get(url: String, startDate: LocalDate, endDate: LocalDate)(implicit context: ExecutionContext): Future[HttpResponse] = {
+
+    val promise = Promise[HttpResponse]()
+
+    val fromParam = startDate.toString // iso 8601
+    val toParam = endDate.toString // iso 8601
+    val request = new Builder().url(s"$url?from=${fromParam}&to=${toParam}&api-key=${ophanApiKey}" ).build()
+    http.newCall(request).enqueue(new Callback() {
+      override def onFailure(call: Call, e: IOException): Unit = promise.failure(e)
+
+      override def onResponse(call: Call, response: Response): Unit = {
+        promise.success(HttpResponse(response.body().bytes, response.code(), response.message()))
+      }
+    })
+    promise.future
+  }
+
+
+}
+
+trait Ophan {
+  def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, toDate: LocalDate): Future[Option[Array[OphanScore]]]
+}

--- a/app/services/Ophan.scala
+++ b/app/services/Ophan.scala
@@ -30,7 +30,6 @@ class GuardianOphan(config: ApplicationConfiguration)(implicit ex: ExecutionCont
       baseDate.plusDays(ophanQueryPrefillParams.timeWindowConfig.startOffset),
       baseDate.plusDays(ophanQueryPrefillParams.timeWindowConfig.endOffset)
     ))
-    println(maybeDates)
     val apiKey = maybeOphanQueryPrefillParams match {
       case Some(params) => params.apiKey  // template specific key
       case None => config.ophanApi.key match {
@@ -38,8 +37,6 @@ class GuardianOphan(config: ApplicationConfiguration)(implicit ex: ExecutionCont
         case None => "fronts"             // fallback, hopefully mostly for dev purposes
       }
     }
-    println(apiKey)
-    println(maybePath)
 
     val host = config.ophanApi.host.getOrElse(DEFAULT_OPHAN_ADDRESS)
     (maybePath, maybeDates) match {

--- a/app/services/Ophan.scala
+++ b/app/services/Ophan.scala
@@ -64,13 +64,11 @@ class GuardianOphan(config: ApplicationConfiguration)(implicit ex: ExecutionCont
     val fromParam = startDate.toString // iso 8601
     val toParam = endDate.toString // iso 8601
     val url = s"$host$promotionPath$path?from=${fromParam}&to=${toParam}&api-key=${ophanApiKey}"
-    println(url)
     cache.get(url, getRequest)
   }
 
 
   private def getRequest(url: String) = {
-    println(url)
     val request = new Builder().url(url).build()
     val promise = Promise[HttpResponse]()
     http.newCall(request).enqueue(new Callback() {

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -31,7 +31,6 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
                       collection.name,
                       collection.prefill.map { prefill =>
                         val prefillParams = PrefillParamsAdapter(issueDate, prefill, frontTemplate.maybeOphanPath, template.ophanQueryPrefillParams, edition)
-                        println(prefillParams)
                         getPrefillArticles(prefillParams)
                       }.getOrElse(Nil),
                       collection.prefill,
@@ -76,7 +75,6 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
         logger.warn(s"Failed to successfully execute CAPI prefill query $prefillParams", t)
         Nil
     }
-    println(maybeOphanScores)
     // Sort by ophan score, descending, default zero, if and only if we got some scores
     // If there is no ophan url OR the request failed, fall back to ordering by newspaperPageNumber
     val sortedItems = maybeOphanScoresMap match {

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -5,15 +5,15 @@ import java.time.LocalDate
 import logging.Logging
 import model.editions._
 import play.api.mvc.{Result, Results}
-import services.Capi
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
+import services.{Capi, Ophan, OphanScore}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 
-class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], capi: Capi) extends Logging {
+class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], capi: Capi, ophan: Ophan) extends Logging {
   def generateEditionTemplate(edition: Edition, issueDate: LocalDate): Either[Result, EditionsIssueSkeleton] = {
     templates.lift(edition) match {
       case Some(template) =>
@@ -30,7 +30,7 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
                     EditionsCollectionSkeleton(
                       collection.name,
                       collection.prefill.map { prefill =>
-                        val prefillParams = PrefillParamsAdapter(issueDate, prefill, edition)
+                        val prefillParams = PrefillParamsAdapter(issueDate, prefill, frontTemplate.ophanUrl, template.ophanRangeSearchDays, edition)
                         getPrefillArticles(prefillParams)
                       }.getOrElse(Nil),
                       collection.prefill,
@@ -52,16 +52,33 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
 
   // this function fetches articles from CAPI with enough data to resolve the defaults
   private def getPrefillArticles(prefillParams: PrefillParamsAdapter): List[EditionsArticleSkeleton] = {
+    val maybeOphanScores = try {
+      val fromDate = prefillParams.issueDate.minusDays(prefillParams.range)
+      Await.result(ophan.getOphanScores(prefillParams.maybeOphanUrl, fromDate, prefillParams.issueDate), 10 seconds)
+    } catch {
+      case NonFatal(t) =>
+        // At least log this as a warning so we can trace frequency
+        logger.warn(s"Failed to successfully fetch Ophan scores from ${prefillParams.maybeOphanUrl}", t)
+        None
+    }
+    val maybeOphanScoresMap = maybeOphanScores.map( os => os.toList.map(o => o.webUrl -> o.promotionScore).toMap)
     // TODO: This being a try will hide a litany of failures, some of which we might want to surface
     val items = try {
-      Await.result(capi.getPrefillArticleItems(prefillParams), 10 seconds)
+      Await.result(capi.getUnsortedPrefillArticleItems(prefillParams), 10 seconds)
     } catch {
       case NonFatal(t) =>
         // At least log this as a warning so we can trace frequency
         logger.warn(s"Failed to successfully execute CAPI prefill query $prefillParams", t)
         Nil
     }
-    items.map { case Prefill(pageCode, metaData, cutoutImage, _, mediaType, pickedKicker) =>
+    // Sort by ophan score, descending, default zero, if and only if we got some scores
+    // If there is no ophan url OR the request failed, fall back to ordering by newspaperPageNumber
+    val sortedItems = maybeOphanScoresMap match {
+      case Some(scoresMap) => items.sortBy(prefill => scoresMap.getOrElse(prefill.webUrl, 0d))(Ordering[Double].reverse)
+      case _ => items.sortBy(prefill => prefill.newspaperPageNumber)
+    }
+    sortedItems
+      .map { case Prefill(pageCode, _, _, metaData, cutoutImage, _, mediaType, pickedKicker) =>
       val articleMetadata = ArticleMetadata.default.copy(
         showByline = if (metaData.showByline) Some(true) else None,
         showQuotedHeadline = if (metaData.showQuotedHeadline) Some(true) else None,

--- a/app/services/editions/prefills/package.scala
+++ b/app/services/editions/prefills/package.scala
@@ -9,6 +9,8 @@ package object prefills {
 
   case class Prefill(
                       internalPageCode: Int,
+                      newspaperPageNumber: Option[Int],
+                      webUrl: String,
                       metaData: ResolvedMetaData,
                       cutout: Option[Image],
                       tone: String,
@@ -18,6 +20,12 @@ package object prefills {
 
   case class CapiQueryTimeWindow(fromDate: Instant, toDate: Instant)
 
-  case class PrefillParamsAdapter(issueDate: LocalDate, capiPrefillQuery: CapiPrefillQuery, edition: Edition)
+  case class PrefillParamsAdapter(
+                                  issueDate: LocalDate,
+                                  capiPrefillQuery: CapiPrefillQuery,
+                                  maybeOphanUrl: Option[String],
+                                  range: Long,
+                                  edition: Edition
+                                 )
 
 }

--- a/app/services/editions/prefills/package.scala
+++ b/app/services/editions/prefills/package.scala
@@ -21,11 +21,11 @@ package object prefills {
   case class CapiQueryTimeWindow(fromDate: Instant, toDate: Instant)
 
   case class PrefillParamsAdapter(
-                                  issueDate: LocalDate,
-                                  capiPrefillQuery: CapiPrefillQuery,
-                                  maybeOphanUrl: Option[String],
-                                  maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams],
-                                  edition: Edition
+                                   issueDate: LocalDate,
+                                   capiPrefillQuery: CapiPrefillQuery,
+                                   maybeOphanPath: Option[String],
+                                   maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams],
+                                   edition: Edition
                                  )
 
 }

--- a/app/services/editions/prefills/package.scala
+++ b/app/services/editions/prefills/package.scala
@@ -3,7 +3,7 @@ package services.editions
 import java.time.{Instant, LocalDate}
 
 import com.gu.facia.api.utils.ResolvedMetaData
-import model.editions.{CapiPrefillQuery, Edition, Image, MediaType}
+import model.editions.{CapiPrefillQuery, Edition, Image, MediaType, OphanQueryPrefillParams}
 
 package object prefills {
 
@@ -24,7 +24,7 @@ package object prefills {
                                   issueDate: LocalDate,
                                   capiPrefillQuery: CapiPrefillQuery,
                                   maybeOphanUrl: Option[String],
-                                  range: Long,
+                                  maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams],
                                   edition: Edition
                                  )
 

--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,8 @@ libraryDependencies ++= Seq(
 
     "com.gu" %% "scanamo" % "1.0.0-M7",
 
+    "com.github.blemale" %% "scaffeine" % "3.1.0" % "compile",
+
     "com.gu" %% "thrift-serializer" % "4.0.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
     "org.julienrf" %% "play-json-derived-codecs" % "4.0.0",

--- a/test/editions/EditionTemplateTest.scala
+++ b/test/editions/EditionTemplateTest.scala
@@ -5,10 +5,11 @@ import fixtures.TestEdition
 import org.scalatest.{FreeSpec, Matchers}
 import services.editions.EditionsTemplating
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
+import java.time.LocalDate
 
 import scala.concurrent.Future
 
-class editionTemplateTest extends FreeSpec with Matchers {
+class EditionTemplateTest extends FreeSpec with Matchers {
 
   // Currently not testing prefills!
   object TestCapi extends Capi {
@@ -16,10 +17,13 @@ class editionTemplateTest extends FreeSpec with Matchers {
 
     override def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
 
-    override def getPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = Future.successful(Nil)
+    override def getUnsortedPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = Future.successful(Nil)
+  }
+  object TestOphan extends Ophan {
+    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = ???
   }
 
-  val templating = new EditionsTemplating(TestEdition.templates, TestCapi)
+  val templating = new EditionsTemplating(TestEdition.templates, TestCapi, TestOphan)
 
   //  "createEdition" - {
   //    "should return Monday's content for Monday" in {

--- a/test/editions/EditionTemplateTest.scala
+++ b/test/editions/EditionTemplateTest.scala
@@ -7,6 +7,8 @@ import services.editions.EditionsTemplating
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
 import java.time.LocalDate
 
+import model.editions.TimeWindowConfigInDays
+
 import scala.concurrent.Future
 
 class EditionTemplateTest extends FreeSpec with Matchers {
@@ -20,7 +22,7 @@ class EditionTemplateTest extends FreeSpec with Matchers {
     override def getUnsortedPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = Future.successful(Nil)
   }
   object TestOphan extends Ophan {
-    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = ???
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = ???
   }
 
   val templating = new EditionsTemplating(TestEdition.templates, TestCapi, TestOphan)

--- a/test/editions/EditionTemplateTest.scala
+++ b/test/editions/EditionTemplateTest.scala
@@ -7,7 +7,7 @@ import services.editions.EditionsTemplating
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
 import java.time.LocalDate
 
-import model.editions.TimeWindowConfigInDays
+import model.editions.{OphanQueryPrefillParams, TimeWindowConfigInDays}
 
 import scala.concurrent.Future
 
@@ -22,7 +22,7 @@ class EditionTemplateTest extends FreeSpec with Matchers {
     override def getUnsortedPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = Future.successful(Nil)
   }
   object TestOphan extends Ophan {
-    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = ???
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] = ???
   }
 
   val templating = new EditionsTemplating(TestEdition.templates, TestCapi, TestOphan)

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -17,7 +17,7 @@ object TestEdition {
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = -1,
-        endOffset= -2)
+        endOffset= 2)
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -21,7 +21,7 @@ object TestEdition {
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
-    2
+    None
   )
 
   lazy val templates: Map[Edition, EditionTemplate] = Map(Edition.TrainingEdition -> template)

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -14,13 +14,14 @@ object TestEdition {
       FrontCulture.front -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs)),
       FrontSpecialSpecial2.front -> Daily(),
     ),
-    zoneId = ZoneId.of("Europe/London"),
-    availability = Daily(),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = -1,
         endOffset= 2)
-    )
+    ),
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily(),
+    2
   )
 
   lazy val templates: Map[Edition, EditionTemplate] = Map(Edition.TrainingEdition -> template)
@@ -36,7 +37,8 @@ object FrontTopStories {
   val front = FrontTemplate(
     name = "Top Stories",
     collections = List(collectionTopStories),
-    presentation = defaultFrontPresentation
+    presentation = defaultFrontPresentation,
+    None
   )
 }
 
@@ -59,7 +61,8 @@ object FrontNewsUkGuardian {
   val front = FrontTemplate(
     name = "UK News",
     collections = List(collectionNewsFrontPage, collectionNewsUkNewsGuardian, collectionNewsWeather),
-    presentation = defaultFrontPresentation
+    presentation = defaultFrontPresentation,
+    None
   )
 }
 
@@ -83,7 +86,8 @@ object FrontNewsUkGuardianSaturday {
   val front = FrontTemplate(
     name = "UK News",
     collections = List(collectionNewsFrontPage, collectionNewsSpecial1, collectionNewsWeather),
-    presentation = defaultFrontPresentation
+    presentation = defaultFrontPresentation,
+    None
   )
 }
 
@@ -101,7 +105,8 @@ object FrontCulture {
   val front = FrontTemplate(
     name = "Culture",
     collections = List(collectionCultureArts, collectionCultureTVandRadio),
-    presentation = defaultFrontPresentation
+    presentation = defaultFrontPresentation,
+    None
   )
 }
 
@@ -116,6 +121,7 @@ object FrontSpecialSpecial2 {
     name = "Special 2",
     collections = List(collectionSpecialSpecial2),
     presentation = defaultFrontPresentation,
+    None,
     hidden = true
   )
 }

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -17,7 +17,7 @@ object TestEdition {
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = -1,
-        endOffset= 2)
+        endOffset= -2)
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -7,8 +7,8 @@ import com.gu.facia.api.utils.ResolvedMetaData
 import fixtures.TestEdition
 import model.editions.{ArticleMetadata, Edition, Image, MediaType}
 import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
-import services.Capi
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
+import services.{Capi, Ophan, OphanScore}
 
 import scala.concurrent.Future
 
@@ -17,17 +17,41 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
   val allFalseMetadata = ResolvedMetaData(false, false, false, false, false, false, false, false, false, false, false, false, false, false)
   val imageUrl = "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif"
 
+  val nullOphan = new Ophan {
+    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = Future.successful(None)
+  }
+
+  val forwardOphan = new Ophan {
+    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = Future.successful(Some(
+      Array(
+        OphanScore("webUrl123456", 3d),
+        OphanScore("webUrl345678", 2d),
+        OphanScore("webUrl574893", 1d)
+      )
+    ))
+  }
+
+  val reverseOphan = new Ophan {
+    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = Future.successful(Some(
+      Array(
+        OphanScore("webUrl123456", 1d),
+        OphanScore("webUrl345678", 2d),
+        OphanScore("webUrl574893", 3d)
+      )
+    ))
+  }
+
   val fakeCapi = new Capi {
     def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)] = ???
 
-    def getPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = {
-
+    def getUnsortedPrefillArticleItems(prefillParams: PrefillParamsAdapter): Future[List[Prefill]] = {
       import prefillParams._
-
       capiPrefillQuery.queryString match {
         case "?tag=theguardian/mainsection/topstories" => Future.successful(List(
           Prefill(
             123456,
+            None,
+            "webUrl123456",
             allFalseMetadata.copy(
               showByline = false,
               showQuotedHeadline = false,
@@ -41,6 +65,8 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
         case "?tag=theguardian/g2/arts" => Future.successful(List(
           Prefill(
             345678,
+            None,
+            "webUrl345678",
             allFalseMetadata.copy(
               showByline = true,
               showQuotedHeadline = true,
@@ -52,6 +78,8 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
             None),
           Prefill(
             574893,
+            None,
+            "webUrl574893",
             allFalseMetadata.copy(
               showByline = true,
               showQuotedHeadline = true,
@@ -69,8 +97,8 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
   }
 
   "Creating a template" - {
-    "Sets the prefill metadata from CAPI for Culture 1" in {
-      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
+    "Sets the prefill metadata from CAPI for Culture 1, with no ordering" in {
+      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi, nullOphan)
       val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
 
       issue.fronts.size shouldBe 4
@@ -94,8 +122,36 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
         Image(None, None, "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif", "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif")
 
     }
+
+
+    "Sets the prefill metadata from CAPI for Culture 1, with reverse ordering" in {
+      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi, reverseOphan)
+      val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
+      issue.fronts.size shouldBe 4
+      val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
+      arts.items.size shouldBe 2
+
+      val arts1 = arts.items.head
+      arts1.pageCode shouldBe "574893"
+
+    }
+
+
+    "Sets the prefill metadata from CAPI for Culture 1, with forward ordering" in {
+      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi, forwardOphan)
+      val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
+      issue.fronts.size shouldBe 4
+      val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
+      arts.items.size shouldBe 2
+
+      val arts1 = arts.items.head
+      arts1.pageCode shouldBe "345678"
+
+    }
+
+
     "Sets the prefill metadata from CAPI for Culture 2" in {
-      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
+      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi, nullOphan)
       val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
       issue.fronts.size shouldBe 4
       val arts = issue.fronts.find(_.name == "Culture").value.collections.find(_.name == "Arts").value
@@ -118,7 +174,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
     }
 
     "Sets the prefill metadata from CAPI for UK News" in {
-      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi)
+      val templating = new EditionsTemplating(TestEdition.templates, fakeCapi, nullOphan)
       val issue = templating.generateEditionTemplate(Edition.TrainingEdition, LocalDate.of(2019, 9, 30)).right.value
       issue.fronts.size shouldBe 4
       val frontPage = issue.fronts.find(_.name == "UK News").value.collections.find(_.name == "Front Page").value

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.contentapi.client.model.v1.SearchResponse
 import com.gu.facia.api.utils.ResolvedMetaData
 import fixtures.TestEdition
-import model.editions.{ArticleMetadata, Edition, Image, MediaType, TimeWindowConfigInDays}
+import model.editions.{ArticleMetadata, Edition, Image, MediaType, OphanQueryPrefillParams, TimeWindowConfigInDays}
 import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
 import services.{Capi, Ophan, OphanScore}
@@ -17,12 +17,12 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
   val allFalseMetadata = ResolvedMetaData(false, false, false, false, false, false, false, false, false, false, false, false, false, false)
   val imageUrl = "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif"
 
-  val nullOphan = new Ophan {
-    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = Future.successful(None)
+  private val nullOphan = new Ophan {
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] = Future.successful(None)
   }
 
-  val forwardOphan = new Ophan {
-    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
+  private val forwardOphan = new Ophan {
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
       Array(
         OphanScore("webUrl123456", 3d),
         OphanScore("webUrl345678", 2d),
@@ -32,7 +32,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
   }
 
   val reverseOphan = new Ophan {
-    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
       Array(
         OphanScore("webUrl123456", 1d),
         OphanScore("webUrl345678", 2d),

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.contentapi.client.model.v1.SearchResponse
 import com.gu.facia.api.utils.ResolvedMetaData
 import fixtures.TestEdition
-import model.editions.{ArticleMetadata, Edition, Image, MediaType}
+import model.editions.{ArticleMetadata, Edition, Image, MediaType, TimeWindowConfigInDays}
 import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
 import services.editions.prefills.{Prefill, PrefillParamsAdapter}
 import services.{Capi, Ophan, OphanScore}
@@ -18,11 +18,11 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
   val imageUrl = "https://media.giphy.com/media/K3PYNk8oh3HGM/source.gif"
 
   val nullOphan = new Ophan {
-    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = Future.successful(None)
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = Future.successful(None)
   }
 
   val forwardOphan = new Ophan {
-    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = Future.successful(Some(
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
       Array(
         OphanScore("webUrl123456", 3d),
         OphanScore("webUrl345678", 2d),
@@ -32,7 +32,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
   }
 
   val reverseOphan = new Ophan {
-    override def getOphanScores(maybeUrl: Option[String], startDate: LocalDate, endDate: LocalDate): Future[Option[Array[OphanScore]]] = Future.successful(Some(
+    override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, timeWindow: Option[TimeWindowConfigInDays]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
       Array(
         OphanScore("webUrl123456", 1d),
         OphanScore("webUrl345678", 2d),

--- a/test/services/editions/prefills/PrefillHelperTest.scala
+++ b/test/services/editions/prefills/PrefillHelperTest.scala
@@ -24,7 +24,7 @@ class PrefillHelperTest extends FunSuite with Matchers {
 
     val prefillQuery = CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)
 
-    val prefillParams = PrefillParamsAdapter(issueDate, prefillQuery, Edition.TrainingEdition)
+    val prefillParams = PrefillParamsAdapter(issueDate, prefillQuery, None, 0l, Edition.TrainingEdition)
 
     val fields = List(
       "newspaperEditionDate",

--- a/test/services/editions/prefills/PrefillHelperTest.scala
+++ b/test/services/editions/prefills/PrefillHelperTest.scala
@@ -34,7 +34,15 @@ class PrefillHelperTest extends FunSuite with Matchers {
 
     val actual = prefillHelper.geneneratePrefillQuery(prefillParams, fields).getUrl("")
 
-    val expected = "/content/print-sent?order-by=newest&page-size=200&tag=theguardian%2Fmainsection%2Ftopstories&to-date=2019-10-07T00%3A00%3A00Z&page=1&use-date=newspaper-edition&show-fields=newspaperEditionDate%2CnewspaperPageNumber%2CinternalPageCode&from-date=2019-10-04T00%3A00%3A00Z"
+    val expected = "/content/print-sent" +
+      "?order-by=newest" +
+      "&page-size=200" +
+      "&tag=theguardian%2Fmainsection%2Ftopstories" +
+      "&to-date=2019-10-07T00%3A00%3A00Z" +
+      "&page=1" +
+      "&use-date=newspaper-edition" +
+      "&show-fields=newspaperEditionDate%2CnewspaperPageNumber%2CinternalPageCode" +
+      "&from-date=2019-10-04T00%3A00%3A00Z"
 
     actual shouldEqual expected
   }

--- a/test/services/editions/prefills/PrefillHelperTest.scala
+++ b/test/services/editions/prefills/PrefillHelperTest.scala
@@ -24,7 +24,7 @@ class PrefillHelperTest extends FunSuite with Matchers {
 
     val prefillQuery = CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)
 
-    val prefillParams = PrefillParamsAdapter(issueDate, prefillQuery, None, 0l, Edition.TrainingEdition)
+    val prefillParams = PrefillParamsAdapter(issueDate, prefillQuery, None, None, Edition.TrainingEdition)
 
     val fields = List(
       "newspaperEditionDate",


### PR DESCRIPTION
## What's changed?
On Edition creation, if an Ophan address is provided, sort the capi prefill query by Ophan promotion metric.  If no Ophan address is provided, or no search results are found, fall back to sort by newpaper page number.

## Implementation notes
Nonw
## Checklist

### General
- [ X] 🤖 Relevant tests added
- [ X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [X ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
