### PR TITLE
Add territories list to collection config form

### DIFF
--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.facia.client.models.{Metadata, Trail}
+import com.gu.facia.client.models.{Metadata, TargetedTerritory, Trail}
 import model.{Cached, FeatureSwitch, UserDataForDefaults}
 import permissions.Permissions
 import play.api.libs.json.{JsValue, Json}
@@ -12,25 +12,26 @@ object Defaults {
 }
 
 case class Defaults(
-  dev: Boolean,
-  env: String,
-  editions: Seq[String],
-  email: String,
-  avatarUrl: Option[String],
-  firstName: String,
-  lastName: String,
-  sentryPublicDSN: String,
-  mediaBaseUrl: String,
-  apiBaseUrl: String,
-  switches: JsValue,
-  acl: AclJson,
-  collectionCap: Int,
-  navListCap: Int,
-  navListType: String,
-  collectionMetadata: Iterable[Metadata],
-  userData: Option[UserDataForDefaults],
-  capiLiveUrl: String = "",
-  capiPreviewUrl: String = ""
+                     dev: Boolean,
+                     env: String,
+                     editions: Seq[String],
+                     email: String,
+                     avatarUrl: Option[String],
+                     firstName: String,
+                     lastName: String,
+                     sentryPublicDSN: String,
+                     mediaBaseUrl: String,
+                     apiBaseUrl: String,
+                     switches: JsValue,
+                     acl: AclJson,
+                     collectionCap: Int,
+                     navListCap: Int,
+                     navListType: String,
+                     collectionMetadata: Iterable[Metadata],
+                     userData: Option[UserDataForDefaults],
+                     capiLiveUrl: String = "",
+                     capiPreviewUrl: String = "",
+                     availableTerritories: Iterable[TargetedTerritory] = Nil
 )
 
 class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
@@ -63,7 +64,8 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
         Metadata.tags.map{
           case (_, meta) => meta
         },
-        None
+        None,
+        availableTerritories = TargetedTerritory.allTerritories
       )))
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.0",
+    "com.gu" %% "fapi-client-play26" % "3.0.8",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.0",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -11,6 +11,7 @@ import fullTrim from 'utils/full-trim';
 import populateObservables from 'utils/populate-observables';
 import urlAbsPath from 'utils/url-abs-path';
 import isPlatformSpecificCollection from 'utils/platform';
+import getAvailableTerritories from 'utils/get-available-territories';
 import CONST from 'constants/defaults';
 
 export default class ConfigCollection extends DropTarget {
@@ -19,8 +20,11 @@ export default class ConfigCollection extends DropTarget {
 
         this.id = opts.id;
 
+        const defaults = vars.model.state().defaults;
+
         this.parents = ko.observableArray(findParents(opts.id));
         this.userVisibilities = CONST.userVisibilities;
+        this.availableTerritories = getAvailableTerritories(defaults);
 
         this.meta = Object.assign(
             asObservableProps([
@@ -42,7 +46,8 @@ export default class ConfigCollection extends DropTarget {
                 'metadata',
                 'platform',
                 'frontsToolSettings',
-                'userVisibility'
+                'userVisibility',
+                'targetedTerritory'
             ]),
             {
                 displayHints: asObservableProps([

--- a/public/src/js/utils/get-available-territories.js
+++ b/public/src/js/utils/get-available-territories.js
@@ -1,0 +1,3 @@
+export default function (defaults) {
+    return defaults.availableTerritories ? defaults.availableTerritories : [];
+}

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -238,12 +238,18 @@
                 <span class="cnf-form__value" data-bind="text: meta.groups"></span>
             <!-- /ko -->
             <label for="userVisibility">User visibility</label>
-            <select data-bind="
+            <select id="userVisibility" data-bind="
                 optionsCaption: 'Select user visibility',
                 options: userVisibilities,
                 value: meta.userVisibility,
                 valueAllowUnset: true"></select>
 
+            <label for="targetedTerritory">Target territory</label>
+            <select id="targetedTerritory" data-bind="
+                optionsCaption: 'Select territory',
+                options: availableTerritories,
+                value: meta.targetedTerritory,
+                valueAllowUnset: true"></select>
 
             <label for="showTags" >Show tag kickers</label>
             <input id="showTags" type="checkbox" data-bind="checked: meta.showTags" />

--- a/test/config/TransformationsSpec.scala
+++ b/test/config/TransformationsSpec.scala
@@ -55,6 +55,7 @@ class TransformationsSpec extends FlatSpec with Matchers {
     None,
     None,
     None,
+    None,
     None
   )
 

--- a/test/services/CollectionServiceTest.scala
+++ b/test/services/CollectionServiceTest.scala
@@ -68,6 +68,7 @@ class CollectionServiceTest extends FreeSpec with Matchers {
     hideShowMore = None,
     displayHints = None,
     userVisibility = None,
+    targetedTerritory = None,
     platform = None,
     frontsToolSettings = None)
   }


### PR DESCRIPTION
Gentle reader -- this PR is in draft until https://github.com/guardian/facia-scala-client/pull/223 is merged, as it won't compile until the new types are available. You're still more than welcome to review 👍 

## What's changed?

This PR adds the territories list to the collection config form, deriving the list of available territories from the relevant object supplied by `facia-scala-client`.

The new types are added in https://github.com/guardian/facia-scala-client/pull/223.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
