### PR TITLE
display Edition name again

### DIFF
--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -59,7 +59,7 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
       <>
         <ManageLink to={urls.manageEditions}>
           <EditionIssueInfo>
-            <EditionTitle>{startCase(editionsIssue.displayName)}</EditionTitle>
+            <EditionTitle>{startCase(editionsIssue.edition)}</EditionTitle>
             <EditionDate>
               {new Date(editionsIssue.issueDate).toDateString()}
             </EditionDate>

--- a/client-v2/src/components/Editions/Issue.tsx
+++ b/client-v2/src/components/Editions/Issue.tsx
@@ -29,7 +29,7 @@ const Issue = (props: IssueProps) => {
         <tbody>
           <tr>
             <td>Issue name: </td>
-            <td>{props.issue.displayName}</td>
+            <td>{props.issue.edition}</td>
           </tr>
           <tr>
             <td>Issue date:</td>

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -27,7 +27,7 @@ interface EditionsFront {
 
 interface EditionsIssue {
   id: string;
-  displayName: string;
+  edition: string;
   issueDate: string; // YYYY-MM-dd
   createdOn: number;
   createdBy: string;


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
We renamed `displayName` to `edition` in #999 - this updates the client side model to reflect that.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

Typescript told me all the places to change 😍.

**Before**
![image](https://user-images.githubusercontent.com/836140/66945695-63401880-f047-11e9-9066-80f2e086e261.png)

![image](https://user-images.githubusercontent.com/836140/66945709-6affbd00-f047-11e9-9af3-c8e8d2159c21.png)

**After**
![image](https://user-images.githubusercontent.com/836140/66945659-53c0cf80-f047-11e9-96e6-c02137a05f21.png)

![image](https://user-images.githubusercontent.com/836140/66945611-3ee43c00-f047-11e9-9f66-1c5f857d38b3.png)


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
