### PR TITLE
Only create a snap link from a Guardian URL when we have whitelisted query params

### DIFF
--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -1,7 +1,11 @@
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
-import { createArticleEntitiesFromDrop, cardsReceived } from '../Cards';
+import {
+  createArticleEntitiesFromDrop,
+  cardsReceived,
+  hasGuMetaData
+} from '../Cards';
 import initialState from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { createSnap, createLatestSnap } from 'shared/util/snap';
@@ -215,6 +219,19 @@ describe('Snap cards actions', () => {
           })
         );
       });
+    });
+    describe('should be able to identify when query params match expect gu meta data', () =>
+      it('should return true if there are query params matching the whitelist', () => {
+        const url =
+          'https://www.theguardian.com?gu-snapType=json.html&gu-snapUri=https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json';
+        const result = hasGuMetaData(url);
+        expect(result).toEqual(true);
+      }));
+    it('should return false if there are query params not matching the whitelist', () => {
+      const url =
+        'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B"source"%3A"EMAIL"%2C"campaignCode"%3A"climate_pledge_2019"%2C"componentId"%3A"climate_pledge_2019_acq_GTodayUK"%7D&INTCMP=climate_pledge_2019&';
+      const result = hasGuMetaData(url);
+      expect(result).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Given a guardian.com link with query parameters that do not match one or more of the snap link query parameters whitelist, the Fronts tool created a malformed snap link.

**Before:**

![Screenshot 2019-10-18 at 14 15 44](https://user-images.githubusercontent.com/12645938/67097374-e1203300-f1b1-11e9-817c-c3a556ae53c3.png)

The URL becomes malformed as https://www.theguardian.comenvironment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019 (missing slash between .com and environment). This also happened with snap pages like https://www.theguardian.com/football/live which the tool converted to https://www.theguardian.comfootball/live (again, missing slash between .com and football).

**After:**

![Screenshot 2019-10-18 at 14 16 09](https://user-images.githubusercontent.com/12645938/67097372-e0879c80-f1b1-11e9-9ce6-d35b5383481d.png)

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
The tool now rationalises about whether the query params provided with a guardian.com link are the params we'd expect with a snap. If one or more of the params match the whitelist, it is treated as a normal snap. If they don't, the params are ignored.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included

