### PR TITLE
SNAP LINKS: Allow marketing urls in particular format

### DIFF
--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -4,7 +4,9 @@ import thunk from 'redux-thunk';
 import {
   createArticleEntitiesFromDrop,
   cardsReceived,
-  hasGuMetaData
+  hasWhitelistedParams,
+  snapMetaWhitelist,
+  marketingParamsWhiteList
 } from '../Cards';
 import initialState from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
@@ -224,14 +226,24 @@ describe('Snap cards actions', () => {
       it('should return true if there are query params matching the whitelist', () => {
         const url =
           'https://www.theguardian.com?gu-snapType=json.html&gu-snapUri=https://interactive.guim.co.uk/atoms/2019/03/29/unmeaningful-vote/snap/snap.json';
-        const result = hasGuMetaData(url);
+        const result = hasWhitelistedParams(url, snapMetaWhitelist);
         expect(result).toEqual(true);
       }));
     it('should return false if there are query params not matching the whitelist', () => {
       const url =
         'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B"source"%3A"EMAIL"%2C"campaignCode"%3A"climate_pledge_2019"%2C"componentId"%3A"climate_pledge_2019_acq_GTodayUK"%7D&INTCMP=climate_pledge_2019&';
-      const result = hasGuMetaData(url);
+      const result = hasWhitelistedParams(url, snapMetaWhitelist);
       expect(result).toEqual(false);
     });
   });
+  describe('should be able to identify when a guardian url has marketing params', () =>
+    it('should just pass through gu urls with markting params that match a whitelist', () => {
+      const url =
+        'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B"source"%3A"EMAIL"%2C"campaignCode"%3A"climate_pledge_2019"%2C"componentId"%3A"climate_pledge_2019_acq_GTodayUK"%7D&INTCMP=climate_pledge_2019&';
+      const result = hasWhitelistedParams(url, snapMetaWhitelist);
+      expect(result).toEqual(false);
+    })
+  )
+
+
 });

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -235,15 +235,20 @@ describe('Snap cards actions', () => {
       const result = hasWhitelistedParams(url, snapMetaWhitelist);
       expect(result).toEqual(false);
     });
+
+    describe('should be able to identify when a guardian url has marketing params', () => {
+      it('should return true for gu urls with markting params that match a whitelist', () => {
+        const url =
+          'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B"source"%3A"EMAIL"%2C"campaignCode"%3A"climate_pledge_2019"%2C"componentId"%3A"climate_pledge_2019_acq_GTodayUK"%7D&INTCMP=climate_pledge_2019&';
+        const result = hasWhitelistedParams(url, marketingParamsWhiteList);
+        expect(result).toEqual(true);
+      });
+      it('should return false for gu urls with markting params that do not match a whitelist', () => {
+        const url =
+          'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?mygreatparam=hellllooo';
+        const result = hasWhitelistedParams(url, marketingParamsWhiteList);
+        expect(result).toEqual(false);
+      });
+    });
   });
-  describe('should be able to identify when a guardian url has marketing params', () =>
-    it('should just pass through gu urls with markting params that match a whitelist', () => {
-      const url =
-        'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B"source"%3A"EMAIL"%2C"campaignCode"%3A"climate_pledge_2019"%2C"componentId"%3A"climate_pledge_2019_acq_GTodayUK"%7D&INTCMP=climate_pledge_2019&';
-      const result = hasWhitelistedParams(url, snapMetaWhitelist);
-      expect(result).toEqual(false);
-    })
-  )
-
-
 });


### PR DESCRIPTION
## What's changed?

Marketing sometimes want to include guardian urls that have query params that are not in the standard `gu-` format.

This allows a new format of query params on guardian urls. It whitelists 

If these params are present it simply passes on the whole url, params and all. 

Example:
```
https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B"source"%3A"EMAIL"%2C"campaignCode"%3A"climate_pledge_2019"%2C"componentId"%3A"climate_pledge_2019_acq_GTodayUK"%7D&INTCMP=climate_pledge_2019&
```

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
