### PR TITLE
More accurate logging and status code for /stories-visible endpoint

### DIFF
--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -20,7 +20,7 @@ class StoriesVisibleController(val containerService: ContainerService, val deps:
     logger.info(s"got stories-visible=$storiesVisible for containerType=$containerType")
 
     storiesVisible.map { storiesVisibleResponse => Ok(Json.toJson(storiesVisibleResponse)) } getOrElse {
-      val errorMSG = s"$containerType is not a valid container id"
+      val errorMSG = s"'$containerType' is not a valid container id"
       logger.error(errorMSG)
       BadRequest(errorMSG)
     }

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -1,8 +1,9 @@
 package controllers
 
+import logging.Logging
 import play.api.libs.json.Json
-import services.{ ContainerService }
-import slices.{ Story }
+import services.ContainerService
+import slices.Story
 
 object StoriesVisibleRequest {
   implicit val jsonFormat = Json.format[StoriesVisibleRequest]
@@ -12,12 +13,16 @@ case class StoriesVisibleRequest(
   stories: Seq[Story]
 )
 
-class StoriesVisibleController(val containerService: ContainerService, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
+class StoriesVisibleController(val containerService: ContainerService, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) with Logging {
   def storiesVisible(containerType: String) = AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
     val storiesVisible = containerService.getStoriesVisible(containerType, request.body.stories)
 
+    logger.info(s"got stories-visible=$storiesVisible for containerType=$containerType")
+
     storiesVisible.map { storiesVisibleResponse => Ok(Json.toJson(storiesVisibleResponse)) } getOrElse {
-      NotFound(s"$containerType is not a valid container id")
+      val errorMSG = s"$containerType is not a valid container id"
+      logger.error(errorMSG)
+      BadRequest(errorMSG)
     }
   }
 }

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -20,7 +20,7 @@ class StoriesVisibleController(val containerService: ContainerService, val deps:
     logger.info(s"got stories-visible=$storiesVisible for containerType=$containerType")
 
     storiesVisible.map { storiesVisibleResponse => Ok(Json.toJson(storiesVisibleResponse)) } getOrElse {
-      val errorMSG = s"'$containerType' is not a valid container id"
+      val errorMSG = s"'$containerType' is not a valid container type"
       logger.error(errorMSG)
       BadRequest(errorMSG)
     }

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -115,6 +115,9 @@ async function fetchVisibleArticles(
   collectionType: string,
   articles: ArticleDetails[]
 ): Promise<VisibleArticlesResponse> {
+  if (!collectionType || collectionType == ''){
+    throw new Error(`collectionType='${collectionType}' is undefined or empty`);
+  }
   // The server does not respond with JSON
   try {
     const response = await pandaFetch(`/stories-visible/${collectionType}`, {
@@ -128,7 +131,7 @@ async function fetchVisibleArticles(
     return await response.json();
   } catch (response) {
     throw new Error(
-      `Tried to fetch visible stories for collection type ${collectionType}, but the server responded with ${
+      `Tried to fetch visible stories for collection type '${collectionType}', but the server responded with ${
         response.status
       }: ${response.body}`
     );

--- a/client-v2/src/services/faciaApi.ts
+++ b/client-v2/src/services/faciaApi.ts
@@ -115,7 +115,7 @@ async function fetchVisibleArticles(
   collectionType: string,
   articles: ArticleDetails[]
 ): Promise<VisibleArticlesResponse> {
-  if (!collectionType || collectionType == ''){
+  if (!collectionType || collectionType === '') {
     throw new Error(`collectionType='${collectionType}' is undefined or empty`);
   }
   // The server does not respond with JSON


### PR DESCRIPTION
More accurate logging and status code for /stories-visible endpoint
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

- logging added to StoriesVisibleController for `/stories-visible` endpoint
- if container id is invalid return bad-request not `Not-Found` status

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [x] 🔍 Checked on CODE
