### PR TITLE
GEOTARGETING: add territory to collection and display on frontend

### DIFF
--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -6,7 +6,7 @@ import com.gu.scanamo.syntax._
 import model.{FeatureSwitch, UserData, UserDataForDefaults}
 
 import scala.concurrent.ExecutionContext
-import com.gu.facia.client.models.Metadata
+import com.gu.facia.client.models.{Metadata, TargetedTerritory}
 import permissions.Permissions
 import play.api.libs.json.Json
 import switchboard.SwitchManager
@@ -71,7 +71,8 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps
       },
       Some(userDataForDefaults),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
-      routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true)
+      routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true),
+      TargetedTerritory.allTerritories
     )
 
     Ok(views.html.V2App.app(

--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -220,9 +220,9 @@ trait UpdateActionsTrait {
   def createCollectionJson(identity: User, update: UpdateList): CollectionJson = {
     val userName = getUserName(identity)
     if (update.live)
-      CollectionJson(List(Trail(update.item, DateTime.now.getMillis, Some(userName), update.itemMeta)), None, None, DateTime.now, userName, identity.email, None, None, None)
+      CollectionJson(List(Trail(update.item, DateTime.now.getMillis, Some(userName), update.itemMeta)), None, None, DateTime.now, userName, identity.email, None, None, None, None)
     else
-      CollectionJson(Nil, Some(List(Trail(update.item, DateTime.now.getMillis, Some(userName), update.itemMeta))), None, DateTime.now, userName, identity.email, None, None, None)
+      CollectionJson(Nil, Some(List(Trail(update.item, DateTime.now.getMillis, Some(userName), update.itemMeta))), None, DateTime.now, userName, identity.email, None, None, None, None)
   }
 
   def capCollection(collectionJson: CollectionJson, collectionType: String): CollectionJson = {
@@ -276,7 +276,8 @@ trait UpdateActionsTrait {
       updatedEmail  = identity.email,
       displayName   = None,
       href          = None,
-      previously    = None)}
+      previously    = None,
+      targetedTerritory = None)}
 
   def updateTreats(collectionId: String, update: UpdateList, identity: User): Future[Option[CollectionJson]] = {
     lazy val updateJson = Json.toJson(update)

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.8",
+    "com.gu" %% "fapi-client-play26" % "3.0.11",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.0",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",

--- a/client-v2/src/actions/__tests__/Collections.spec.ts
+++ b/client-v2/src/actions/__tests__/Collections.spec.ts
@@ -90,7 +90,11 @@ describe('Collection actions', () => {
     );
 
     it('should add fetched Collections to the store', async () => {
-      const collectionIds = ['testCollection1', 'testCollection2'];
+      const collectionIds = [
+        'testCollection1',
+        'testCollection2',
+        'geoLocatedCollection'
+      ];
       fetchMock.post('/collections', getCollectionsApiResponse);
       await store.dispatch(getCollections(collectionIds) as any);
       expect(store.getState().shared.collections.data).toEqual({
@@ -137,6 +141,21 @@ describe('Collection actions', () => {
           previously: ['uuid'],
           previouslyCardIds: [],
           type: 'type'
+        },
+        geoLocatedCollection: {
+          displayName: 'New Zealand News',
+          draft: ['uuid'],
+          frontsToolSettings: undefined,
+          groups: undefined,
+          id: 'geoLocatedCollection',
+          lastUpdated: 1547479667115,
+          live: ['uuid'],
+          metadata: undefined,
+          platform: undefined,
+          previously: ['uuid'],
+          previouslyCardIds: [],
+          type: 'type',
+          targetedTerritory: 'NZ'
         }
       });
     });
@@ -201,6 +220,21 @@ describe('Collection actions', () => {
           previously: ['uuid'],
           previouslyCardIds: [],
           type: 'type'
+        },
+        geoLocatedCollection: {
+          displayName: 'New Zealand News',
+          draft: ['uuid'],
+          frontsToolSettings: undefined,
+          groups: undefined,
+          id: 'geoLocatedCollection',
+          lastUpdated: 1547479667115,
+          live: ['uuid'],
+          metadata: undefined,
+          platform: undefined,
+          previously: ['uuid'],
+          previouslyCardIds: [],
+          type: 'type',
+          targetedTerritory: 'NZ'
         }
       });
     });

--- a/client-v2/src/fixtures/collectionsEndpointResponse.ts
+++ b/client-v2/src/fixtures/collectionsEndpointResponse.ts
@@ -78,6 +78,22 @@ export const getCollectionsApiResponse = [
       live: { desktop: 4, mobile: 4 },
       draft: { desktop: 4, mobile: 4 }
     }
+  },
+  {
+    id: 'geoLocatedCollection',
+    collection: {
+      displayName: 'geoLocatedCollection',
+      live: ['abc'],
+      draft: ['def'],
+      lastUpdated: 1547479667115,
+      previously: undefined,
+      type: 'type',
+      targetedTerritory: 'NZ'
+    },
+    storiesVisibleByStage: {
+      live: { desktop: 4, mobile: 4 },
+      draft: { desktop: 4, mobile: 4 }
+    }
   }
 ];
 

--- a/client-v2/src/shared/components/Collection.tsx
+++ b/client-v2/src/shared/components/Collection.tsx
@@ -179,6 +179,17 @@ const CollectionShortVerticalPinline = styled(ShortVerticalPinline)`
   left: 0;
 `;
 
+const TargetedTerritoryBox = styled.div`
+  background-color: black;
+  color: white;
+  font-size: 15px;
+  padding: 0 5px;
+  span {
+    font-size: 7px;
+    vertical-align: middle;
+  }
+`;
+
 class CollectionDisplay extends React.Component<Props, CollectionState> {
   public static defaultProps = {
     isUneditable: false,
@@ -212,6 +223,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
     const displayName = collection ? collection.displayName : 'Loading';
+    const targetedTerritory = collection ? collection.targetedTerritory : null;
     return (
       <CollectionContainer
         id={collection && createCollectionId(collection)}
@@ -243,6 +255,12 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
                       {`${collection.platform} Only`}
                     </CollectionConfigText>
                   ) : null}
+                  {targetedTerritory && (
+                    <TargetedTerritoryBox>
+                      {targetedTerritory}
+                      <span> &nbsp;ONLY</span>
+                    </TargetedTerritoryBox>
+                  )}
                 </CollectionConfigContainer>
               </CollectionHeadingText>
             </CollectionHeadlineWithConfigContainer>

--- a/client-v2/src/shared/fixtures/shared.ts
+++ b/client-v2/src/shared/fixtures/shared.ts
@@ -646,6 +646,11 @@ const stateWithCollection: any = {
           testCollection5: {
             displayName: 'testCollection5',
             type: 'type'
+          },
+          geoLocatedCollection: {
+            displayName: 'New Zealand News',
+            type: 'type',
+            targetedTerritory: 'NZ'
           }
         }
       },

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -109,6 +109,7 @@ interface CollectionFromResponse {
   groups?: string[];
   metadata?: Array<{ type: string }>;
   uneditable?: boolean;
+  targetedTerritory?: string;
 }
 
 type CollectionWithNestedArticles = CollectionFromResponse & {
@@ -133,6 +134,7 @@ interface Collection {
   type: string;
   frontsToolSettings?: FrontsToolSettings;
   isHidden?: boolean;
+  targetedTerritory?: string;
 }
 
 interface ArticleTag {

--- a/client-v2/src/types/FaciaApi.ts
+++ b/client-v2/src/types/FaciaApi.ts
@@ -53,6 +53,7 @@ interface CollectionConfigResponse {
   platform?: Platform;
   frontsToolSettings?: FrontsToolSettings;
   prefill?: EditionsPrefill;
+  targetedTerritory?: string;
 }
 
 interface FrontsConfigResponse {

--- a/client-v2/src/util/frontsUtils.ts
+++ b/client-v2/src/util/frontsUtils.ts
@@ -37,7 +37,8 @@ const combineCollectionWithConfig = (
     type: collectionConfig.type,
     frontsToolSettings: collectionConfig.frontsToolSettings,
     platform: collectionConfig.platform,
-    metadata: collectionConfig.metadata
+    metadata: collectionConfig.metadata,
+    targetedTerritory: collectionConfig.targetedTerritory
   });
 };
 

--- a/test/commands/V2GetCollectionsCommandTest.scala
+++ b/test/commands/V2GetCollectionsCommandTest.scala
@@ -26,7 +26,8 @@ class V2GetCollectionsCommandTest extends FreeSpec with Matchers {
       updatedEmail = "",
       displayName = None,
       href = None,
-      previously = None
+      previously = None,
+      targetedTerritory = None
     )
   }
 

--- a/test/services/CollectionServiceTest.scala
+++ b/test/services/CollectionServiceTest.scala
@@ -41,7 +41,7 @@ class CollectionServiceTest extends FreeSpec with Matchers {
   private def collectionJson: CollectionJson = {
     val live = List(Trail("existingId", 0, Some(""), None))
     val draft = Trail("newId", 0, Some(""), None) :: live
-    CollectionJson(live, Some(draft), None, new DateTime(0), "oldUpdatedBy", "oldUpdatedEmail", None, None, None)
+    CollectionJson(live, Some(draft), None, new DateTime(0), "oldUpdatedBy", "oldUpdatedEmail", None, None, None, None)
   }
 
   private def configJson: ConfigJson = {

--- a/test/tools/FaciaApiTest.scala
+++ b/test/tools/FaciaApiTest.scala
@@ -56,7 +56,7 @@ class FaciaApiTest extends FreeSpec with Matchers {
     val identity = User("John", "Duffell", "email@email.com", None)
     val live = List(Trail("existingId", 0, Some(""), None))
     val draft = Trail("newId", 0, Some(""), None) :: live
-    val collectionJson = CollectionJson(live, Some(draft), None, new DateTime(0), "oldUpdatedBy", "oldUpdatedEmail", None, None, None)
+    val collectionJson = CollectionJson(live, Some(draft), None, new DateTime(0), "oldUpdatedBy", "oldUpdatedEmail", None, None, None, None)
     (identity, collectionJson)
   }
 }


### PR DESCRIPTION
## What's changed?

Editorial have requested GeoTargeted collections - that would only be visible in certain geographical areas as determined by Fastly configuration. 

Current supported zones are: NZ, US-EAST-COAST and EU-27. 

The territory is added in the Config tool for a given collection. 

The front-end display now looks like:
![Screenshot 2019-10-22 at 17 57 40](https://user-images.githubusercontent.com/10324129/67311165-fa4d1a80-f4f6-11e9-9965-ad85901fb18d.png)

The json output of a collection that is passed onto Facia-Press now looks like: 

```
"live": [], 
"lastUpdated": 1571761811097,
"updatedBy": "Anna Leach",
"updatedEmail": "Anna.Leach@guardian.co.uk",
"displayName": "beyond-the-blade",
"previously": [],
"targetedTerritory": "NZ"
```

## Implementation notes

This relates to changes in [Facia-Scala-Client](https://github.com/guardian/facia-scala-client/pull/227) (where the zones are set) and models have been updated to send on the territory property. The version of Facia-Scala-Client has to be bumped to `3.0.11`


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
