### PR TITLE
adding capi prefill time window columns int DB

### DIFF
--- a/conf/evolutions/default/9.sql
+++ b/conf/evolutions/default/9.sql
@@ -1,0 +1,19 @@
+# --- !Ups
+
+ALTER TABLE collections ADD COLUMN content_prefill_window_start TIMESTAMPTZ;
+ALTER TABLE collections ADD COLUMN content_prefill_window_end TIMESTAMPTZ;
+UPDATE  collections  SET content_prefill_window_start = CONCAT(cast((select issue_date from edition_issues where edition_issues.id = (select issue_id from fronts where fronts.id = front_id)) as text), ' 01:00:00.00 UTC')::TIMESTAMP where prefill IS NOT NULL;
+UPDATE  collections  SET content_prefill_window_end = CONCAT(cast((select issue_date from edition_issues where edition_issues.id = (select issue_id from fronts where fronts.id = front_id)) as text), ' 01:00:00.00 UTC')::TIMESTAMP where prefill IS NOT NULL;
+
+-- Why [content_prefill_window_start] and [content_prefill_window_end] will be issue_date + 1 hour while migration ?
+-- look at 6.sql issue_date is in GMT+1
+-- [content_prefill_window_start] and [content_prefill_window_end] are in UTC
+-- by using CONCAT ' 01:00:00.00 UTC' we will have issue_date=2019-10-11 and [content_prefill_window_start] and [content_prefill_window_end]=2019-10-11 00:00:00+00
+-- while migration
+-- os it will by like issue_date with start of the day time
+-- otherwise without that CONCAT ' 01:00:00.00 UTC' we may get for example issue_date=2019-10-11 and [content_prefill_window_start] and [content_prefill_window_end]=2019-10-10 23:00:00+00
+
+# --- !Downs
+
+ALTER TABLE collections DROP COLUMN content_prefill_window_start;
+ALTER TABLE collections DROP COLUMN content_prefill_window_end;


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
adding capi prefill time window columns int DB

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
- `content_prefill_window_start` and `content_prefill_window_start` columns added to collections table
- plus migration with comment: 
```
-- Why [content_prefill_window_start] and [content_prefill_window_end] will be issue_date + 1 hour while migration ?
-- look at 6.sql issue_date is in GMT+1
-- [content_prefill_window_start] and [content_prefill_window_end] are in UTC
-- by using CONCAT ' 01:00:00.00 UTC' we will have issue_date=2019-10-11 and [content_prefill_window_start] and [content_prefill_window_end]=2019-10-11 00:00:00+00
-- while migration
-- os it will by like issue_date with start of the day time
-- otherwise without that CONCAT ' 01:00:00.00 UTC' we may get for example issue_date=2019-10-11 and [content_prefill_window_start] and [content_prefill_window_end]=2019-10-10 23:00:00+00
```

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
