### PR TITLE
Be able to Specify useDate param in editions templates config

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -6,7 +6,7 @@ import cats.syntax.either._
 import com.gu.contentapi.json.CirceEncoders._
 import io.circe.syntax._
 import logging.Logging
-import model.editions.{Edition, EditionsFrontMetadata, EditionsFrontendCollectionWrapper, EditionsTemplates}
+import model.editions.{CapiQueryPrefillParams, Edition, EditionsFrontMetadata, EditionsFrontendCollectionWrapper, EditionsTemplates}
 import model.forms._
 import net.logstash.logback.marker.Markers
 import play.api.Logger
@@ -15,7 +15,7 @@ import play.api.mvc.Result
 import services.Capi
 import services.editions.EditionsTemplating
 import services.editions.db.EditionsDB
-import services.editions.prefills.{MetadataForLogging, PrefillParamsAdapter}
+import services.editions.prefills.{ContentPrefillTimeParams, MetadataForLogging, PrefillParamsAdapter}
 import services.editions.publishing.EditionsPublishing
 import services.editions.publishing.PublishedIssueFormatters._
 import util.ContentUpgrade.rewriteBody
@@ -135,10 +135,12 @@ class EditionsController(db: EditionsDB,
     db.getCollectionPrefill(id).map { prefillUpdate =>
       logger.info(s"getPrefillForCollection id=$id, prefillUpdate")
       import prefillUpdate._
+      val useDate = EditionsTemplates.templates(edition).capiQueryPrefillParams.timeWindowConfig.useDate
+      val contentPrefillTimeParams = ContentPrefillTimeParams(contentPrefillTimeWindow, useDate)
       val getPrefillParams = PrefillParamsAdapter(
         issueDate,
         contentPrefillQueryUrlSegments,
-        contentPrefillTimeWindow,
+        contentPrefillTimeParams,
         maybeOphanPath = None,
         maybeOphanQueryPrefillParams = None,
         edition,

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -54,9 +54,13 @@ object Swatch extends PlayEnum[Swatch] {
 sealed abstract class Edition extends EnumEntry with Hyphencase
 
 object Edition extends PlayEnum[Edition] {
+
   case object DailyEdition extends Edition
+
   case object AmericanEdition extends Edition
+
   case object AustralianEdition extends Edition
+
   case object TrainingEdition extends Edition
 
   override def values = findValues
@@ -122,16 +126,21 @@ object PathType extends PlayEnum[PathType] {
 }
 
 case class CollectionTemplate(
-  name: String,
-  prefill: Option[CapiPrefillQuery],
-  presentation: CollectionPresentation,
-  hidden: Boolean = false
-) {
+                               name: String,
+                               prefill: Option[CapiPrefillQuery],
+                               presentation: CollectionPresentation,
+                               hidden: Boolean = false
+                             ) {
   def special = copy(hidden = true)
+
   def withPresentation(presentation: CollectionPresentation) = copy(presentation = presentation)
+
   def printSentPrefill(prefillQuery: String) = copy(prefill = Some(CapiPrefillQuery(prefillQuery, PrintSent)))
+
   def printSentAnyTag(tags: String*) = printSentPrefill(s"?tag=${tags.mkString("|")}")
+
   def printSentAllTags(tags: String*) = printSentPrefill(s"?tag=${tags.mkString(",")}")
+
   def searchPrefill(prefillQuery: String) = copy(prefill = Some(CapiPrefillQuery(prefillQuery, Search)))
 }
 
@@ -142,38 +151,60 @@ case class FrontTemplate(
                           maybeOphanPath: Option[String],
                           isSpecial: Boolean = false,
                           hidden: Boolean = false
-) {
+                        ) {
   def special = copy(isSpecial = true, hidden = true)
+
   def swatch(swatch: Swatch) = copy(presentation = FrontPresentation(swatch))
 }
 
-case class TimeWindowConfigInDays(startOffset: Int, endOffset: Int)
-case class CapiQueryPrefillParams(timeWindowConfig: TimeWindowConfigInDays)
+sealed abstract class UseDateQueryParamValue extends EnumEntry with Hyphencase with Uncapitalised
+
+object UseDateQueryParamValue extends PlayEnum[UseDateQueryParamValue] {
+
+  case object NewspaperEdition extends UseDateQueryParamValue
+
+  case object Published extends UseDateQueryParamValue
+
+  override def values = findValues
+}
+
+trait BaseTimeWindowConfig {
+  def startOffset: Int
+
+  def endOffset: Int
+}
+
+case class TimeWindowConfigInDays(startOffset: Int, endOffset: Int) extends BaseTimeWindowConfig
+
+case class CapiTimeWindowConfigInDays(startOffset: Int, endOffset: Int, useDate: UseDateQueryParamValue) extends BaseTimeWindowConfig
+
+case class CapiQueryPrefillParams(timeWindowConfig: CapiTimeWindowConfigInDays)
+
 case class OphanQueryPrefillParams(apiKey: String, timeWindowConfig: TimeWindowConfigInDays)
 
 case class EditionTemplate(
-  fronts: List[(FrontTemplate, Periodicity)],
-  capiQueryPrefillParams: CapiQueryPrefillParams,
-  zoneId: ZoneId,
-  availability: Periodicity,
-  ophanQueryPrefillParams: Option[OphanQueryPrefillParams]
-)
+                            fronts: List[(FrontTemplate, Periodicity)],
+                            capiQueryPrefillParams: CapiQueryPrefillParams,
+                            zoneId: ZoneId,
+                            availability: Periodicity,
+                            ophanQueryPrefillParams: Option[OphanQueryPrefillParams]
+                          )
 
 // Issue skeletons are what is generated when you create a new issue for a given date
 // (Date + Template) => Skeleton
 case class EditionsIssueSkeleton(
-  issueDate: LocalDate,
-  zoneId: ZoneId,
-  fronts: List[EditionsFrontSkeleton]
-)
+                                  issueDate: LocalDate,
+                                  zoneId: ZoneId,
+                                  fronts: List[EditionsFrontSkeleton]
+                                )
 
 case class EditionsFrontSkeleton(
-  name: String,
-  collections: List[EditionsCollectionSkeleton],
-  presentation: FrontPresentation,
-  hidden: Boolean,
-  isSpecial: Boolean
-) {
+                                  name: String,
+                                  collections: List[EditionsCollectionSkeleton],
+                                  presentation: FrontPresentation,
+                                  hidden: Boolean,
+                                  isSpecial: Boolean
+                                ) {
   def metadata() = {
     val metadataParam = new PGobject()
     metadataParam.setType("jsonb")
@@ -184,14 +215,14 @@ case class EditionsFrontSkeleton(
 
 
 case class EditionsCollectionSkeleton(
-  name: String,
-  items: List[EditionsArticleSkeleton],
-  prefill: Option[CapiPrefillQuery],
-  presentation: CollectionPresentation,
-  hidden: Boolean
-)
+                                       name: String,
+                                       items: List[EditionsArticleSkeleton],
+                                       prefill: Option[CapiPrefillQuery],
+                                       presentation: CollectionPresentation,
+                                       hidden: Boolean
+                                     )
 
 case class EditionsArticleSkeleton(
-  pageCode: String,
-  metadata: ArticleMetadata
-)
+                                    pageCode: String,
+                                    metadata: ArticleMetadata
+                                  )

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -60,7 +60,7 @@ object AmericanEdition {
       timeWindowConfig = CapiTimeWindowConfigInDays(
         startOffset = 0,
         endOffset = 0,
-        useDate =UseDateQueryParamValue.NewspaperEdition
+        useDate = UseDateQueryParamValue.NewspaperEdition
       )
     ),
     zoneId = ZoneId.of("Europe/London"),

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -57,9 +57,11 @@ object AmericanEdition {
       FrontCrosswords -> Daily(),
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
-      timeWindowConfig = TimeWindowConfigInDays(
+      timeWindowConfig = CapiTimeWindowConfigInDays(
         startOffset = 0,
-        endOffset = 0)
+        endOffset = 0,
+        useDate =UseDateQueryParamValue.NewspaperEdition
+      )
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -20,9 +20,10 @@ object AustralianEdition {
       FrontCrosswordsAu -> WeekDays(List(WeekDay.Sat))
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
-      timeWindowConfig = TimeWindowConfigInDays(
+      timeWindowConfig = CapiTimeWindowConfigInDays(
         startOffset = -6,
-        endOffset = 0
+        endOffset = 0,
+        useDate = UseDateQueryParamValue.Published
       )
     ),
     zoneId = ZoneId.of("Europe/London"),
@@ -31,7 +32,7 @@ object AustralianEdition {
       apiKey = "fronts-editions-au",
       timeWindowConfig = TimeWindowConfigInDays(
         startOffset = -6,
-        endOffset = 0
+        endOffset = 0,
       ))
     )
   )

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -57,9 +57,11 @@ object DailyEdition {
       FrontCrosswords -> Daily(),
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
-      timeWindowConfig = TimeWindowConfigInDays(
+      timeWindowConfig = CapiTimeWindowConfigInDays(
         startOffset = 0,
-        endOffset = 0)
+        endOffset = 0,
+        useDate = UseDateQueryParamValue.NewspaperEdition
+      )
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),
@@ -83,7 +85,7 @@ object DailyEdition {
     collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
@@ -94,7 +96,7 @@ object DailyEdition {
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2")
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsSpecial = specialFront("News Special", News).swatch(News)
 
@@ -103,7 +105,7 @@ object DailyEdition {
     collection("World News").printSentAnyTag("theguardian/mainsection/international"),
     collection("World Special").special
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
@@ -113,7 +115,7 @@ object DailyEdition {
     collection("Focus").printSentAnyTag("theobserver/news/focus").special,
     collection("News Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
@@ -131,7 +133,7 @@ object DailyEdition {
     collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
     collection("Financial Special").special,
   )
-  .swatch(News)
+    .swatch(News)
 
   def FrontFinancialObserver = front(
     "Financial",
@@ -159,7 +161,7 @@ object DailyEdition {
     collection("Comment 2"),
     collection("Comment Special").special,
   )
-  .swatch(Opinion)
+    .swatch(Opinion)
 
   def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
 
@@ -198,14 +200,14 @@ object DailyEdition {
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
     collection("Culture Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
     collection("Books Special").special,
   )
-  .swatch(Culture)
+    .swatch(Culture)
 
   def FrontCultureSpecial = specialFront("Culture Special", Culture)
 
@@ -234,14 +236,14 @@ object DailyEdition {
     collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life Special").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
     collection("Travel Special").special,
-    )
-  .swatch(Lifestyle);
+  )
+    .swatch(Lifestyle);
 
   def FrontLifeMagazineObserver = front(
     "Life",
@@ -249,7 +251,7 @@ object DailyEdition {
     collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
     collection("Life Special").printSentAnyTag("theobserver/design/design").special,
   )
-  .swatch(Lifestyle)
+    .swatch(Lifestyle)
 
   def FrontFood = front(
     "Food",
@@ -286,7 +288,7 @@ object DailyEdition {
     collection("Sport 3"),
     collection("Sport Special").special,
   )
-  .swatch(Sport)
+    .swatch(Sport)
 
   def FrontSportSpecial = specialFront("Sport Special", Sport)
 

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -16,9 +16,11 @@ object TrainingEdition {
       FrontCrosswords -> Daily(),
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
-      timeWindowConfig = TimeWindowConfigInDays(
+      timeWindowConfig = CapiTimeWindowConfigInDays(
         startOffset = 0,
-        endOffset = 0)
+        endOffset = 0,
+        useDate = UseDateQueryParamValue.NewspaperEdition
+      )
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -148,13 +148,14 @@ object GuardianCapi extends Logging {
       .parse(new URI(contentPrefillUrlSegments.escapedQueryString()), Charset.forName("UTF-8"))
       .asScala
 
+    import contentPrefillTimeParams.{contentPrefillTimeWindow, useDate}
     import contentPrefillTimeWindow.{fromDate, toDate}
 
     var query = CapiQueryGenerator(contentPrefillUrlSegments.pathType)
       .page(1)
       .pageSize(200)
       .showFields(fields.mkString(","))
-      .useDate("newspaper-edition") // deliberately-kebab-case
+      .useDate(useDate.entryName)
       .orderBy("newest")
       .fromDate(fromDate)
       .toDate(toDate)

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -5,7 +5,7 @@ import java.time.{LocalDate, ZoneOffset}
 import logging.Logging
 import model.editions._
 import play.api.mvc.{Result, Results}
-import services.editions.prefills.{CapiQueryTimeWindow, MetadataForLogging, Prefill, PrefillParamsAdapter}
+import services.editions.prefills.{CapiQueryTimeWindow, ContentPrefillTimeParams, MetadataForLogging, Prefill, PrefillParamsAdapter}
 import services.{Capi, Ophan}
 
 import scala.concurrent.Await
@@ -28,9 +28,13 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
           val contentPrefillTimeWindow: CapiQueryTimeWindow = EditionsTemplating
             .defineContentQueryTimeWindow(issueDate, capiQueryPrefillParams.timeWindowConfig)
 
+          val useDate = editionTemplate.capiQueryPrefillParams.timeWindowConfig.useDate
+
           val frontsSkeleton = editionTemplate.fronts
             .filter(_._2.isValid(issueDate))
             .map { case (frontTemplate, _) =>
+
+              val contentPrefillTimeWindowParams = ContentPrefillTimeParams(contentPrefillTimeWindow, useDate)
 
               val editionsCollectionSkeletons = collectionsTemplating.generateCollectionTemplates(
                 frontTemplate.collections,
@@ -38,7 +42,7 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
                 issueDate,
                 editionTemplate,
                 frontTemplate.maybeOphanPath,
-                contentPrefillTimeWindow,
+                contentPrefillTimeWindowParams,
                 ophanQueryPrefillParams)
 
               EditionsFrontSkeleton(
@@ -67,7 +71,7 @@ class EditionsTemplating(templates: PartialFunction[Edition, EditionTemplate], c
 }
 
 object EditionsTemplating {
-  def defineContentQueryTimeWindow(issueDate: LocalDate, timeWindowConfig: TimeWindowConfigInDays): CapiQueryTimeWindow = {
+  def defineContentQueryTimeWindow(issueDate: LocalDate, timeWindowConfig: CapiTimeWindowConfigInDays): CapiQueryTimeWindow = {
     val issueDateStart = issueDate.atStartOfDay()
     // Regarding UTC Hack because composer/capi/whoever doesn't worry about timezones in the newspaper-edition date
     val fromDateUTC = issueDateStart.plusDays(timeWindowConfig.startOffset).toInstant(ZoneOffset.UTC)
@@ -88,7 +92,7 @@ class CollectionTemplatingHelper(capi: Capi, ophan: Ophan) extends Logging {
                                   issueDate: LocalDate,
                                   template: EditionTemplate,
                                   maybeOphanPath: Option[String],
-                                  contentPrefillTimeWindow: CapiQueryTimeWindow,
+                                  contentPrefillTimeParams: ContentPrefillTimeParams,
                                   ophanQueryPrefillParams: Option[OphanQueryPrefillParams]): List[EditionsCollectionSkeleton] = {
     collections.map { collection =>
       import collection.{hidden, name, prefill, presentation}
@@ -98,7 +102,7 @@ class CollectionTemplatingHelper(capi: Capi, ophan: Ophan) extends Logging {
           val getPrefillParams = PrefillParamsAdapter(
             issueDate,
             contentPrefillUrlSegments,
-            contentPrefillTimeWindow,
+            contentPrefillTimeParams,
             maybeOphanPath,
             ophanQueryPrefillParams,
             edition,

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -3,7 +3,7 @@ package services.editions.db
 import java.time._
 
 import model.editions.internal.PrefillUpdate
-import model.editions.{CapiPrefillQuery, Edition, EditionsCollection, PathType}
+import model.editions.{CapiPrefillQuery, Edition, EditionsCollection, EditionsTemplates, PathType}
 import model.forms.GetCollectionsFilter
 import play.api.libs.json.Json
 import scalikejdbc._

--- a/app/services/editions/prefills/package.scala
+++ b/app/services/editions/prefills/package.scala
@@ -5,7 +5,6 @@ import java.time.{Instant, LocalDate}
 import com.gu.facia.api.utils.ResolvedMetaData
 import model.editions._
 import play.api.libs.json.Json
-import services.editions.prefills.MetadataForLogging
 
 package object prefills {
 
@@ -35,10 +34,12 @@ package object prefills {
     }
   }
 
+  case class ContentPrefillTimeParams(contentPrefillTimeWindow: CapiQueryTimeWindow, useDate: UseDateQueryParamValue)
+
   case class PrefillParamsAdapter(
                                    issueDate: LocalDate,
                                    contentPrefillUrlSegments: CapiPrefillQuery,
-                                   contentPrefillTimeWindow: CapiQueryTimeWindow,
+                                   contentPrefillTimeParams: ContentPrefillTimeParams,
                                    maybeOphanPath: Option[String],
                                    maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams],
                                    edition: Edition,

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -8,6 +8,7 @@ import model.editions._
 object TestEdition {
   val ContentQueryStartOffsetInDays = -1
   val ContentQueryEndOffsetInDays = 2
+  val UseDate = UseDateQueryParamValue.Published
 
   val template = EditionTemplate(
     List(
@@ -18,9 +19,11 @@ object TestEdition {
       FrontSpecialSpecial2.front -> Daily(),
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
-      timeWindowConfig = TimeWindowConfigInDays(
+      timeWindowConfig = CapiTimeWindowConfigInDays(
         startOffset = ContentQueryStartOffsetInDays,
-        endOffset= ContentQueryEndOffsetInDays)
+        endOffset = ContentQueryEndOffsetInDays,
+        useDate = UseDate,
+      )
     ),
     zoneId = ZoneId.of("Europe/London"),
     availability = Daily(),

--- a/test/services/GuardianCapiTest.scala
+++ b/test/services/GuardianCapiTest.scala
@@ -3,10 +3,10 @@ package services
 import java.time.LocalDate
 
 import fixtures.TestEdition
-import model.editions.{CapiPrefillQuery, Edition, PathType}
+import model.editions.{CapiPrefillQuery, Edition, PathType, UseDateQueryParamValue}
 import org.scalatest.{FunSuite, Matchers}
 import services.editions.EditionsTemplating
-import services.editions.prefills.{CapiQueryTimeWindow, MetadataForLogging, PrefillParamsAdapter}
+import services.editions.prefills.{CapiQueryTimeWindow, ContentPrefillTimeParams, MetadataForLogging, PrefillParamsAdapter}
 
 class GuardianCapiTest extends FunSuite with Matchers {
 
@@ -18,15 +18,16 @@ class GuardianCapiTest extends FunSuite with Matchers {
 
   private val contentPrefillTimeWindow: CapiQueryTimeWindow = EditionsTemplating.defineContentQueryTimeWindow(issueDate, timeWindowCfg)
 
-  private val getPrefillParams = PrefillParamsAdapter(issueDate, contentPrefillQuery, contentPrefillTimeWindow, None, None, Edition.TrainingEdition,
-    MetadataForLogging(LocalDate.now(), collectionId = None, collectionName = None))
-
   test("geneneratePrefillQuery") {
 
-    val fields = List(
-      "newspaperEditionDate",
-      "newspaperPageNumber",
-      "internalPageCode"
+    val getPrefillParams = PrefillParamsAdapter(
+      issueDate,
+      contentPrefillQuery,
+      ContentPrefillTimeParams(contentPrefillTimeWindow, UseDateQueryParamValue.Published),
+      None, None,
+      Edition.TrainingEdition,
+      MetadataForLogging(LocalDate.now(),
+        collectionId = None, collectionName = None)
     )
 
     val actual = GuardianCapi.prepareGetUnsortedPrefillArticleItemsQuery(getPrefillParams).getUrl("")
@@ -37,7 +38,7 @@ class GuardianCapiTest extends FunSuite with Matchers {
       "&tag=theguardian%2Fmainsection%2Ftopstories" +
       "&to-date=2019-10-07T00%3A00%3A00Z" +
       "&page=1" +
-      "&use-date=newspaper-edition" +
+      "&use-date=published" +
       "&show-fields=newspaperEditionDate%2CnewspaperPageNumber%2CinternalPageCode" +
       "&show-tags=all" +
       "&from-date=2019-10-04T00%3A00%3A00Z"
@@ -48,6 +49,16 @@ class GuardianCapiTest extends FunSuite with Matchers {
   test("prepareGetPrefillArticlesQuery") {
 
     val currentPageCodes = List("123", "456")
+
+    val getPrefillParams = PrefillParamsAdapter(
+      issueDate,
+      contentPrefillQuery,
+      ContentPrefillTimeParams(contentPrefillTimeWindow, UseDateQueryParamValue.NewspaperEdition),
+      None, None,
+      Edition.TrainingEdition,
+      MetadataForLogging(LocalDate.now(),
+        collectionId = None, collectionName = None)
+    )
 
     val actual = GuardianCapi.prepareGetPrefillArticlesQuery(getPrefillParams, currentPageCodes).getUrl("")
 

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -98,7 +98,8 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
 
   "defineTimeWindow for contentPrefill" - {
     "should return expected time window" in {
-      val timeWindowCfg = TimeWindowConfigInDays(startOffset = -1, endOffset = 2)
+      val useDate =  UseDateQueryParamValue.Published
+      val timeWindowCfg = CapiTimeWindowConfigInDays(startOffset = -1, endOffset = 2, useDate)
       EditionsTemplating.defineContentQueryTimeWindow(LocalDate.of(2019, 10, 5), timeWindowCfg) shouldEqual CapiQueryTimeWindow(
         LocalDate.of(2019, 10, 4).atStartOfDay().toInstant(ZoneOffset.UTC),
         LocalDate.of(2019, 10, 7).atStartOfDay().toInstant(ZoneOffset.UTC)


### PR DESCRIPTION
Be able to Specify useDate param in editions templates config

(trello card)[https://trello.com/c/99LcHWIr/148-use-published-not-newspaper-edition-for-non-print-sent-queries]

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
