### PR TITLE
Un-revert "Remove the 'shared' state from the clipboard""

### DIFF
--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -76,6 +76,16 @@ test('Drag from feed to group position', async t => {
     .eql(true);
 });
 
+test('Drag from feed to group position', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  await t
+    .dragToElement(feedItem(0), frontDropZone(2))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2)
+    .expect(collectionLaunchButton(1).exists)
+    .eql(true);
+});
+
 test('Drag from feed to supporting position', async t => {
   const frontDropsCount = await frontDropZone().count;
   await t

--- a/client-v2/src/actions/Cards.ts
+++ b/client-v2/src/actions/Cards.ts
@@ -25,7 +25,7 @@ import {
 } from 'util/moveUtils';
 import { PosSpec } from 'lib/dnd';
 import { Action } from 'types/Action';
-import { insertClipboardCard, removeClipboardCard } from './Clipboard';
+import { removeClipboardCard, thunkInsertClipboardCard } from './Clipboard';
 import { State } from 'types/State';
 import { capGroupSiblings } from 'shared/actions/Groups';
 import { selectCollectionCap } from 'selectors/configSelectors';
@@ -43,7 +43,7 @@ type InsertActionCreator = (
   id: string,
   index: number,
   cardId: string
-) => Action;
+) => ThunkResult<void> | Action;
 
 type InsertThunkActionCreator = (
   persistTo: 'collection' | 'clipboard'
@@ -62,20 +62,19 @@ type InsertThunkActionCreator = (
 // the persistence stuff needs to be dynamic as we sometimes need to insert an
 // card and save to clipboard and sometimes save to collection
 // depending on the location of that card
-const createInsertCardThunk = (action: InsertActionCreator) => (
-  persistTo: 'collection' | 'clipboard'
-) => (id: string, index: number, cardId: string, removeAction?: Action) => (
-  dispatch: Dispatch
-) => {
+const createInsertCardThunk = (action: InsertActionCreator) => () => (
+  id: string,
+  index: number,
+  cardId: string,
+  removeAction?: Action
+) => (dispatch: Dispatch) => {
   if (removeAction) {
     dispatch(removeAction);
   }
-  dispatch(
-    addPersistMetaToAction(action, {
-      persistTo,
-      key: 'cardId'
-    })(id, index, cardId)
-  );
+  // This cast seems to be necessary to disambiguate the type fed to Dispatch,
+  // whose call signature accepts either an Action or a ThunkResult. I'm not really
+  // sure why.
+  dispatch(action(id, index, cardId) as Action);
 };
 
 const copyCardImageMetaWithPersist = addPersistMetaToAction(copyCardImageMeta, {
@@ -178,7 +177,7 @@ const getInsertionActionCreatorFromType = (
   const actionMap: { [type: string]: InsertThunkActionCreator | undefined } = {
     card: createInsertCardThunk(insertSupportingCard),
     group: maybeInsertGroupCard,
-    clipboard: createInsertCardThunk(insertClipboardCard)
+    clipboard: createInsertCardThunk(thunkInsertClipboardCard)
   };
 
   const actionCreator = actionMap[type] || null;

--- a/client-v2/src/actions/Clipboard.ts
+++ b/client-v2/src/actions/Clipboard.ts
@@ -13,6 +13,7 @@ import {
 } from 'types/Action';
 import { State } from 'types/State';
 import { addPersistMetaToAction } from 'util/action';
+import { selectCards, selectSharedState } from 'shared/selectors/shared';
 
 export const REMOVE_CLIPBOARD_CARD = 'REMOVE_CLIPBOARD_CARD';
 export const UPDATE_CLIPBOARD_CONTENT = 'UPDATE_CLIPBOARD_CONTENT';
@@ -67,26 +68,39 @@ function updateClipboard(clipboardContent: {
   };
 }
 
-const insertClipboardCard = (
+const actionInsertClipboardCard = (
   id: string,
   index: number,
-  cardId: string
+  cardId: string,
+  currentCards: { [uuid: string]: Card }
 ): InsertClipboardCard => ({
   type: INSERT_CLIPBOARD_CARD,
   payload: {
     id,
     index,
-    cardId
+    cardId,
+    currentCards
   }
 });
 
-const insertClipboardCardWithPersist = addPersistMetaToAction(
-  insertClipboardCard,
+const actionInsertClipboardCardWithPersist = addPersistMetaToAction(
+  actionInsertClipboardCard,
   {
     persistTo: 'clipboard',
     key: 'cardId'
   }
 );
+
+const thunkInsertClipboardCard = (
+  id: string,
+  index: number,
+  cardId: string
+): ThunkResult<void> => (dispatch, getState) => {
+  const currentCards = selectCards(selectSharedState(getState()));
+  dispatch(
+    actionInsertClipboardCardWithPersist(id, index, cardId, currentCards)
+  );
+};
 
 const removeClipboardCard = (
   id: string,
@@ -114,8 +128,7 @@ export {
   storeClipboardContent,
   updateClipboard,
   updateClipboardContent,
-  insertClipboardCard,
-  insertClipboardCardWithPersist,
+  thunkInsertClipboardCard,
   removeClipboardCard,
   clearClipboard,
   clearClipboardWithPersist

--- a/client-v2/src/actions/__tests__/Cards.spec.ts
+++ b/client-v2/src/actions/__tests__/Cards.spec.ts
@@ -30,7 +30,7 @@ import { selectClipboardArticles } from 'selectors/clipboardSelectors';
 
 const root = (state: any = {}, action: any) => ({
   optionsModal: optionsModal(state.optionsModal, action),
-  clipboard: clipboardReducer(state.clipboard, action, state.shared),
+  clipboard: clipboardReducer(state.clipboard, action),
   path: '',
   shared: {
     cards: cardsReducer(state.shared.cards, action),

--- a/client-v2/src/keyboard/index.ts
+++ b/client-v2/src/keyboard/index.ts
@@ -14,7 +14,7 @@ import { RefDrop } from 'util/collectionUtils';
 import { createArticleEntitiesFromDrop } from 'shared/actions/Cards';
 import { moveUp, moveDown } from './keyboardActionMaps/move';
 import { Card } from '../shared/types/Collection';
-import { insertClipboardCardWithPersist } from 'actions/Clipboard';
+import { thunkInsertClipboardCard } from 'actions/Clipboard';
 
 type FocusableTypes =
   | 'clipboard'
@@ -82,7 +82,7 @@ export const createKeyboardActionMap = (store: Store): KeyboardBindingMap => ({
         if (!card) {
           return;
         }
-        dispatch(insertClipboardCardWithPersist('clipboard', 0, card.uuid));
+        dispatch(thunkInsertClipboardCard('clipboard', 0, card.uuid));
       } catch (e) {
         Raven.captureMessage(`Paste to clipboard failed: ${e.message}`);
       }

--- a/client-v2/src/reducers/clipboardReducer.ts
+++ b/client-v2/src/reducers/clipboardReducer.ts
@@ -1,7 +1,5 @@
 import { Action } from 'types/Action';
 import { insertAndDedupeSiblings } from 'shared/util/insertAndDedupeSiblings';
-import { State as SharedState } from '../shared/types/State';
-import { selectCards } from 'shared/selectors/shared';
 import {
   INSERT_CLIPBOARD_CARD,
   REMOVE_CLIPBOARD_CARD,
@@ -11,11 +9,7 @@ import {
 
 type State = string[];
 
-const clipboard = (
-  state: State = [],
-  action: Action,
-  prevSharedState: SharedState
-): State => {
+const clipboard = (state: State = [], action: Action): State => {
   switch (action.type) {
     case UPDATE_CLIPBOARD_CONTENT: {
       const { payload } = action;
@@ -29,7 +23,7 @@ const clipboard = (
         state,
         [action.payload.cardId],
         action.payload.index,
-        selectCards(prevSharedState)
+        action.payload.currentCards
       );
     }
     case CLEAR_CLIPBOARD: {

--- a/client-v2/src/reducers/rootReducer.ts
+++ b/client-v2/src/reducers/rootReducer.ts
@@ -28,7 +28,7 @@ const rootReducer = (state: any = { feed: {} }, action: any) => ({
   path: path(state.path, action),
   shared: shared(state.shared, action),
   unpublishedChanges: unpublishedChanges(state.unpublishedChanges, action),
-  clipboard: clipboard(state.clipboard, action, state.shared),
+  clipboard: clipboard(state.clipboard, action),
   editor: editor(state.editor, action, state.shared),
   staleFronts: staleFronts(state.staleFronts, action),
   form: form(state.form, action),

--- a/client-v2/src/selectors/clipboardSelectors.ts
+++ b/client-v2/src/selectors/clipboardSelectors.ts
@@ -7,7 +7,7 @@ const selectClipboardContent = (state: State) => state.clipboard || [];
 const selectClipboardArticles = createShallowEqualResultSelector(
   selectClipboardContent,
   selectCardsFromRootState,
-  (clipboard, cards) => clipboard.map(afId => cards[afId])
+  (clipboard, cards) => clipboard.map((afId: string) => cards[afId])
 );
 
 export { selectClipboardArticles, selectClipboardContent };

--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -107,26 +107,36 @@ function removeSupportingCard(
 const insertGroupCard = (
   id: string,
   index: number,
-  cardId: string
+  cardId: string,
+  persistTo: 'collection' | 'clipboard'
 ): InsertGroupCard => ({
   type: INSERT_GROUP_CARD,
   payload: {
     id,
     index,
     cardId
+  },
+  meta: {
+    persistTo,
+    key: 'cardId'
   }
 });
 
 const insertSupportingCard = (
   id: string,
   index: number,
-  cardId: string
+  cardId: string,
+  persistTo: 'collection' | 'clipboard'
 ): InsertSupportingCard => ({
   type: INSERT_SUPPORTING_CARD,
   payload: {
     id,
     index,
     cardId
+  },
+  meta: {
+    persistTo,
+    key: 'cardId'
   }
 });
 

--- a/client-v2/src/shared/types/Action.ts
+++ b/client-v2/src/shared/types/Action.ts
@@ -3,6 +3,7 @@ import { Collection, Card, Group, CardMeta } from './Collection';
 import { Actions } from 'lib/createAsyncResourceBundle';
 import { copyCardImageMeta } from 'shared/actions/Cards';
 import { PageViewStory } from './PageViewData';
+import { PersistMeta } from 'util/storeMiddleware';
 
 interface CardsReceived {
   type: 'SHARED/CARDS_RECEIVED';
@@ -35,12 +36,14 @@ type InsertGroupCard = {
   type: 'SHARED/INSERT_GROUP_CARD';
 } & {
   payload: InsertCardPayload;
+  meta: PersistMeta;
 };
 
 type InsertSupportingCard = {
   type: 'SHARED/INSERT_SUPPORTING_CARD';
 } & {
   payload: InsertCardPayload;
+  meta: PersistMeta;
 };
 
 interface RemoveCardPayload {

--- a/client-v2/src/types/Action.ts
+++ b/client-v2/src/types/Action.ts
@@ -19,7 +19,7 @@ import {
   EditionsFrontMetadata
 } from './FaciaApi';
 import { BatchAction } from 'redux-batched-actions';
-import { Stages } from 'shared/types/Collection';
+import { Stages, Card } from 'shared/types/Collection';
 import {
   EDITOR_OPEN_CURRENT_FRONTS_MENU,
   EDITOR_CLOSE_CURRENT_FRONTS_MENU,
@@ -172,7 +172,7 @@ type InsertGroupCard = SharedInsertGroupCard & ActionPersistMeta;
 type InsertSupportingCard = SharedInsertSupportingCard & ActionPersistMeta;
 type InsertClipboardCard = {
   type: 'INSERT_CLIPBOARD_CARD';
-} & { payload: InsertCardPayload };
+} & { payload: InsertCardPayload & { currentCards: { [uuid: string]: Card } } };
 
 type RemoveGroupCard = SharedRemoveGroupCard & ActionPersistMeta;
 type RemoveSupportingCard = SharedRemoveSupportingCard & ActionPersistMeta;


### PR DESCRIPTION
Warm regards, interloper! Please review #1088 first, as it protects us against the regression this PR is designed to fix 😁 

## What's changed?

Reverts guardian/facia-tool#1075, adding what was originally missed -- the action meta that would correctly trigger a call to persistence.

We should be protected from the regression this originally caused by the integration tests added in #1088.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included