### PR TITLE
Add integration test to ensure 'launch changes' button appears

### DIFF
--- a/client-v2/integration/fixtures/collection2.js
+++ b/client-v2/integration/fixtures/collection2.js
@@ -1,6 +1,5 @@
 module.exports = {
-  live: [],
-  draft: [
+  live: [
     {
       id: 'internal-code/page/2309422',
       frontPublicationDate: 1540379258808,
@@ -24,7 +23,7 @@ module.exports = {
       }
     }
   ],
-  lastUpdated: 1540558153650,
+  lastUpdated: 1540379258808,
   updatedBy: 'Richard Beddington',
   updatedEmail: 'richard.beddington@guardian.co.uk',
   displayName: 'Second Collection 2'

--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -14,6 +14,7 @@ const SNAP_SELECTOR = 'snap';
 const COLLECTION_SELECTOR = 'collection';
 const CARD_SELECTOR = 'article-body';
 const COLLECTION_DISCARD_BUTTON = 'collection-discard-button';
+const COLLECTION_LAUNCH_BUTTON = 'collection-launch-button';
 const DELETE_BUTTON = 'delete-hover-button';
 const EDIT_FORM = 'edit-form';
 const EDIT_FORM_HEADLINE_FIELD = 'edit-form-headline-field';
@@ -97,6 +98,11 @@ export const cardBreakingNews = (collectionIndex, itemIndex = 0) =>
 export const collectionDiscardButton = collectionIndex =>
   collection(collectionIndex).find(
     `[data-testid="${COLLECTION_DISCARD_BUTTON}"]`
+  );
+
+export const collectionLaunchButton = collectionIndex =>
+  collection(collectionIndex).find(
+    `[data-testid="${COLLECTION_LAUNCH_BUTTON}"]`
   );
 
 export const cardDeleteButton = (collectionIndex, itemIndex = 0) =>

--- a/client-v2/integration/server/server.js
+++ b/client-v2/integration/server/server.js
@@ -181,19 +181,17 @@ module.exports = async () =>
     });
 
     // catch requests to discard collection endpoint
-    app.post(
-      '/collection/v2Discard/e59785e9-ba82-48d8-b79a-0a80b2f9f808',
-      (req, res) => {
-        return res.json({
-          id: req.body.collectionId,
-          collection: collectionThree,
-          storiesVisibleByStage: {
-            live: { desktop: 4, mobile: 4 },
-            draft: { desktop: 4, mobile: 4 }
-          }
-        });
-      }
-    );
+    app.post('/collection/v2Discard/*', (req, res) => {
+      return res.json({
+        id: req.body.collectionId,
+        // Collection three is empty, simulating a discard event
+        collection: collectionThree,
+        storiesVisibleByStage: {
+          live: { desktop: 4, mobile: 4 },
+          draft: { desktop: 4, mobile: 4 }
+        }
+      });
+    });
 
     // Ophan requests
     app.get('/ophan*', (req, res) => {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -22,6 +22,7 @@ import {
   allCollectionDropZones,
   cardDeleteButton,
   collectionDiscardButton,
+  collectionLaunchButton,
   cardAddToClipboardButton,
   clipboardItemDeleteButton,
   optionsModalChoice
@@ -65,6 +66,44 @@ test('Drag and drop', async t => {
     .eql(topFrontHeadline);
 });
 
+test('Drag and drop', async t => {
+  const topFrontHeadline = await frontHeadline(0).textContent;
+  const topFeedHeadline = await feedItemHeadline(0).textContent;
+  const frontDropsCount = await frontDropZone().count;
+  await t
+    // drag from feed to front
+    .dragToElement(feedItem(0), frontDropZone(0))
+    .wait(1000)
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2)
+    .expect(frontHeadline().textContent)
+    .notEql(topFrontHeadline)
+    .expect(frontHeadline().textContent)
+    .eql(topFeedHeadline)
+    // drag top to bottom in front
+    .dragToElement(frontHeadline(), frontDropZone(3))
+    // wait for collection to update
+    .wait(1000)
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2)
+    .expect(frontHeadline().textContent)
+    .notEql(topFeedHeadline)
+    .expect(frontHeadline().textContent)
+    .eql(topFrontHeadline);
+});
+
+test('Drag from feed to supporting position', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  await t
+    .dragToElement(feedItem(0), frontDropZone(3))
+    .expect(frontDropZone().count)
+    // Adding an initial sublink removes a dropzone, as the '<n> sublinks'
+    // dropdown menu replaces the dropzone we dropped into.
+    .eql(frontDropsCount - 1)
+    .expect(collectionLaunchButton(1).exists)
+    .eql(true);
+});
+
 test('Drag between two collections', async t => {
   const firstCollectionStory = card(0, 0);
   const secondCollectionDropZone = collectionDropZone(1, 0);
@@ -89,8 +128,8 @@ test('Drag from clipboard to collection', async t => {
 
 test('Discarding changes to a collection works', async t => {
   await t
-    .click(collectionDiscardButton(1))
-    .expect(allCards(1).count) // discarding overwrites a collection's draft content with its live content
+    .click(collectionDiscardButton(0))
+    .expect(allCards(0).count) // discarding overwrites a collection's draft content with its live content
     .eql(0);
 });
 

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -92,6 +92,16 @@ test('Drag and drop', async t => {
     .eql(topFrontHeadline);
 });
 
+test('Drag from feed to group position', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  await t
+    .dragToElement(feedItem(0), frontDropZone(2))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2)
+    .expect(collectionLaunchButton(1).exists)
+    .eql(true);
+});
+
 test('Drag from feed to supporting position', async t => {
   const frontDropsCount = await frontDropZone().count;
   await t

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -66,32 +66,6 @@ test('Drag and drop', async t => {
     .eql(topFrontHeadline);
 });
 
-test('Drag and drop', async t => {
-  const topFrontHeadline = await frontHeadline(0).textContent;
-  const topFeedHeadline = await feedItemHeadline(0).textContent;
-  const frontDropsCount = await frontDropZone().count;
-  await t
-    // drag from feed to front
-    .dragToElement(feedItem(0), frontDropZone(0))
-    .wait(1000)
-    .expect(frontDropZone().count)
-    .eql(frontDropsCount + 2)
-    .expect(frontHeadline().textContent)
-    .notEql(topFrontHeadline)
-    .expect(frontHeadline().textContent)
-    .eql(topFeedHeadline)
-    // drag top to bottom in front
-    .dragToElement(frontHeadline(), frontDropZone(3))
-    // wait for collection to update
-    .wait(1000)
-    .expect(frontDropZone().count)
-    .eql(frontDropsCount + 2)
-    .expect(frontHeadline().textContent)
-    .notEql(topFeedHeadline)
-    .expect(frontHeadline().textContent)
-    .eql(topFrontHeadline);
-});
-
 test('Drag from feed to group position', async t => {
   const frontDropsCount = await frontDropZone().count;
   await t

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -260,6 +260,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
                     onClick={() => this.startPublish(id, frontId)}
                     tabIndex={-1}
                     disabled={isLaunching}
+                    data-testid="collection-launch-button"
                   >
                     {isLaunching ? (
                       <LoadingImageBox>


### PR DESCRIPTION
## What's changed?

This PR adds integration test to ensure 'launch changes' button appears when cards are added from the feed into either a group or supporting position. 

This should help us catch regressions like the one introduced by #1063.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
