### PR TITLE
issue version ui

### DIFF
--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -330,8 +330,10 @@ trait IssueQueries {
         .apply()
 
     (rows.groupBy(_.version) map {
-      case (version, rows) => version.copy(events = rows.map(_.event))
+      case (version, rows) => version.copy(events = rows.map(_.event).sortBy(_.eventTime))
     }).toList
+      .sortBy(_.launchedOn)
+      .reverse
   }
 
   def insertIssueVersionEvent(event: PublishEvent) = DB localTx { implicit session =>

--- a/client-v2/src/actions/Editions.tsx
+++ b/client-v2/src/actions/Editions.tsx
@@ -11,6 +11,7 @@ import { actions } from 'bundles/editionsIssueBundle';
 import { EditionsFrontMetadata } from 'types/FaciaApi';
 import noop from 'lodash/noop';
 import { startOptionsModal } from './OptionsModal';
+import IssueVersions from 'components/Editions/IssueVersions';
 
 export const getEditionIssue = (
   id: string
@@ -41,6 +42,8 @@ export const publishEditionIssue = (
             If you do not see the issue within 5 minutes please contact a member
             of the suport team.
           </p>
+
+          <IssueVersions issueId={id} />
         </>,
         [{ buttonText: 'Dismiss', callback: noop }],
         noop,

--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -93,7 +93,11 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
 
     startConfirmPublishModal(
       'Confirm publish',
-      <IssueVersions issueId={editionsIssue.id} />,
+      <>
+        <p>Confirm the publication of a new version of this issue.</p>
+        <p>Publishing a new version will not halt in-progress versions.</p>
+        <IssueVersions issueId={editionsIssue.id} />
+      </>,
       () => publishEditionsIssue(editionsIssue.id)
     );
   };

--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { EditionsIssue } from '../types/Edition';
 import { connect } from 'react-redux';
 import { State } from '../types/State';
@@ -13,12 +13,13 @@ import { Link } from 'react-router-dom';
 import urls from 'constants/urls';
 import noop from 'lodash/noop';
 import { startOptionsModal } from 'actions/OptionsModal';
+import IssueVersions from './Editions/IssueVersions/index';
 
 interface ComponentProps {
   editionsIssue: EditionsIssue;
   startConfirmPublishModal: (
     title: string,
-    description: string,
+    description: ReactNode,
     onAccept: () => void
   ) => void;
   publishEditionsIssue: (id: string) => Promise<void>;
@@ -92,7 +93,7 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
 
     startConfirmPublishModal(
       'Confirm publish',
-      'Are you sure you want to publish?',
+      <IssueVersions issueId={editionsIssue.id} />,
       () => publishEditionsIssue(editionsIssue.id)
     );
   };
@@ -107,14 +108,14 @@ const mapStateToProps = () => {
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   startConfirmPublishModal: (
     title: string,
-    description: string,
+    description: ReactNode,
     onAccept: () => void
   ) =>
     dispatch(
       startOptionsModal(
         title,
         description,
-        [{ buttonText: 'Confirm', callback: onAccept }],
+        [{ buttonText: 'Publish', callback: onAccept }],
         noop
       )
     ),

--- a/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { styled } from 'constants/theme';
+
+import { IssueVersionEvent } from 'types/Edition';
+
+const PublicationHistoryTable = styled.table`
+  border-collapse: collapse;
+  border: 1px solid #eee;
+
+  thead tr,
+  tbody tr:nth-child(even) {
+    background-color: #eee;
+  }
+
+  th,
+  td {
+    padding: 10px;
+  }
+`;
+
+interface Props {
+  events: Array<IssueVersionEvent>;
+}
+
+export default (props: Props) => {
+  return (
+    <PublicationHistoryTable>
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Status</th>
+          <th>Message</th>
+        </tr>
+      </thead>
+      <tbody>
+        {props.events.map(event => {
+          return (
+            <tr key={event.eventTime}>
+              <td>{event.eventTime}</td>
+              <td>{event.status}</td>
+              <td>{event.message}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </PublicationHistoryTable>
+  );
+};

--- a/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { styled } from 'constants/theme';
+import moment from 'moment';
 
+import { styled } from 'constants/theme';
 import { IssueVersionEvent } from 'types/Edition';
 
 const PublicationHistoryTable = styled.table`
@@ -36,7 +37,7 @@ export default (props: Props) => {
         {props.events.map(event => {
           return (
             <tr key={event.eventTime}>
-              <td>{event.eventTime}</td>
+              <td>{moment(event.eventTime).format('YYYY-MM-DD HH:mm:ss')}</td>
               <td>{event.status}</td>
               <td>{event.message}</td>
             </tr>

--- a/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
@@ -5,6 +5,7 @@ import { styled } from 'constants/theme';
 import { IssueVersionEvent } from 'types/Edition';
 
 const PublicationHistoryTable = styled.table`
+  width: 100%;
   border-collapse: collapse;
   border: 1px solid #eee;
 
@@ -28,8 +29,8 @@ export default (props: Props) => {
     <PublicationHistoryTable>
       <thead>
         <tr>
-          <th>Time</th>
-          <th>Status</th>
+          <th style={{ width: '200px' }}>Time</th>
+          <th style={{ width: '200px' }}>Status</th>
           <th>Message</th>
         </tr>
       </thead>

--- a/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/VersionPublicationTable.tsx
@@ -20,7 +20,7 @@ const PublicationHistoryTable = styled.table`
 `;
 
 interface Props {
-  events: Array<IssueVersionEvent>;
+  events: IssueVersionEvent[];
 }
 
 export default (props: Props) => {

--- a/client-v2/src/components/Editions/IssueVersions/index.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/index.tsx
@@ -21,7 +21,7 @@ interface ComponentProps {
 }
 
 interface ComponentState {
-  data: Array<IssueVersion>;
+  data: IssueVersion[];
   polling: any;
 }
 
@@ -35,19 +35,11 @@ class IssueVersions extends React.Component<ComponentProps, ComponentState> {
     };
   }
 
-  componentWillUnmount() {
+  public componentWillUnmount() {
     clearInterval(this.state.polling);
   }
 
-  private update = async () => {
-    const { issueId } = this.props;
-
-    const data = await getIssueVersions(issueId);
-
-    this.setState({ data });
-  };
-
-  render() {
+  public render() {
     const { data } = this.state;
 
     return (
@@ -70,6 +62,14 @@ class IssueVersions extends React.Component<ComponentProps, ComponentState> {
       </>
     );
   }
+
+  private update = async () => {
+    const { issueId } = this.props;
+
+    const data = await getIssueVersions(issueId);
+
+    this.setState({ data });
+  };
 }
 
 export default IssueVersions;

--- a/client-v2/src/components/Editions/IssueVersions/index.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/index.tsx
@@ -49,23 +49,20 @@ class IssueVersions extends React.Component<ComponentProps, ComponentState> {
     }
 
     return (
-      <>
-        <p>Previously published versions of this issue:</p>
-        <IssueVersionList>
-          {data.map(issueVersion => (
-            <li key={issueVersion.id}>
-              <strong>
-                {moment(issueVersion.launchedOn).format('YYYY-MM-DD HH:mm:ss')}
-              </strong>
-              &nbsp;launched by&nbsp;
-              <span title={issueVersion.launchedEmail}>
-                {issueVersion.launchedBy}
-              </span>
-              <VersionPublicationTable events={issueVersion.events} />
-            </li>
-          ))}
-        </IssueVersionList>
-      </>
+      <IssueVersionList>
+        {data.map(issueVersion => (
+          <li key={issueVersion.id}>
+            <strong>
+              {moment(issueVersion.launchedOn).format('YYYY-MM-DD HH:mm:ss')}
+            </strong>
+            &nbsp;launched by&nbsp;
+            <span title={issueVersion.launchedEmail}>
+              {issueVersion.launchedBy}
+            </span>
+            <VersionPublicationTable events={issueVersion.events} />
+          </li>
+        ))}
+      </IssueVersionList>
     );
   }
 

--- a/client-v2/src/components/Editions/IssueVersions/index.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/index.tsx
@@ -7,6 +7,8 @@ import VersionPublicationTable from './VersionPublicationTable';
 import { getIssueVersions } from 'services/editionsApi';
 
 const IssueVersionList = styled.ul`
+  max-height: 500px;
+  overflow: scroll;
   padding: 0;
   margin: 0;
   list-style: none;

--- a/client-v2/src/components/Editions/IssueVersions/index.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/index.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { styled } from 'constants/theme';
+
+import { IssueVersion, IssueVersionEvent } from 'types/Edition';
+import VersionPublicationTable from './VersionPublicationTable';
+
+function sortEvents(events: Array<IssueVersionEvent>) {
+  return events.sort((a, b) => {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  });
+}
+
+function getData(issueId: string): Array<IssueVersion> {
+  const data: Array<IssueVersion> = [
+    {
+      id: '2019-10-28T16:42:34.731Z',
+      launchedOn: 1572280954731,
+      launchedBy: 'Akash Askoolum',
+      launchedEmail: 'akash.askoolum@guardian.co.uk',
+      events: [
+        {
+          eventTime: 1572280954731,
+          status: 'Started'
+        }
+      ]
+    },
+    {
+      id: '2019-10-28T20:00:02.569Z',
+      launchedOn: 1572292802569,
+      launchedBy: 'Akash Askoolum',
+      launchedEmail: 'akash.askoolum@guardian.co.uk',
+      events: [
+        {
+          eventTime: 1572292802569,
+          status: 'Started'
+        }
+      ]
+    }
+  ];
+
+  return data.map(d => ({
+    ...d,
+    events: sortEvents(d.events)
+  }));
+}
+
+const IssueVersionList = styled.ol`
+  padding: 0;
+  margin: 0;
+`;
+
+interface Props {
+  issueId: string;
+}
+
+export default (props: Props) => {
+  const data: Array<IssueVersion> = getData(props.issueId);
+
+  return (
+    <>
+      <p>Previously published versions of this issue</p>
+      <IssueVersionList>
+        {data.map(issueVersion => (
+          <li key={issueVersion.id}>
+            {issueVersion.launchedOn}
+            &nbsp;launched by&nbsp;
+            <span title={issueVersion.launchedEmail}>
+              {issueVersion.launchedBy}
+            </span>
+            <VersionPublicationTable events={issueVersion.events} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};

--- a/client-v2/src/components/Editions/IssueVersions/index.tsx
+++ b/client-v2/src/components/Editions/IssueVersions/index.tsx
@@ -42,6 +42,10 @@ class IssueVersions extends React.Component<ComponentProps, ComponentState> {
   public render() {
     const { data } = this.state;
 
+    if (data.length === 0) {
+      return <p>This issue has not been published yet.</p>;
+    }
+
     return (
       <>
         <p>Previously published versions of this issue:</p>

--- a/client-v2/src/components/OptionsModal.tsx
+++ b/client-v2/src/components/OptionsModal.tsx
@@ -27,7 +27,7 @@ const StyledModal = styled(Modal)`
   padding: 20px;
   margin-left: -${({ width = 400 }: StyledModalProps) => width / 2}px;
   min-height: 200px;
-  width: ${({ width = 400 }: StyledModalProps) => width}px;
+  min-width: ${({ width = 400 }: StyledModalProps) => width}px;
 `;
 
 const Actions = styled.div`

--- a/client-v2/src/components/OptionsModal.tsx
+++ b/client-v2/src/components/OptionsModal.tsx
@@ -27,6 +27,7 @@ const StyledModal = styled(Modal)`
   padding: 20px;
   margin-left: -${({ width = 400 }: StyledModalProps) => width / 2}px;
   min-height: 200px;
+  max-height: calc(100vh - 80px);
   min-width: ${({ width = 400 }: StyledModalProps) => width}px;
 `;
 

--- a/client-v2/src/components/OptionsModal.tsx
+++ b/client-v2/src/components/OptionsModal.tsx
@@ -14,21 +14,17 @@ import { Dispatch } from 'types/Store';
 import { endOptionsModal } from 'actions/OptionsModal';
 import Modal from 'react-modal';
 import { styled, theme } from 'constants/theme';
-import { StyledModalProps } from '../types/Modals';
 
 const StyledModal = styled(Modal)`
-  position: absolute;
-  top: 40px;
   font-size: 14px;
-  left: 50%;
   background: ${theme.shared.base.colors.backgroundColorLight};
-  overflow: auto;
   outline: none;
   padding: 20px;
-  margin-left: -${({ width = 400 }: StyledModalProps) => width / 2}px;
   min-height: 200px;
-  max-height: calc(100vh - 80px);
-  min-width: ${({ width = 400 }: StyledModalProps) => width}px;
+  max-height: calc(100vh - 40px);
+  width: 50%;
+  margin: 20px auto;
+  overflow: scroll;
 `;
 
 const Actions = styled.div`
@@ -56,7 +52,9 @@ const OptionsModal = ({
     isOpen={isOpen}
     onRequestClose={onCancel}
   >
-    <h1 data-testid="options-modal">{title}</h1>
+    <h1 data-testid="options-modal" style={{ margin: 0 }}>
+      {title}
+    </h1>
     {description &&
       (typeof description === 'string' ? <p>{description}</p> : description)}
     <Actions>

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -110,7 +110,7 @@ export const putFrontHiddenState = (id: string, hidden: boolean) => {
 
 export async function getIssueVersions(
   issueId: string
-): Promise<Array<IssueVersion>> {
+): Promise<IssueVersion[]> {
   return await pandaFetch(`/editions-api/issues/${issueId}/versions`, {
     method: 'get'
   }).then(response => response.json());

--- a/client-v2/src/services/editionsApi.ts
+++ b/client-v2/src/services/editionsApi.ts
@@ -1,4 +1,4 @@
-import { EditionsIssue } from 'types/Edition';
+import { EditionsIssue, IssueVersion } from 'types/Edition';
 import { Moment } from 'moment';
 import pandaFetch from './pandaFetch';
 import { CAPISearchQueryResponse } from './capiQuery';
@@ -107,3 +107,11 @@ export const putFrontHiddenState = (id: string, hidden: boolean) => {
     method: 'PUT'
   }).then(response => response.json());
 };
+
+export async function getIssueVersions(
+  issueId: string
+): Promise<Array<IssueVersion>> {
+  return await pandaFetch(`/editions-api/issues/${issueId}/versions`, {
+    method: 'get'
+  }).then(response => response.json());
+}

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -38,10 +38,36 @@ interface EditionsIssue {
   fronts: EditionsFront[];
 }
 
+const issueVersionStatus = [
+  'Started',
+  'Processing',
+  'Published',
+  'Failed'
+] as const;
+
+type IssueVersionStatus = typeof issueVersionStatus[number];
+
+interface IssueVersionEvent {
+  eventTime: number;
+  status: IssueVersionStatus;
+  message?: string;
+}
+
+interface IssueVersion {
+  id: string;
+  launchedOn: number;
+  launchedBy: string;
+  launchedEmail: string;
+  events: Array<IssueVersionEvent>;
+}
+
 export {
   EditionsIssue,
   EditionsFront,
   EditionsCollection,
   EditionsArticle,
-  EditionsPrefill
+  EditionsPrefill,
+  IssueVersionStatus,
+  IssueVersionEvent,
+  IssueVersion
 };

--- a/client-v2/src/types/Edition.ts
+++ b/client-v2/src/types/Edition.ts
@@ -58,7 +58,7 @@ interface IssueVersion {
   launchedOn: number;
   launchedBy: string;
   launchedEmail: string;
-  events: Array<IssueVersionEvent>;
+  events: IssueVersionEvent[];
 }
 
 export {


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Following https://github.com/guardian/facia-tool/pull/1065, display the publication update messages on the UI to provide production staff with confidence that something is happening.

**Before**
![image](https://user-images.githubusercontent.com/836140/67800756-c1c1b980-fa7f-11e9-8116-151758845f19.png)

**After**
![image](https://user-images.githubusercontent.com/836140/67893304-40852800-fb4e-11e9-97f5-b5dd1e462399.png)


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
The `IssueVersions` component keeps track of its own state and gets updates from the API every 500ms.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
