### PR TITLE
Do not lose promotion metric

### DIFF
--- a/app/model/editions/client/ClientArticleMetadata.scala
+++ b/app/model/editions/client/ClientArticleMetadata.scala
@@ -76,7 +76,7 @@ case class ClientArticleMetadata (
       replaceImage,
       overrideArticleMainMedia,
       coverCardImages,
-      None
+      promotionMetric
     )
   }
 }

--- a/test/model/editions/client/ClientArticleMetadataTest.scala
+++ b/test/model/editions/client/ClientArticleMetadataTest.scala
@@ -6,6 +6,64 @@ import org.scalatest.{FreeSpec, Matchers}
 class ClientArticleMetadataTest extends FreeSpec with Matchers {
 
   "ClientArticleMetadata from ArticleMetadata" - {
+
+    "should recover promotion metric from a simple ArticleMetadata" in {
+      val articleMetadata = ArticleMetadata(
+        Some("Britain has summer!"),
+        Some("Breaking News"),
+        Some("Goneth the rain, cometh the sun"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(1)
+      )
+      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+      clientArticleMetadata.promotionMetric should be (Some(1))
+    }
+
+    "should send promotion metric to a simple ArticleMetadata" in {
+      val clientArticleMetadata = ClientArticleMetadata(
+        Some("Britain has summer!"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+
+        None,
+
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+
+        None,
+        None,
+        None,
+        None,
+        None,
+
+        None,
+
+        None,
+        None,
+        None,
+        Some(1)
+      )
+      val articleMetadata = clientArticleMetadata.toArticleMetadata
+      articleMetadata.promotionMetric should be (Some(1))
+    }
+
     "should serialise from a simple ArticleMetadata" in {
       val articleMetadata = ArticleMetadata(
         Some("Britain has summer!"),
@@ -233,4 +291,5 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
       ))
     }
   }
+
 }


### PR DESCRIPTION
## What's changed?
Doesn't lose the promotion metric.

## Implementation notes
In order to not lose the promotion metric, this code actually reads the promotion metric rather than just use 'None', which is dumb.

## Checklist

### General
- [X ] 🤖 Relevant tests added
- [ X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
