### PR TITLE
Add an election topic to breaking news

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -89,7 +89,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
 
   private def createPayload(trail: ClientHydratedTrail, email: String): BreakingNewsPayload = {
     BreakingNewsPayload(
-      message = StringEscapeUtils.unescapeHtml4(trail.headline),
+      message = Some(StringEscapeUtils.unescapeHtml4(trail.headline)),
       thumbnailUrl = trail.thumb.map{new URI(_)},
       sender = email,
       link = createLinkDetails(trail),
@@ -136,6 +136,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
       case Some("uk") => List(BreakingNewsUk)
       case Some("us") => List(BreakingNewsUs)
       case Some("sport") => List(BreakingNewsSport)
+      case Some("election") => List(BreakingNewsElection)
       case Some("") => throw new InvalidParameterException(s"Invalid empty string topic")
       case Some(notYetImplementedTopic) => List(Topic(Breaking, notYetImplementedTopic))
       case None => throw new InvalidParameterException(s"Invalid empty topic")

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -136,7 +136,7 @@ class BreakingNewsUpdate(val config: ApplicationConfiguration, val ws: WSClient,
       case Some("uk") => List(BreakingNewsUk)
       case Some("us") => List(BreakingNewsUs)
       case Some("sport") => List(BreakingNewsSport)
-      case Some("election") => List(BreakingNewsElection)
+      case Some("uk-general-election") => List(BreakingNewsElection)
       case Some("") => throw new InvalidParameterException(s"Invalid empty string topic")
       case Some(notYetImplementedTopic) => List(Topic(Breaking, notYetImplementedTopic))
       case None => throw new InvalidParameterException(s"Invalid empty topic")

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.gu" %% "fapi-client-play26" % "3.0.11",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "mobile-notifications-api-models" % "1.0.4-SNAPSHOT",
+    "com.gu" %% "mobile-notifications-api-models" % "1.0.4",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",
 
     "com.gu" %% "scanamo" % "1.0.0-M7",

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.gu" %% "fapi-client-play26" % "3.0.11",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "mobile-notifications-api-models" % "1.0.0",
+    "com.gu" %% "mobile-notifications-api-models" % "1.0.4-SNAPSHOT",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",
 
     "com.gu" %% "scanamo" % "1.0.0-M7",


### PR DESCRIPTION
## What's changed?

Adds a new election topic to the breaking news part of the tool. Breaking news containers with the link name 'election' will send alerts with this topic.

In draft, as we'll need to merge https://github.com/guardian/mobile-n10n/pull/478 before we can build this PR.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
