### PR TITLE
Add a way of adding free-text snap links without leaving the tool

### DIFF
--- a/client-v2/integration/selectors/index.js
+++ b/client-v2/integration/selectors/index.js
@@ -36,6 +36,8 @@ const OPTIONS_MODAL = 'options-modal';
 const GUARDIAN_TAG_ANCHOR = 'guardian-tag';
 const EXTERNAL_LINK_ANCHOR = 'external-link';
 
+const DRAG_TO_ADD_SNAP = 'drag-to-add-snap';
+
 const maybeGetNth = selector => (n = null) =>
   n === null ? selector : selector.nth(n);
 
@@ -71,6 +73,11 @@ export const collection = maybeGetNth(select(COLLECTION_SELECTOR));
 export const allCards = collectionIndex => {
   const collectionSelected = collection(collectionIndex);
   return collectionSelected.find(`[data-testid="${CARD_SELECTOR}"]`);
+};
+
+export const allSnaps = collectionIndex => {
+  const collectionSelected = collection(collectionIndex);
+  return collectionSelected.find(`[data-testid="${SNAP_SELECTOR}"]`);
 };
 
 export const allCollectionDropZones = collectionIndex => {
@@ -166,3 +173,5 @@ export const previouslyDropZone = maybeGetNth(
   select(PREVIOUSLY_SELECTOR, DROP_ZONE_SELECTOR)
 );
 export const clipboardWrapper = () => select(CLIPBOARD_WRAPPER_SELECTOR);
+
+export const dragToAddSnapItem = () => select(DRAG_TO_ADD_SNAP);

--- a/client-v2/integration/server/index.html
+++ b/client-v2/integration/server/index.html
@@ -107,7 +107,8 @@
           ],
           frontIds: ['test/front'],
           frontIdsByPriority: {
-            editorial: ['test/front']
+            editorial: ['test/front'],
+            email: ['test/front']
           },
           featureSwitches: []
         },

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -25,9 +25,7 @@ import {
   collectionLaunchButton,
   cardAddToClipboardButton,
   clipboardItemDeleteButton,
-  optionsModalChoice,
-  dragToAddSnapItem,
-  allSnaps
+  optionsModalChoice
 } from '../selectors';
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
@@ -122,59 +120,11 @@ test('Drag from clipboard to collection', async t => {
     .eql(clipboardStoryCount);
 });
 
-test.only("Drag from 'drag to add text snap' item to create text snap", async t => {
-  const firstCollectionSnapCount = await allSnaps(0).count;
-  await t
-    .dragToElement(dragToAddSnapItem(), collection(0))
-    .expect(allSnaps(0).count)
-    .eql(firstCollectionSnapCount + 1);
-});
-
 test('Discarding changes to a collection works', async t => {
   await t
     .click(collectionDiscardButton(0))
     .expect(allCards(0).count) // discarding overwrites a collection's draft content with its live content
     .eql(0);
-});
-
-test('Snap Links - Guardian', async t => {
-  const frontDropsCount = await frontDropZone().count;
-  const tagSnap = await guardianSnapLink();
-  await t
-    .dragToElement(tagSnap, frontDropZone(1)) //drag tag into parent position (not a sublink)
-    .click(optionsModalChoice('options-modal-link'))
-    .expect(frontDropZone().count)
-    .eql(frontDropsCount + 2) // adding a sublink adds 1 dropzone, adding a normal article adds 2
-    .expect(frontSnapLink(0).textContent)
-    .contains('Recipes | The Guardian')
-    .expect(frontSnapLink(0).textContent)
-    .notContains('Latest');
-});
-
-test('Snap Links - Guardian Latest', async t => {
-  const frontDropsCount = await frontDropZone().count;
-  const tagSnap = await guardianSnapLink();
-  await t
-    .dragToElement(tagSnap, frontDropZone(1))
-    .click(optionsModalChoice('options-modal-latest-from'))
-    .expect(frontDropZone().count)
-    .eql(frontDropsCount + 2)
-    .expect(frontSnapLink(0).textContent)
-    .contains('{ Recipes }')
-    .expect(frontSnapLink(0).textContent)
-    .contains('Latest');
-});
-
-test('Snap Links - External', async t => {
-  const frontDropsCount = await frontDropZone().count;
-  const externalSnap = await externalSnapLink();
-  await t
-    .setNativeDialogHandler(() => false)
-    .dragToElement(externalSnap, frontDropZone(1))
-    .expect(frontDropZone().count)
-    .eql(frontDropsCount + 2)
-    .expect(frontSnapLink(0).textContent)
-    .contains('Business - BBC News');
 });
 
 test('Previously', async t => {

--- a/client-v2/integration/tests/main.spec.js
+++ b/client-v2/integration/tests/main.spec.js
@@ -25,7 +25,9 @@ import {
   collectionLaunchButton,
   cardAddToClipboardButton,
   clipboardItemDeleteButton,
-  optionsModalChoice
+  optionsModalChoice,
+  dragToAddSnapItem,
+  allSnaps
 } from '../selectors';
 
 fixture`Fronts edit`.page`http://localhost:3456/v2/editorial`
@@ -118,6 +120,14 @@ test('Drag from clipboard to collection', async t => {
     .eql(firstCollectionStoryCount + 1)
     .expect(clipboardItem().count)
     .eql(clipboardStoryCount);
+});
+
+test.only("Drag from 'drag to add text snap' item to create text snap", async t => {
+  const firstCollectionSnapCount = await allSnaps(0).count;
+  await t
+    .dragToElement(dragToAddSnapItem(), collection(0))
+    .expect(allSnaps(0).count)
+    .eql(firstCollectionSnapCount + 1);
 });
 
 test('Discarding changes to a collection works', async t => {

--- a/client-v2/integration/tests/snap.spec.js
+++ b/client-v2/integration/tests/snap.spec.js
@@ -1,0 +1,66 @@
+import setup from '../server/setup';
+import teardown from '../server/teardown';
+import {
+  frontDropZone,
+  frontSnapLink,
+  guardianSnapLink,
+  externalSnapLink,
+  clipboardWrapper,
+  collection,
+  cardDeleteButton,
+  optionsModalChoice,
+  dragToAddSnapItem,
+  allSnaps
+} from '../selectors';
+
+fixture`Fronts edit`.page`http://localhost:3456/v2/email`
+  .before(setup)
+  .after(teardown);
+
+test("Drag from 'drag to add text snap' item to create text snap", async t => {
+  const firstCollectionSnapCount = await allSnaps(0).count;
+  await t
+    .dragToElement(dragToAddSnapItem(), collection(0))
+    .expect(allSnaps(0).count)
+    .eql(firstCollectionSnapCount + 1);
+});
+
+test('Snap Links - Guardian', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  const tagSnap = await guardianSnapLink();
+  await t
+    .dragToElement(tagSnap, frontDropZone(1)) //drag tag into parent position (not a sublink)
+    .click(optionsModalChoice('options-modal-link'))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2) // adding a sublink adds 1 dropzone, adding a normal article adds 2
+    .expect(frontSnapLink(0).textContent)
+    .contains('Recipes | The Guardian')
+    .expect(frontSnapLink(0).textContent)
+    .notContains('Latest');
+});
+
+test('Snap Links - Guardian Latest', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  const tagSnap = await guardianSnapLink();
+  await t
+    .dragToElement(tagSnap, frontDropZone(1))
+    .click(optionsModalChoice('options-modal-latest-from'))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2)
+    .expect(frontSnapLink(0).textContent)
+    .contains('{ Recipes }')
+    .expect(frontSnapLink(0).textContent)
+    .contains('Latest');
+});
+
+test('Snap Links - External', async t => {
+  const frontDropsCount = await frontDropZone().count;
+  const externalSnap = await externalSnapLink();
+  await t
+    .setNativeDialogHandler(() => false)
+    .dragToElement(externalSnap, frontDropZone(1))
+    .expect(frontDropZone().count)
+    .eql(frontDropsCount + 2)
+    .expect(frontSnapLink(0).textContent)
+    .contains('Business - BBC News');
+});

--- a/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
+++ b/client-v2/src/components/FrontsCAPIInterface/FeedItem.tsx
@@ -36,6 +36,7 @@ import { VideoIcon } from 'shared/components/icons/Icons';
 import CircularIconContainer from 'shared/components/icons/CircularIconContainer';
 import RefreshPeriodically from '../util/RefreshPeriodically';
 import { collectionArticlesPollInterval } from 'constants/polling';
+import RenderOffscreen from 'components/util/RenderOffscreen';
 
 const Container = styled.div`
   display: flex;
@@ -117,13 +118,6 @@ const Body = styled.div`
   padding-left: 8px;
 `;
 
-// The visual representation of an article as it is being dragged.
-// This needs to be rendered by the DOM before it can be used by the Drag&Drop API, so we pushed it off to the side.
-const DraggingArticleContainer = styled.div`
-  position: absolute;
-  transform: translateX(-9999px);
-`;
-
 const VideoIconContainer = styled(CircularIconContainer)`
   position: absolute;
   bottom: 2px;
@@ -162,9 +156,9 @@ class FeedItem extends React.Component<ComponentProps> {
         draggable={true}
         onDragStart={this.handleDragStart}
       >
-        <DraggingArticleContainer ref={this.dragNode}>
+        <RenderOffscreen ref={this.dragNode}>
           <DraggingArticleComponent headline={article.webTitle} />
-        </DraggingArticleContainer>
+        </RenderOffscreen>
         <FeedItemContainer
           href={getPaths(article.id).live}
           onClick={e => e.preventDefault()}

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
@@ -24,13 +24,13 @@ export const dragOffsetY = 50;
 const DragContainer = styled.div`
   position: relative;
   padding: 0 0 10px 10px;
-  display: flex;
-  flex-direction: column;
   width: 330px;
 `;
 
 const DragContent = styled.div`
   background: ${theme.shared.colors.yellow};
+  position: absolute;
+  display: inline-block;
   border-radius: 4px;
   overflow: hidden;
   padding: 8px;
@@ -39,21 +39,21 @@ const DragContent = styled.div`
   font-weight: 600;
   font-size: 12px;
   font: TS3TextSans;
-  flex: 4;
-  align-self: flex-end;
-  width: 300px;
+  bottom: 25px;
+  left: 25px;
+  max-width: 300px;
 `;
 
 const DragContentIcon = styled.div`
+  position: absolute;
+  top: -30px;
   width: 28px;
   height: 28px;
   border-radius: 14px;
   background: ${theme.shared.colors.yellow};
-  flex: 1;
-  align-self: flex-start;
   padding: 6px 8px;
-  margin-top: -15px;
-  box-shadow: 1px -1px 20px black;
+
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 `;
 
 export const DraggingArticleComponent = ({ headline }: ComponentProps) =>

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
@@ -58,6 +58,7 @@ const DragToAddTextSnap = () => {
         <DraggingArticleComponent headline="Free text snaplink" />
       </RenderOffscreen>
       <DragToAddSnapContainer
+        data-testid="drag-to-add-snap"
         onDragStart={e => handleDragStart(e, ref.current)}
         draggable={true}
       >

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
@@ -1,0 +1,70 @@
+import React, { useRef } from 'react';
+import v4 from 'uuid/v4';
+import { DragIcon } from 'shared/components/icons/Icons';
+import { styled, theme } from 'constants/theme';
+import RenderOffscreen from 'components/util/RenderOffscreen';
+import {
+  DraggingArticleComponent,
+  dragOffsetX,
+  dragOffsetY
+} from './ArticleDrag';
+
+const DragToAddSnapContainer = styled.div`
+  border-top: 1px solid ${theme.shared.card.border};
+  background-color: ${theme.shared.colors.whiteMedium};
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 18px;
+  padding: 0 5px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.shared.colors.whiteDark};
+  }
+  > a {
+    text-decoration: none;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+`;
+
+const handleDragStart = (
+  event: React.DragEvent<HTMLDivElement>,
+  dragImageElement: HTMLDivElement | null
+) => {
+  // We must provide a unique URL for our snaplink, otherwise platforms might deduplicate
+  // this content when rendering it on a front. Because we know that in a free-text snaplink,
+  // the URL is not used, we supply a URL here that's a) guaranteed to be unique, and b)
+  // gives some indication why it's there. When snaplinks don't need URLs, possibly because
+  // there's a snap type for inserting arbitrary HTML, this will no longer be necessary.
+  const uniqueId = v4().substr(0, 4);
+  const url = `https://www.theguardian.com/free-text-${uniqueId}?gu-headline=Text%20snap%20--%20click%20to%20change%20content&gu-snapType=link`;
+
+  // Setting both types re: https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types
+  event.dataTransfer.setData('text/plain', url);
+  event.dataTransfer.setData('text/uri-list', url);
+
+  if (dragImageElement) {
+    event.dataTransfer.setDragImage(dragImageElement, dragOffsetX, dragOffsetY);
+  }
+};
+
+const DragToAddTextSnap = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <>
+      <RenderOffscreen ref={ref}>
+        <DraggingArticleComponent headline="Free text snaplink" />
+      </RenderOffscreen>
+      <DragToAddSnapContainer
+        onDragStart={e => handleDragStart(e, ref.current)}
+        draggable={true}
+      >
+        <DragIcon /> Drag to add a text snap
+      </DragToAddSnapContainer>
+    </>
+  );
+};
+
+export default DragToAddTextSnap;

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -23,6 +23,7 @@ import ButtonRoundedWithLabel, {
 import { DownCaretIcon } from 'shared/components/icons/Icons';
 import FrontCollectionsOverview from './FrontCollectionsOverview';
 import FrontContent from './FrontContent';
+import DragToAddSnap from './CollectionComponents/DragToAddSnap';
 
 const FrontWrapper = styled.div`
   height: 100%;
@@ -48,6 +49,12 @@ const OverviewToggleContainer = styled.div<{ active: boolean }>`
   text-align: right;
   margin-left: ${props => (props.active ? '0' : '-1px')};
   cursor: pointer;
+`;
+
+const DragToAddSnapContainer = styled.div`
+  margin-right: auto;
+  margin-bottom: 10px;
+  margin-top: 10px;
 `;
 
 const OverviewHeading = styled.label`
@@ -140,6 +147,9 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
         <FrontWrapper>
           <FrontContentContainer>
             <SectionContentMetaContainer>
+              <DragToAddSnapContainer>
+                <DragToAddSnap />
+              </DragToAddSnapContainer>
               <OverviewHeadingButton onClick={this.handleOpenCollections}>
                 <ButtonLabel>Expand all&nbsp;</ButtonLabel>
                 <DownCaretIcon fill={sharedTheme.base.colors.text} />

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -24,6 +24,8 @@ import { DownCaretIcon } from 'shared/components/icons/Icons';
 import FrontCollectionsOverview from './FrontCollectionsOverview';
 import FrontContent from './FrontContent';
 import DragToAddSnap from './CollectionComponents/DragToAddSnap';
+import { selectPriority } from 'selectors/pathSelectors';
+import { Priorities } from 'types/Priority';
 
 const FrontWrapper = styled.div`
   height: 100%;
@@ -96,6 +98,7 @@ const FrontDetailContainer = styled(BaseFrontContentContainer)`
 interface FrontPropsBeforeState {
   id: string;
   browsingStage: CardSets;
+  priority?: keyof Priorities;
 }
 
 type FrontProps = FrontPropsBeforeState & {
@@ -130,7 +133,7 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
   };
 
   public render() {
-    const { overviewIsOpen, id, browsingStage } = this.props;
+    const { overviewIsOpen, id, browsingStage, priority } = this.props;
     return (
       <React.Fragment>
         <div
@@ -147,9 +150,11 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
         <FrontWrapper>
           <FrontContentContainer>
             <SectionContentMetaContainer>
-              <DragToAddSnapContainer>
-                <DragToAddSnap />
-              </DragToAddSnapContainer>
+              {priority === 'email' && (
+                <DragToAddSnapContainer>
+                  <DragToAddSnap />
+                </DragToAddSnapContainer>
+              )}
               <OverviewHeadingButton onClick={this.handleOpenCollections}>
                 <ButtonLabel>Expand all&nbsp;</ButtonLabel>
                 <DownCaretIcon fill={sharedTheme.base.colors.text} />
@@ -242,7 +247,8 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
 
 const mapStateToProps = (state: State, { id }: FrontPropsBeforeState) => {
   return {
-    overviewIsOpen: selectIsFrontOverviewOpen(state, id)
+    overviewIsOpen: selectIsFrontOverviewOpen(state, id),
+    priority: selectPriority(state)
   };
 };
 

--- a/client-v2/src/components/util/RenderOffscreen.tsx
+++ b/client-v2/src/components/util/RenderOffscreen.tsx
@@ -1,0 +1,11 @@
+import { styled } from 'constants/theme';
+
+/**
+ * Render an item offscreen. Useful when providing drag images to drag events,
+ * which need to be rendered by the DOM before they appear at the cursor, but
+ * don't belong on the page as the user sees it.
+ */
+export default styled.div`
+  position: absolute;
+  transform: translateX(-9999px);
+`;

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -1,6 +1,7 @@
 import { matchIssuePath, matchFrontsEditPath } from 'routes/routes';
 import urls from 'constants/urls';
 import { EditMode } from 'types/EditMode';
+import { Priorities } from 'types/Priority';
 
 const matchRootPath = new RegExp(`^\/${urls.appRoot}`);
 const maybeRemoveV2Prefix = (path: string) => path.replace(matchRootPath, '');
@@ -16,13 +17,15 @@ const selectEditMode = <T>(state: { path: string } & T): EditMode => {
   }
 };
 
-const selectPriority = <T>(state: { path: string } & T) => {
+const selectPriority = <T>(
+  state: { path: string } & T
+): keyof Priorities | undefined => {
   const path = selectV2SubPath(state);
   const match = matchFrontsEditPath(path) || matchIssuePath(path);
   if (!match || !match.params.priority) {
     return;
   }
-  return match.params.priority;
+  return match.params.priority as keyof Priorities;
 };
 
 export { selectFullPath, selectV2SubPath, selectEditMode, selectPriority };

--- a/client-v2/src/shared/components/icons/Icons.tsx
+++ b/client-v2/src/shared/components/icons/Icons.tsx
@@ -268,6 +268,20 @@ const VideoIcon = ({}) => (
   </svg>
 );
 
+const DragHandleIcon = ({ fill = theme.colors.greyDark }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="13"
+    height="10"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fill={fill}
+      d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2m0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8m0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14m6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6m0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8m0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14"
+    />
+  </svg>
+);
+
 export {
   DownCaretIcon,
   RubbishBinIcon,
@@ -280,5 +294,6 @@ export {
   AddImageIcon,
   StarIcon,
   PreviewEyeIcon,
-  VideoIcon
+  VideoIcon,
+  DragHandleIcon as DragIcon
 };


### PR DESCRIPTION
## What's changed?

This PR adds a way of adding free-text snap links without leaving the tool.

![create-snap](https://user-images.githubusercontent.com/7767575/68845566-86e89400-06c3-11ea-9b03-119875c6e76f.gif)

## Implementation notes

This rather 𝓮𝓵𝓮𝓰𝓪𝓷𝓽 hack (YMMV 😁) depends on the way we handle domains and url params when ingesting snaplinks -- specifically, that we understand incoming links from gu.com to be snaplinks, and that we treat url params prefixed `gu-` in a special way. See the comments on `DragToAddSnap.tsx`, ln36.

Eventually, we should be able to migrate to a snap type of 'text' or 'html' or something and remove this workaround.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
