### PR TITLE
Use training edition to mock up an annual product, eg "Music of the year"

### DIFF
--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -10,16 +10,25 @@ import model.editions.templates.TemplateHelpers._
 object TrainingEdition {
   lazy val template = EditionTemplate(
     List(
-      FrontNewsSpecial -> Daily(),
-      FrontWorldSpecial -> Daily(),
-      FrontOpinionSpecial -> Daily(),
-      FrontCrosswords -> Daily(),
+      FrontSpecial01 -> Daily(),
+      FrontSpecial02 -> Daily(),
+      FrontSpecial03 -> Daily(),
+      FrontSpecial04 -> Daily(),
+      FrontSpecial05 -> Daily(),
+      FrontSpecial06 -> Daily(),
+      FrontSpecial07 -> Daily(),
+      FrontSpecial08 -> Daily(),
+      FrontSpecial09 -> Daily(),
+      FrontSpecial10 -> Daily(),
+      FrontSpecial11 -> Daily(),
+      FrontSpecial12 -> Daily(),
+      FrontSpecial13 -> Daily(),
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = CapiTimeWindowConfigInDays(
-        startOffset = 0,
+        startOffset = -365,
         endOffset = 0,
-        useDate = UseDateQueryParamValue.NewspaperEdition
+        useDate = UseDateQueryParamValue.Published
       )
     ),
     zoneId = ZoneId.of("Europe/London"),
@@ -28,20 +37,166 @@ object TrainingEdition {
     ophanQueryPrefillParams = Some(OphanQueryPrefillParams(
       apiKey = s"fronts-editions-${this.getClass.toString}",
       timeWindowConfig = TimeWindowConfigInDays(
-        startOffset = 0,
-        endOffset = -3
+        startOffset = -365,
+        endOffset = 0
       ))
     )
   )
 
-  def FrontNewsSpecial = specialFront("News Special", News)
-
-  def FrontWorldSpecial = specialFront("World Special", News)
-
-  def FrontOpinionSpecial = specialFront("Journal Special", Opinion)
-
-  def FrontCrosswords = front(
-    "Crosswords",
-    collection("Crosswords").searchPrefill("?tag=type/crossword"),
+  def FrontSpecial01 = front(
+    "Front Special 1",
+    collection("1 Special 1").special,
+    collection("1 Special 2").special,
+    collection("1 Special 3").special,
+    collection("1 Special 4").special,
+    collection("1 Special 5").special,
+    collection("1 Special 6").special
   )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial02 = front(
+    "Front Special 2",
+    collection("2 Special 1").special,
+    collection("2 Special 2").special,
+    collection("2 Special 3").special,
+    collection("2 Special 4").special,
+    collection("2 Special 5").special,
+    collection("2 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial03 = front(
+    "Front Special 3",
+    collection("3 Special 1").special,
+    collection("3 Special 2").special,
+    collection("3 Special 3").special,
+    collection("3 Special 4").special,
+    collection("3 Special 5").special,
+    collection("3 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial04 = front(
+    "Front Special 4",
+    collection("4 Special 1").special,
+    collection("4 Special 2").special,
+    collection("4 Special 3").special,
+    collection("4 Special 4").special,
+    collection("4 Special 5").special,
+    collection("4 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial05 = front(
+    "Front Special 5",
+    collection("5 Special 1").special,
+    collection("5 Special 2").special,
+    collection("5 Special 3").special,
+    collection("5 Special 4").special,
+    collection("5 Special 5").special,
+    collection("5 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial06 = front(
+    "Front Special 6",
+    collection("6 Special 1").special,
+    collection("6 Special 2").special,
+    collection("6 Special 3").special,
+    collection("6 Special 4").special,
+    collection("6 Special 5").special,
+    collection("6 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial07 = front(
+    "Front Special 7",
+    collection("7 Special 1").special,
+    collection("7 Special 2").special,
+    collection("7 Special 3").special,
+    collection("7 Special 4").special,
+    collection("7 Special 5").special,
+    collection("7 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial08 = front(
+    "Front Special 8",
+    collection("8 Special 1").special,
+    collection("8 Special 2").special,
+    collection("8 Special 3").special,
+    collection("8 Special 4").special,
+    collection("8 Special 5").special,
+    collection("8 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial09 = front(
+    "Front Special 9",
+    collection("9 Special 1").special,
+    collection("9 Special 2").special,
+    collection("9 Special 3").special,
+    collection("9 Special 4").special,
+    collection("9 Special 5").special,
+    collection("9 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial10 = front(
+    "Front Special 10",
+    collection("10 Special 1").special,
+    collection("10 Special 2").special,
+    collection("10 Special 3").special,
+    collection("10 Special 4").special,
+    collection("10 Special 5").special,
+    collection("10 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial11 = front(
+    "Front Special 11",
+    collection("11 Special 1").special,
+    collection("11 Special 2").special,
+    collection("11 Special 3").special,
+    collection("11 Special 4").special,
+    collection("11 Special 5").special,
+    collection("11 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial12 = front(
+    "Front Special 12",
+    collection("12 Special 1").special,
+    collection("12 Special 2").special,
+    collection("12 Special 3").special,
+    collection("12 Special 4").special,
+    collection("12 Special 5").special,
+    collection("12 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
+  def FrontSpecial13 = front(
+    "Front Special 13",
+    collection("13 Special 1").special,
+    collection("13 Special 2").special,
+    collection("13 Special 3").special,
+    collection("13 Special 4").special,
+    collection("13 Special 5").special,
+    collection("13 Special 6").special
+  )
+  .special
+  .swatch(Culture)
+  
 }

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -22,7 +22,7 @@ object TrainingEdition {
       FrontSpecial10 -> Daily(),
       FrontSpecial11 -> Daily(),
       FrontSpecial12 -> Daily(),
-      FrontSpecial13 -> Daily(),
+      FrontSpecial13 -> Daily()
     ),
     capiQueryPrefillParams = CapiQueryPrefillParams(
       timeWindowConfig = CapiTimeWindowConfigInDays(


### PR DESCRIPTION
## What's changed?

Hijacking the training config to create a playpen for Katy Vans and Chris Moran to see what the shape of a annual product might take.

## Implementation notes

I've used special containers and fronts throughout so that they can rename the fronts as they see fit in the fronts tool.

There are no prefills or promotion metrics used, but if we did I've defaulted them to look at the preceding year.

It's configured as a daily product, for testing, but clearly it isn't one.

I've not used the boilerplate 'Special' definitions, since we wanted six containers in each front not the standard three that the boilerplate gives you.

The product is likely to be mocked up with Film or Music content, so we've set every front to the Culture swatch.
## Checklist

### General
- [x] 🤖 David did this in Github
- [x] ✅ There are no tests
- [x] 🔍 It's never been tested and may not compile
