### PR TITLE
Add a snaplink of type `HTML`

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import v4 from 'uuid/v4';
 import { DragIcon } from 'shared/components/icons/Icons';
 import { styled, theme } from 'constants/theme';
 import RenderOffscreen from 'components/util/RenderOffscreen';
@@ -32,8 +33,15 @@ const handleDragStart = (
   event: React.DragEvent<HTMLDivElement>,
   dragImageElement: HTMLDivElement | null
 ) => {
+  // We must provide a unique URL for our snaplink, otherwise platforms might deduplicate
+  // this content when rendering it on a front. Because we know that in a free-text snaplink,
+  // the URL is not used, we supply a URL here that's a) guaranteed to be unique, and b)
+  // gives some indication why it's there. When snaplinks don't need URLs, possibly because
+  // there's a snap type for inserting arbitrary HTML, this will no longer be necessary.
+  const uniqueId = v4().substr(0, 4);
+
   // We could also pass this as a custom drag type, which would arguably be cleaner, but require more code.
-  const url = `https://www.theguardian.com?gu-headline=HTML%20snap%20--%20click%20to%20change%20content&gu-snapType=html`;
+  const url = `https://www.theguardian.com/free-text-${uniqueId}?gu-headline=HTML%20snap%20--%20click%20to%20change%20content&gu-snapType=html`;
 
   // Setting both types re: https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types
   event.dataTransfer.setData('text/plain', url);

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import v4 from 'uuid/v4';
 import { DragIcon } from 'shared/components/icons/Icons';
 import { styled, theme } from 'constants/theme';
 import RenderOffscreen from 'components/util/RenderOffscreen';
@@ -33,13 +32,8 @@ const handleDragStart = (
   event: React.DragEvent<HTMLDivElement>,
   dragImageElement: HTMLDivElement | null
 ) => {
-  // We must provide a unique URL for our snaplink, otherwise platforms might deduplicate
-  // this content when rendering it on a front. Because we know that in a free-text snaplink,
-  // the URL is not used, we supply a URL here that's a) guaranteed to be unique, and b)
-  // gives some indication why it's there. When snaplinks don't need URLs, possibly because
-  // there's a snap type for inserting arbitrary HTML, this will no longer be necessary.
-  const uniqueId = v4().substr(0, 4);
-  const url = `https://www.theguardian.com/free-text-${uniqueId}?gu-headline=Text%20snap%20--%20click%20to%20change%20content&gu-snapType=link`;
+  // We could also pass this as a custom drag type, which would arguably be cleaner, but require more code.
+  const url = `https://www.theguardian.com?gu-headline=HTML%20snap%20--%20click%20to%20change%20content&gu-snapType=html`;
 
   // Setting both types re: https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types
   event.dataTransfer.setData('text/plain', url);

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -141,11 +141,15 @@ const SnapLink = ({
             {!showMeta && <CardMetaHeading>Snap link </CardMetaHeading>}
             <CardHeading html>{headline}</CardHeading>
             <SnapLinkURL>
-              <strong>url:&nbsp;</strong>
-              <a href={urlPath} target="_blank">
-                {card.meta.href}
-              </a>
-              &nbsp;
+              {card.meta.href && (
+                <>
+                  <strong>url:&nbsp;</strong>
+                  <a href={urlPath} target="_blank">
+                    {card.meta.href}
+                  </a>
+                  &nbsp;
+                </>
+              )}
               {card.meta.snapUri && (
                 <>
                   <strong>snap uri:&nbsp;</strong>


### PR DESCRIPTION
## What's changed?

Our fancy 'drag to add a snaplink' button now adds bona fide `HTML` snaps. Behold, no URL:

<img width="529" alt="Screenshot 2019-11-18 at 21 14 12" src="https://user-images.githubusercontent.com/7767575/69095303-ec34e000-0a49-11ea-8e0b-534fec50b815.png">

## Implementation notes

I've used the old url-parsing code for convenience, but if there are serious objects, we can always use a custom drop type to express the same thing -- it's just more lines.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
