### PR TITLE
Alter fields for HTML snaps

### DIFF
--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -408,7 +408,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               <Field
                 name="headline"
                 label={this.getHeadlineLabel()}
-                rows={this.getHeadlineRows()}
+                rows="2"
                 placeholder={articleCapiFieldValues.headline}
                 component={InputTextArea}
                 originalValue={articleCapiFieldValues.headline}
@@ -749,7 +749,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
    */
   private getHeadlineLabel = () =>
     this.props.snapType === 'html' ? 'HTML content' : 'Headline';
-  private getHeadlineRows = () => (this.props.snapType === 'html' ? '8' : '2');
 }
 
 const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({

--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -747,9 +747,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
    * point we'll be able to use another, saner field to do the same job, but in the meantime,
    * for snaps of type `html`, the field `headline` is where the html lives.
    */
-  private getHeadlineLabel = () => this.props.snapType === 'html' ? 'HTML content' : 'Headline';
-  private getHeadlineRows = () => this.props.snapType === 'html' ? '8' : '2';
-
+  private getHeadlineLabel = () =>
+    this.props.snapType === 'html' ? 'HTML content' : 'Headline';
+  private getHeadlineRows = () => (this.props.snapType === 'html' ? '8' : '2');
 }
 
 const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({

--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -739,6 +739,14 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     });
   };
 
+  /**
+   * You may be thinking -- why on earth would we use the `headline` field to contain
+   * HTML, renaming it in the process so our users are none the wiser? It's because the e-mail
+   * frontend, which currently consumes snaps of this type, knows what to do with headlines
+   * (it renders them as HTML). At some point in the future, it will be refactored, at which
+   * point we'll be able to use another, saner field to do the same job, but in the meantime,
+   * for snaps of type `html`, the field `headline` is where the html lives.
+   */
   private getHeadlineLabel = () => this.props.snapType === 'html' ? 'HTML content' : 'Headline';
   private getHeadlineRows = () => this.props.snapType === 'html' ? '8' : '2';
 

--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -748,7 +748,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
    * for snaps of type `html`, the field `headline` is where the html lives.
    */
   private getHeadlineLabel = () =>
-    this.props.snapType === 'html' ? 'HTML content' : 'Headline';
+    this.props.snapType === 'html' ? 'Content' : 'Headline';
 }
 
 const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({

--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -19,6 +19,7 @@ import {
   selectArticleTag
 } from 'shared/selectors/shared';
 import { createSelectFormFieldsForCard } from 'selectors/formSelectors';
+import { defaultObject } from 'shared/util/selectorUtils';
 import { CardMeta, ArticleTag } from 'shared/types/Collection';
 import InputText from 'shared/components/input/InputText';
 import InputTextArea from 'shared/components/input/InputTextArea';
@@ -195,6 +196,9 @@ const CheckboxFieldsContainer: React.SFC<{
   const childrenToRender = children.filter(child =>
     shouldRenderField(child.props.name, editableFields)
   );
+  if (!childrenToRender.length) {
+    return null;
+  }
   return (
     <FieldsContainerWrap>
       {childrenToRender.map(child => {
@@ -371,6 +375,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             <ConditionalField
               name="customKicker"
               label="Kicker"
+              permittedFields={editableFields}
               component={InputText}
               disabled={isBreaking}
               title={
@@ -401,12 +406,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             />
             {shouldRenderField('headline', editableFields) && (
               <Field
-                permittedFields={editableFields}
                 name="headline"
-                label="Headline"
+                label={this.getHeadlineLabel()}
+                rows={this.getHeadlineRows()}
                 placeholder={articleCapiFieldValues.headline}
                 component={InputTextArea}
-                rows="2"
                 originalValue={articleCapiFieldValues.headline}
                 data-testid="edit-form-headline-field"
               />
@@ -734,6 +738,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       }
     });
   };
+
+  private getHeadlineLabel = () => this.props.snapType === 'html' ? 'HTML content' : 'Headline';
+  private getHeadlineRows = () => this.props.snapType === 'html' ? '8' : '2';
+
 }
 
 const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({
@@ -760,6 +768,7 @@ const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({
 interface ContainerProps {
   articleExists: boolean;
   collectionId: string | null;
+  snapType: string | undefined;
   getLastUpdatedBy: (collectionId: string) => string | null;
   imageSlideshowReplace: boolean;
   imageCutoutReplace: boolean;
@@ -830,13 +839,14 @@ const createMapStateToProps = () => {
       hasMainVideo: !!article && !!article.hasMainVideo,
       collectionId: (parentCollection && parentCollection.id) || null,
       getLastUpdatedBy,
+      snapType: article && article.snapType,
       initialValues: getInitialValuesForCardForm(article),
       articleCapiFieldValues: getCapiValuesForArticleFields(externalArticle),
       editableFields:
         article && selectFormFields(state, article.uuid, isSupporting),
       kickerOptions: article
         ? selectArticleTag(selectSharedState(state), cardId)
-        : {},
+        : defaultObject,
       imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
       imageHide: valueSelector(state, 'imageHide'),
       imageReplace: valueSelector(state, 'imageReplace'),

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
@@ -64,7 +64,7 @@ const DragToAddTextSnap = () => {
         onDragStart={e => handleDragStart(e, ref.current)}
         draggable={true}
       >
-        <DragIcon /> Drag to add a text snap
+        <DragIcon /> Drag to add a text card
       </DragToAddSnapContainer>
     </>
   );

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -42,7 +42,9 @@ export const htmlSnapFields = [
   'headline',
   'imageHide',
   'imageReplace',
-  'primaryImage'
+  'primaryImage',
+  'imageCutoutReplace',
+  'cutoutImage',
 ];
 
 export const emailFieldsToExclude = [

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -51,9 +51,7 @@ export const emailFieldsToExclude = [
   'isBreaking',
   'showLargeHeadline',
   'slideshow',
-  'cutoutImage',
   'imageSlideshowReplace',
-  'imageCutoutReplace'
 ] as FormFields[];
 
 const selectIsSupporting = (_: unknown, __: unknown, isSupporting: boolean) =>

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -38,6 +38,13 @@ export const supportingFields = [
   'showKickerCustom'
 ] as FormFields[];
 
+export const htmlSnapFields = [
+  'headline',
+  'imageHide',
+  'imageReplace',
+  'primaryImage',
+]
+
 export const emailFieldsToExclude = [
   'isBreaking',
   'showLargeHeadline',
@@ -77,6 +84,9 @@ export const createSelectFormFieldsForCard = () => {
     ) => {
       if (!derivedArticle) {
         return [];
+      }
+      if (derivedArticle.snapType === 'html') {
+        return htmlSnapFields;
       }
       if (isSupporting) {
         return supportingFields;

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -44,14 +44,14 @@ export const htmlSnapFields = [
   'imageReplace',
   'primaryImage',
   'imageCutoutReplace',
-  'cutoutImage',
+  'cutoutImage'
 ];
 
 export const emailFieldsToExclude = [
   'isBreaking',
   'showLargeHeadline',
   'slideshow',
-  'imageSlideshowReplace',
+  'imageSlideshowReplace'
 ] as FormFields[];
 
 const selectIsSupporting = (_: unknown, __: unknown, isSupporting: boolean) =>

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -42,8 +42,8 @@ export const htmlSnapFields = [
   'headline',
   'imageHide',
   'imageReplace',
-  'primaryImage',
-]
+  'primaryImage'
+];
 
 export const emailFieldsToExclude = [
   'isBreaking',

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -142,7 +142,7 @@ const SnapLink = ({
             {!showMeta && <CardMetaHeading>Snap link </CardMetaHeading>}
             <CardHeading html>{headline}</CardHeading>
             <SnapLinkURL>
-              {card.meta.href && (
+              {card.meta.snapType !== 'html' && card.meta.href && (
                 <>
                   <strong>url:&nbsp;</strong>
                   <a href={urlPath} target="_blank">

--- a/client-v2/src/shared/components/snapLink/SnapLink.tsx
+++ b/client-v2/src/shared/components/snapLink/SnapLink.tsx
@@ -37,6 +37,7 @@ import ArticleGraph from '../article/ArticleGraph';
 import { selectFeatureValue } from 'shared/redux/modules/featureSwitches/selectors';
 import PageViewDataWrapper from '../PageViewDataWrapper';
 import ImageAndGraphWrapper from '../image/ImageAndGraphWrapper';
+import { ThumbnailCutout } from '../image/Thumbnail';
 
 const SnapLinkBodyContainer = styled(CardBody)`
   justify-content: space-between;
@@ -169,15 +170,22 @@ const SnapLink = ({
               />
             </PageViewDataWrapper>
           )}
-          <ThumbnailSmall
-            imageHide={article && article.imageHide}
-            url={article && article.imageReplace ? article.thumbnail : ''}
-          />
-          <ImageMetadataContainer
-            imageSlideshowReplace={article && article.imageSlideshowReplace}
-            imageReplace={article && article.imageReplace}
-            imageCutoutReplace={article && article.imageCutoutReplace}
-          />
+          {article && (
+            <div>
+              <ThumbnailSmall
+                imageHide={article.imageHide}
+                url={article.thumbnail}
+              />
+              {article.cutoutThumbnail ? (
+                <ThumbnailCutout src={article.cutoutThumbnail} />
+              ) : null}
+              <ImageMetadataContainer
+                imageSlideshowReplace={article && article.imageSlideshowReplace}
+                imageReplace={article && article.imageReplace}
+                imageCutoutReplace={article && article.imageCutoutReplace}
+              />
+            </div>
+          )}
         </ImageAndGraphWrapper>
         <HoverActionsAreaOverlay
           disabled={isUneditable}

--- a/client-v2/src/shared/util/selectorUtils.ts
+++ b/client-v2/src/shared/util/selectorUtils.ts
@@ -1,6 +1,9 @@
 import { createSelectorCreator } from 'reselect';
 import shallowequal from 'shallowequal';
 
+export const defaultObject = {};
+export const defaultArray = [];
+
 const defaultEqualityCheck = (a: any, b: any) => a === b;
 
 function resultCheckMemoize<A extends any[], R>(func: (...args: A) => R) {

--- a/client-v2/src/util/CAPIUtils.ts
+++ b/client-v2/src/util/CAPIUtils.ts
@@ -65,13 +65,14 @@ function getThumbnail(
     return metaImageSrcThumb;
   } else if (imageSrc) {
     return imageSrc;
-  } else if (meta.imageCutoutReplace && externalArticle) {
+  } else if (meta.imageCutoutReplace) {
     return (
       meta.imageCutoutSrc ||
-      getContributorImage(externalArticle) ||
-      externalArticle.fields.secureThumbnail ||
-      externalArticle.fields.thumbnail ||
-      undefined
+      (externalArticle &&
+        (getContributorImage(externalArticle) ||
+          externalArticle.fields.secureThumbnail ||
+          externalArticle.fields.thumbnail ||
+          undefined))
     );
   } else if (
     meta.imageSlideshowReplace &&


### PR DESCRIPTION
_NB: Don't merge this just yet! It's missing tests, and I'd quite like to add some. But, gentle reader, you are of course more than welcome to review._

## What's changed?

Hot on the heels of #1105, this PR alters the fields for the `html` snap. Users of this snap type are allowed precisely three: 

<img width="774" alt="Screenshot 2019-11-18 at 21 14 54" src="https://user-images.githubusercontent.com/7767575/69095380-1be3e800-0a4a-11ea-8224-bab528fb16ef.png">

That's yer lot.

## Implementation notes

I've added some commenting, as we repurpose the `headline` field here for our own nefarious purposes (although, it was always being used this way -- we've simply called it something nice for our users that isn't `headline`). Once e-mail renderer has caught up, we should be able to use a proper `html` field for our proper `html` snap.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
