### PR TITLE
Dependency cleanup: Bump Capi & facia-scala-client versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,8 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.11.293"
-val capiModelsVersion = "14.1"
-val capiClientVersion = "14.3"
+val capiModelsVersion = "15.4"
+val capiClientVersion = "15.4"
 val json4sVersion = "3.6.0-M2"
 val enumeratumPlayVersion = "1.5.13"
 val circeVersion = "0.11.1"
@@ -90,12 +90,12 @@ libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
-    "com.gu" %% "content-api-models" % capiModelsVersion,
+    "com.gu" %% "content-api-models-scala" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.11",
+    "com.gu" %% "fapi-client-play26" % "3.0.14",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.4",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,4 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "2.0.0-RC2")
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
## What's changed?
Various dependencies had got out of date which was preventing facia-scala-client upgrades being applied to the Fronts tool

This brings us almost up to date with facia-scala-client, and means that the capi version matches between Facia-scala-client and Facia tool. 

Several other Scala libraries are getting out of date (run `sbt eviction` to see what...) so we should return at some point to make these fixes. 

**Why `content-api-models-scala` instead of `content-api-models`?** 
This is now recommended practice - see: https://github.com/guardian/content-api-models#information-about-built-jars

**Why the deletion of this line?**  
`addSbtPlugin("io.get-coursier" % "sbt-coursier" % "2.0.0-RC2")`
The newer version of sbt includes a version of `coursier` that is incompatible with the trial version we had incorporated manually into the project. This was causing errors. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
