### PR TITLE
Remove image for the html snap

### DIFF
--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -499,9 +499,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             <ImageRowContainer size={this.props.size}>
               <Row>
                 <ImageCol faded={imageHide || !!coverCardImageReplace}>
-                  <InputLabel htmlFor={this.getImageFieldName()}>
-                    Trail image
-                  </InputLabel>
+                  {shouldRenderField(this.getImageFieldName(), editableFields) && (
+                    <InputLabel htmlFor={this.getImageFieldName()}>
+                      Trail image
+                    </InputLabel>
+                  )}
                   <ConditionalField
                     permittedFields={editableFields}
                     name={this.getImageFieldName()}

--- a/client-v2/src/components/FrontsEdit/CardFormInline.tsx
+++ b/client-v2/src/components/FrontsEdit/CardFormInline.tsx
@@ -499,7 +499,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             <ImageRowContainer size={this.props.size}>
               <Row>
                 <ImageCol faded={imageHide || !!coverCardImageReplace}>
-                  {shouldRenderField(this.getImageFieldName(), editableFields) && (
+                  {shouldRenderField(
+                    this.getImageFieldName(),
+                    editableFields
+                  ) && (
                     <InputLabel htmlFor={this.getImageFieldName()}>
                       Trail image
                     </InputLabel>

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -39,12 +39,7 @@ export const supportingFields = [
 ] as FormFields[];
 
 export const htmlSnapFields = [
-  'headline',
-  'imageHide',
-  'imageReplace',
-  'primaryImage',
-  'imageCutoutReplace',
-  'cutoutImage'
+  'headline'
 ];
 
 export const emailFieldsToExclude = [

--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -38,9 +38,7 @@ export const supportingFields = [
   'showKickerCustom'
 ] as FormFields[];
 
-export const htmlSnapFields = [
-  'headline'
-];
+export const htmlSnapFields = ['headline'];
 
 export const emailFieldsToExclude = [
   'isBreaking',


### PR DESCRIPTION
## What's changed?

Remove the image for the html snap. It's troublesome on the e-mail frontend -- it renders links that shouldn't be there.

Before:

<img width="501" alt="Screenshot 2019-11-21 at 16 07 26" src="https://user-images.githubusercontent.com/7767575/69355036-0c96b180-0c79-11ea-9ba8-9aca282e7141.png">

After:

<img width="500" alt="Screenshot 2019-11-21 at 16 06 36" src="https://user-images.githubusercontent.com/7767575/69355040-0e607500-0c79-11ea-988f-f0955bde410b.png">

When the new e-mail redesign kicks in, we can re-add this and remove the `href` property for `html` snaplinks.

Because this is a temporary change, I haven't refactored the form to expand the full width of the card when the form is full-width to keep the task quick.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
