### PR TITLE
ATOM ID: Add atomId to the data in an atom snaplink

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.14",
+    "com.gu" %% "fapi-client-play26" % "3.0.16",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.5",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.16",
+    "com.gu" %% "fapi-client-play26" % "3.0.17",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.5",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",

--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -196,6 +196,8 @@ const getArticleEntitiesFromDrop = async (
   const isCAPIUrl = isCapiUrl(resourceIdOrUrl);
   if (isCAPIUrl) {
     const card = await createAtomSnap(resourceIdOrUrl);
+
+    console.log("==========>", card);
     return [card];
   }
   if (isPlainUrl) {

--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -196,8 +196,6 @@ const getArticleEntitiesFromDrop = async (
   const isCAPIUrl = isCapiUrl(resourceIdOrUrl);
   if (isCAPIUrl) {
     const card = await createAtomSnap(resourceIdOrUrl);
-
-    console.log("==========>", card);
     return [card];
   }
   if (isPlainUrl) {

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -272,6 +272,7 @@ describe('Snap cards actions', () => {
             frontPublicationDate: 1487076708000,
             id: 'snap/1487076708000',
             meta: {
+              atomId: '/atom/interactive/interactives/2017/06/general-election',
               headline: 'General Election 2017',
               byline: 'Guardian Visuals',
               showByline: false,

--- a/client-v2/src/shared/fixtures/capiAtom.js
+++ b/client-v2/src/shared/fixtures/capiAtom.js
@@ -1,0 +1,49 @@
+export const capiAtom = {
+  response: {
+    status: 'ok',
+    userTier: 'internal',
+    total: 1,
+    interactive: {
+      id: 'interactives/2017/06/general-election',
+      atomType: 'interactive',
+      labels: [],
+      defaultHtml: 'default',
+      data: {
+        interactive: {
+          type: 'interactive',
+          title: 'General Election 2017',
+          css: 'css content',
+          html: 'html content'
+        }
+      },
+      contentChangeDetails: {
+        lastModified: {
+          date: 1561564370000,
+          user: {
+            email: 'graphics@theguardian.com',
+            firstName: 'Visuals',
+            lastName: 'Guardian'
+          }
+        },
+        created: {
+          date: 1561564370000,
+          user: {
+            email: 'graphics@theguardian.com',
+            firstName: 'Visuals',
+            lastName: 'Guardian'
+          }
+        },
+        published: {
+          date: 1561564370000,
+          user: {
+            email: 'graphics@theguardian.com',
+            firstName: 'Visuals',
+            lastName: 'Guardian'
+          }
+        },
+        revision: 1561564370681
+      },
+      commissioningDesks: []
+    }
+  }
+};

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -62,6 +62,7 @@ interface CardRootMeta {
   snapUri?: string;
   snapType?: string;
   snapCss?: string;
+  atomId?: string;
   imageSlideshowReplace?: boolean;
   slideshow?: Array<{
     src?: string;

--- a/client-v2/src/shared/util/__tests__/snap.spec.ts
+++ b/client-v2/src/shared/util/__tests__/snap.spec.ts
@@ -1,7 +1,8 @@
-import { validateId, generateId, createLatestSnap, createSnap } from '../snap';
+import { validateId, generateId, createLatestSnap, createSnap, createAtomSnap } from '../snap';
 import tagPageHtml from '../../fixtures/guardianTagPage';
 import fetchMock from 'fetch-mock';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
+import {capiAtom} from 'shared/fixtures/capiAtom.js'
 
 jest.mock('uuid/v4', () => () => 'uuid');
 
@@ -87,4 +88,29 @@ describe('utils/snap', () => {
       });
     });
   });
+
+  describe("convert to Atom snap", async () => {
+    it("should create a snap of 'interactive', given a link to an atom in the public content api", async () => {
+      fetchMock.once('begin:/api/live', capiAtom);
+      const atomLinkSnap = await createAtomSnap('https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter');
+      expect(atomLinkSnap).toEqual(
+        {
+          uuid: 'uuid',
+          frontPublicationDate: 1487076708000,
+          id: 'snap/1487076708000',
+          meta: {
+            headline: 'General Election 2017',
+            byline: 'Guardian Visuals',
+            showByline: false,
+            snapType: 'interactive',
+            snapUri: 'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter',
+            atomId: '/atom/interactive/interactives/2017/06/general-election',
+            href: 'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
+          }
+        }
+      )
+    });
+  })
+
 });
+

--- a/client-v2/src/shared/util/__tests__/snap.spec.ts
+++ b/client-v2/src/shared/util/__tests__/snap.spec.ts
@@ -1,8 +1,14 @@
-import { validateId, generateId, createLatestSnap, createSnap, createAtomSnap } from '../snap';
+import {
+  validateId,
+  generateId,
+  createLatestSnap,
+  createSnap,
+  createAtomSnap
+} from '../snap';
 import tagPageHtml from '../../fixtures/guardianTagPage';
 import fetchMock from 'fetch-mock';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
-import {capiAtom} from 'shared/fixtures/capiAtom.js'
+import { capiAtom } from 'shared/fixtures/capiAtom.js';
 
 jest.mock('uuid/v4', () => () => 'uuid');
 
@@ -89,28 +95,28 @@ describe('utils/snap', () => {
     });
   });
 
-  describe("convert to Atom snap", async () => {
+  describe('convert to Atom snap', async () => {
     it("should create a snap of 'interactive', given a link to an atom in the public content api", async () => {
       fetchMock.once('begin:/api/live', capiAtom);
-      const atomLinkSnap = await createAtomSnap('https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter');
-      expect(atomLinkSnap).toEqual(
-        {
-          uuid: 'uuid',
-          frontPublicationDate: 1487076708000,
-          id: 'snap/1487076708000',
-          meta: {
-            headline: 'General Election 2017',
-            byline: 'Guardian Visuals',
-            showByline: false,
-            snapType: 'interactive',
-            snapUri: 'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter',
-            atomId: '/atom/interactive/interactives/2017/06/general-election',
-            href: 'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
-          }
+      const atomLinkSnap = await createAtomSnap(
+        'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
+      );
+      expect(atomLinkSnap).toEqual({
+        uuid: 'uuid',
+        frontPublicationDate: 1487076708000,
+        id: 'snap/1487076708000',
+        meta: {
+          headline: 'General Election 2017',
+          byline: 'Guardian Visuals',
+          showByline: false,
+          snapType: 'interactive',
+          snapUri:
+            'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter',
+          atomId: '/atom/interactive/interactives/2017/06/general-election',
+          href:
+            'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
         }
-      )
+      });
     });
-  })
-
+  });
 });
-

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -83,7 +83,8 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
         showByline: false,
         snapType: 'interactive',
         snapUri: url,
-        atomId
+        atomId,
+        ...meta
       }
     });
   } catch (e) {

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -71,10 +71,7 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
       getAbsolutePath(url, false)
     );
     const { title } = atom.response.interactive.data.interactive;
-
-    //grab the path from the url
     const atomId = new URL(url).pathname;
-    console.log("atome id here", atomId)
 
     return convertToSnap({
       uuid,

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -72,6 +72,10 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
     );
     const { title } = atom.response.interactive.data.interactive;
 
+    //grab the path from the url
+    const atomId = new URL(url).pathname;
+    console.log("atome id here", atomId)
+
     return convertToSnap({
       uuid,
       id: url,
@@ -81,7 +85,8 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
         byline: 'Guardian Visuals',
         showByline: false,
         snapType: 'interactive',
-        snapUri: url
+        snapUri: url,
+        atomId
       }
     });
   } catch (e) {


### PR DESCRIPTION
## What's changed?
When snap links are created with links to atoms in the content api eg: 
`https://content.guardianapis.com/atom/interactive/interactives/2019/10/test-snap`. 

We want to extract the `atomId` - the path of the atom and send it on in a new optional `atomId` property.

This makes it easier for downstream teams like Dotcom and MAPI to fetch the atom from CAPI. 

This is follow-up work to https://github.com/guardian/facia-tool/pull/1067

It can be released after the new version of Facia-Scala-Client is updated: https://github.com/guardian/facia-scala-client/pull/231


The resulting json looks like this: 
 ```
{
	"id": "snap/1574361251494",
	"frontPublicationDate": 1574361316176,
	"meta": {
		"headline": "Test snap atom",
		"snapType": "interactive",
		"showByline": false,
		"atomId": "/atom/interactive/interactives/2019/10/test-snap",
		"snapUri": "https://content.guardianapis.com/atom/interactive/interactives/2019/10/test-snap",
		"byline": "Guardian Visuals",
		"href": "https://content.guardianapis.com/atom/interactive/interactives/2019/10/test-snap"
	}
}
```

**The version for Facia-Scala-Client will need to be updated in downstream apps.** 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
