### PR TITLE
Drop leading slash from atomId

### DIFF
--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -272,7 +272,7 @@ describe('Snap cards actions', () => {
             frontPublicationDate: 1487076708000,
             id: 'snap/1487076708000',
             meta: {
-              atomId: '/atom/interactive/interactives/2017/06/general-election',
+              atomId: 'atom/interactive/interactives/2017/06/general-election',
               headline: 'General Election 2017',
               byline: 'Guardian Visuals',
               showByline: false,

--- a/client-v2/src/shared/util/__tests__/snap.spec.ts
+++ b/client-v2/src/shared/util/__tests__/snap.spec.ts
@@ -112,7 +112,7 @@ describe('utils/snap', () => {
           snapType: 'interactive',
           snapUri:
             'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter',
-          atomId: '/atom/interactive/interactives/2017/06/general-election',
+          atomId: 'atom/interactive/interactives/2017/06/general-election',
           href:
             'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
         }

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -71,7 +71,7 @@ async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
       getAbsolutePath(url, false)
     );
     const { title } = atom.response.interactive.data.interactive;
-    const atomId = new URL(url).pathname;
+    const atomId = new URL(url).pathname.substr(1);
 
     return convertToSnap({
       uuid,


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This PR makes `atomId` consistent with other id's provided by the tool by dropping the leading slash.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
