### PR TITLE
Handle Google redirect URLs

### DIFF
--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -327,7 +327,10 @@ const isGoogleRedirectUrl = (url: string) => {
 
 const getRelevantURLFromGoogleRedirectURL = (url: string) => {
   const params = checkQueryParams(url, ['q']);
-  return params ? params[0][1] : url;
+  if (params && isValidURL(params[0][1])) {
+    return params[0][1];
+  }
+  return url;
 };
 
 const getArticleEntitiesFromGuardianPath = async (

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -322,4 +322,74 @@ describe('Snap cards actions', () => {
       );
     });
   });
+  describe('should drop the Google redirect URL when present', () => {
+    it('drops the redirect from Content API URLs', async () => {
+      const store = mockStore(initialState);
+      const snapUrl =
+        'https://www.google.com/url?q=https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election&amp;source=gmail&amp;ust=someId&amp;usg=anotherId';
+      const CapiResponse = capiInteractiveAtomResponse;
+      fetchMock.mock(
+        '/api/live/atom/interactive/interactives/2017/06/general-election',
+        CapiResponse
+      );
+      await store.dispatch(createArticleEntitiesFromDrop(
+        idDrop(snapUrl)
+      ) as any);
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(
+        cardsReceived({
+          card1: {
+            frontPublicationDate: 1487076708000,
+            id: 'snap/1487076708000',
+            meta: {
+              atomId: 'atom/interactive/interactives/2017/06/general-election',
+              headline: 'General Election 2017',
+              byline: 'Guardian Visuals',
+              showByline: false,
+              snapType: 'interactive',
+              snapUri:
+                'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election',
+              href:
+                'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election'
+            },
+            uuid: 'card1'
+          }
+        })
+      );
+    });
+    it('drops the redirect from snap link URLs with query params', async () => {
+      const store = mockStore(initialState);
+      const snapUrl =
+        'https://www.google.ca/url?q=https://www.theguardian.com/football/live?gu-snapType%3Djson.html%26gu-snapCss%3Dfootball%26gu-snapUri%3Dhttps%253A%252F%252Fapi.nextgen.guardianapps.co.uk%252Ffootball%252Flive.json%26gu-headline%3DLive%2Bmatches%26gu-trailText%3DToday%2527s%2Bmatches&sa=D&source=hangouts&ust=someId&usg=anotherId';
+      const CapiResponse = capiInteractiveAtomResponse;
+      fetchMock.mock(
+        '/api/live/atom/interactive/interactives/2017/06/general-election',
+        CapiResponse
+      );
+      await store.dispatch(createArticleEntitiesFromDrop(
+        idDrop(snapUrl)
+      ) as any);
+      const actions = store.getActions();
+      expect(actions[0]).toEqual(
+        cardsReceived({
+          card1: {
+            frontPublicationDate: 1487076708000,
+            id: 'snap/1487076708000',
+            meta: {
+              byline: undefined,
+              headline: 'Live matches',
+              href: 'football/live',
+              showByline: false,
+              snapCss: 'football',
+              snapType: 'json.html',
+              snapUri:
+                'https://api.nextgen.guardianapps.co.uk/football/live.json',
+              trailText: "Today's matches"
+            },
+            uuid: 'card1'
+          }
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
When dragging or copying a link from Google (Hangouts, Mail, Drive...) into the Fronts tool, the link may be prepended with a Google 'redirect' that looks like `https://www.google.com/url?q=https://example.com/foobar&sa=D&source=hangouts...`

As a consequence, links copied from Google into the tool aren't handled correctly. For an example, see the below image. The first snap is how the link should be handled and the second is how it is currently handled.

![Screenshot 2019-11-26 at 11 43 21](https://user-images.githubusercontent.com/12645938/69721710-59610900-110d-11ea-84c3-884c2113217b.png)

This PR introduces changes to ensure that links dragged or copied from Google are interpreted correctly by the tool.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
When we use pandaFetch to determine the title and descriptions for a URL like `https://www.google.com/url?q=https://example.com/foobar&sa=D&source=hangouts...`, Google returns a 200 rather than a 3xx code that we can follow. 

To work around this, we can identify up-front if the link contains a Google redirect, then extract the relevant URL from the query parameters. The potential URL is extracted from a parameter called `q` and is then validated to confirm it is a URL. 
## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
