### PR TITLE
Rich text: Add hard line break on 'Enter'

### DIFF
--- a/client-v2/integration/fixtures/collection2.js
+++ b/client-v2/integration/fixtures/collection2.js
@@ -7,7 +7,7 @@ module.exports = {
         trailText:
           'Social media gives people a megaphone. But if companies keep giving that megaphone to trolls intending to hurt people, they start to look complicit',
         headline:
-          '<p><strong><a href="https://bbc.co.uk/">Bold with a link Test3</a></strong></p>',
+          '<strong><a href="https://bbc.co.uk/">Bold with a link Test3</a></strong>',
         isBreaking: false,
         isBoosted: false,
         imageHide: false,

--- a/client-v2/integration/fixtures/collection4.js
+++ b/client-v2/integration/fixtures/collection4.js
@@ -445,7 +445,7 @@ module.exports = {
       frontPublicationDate: 1574268324019,
       id: 'snap/1574268232716',
       meta: {
-        headline: '<p>Test2</p>',
+        headline: 'Test2',
         showByline: false,
         snapType: 'html'
       }
@@ -455,7 +455,7 @@ module.exports = {
       id: 'snap/1574268232717',
       meta: {
         headline:
-          '<p><strong><a href="https://bbc.co.uk/">Bold with a link Test3</a><strong></p>',
+          '<strong><a href="https://bbc.co.uk/">Bold with a link Test3</a><strong>',
         showByline: false,
         snapType: 'html'
       }

--- a/client-v2/integration/tests/text-editing.spec.js
+++ b/client-v2/integration/tests/text-editing.spec.js
@@ -36,10 +36,10 @@ test('Rich text editor bolds text', async t => {
     .wait(300)
     .click(editFormSaveButton())
     .expect(getSnapHeadlineHtml())
-    .eql('<p><strong>Test2</strong></p>');
+    .eql('<strong>Test2</strong>');
 });
 
-// changing this headline: '<p><strong><a href="https://bbc.co.uk/">Bold with a link Test3</a></strong></p>',
+// changing this headline: '<strong><a href="https://bbc.co.uk/">Bold with a link Test3</a></strong>',
 test('Rich text editor removes bold from bold text', async t => {
   const secondCollectionStory1 = snap(2, 1);
   const richTextInput = editFormRichText();
@@ -57,7 +57,7 @@ test('Rich text editor removes bold from bold text', async t => {
     .wait(300)
     .click(editFormSaveButton())
     .expect(getSnapHeadlineHtml())
-    .eql('<p><a href="https://bbc.co.uk/">Bold with a link Test3</a></p>');
+    .eql('<a href="https://bbc.co.uk/">Bold with a link Test3</a>');
 });
 
 test('Rich text editor adds a link to text', async t => {
@@ -78,10 +78,10 @@ test('Rich text editor adds a link to text', async t => {
     .wait(300)
     .click(editFormSaveButton())
     .expect(getSnapHeadlineHtml())
-    .eql('<p><a href="https://bbc.co.uk/">Test2</a></p>');
+    .eql('<a href="https://bbc.co.uk/">Test2</a>');
 });
 
-// changing this headline: '<p><strong><a href="https://bbc.co.uk/">Bold with a link Test3</a></strong></p>',
+// changing this headline: '<strong><a href="https://bbc.co.uk/">Bold with a link Test3</a></strong>',
 test('Rich text editor removes a link from text', async t => {
   const secondCollectionStory1 = snap(2, 1);
   const richTextInput = editFormRichText();
@@ -99,5 +99,5 @@ test('Rich text editor removes a link from text', async t => {
     .wait(300)
     .click(editFormSaveButton())
     .expect(getSnapHeadlineHtml())
-    .eql('<p><strong>Bold with a link Test3</strong></p>');
+    .eql('<strong>Bold with a link Test3</strong>');
 });

--- a/client-v2/src/components/inputs/richtext/setup.ts
+++ b/client-v2/src/components/inputs/richtext/setup.ts
@@ -1,6 +1,5 @@
 import { buildKeymap } from './utils/keymap';
 import { keymap } from 'prosemirror-keymap';
-import { baseKeymap } from 'prosemirror-commands';
 import { Schema, DOMSerializer, DOMParser, NodeSpec } from 'prosemirror-model';
 import { schema } from 'prosemirror-schema-basic';
 import { addListNodes } from 'prosemirror-schema-list';
@@ -14,18 +13,13 @@ import { history } from 'prosemirror-history';
 const createBasePlugins = (s: Schema) => {
   const plugins = [
     keymap(buildKeymap(s, {}, {})),
-    keymap(baseKeymap),
     history({ depth: 100, newGroupDelay: 500 })
   ];
   return plugins;
 };
 
 export const basicSchema = new Schema({
-  nodes: addListNodes(
-    schema.spec.nodes as OrderedMap<NodeSpec>,
-    'paragraph block*',
-    'block'
-  ),
+  nodes: addListNodes(schema.spec.nodes as OrderedMap<NodeSpec>, 'block*'),
   marks: schema.spec.marks
 });
 

--- a/client-v2/src/components/inputs/richtext/setup.ts
+++ b/client-v2/src/components/inputs/richtext/setup.ts
@@ -1,7 +1,7 @@
 import { buildKeymap } from './utils/keymap';
 import { keymap } from 'prosemirror-keymap';
-import { Schema, DOMSerializer, DOMParser, NodeSpec } from 'prosemirror-model';
-import { schema } from 'prosemirror-schema-basic';
+import { Schema, DOMSerializer, DOMParser } from 'prosemirror-model';
+import { schema, nodes } from 'prosemirror-schema-basic';
 import { addListNodes } from 'prosemirror-schema-list';
 import { EditorView } from 'prosemirror-view';
 import { EditorState, Transaction } from 'prosemirror-state';
@@ -18,8 +18,16 @@ const createBasePlugins = (s: Schema) => {
   return plugins;
 };
 
+const nodeMap = OrderedMap.from({
+  doc: {
+    content: '(text | hard_break)+'
+  },
+  text: nodes.text,
+  hard_break: nodes.hard_break
+});
+
 export const basicSchema = new Schema({
-  nodes: addListNodes(schema.spec.nodes as OrderedMap<NodeSpec>, 'block*'),
+  nodes: addListNodes(nodeMap, 'doc *'),
   marks: schema.spec.marks
 });
 

--- a/client-v2/src/components/inputs/richtext/utils/command-helpers.ts
+++ b/client-v2/src/components/inputs/richtext/utils/command-helpers.ts
@@ -31,7 +31,7 @@ export const linkItemCommand = (markType: MarkType) => (passedUrl = null) => (
     ? { url: passedUrl, from: state.selection.from, to: state.selection.to }
     : promptForLink(state, markType);
 
-  if (url && from && to) {
+  if (url && from !== undefined && to !== undefined) {
     const { valid, message } = linkValidator(url);
     if (valid) {
       const parsedUrl = parseURL(url);

--- a/client-v2/src/components/inputs/richtext/utils/keymap.ts
+++ b/client-v2/src/components/inputs/richtext/utils/keymap.ts
@@ -1,15 +1,9 @@
-import {
-  chainCommands,
-  toggleMark,
-  liftEmptyBlock,
-  createParagraphNear,
-  newlineInCode,
-  splitBlockKeepMarks
-} from 'prosemirror-commands';
+import { toggleMark } from 'prosemirror-commands';
 import { linkItemCommand, unlinkItemCommand } from './command-helpers';
 import { Schema } from 'prosemirror-model';
 import { undo, redo } from 'prosemirror-history';
 import { undoInputRule } from 'prosemirror-inputrules';
+import { EditorState, Transaction } from 'prosemirror-state';
 
 // These prosemirror-helper functions are a simplified version of what we use in Composer, and have been lifted and shifted from that repo
 
@@ -18,6 +12,20 @@ interface MapObject {
 }
 const mac =
   typeof navigator !== undefined ? /Mac/.test(navigator.platform) : false;
+
+const createAddHardBreak = (schema: Schema) => (
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void
+) => {
+  if (dispatch) {
+    dispatch(
+      state.tr
+        .replaceSelectionWith(schema.nodes.hard_break.create())
+        .scrollIntoView()
+    );
+  }
+  return true;
+};
 
 export const buildKeymap = (schema: Schema, init = {}, mapKeys: MapObject) => {
   const keys: MapObject = init;
@@ -42,15 +50,7 @@ export const buildKeymap = (schema: Schema, init = {}, mapKeys: MapObject) => {
     bind('Mod-y', redo);
   }
 
-  bind(
-    'Enter',
-    chainCommands(
-      newlineInCode,
-      createParagraphNear,
-      liftEmptyBlock,
-      splitBlockKeepMarks
-    )
-  );
+  bind('Enter', createAddHardBreak(schema));
 
   if (schema.marks.strong) {
     bind('Mod-b', toggleMark(schema.marks.strong));


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Our rich text editor for email fronts previously (#1072) created a new `<p>` tag whenever users pressed the enter key. In the Fronts tool, this could be used to create spacing between paragraphs. At the point of rendering in preview, the spacing was lost. 

Instead of adding a new paragraph, the tool now inserts a `<br>` tag. This ensures that there is parity between the styling in the Fronts tool and the styling in preview. It also means that no change is required to the styling applied during rendering.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
