### PR TITLE
Update resolvers to use HTTPS

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,8 @@ resolvers ++= Seq(
   Classpaths.typesafeReleases,
   Resolver.sonatypeRepo("releases"),
   Resolver.typesafeRepo("releases"),
-  Resolver.url("sbt-plugin-snapshots", new URL("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots/"))(Resolver.ivyStylePatterns),
-  "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
+  Resolver.url("sbt-plugin-snapshots", new URL("https://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots/"))(Resolver.ivyStylePatterns),
+  "Guardian Github Releases" at "https://guardian.github.com/maven/repo-releases",
   "Spy" at "https://files.couchbase.com/maven2/"
 )
 


### PR DESCRIPTION
When spinning up `facia-tool` locally, you may have noticed warnings relating to HTTP request deprecation. e.g.

```[warn] insecure HTTP request is deprecated 'http://guardian.github.com/maven/repo-releases'; switch to HTTPS or opt-in as ("Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases").withAllowInsecureProtocol(true)```

This PR switches resolver requests to use HTTPS instead of HTTP requests.