### PR TITLE
handle pagination to get all data from capi on Suggest Articles

### DIFF
--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -211,10 +211,10 @@ object GuardianCapi extends Logging {
     val firstPageResponse = Await.result(getResponse(query.page(1)), FirstPageReqTimeout)
     val totalPages = firstPageResponse.pages
 
-    if (totalPages == 0 || totalPages == 1) return List(firstPageResponse)
-
-    val remainingPages = readRemainingPages(totalPages, query, getResponse)
-    val allResponsePages: List[SearchResponse] = firstPageResponse +: remainingPages
+    val allResponsePages = if (totalPages == 0 || totalPages == 1) List(firstPageResponse) else {
+      val remainingPages = readRemainingPages(totalPages, query, getResponse)
+      firstPageResponse +: remainingPages
+    }
     logger.info(s"readAllSearchResponsePages, fetched CAPI search Response pages count ${allResponsePages.size}")
     allResponsePages
   }

--- a/app/util/SearchResponseUtil.scala
+++ b/app/util/SearchResponseUtil.scala
@@ -1,0 +1,20 @@
+package util
+
+import com.gu.contentapi.client.model.v1.{Content, SearchResponse}
+
+object SearchResponseUtil {
+
+  def aggregateResults(responses: Seq[SearchResponse]): SearchResponse = {
+    val allResults: Seq[Content] = responses.flatMap(_.results)
+    val count = allResults.size
+    responses.head.copy(
+      results = allResults,
+      total = count,
+      pages = 1,
+      pageSize = count,
+      currentPage = 1,
+      startIndex = 1
+    )
+  }
+
+}

--- a/test/editions/EditionTemplateTest.scala
+++ b/test/editions/EditionTemplateTest.scala
@@ -16,7 +16,7 @@ class EditionTemplateTest extends FreeSpec with Matchers {
   object TestCapi extends Capi {
     override def getPreviewHeaders(headers: Map[String, String], url: String): Seq[(String, String)] = Seq.empty[(String, String)]
 
-    override def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): Future[SearchResponse] = Future.successful(null)
+    override def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): List[SearchResponse] = Nil
 
     override def getUnsortedPrefillArticleItems(prefillParams: PrefillParamsAdapter): List[Prefill] = Nil
   }

--- a/test/fixtures/FakeCapiAndOphan.scala
+++ b/test/fixtures/FakeCapiAndOphan.scala
@@ -185,7 +185,7 @@ trait FakeCapiAndOphan {
       }
     }
 
-    def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): Future[SearchResponse] = ???
+    def getPrefillArticles(prefillParams: PrefillParamsAdapter, currentPageCodes: List[String]): List[SearchResponse] = ???
   }
 
   val nullOphan = new Ophan {

--- a/test/util/SearchResponseUtilTest.scala
+++ b/test/util/SearchResponseUtilTest.scala
@@ -1,0 +1,63 @@
+package util
+
+import com.gu.contentapi.client.model.v1.{Content, SearchResponse}
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class SearchResponseUtilTest extends FlatSpec with Matchers {
+
+  behavior of "aggregateResults"
+
+  private val ignoredStr = "ignore"
+  private val ignoredInt = -1
+  private val dummyContent = Content(
+    id = ignoredStr,
+    webTitle = ignoredStr,
+    webUrl = ignoredStr,
+    apiUrl = ignoredStr,
+  )
+
+  private val responseWith3TotalPagesWith2ItemsPerPage = SearchResponse(
+    status = ignoredStr,
+    userTier = ignoredStr,
+    total = 6,
+    startIndex = ignoredInt,
+    pageSize = 2,
+    currentPage = 1,
+    pages = 3,
+    orderBy = ignoredStr,
+    results = Seq(dummyContent, dummyContent)
+  )
+
+  private val emptyResponse = responseWith3TotalPagesWith2ItemsPerPage.copy(total = 0, pageSize = 0, pages = 1, currentPage = 0, results = Nil)
+
+  private def nextPage = (r: SearchResponse) => {
+    val cur = r.currentPage
+    r.copy(currentPage = cur + 1)
+  }
+
+  it should "aggregate all results into 1 SearchResponse for 3 pages" in {
+    val firstPage = responseWith3TotalPagesWith2ItemsPerPage
+    val secPage = nextPage(firstPage)
+    val thirdPage = nextPage(secPage)
+    val responses = Seq(firstPage, secPage, thirdPage)
+    val actualResponse = SearchResponseUtil.aggregateResults(responses)
+
+    actualResponse.results.size shouldEqual 6
+    actualResponse.total shouldEqual 6
+    actualResponse.pageSize shouldEqual 6
+    actualResponse.pages shouldEqual 1
+    actualResponse.currentPage shouldEqual 1
+  }
+
+  it should "handle situation if search result pages is 0" in {
+    val responses = Seq(emptyResponse)
+    val actualResponse = SearchResponseUtil.aggregateResults(responses)
+    actualResponse.results.size shouldEqual 0
+    actualResponse.total shouldEqual 0
+    actualResponse.pageSize shouldEqual 0
+    actualResponse.pages shouldEqual 1
+    actualResponse.currentPage shouldEqual 1
+  }
+
+}


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Adding support for reading all pages from paginated CAPI response while triggering Suggest Articles request

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
i introduced `aggregateResults` function that is aggregating results from multiple SearchResponses into single SearchResponse

Which is a Is a quick temp solution to be able to handle pagination on Suggest Articles request

currently result item from SearchResponse.results is a dynamic type which is enhanced by `rewriteBody` function
 
see `rewriteBody` function implementation https://github.com/guardian/facia-tool/blob/master/app/util/ContentUpgrade.scala#L29

rewriteBody dynamically adjust Content type from SearchResponse into type CapiArticle type used on Front-end https://github.com/guardian/facia-tool/blob/master/client-v2/src/types/Capi.ts
making that type safe will require more work and will be done later

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
