### PR TITLE
Bump facia-scala-client to 3.0.20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.19",
+    "com.gu" %% "fapi-client-play26" % "3.0.20",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.5",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",


### PR DESCRIPTION
NB: DO NOT MERGE until dotcom and mapi have bumped `facia-scala-client` to >= `3.0.20` -- an errant `US-West-Coast` could break downstream platforms.

## What's changed?

Bump facia-scala-client to 3.0.20, which adds US-West-Coast to the list of targeted territories.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
