### PR TITLE
Fix long polling sqs failures

### DIFF
--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -361,7 +361,15 @@ trait IssueQueries {
         true
       }
       case Failure(exception: PSQLException) if exception.getSQLState == ForeignKeyViolationSQLState => {
-        Logger.warn("constraint violation encountered when inserting issue version event")(event.toLogMarker)
+        Logger.warn("Foreign key constraint violation encountered when inserting issue version event")(event.toLogMarker)
+        true
+      }
+      case Failure(exception: PSQLException)  => {
+        Logger.warn(s"Postgres exception (${exception.getMessage}) encountered when inserting issue version event")(event.toLogMarker)
+        true
+      }
+      case Failure(exception)  => {
+        Logger.warn("Non-database exception (${exception.getMessage}) encountered when inserting issue version event")(event.toLogMarker)
         true
       }
     }


### PR DESCRIPTION
## What's changed?
Catch exceptions which are not FK violations.

## Implementation notes
It appears the SQS dequeue can give us non-unique results.  When we try to write these uniquely, we fail.  We need to tolerate them.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
