### PR TITLE
Link back to correct edition for date-picker

### DIFF
--- a/client-v2/src/components/EditionFeedSectionHeader.tsx
+++ b/client-v2/src/components/EditionFeedSectionHeader.tsx
@@ -59,7 +59,7 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
 
     return (
       <>
-        <ManageLink to={urls.manageEditions}>
+        <ManageLink to={urls.manageEditions + editionsIssue.edition}>
           <EditionIssueInfo>
             <EditionTitle>{startCase(editionsIssue.edition)}</EditionTitle>
             <EditionDate>

--- a/client-v2/src/constants/urls.ts
+++ b/client-v2/src/constants/urls.ts
@@ -1,7 +1,7 @@
 export default {
   capiLiveUrl: '/api/live',
   capiPreviewUrl: '/api/preview',
-  manageEditions: '/manage-editions/daily-edition',
+  manageEditions: '/manage-editions/',
   appRoot: 'v2',
   editionsCardBuilder: 'https://editions-card-builder.gutools.co.uk'
 };


### PR DESCRIPTION
## What's changed?
The edition/date block at the top left of an issue page currently links back to the (hard coded) Daily Edition date picker.  It will now link back to the date picker for the edition of the current issue.

## Implementation notes
N/A

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
