### PR TITLE
Prevent incorrect scroll behaviour when collections are shared

### DIFF
--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -116,7 +116,7 @@ const CollectionOverview = ({
       onClick={e => {
         e.preventDefault();
         events.overviewItemClicked(frontId);
-        const el = document.getElementById(createCollectionId(collection));
+        const el = document.getElementById(createCollectionId(collection, frontId));
         if (el) {
           el.scrollIntoView({
             behavior: 'smooth',

--- a/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionOverview.tsx
@@ -116,7 +116,9 @@ const CollectionOverview = ({
       onClick={e => {
         e.preventDefault();
         events.overviewItemClicked(frontId);
-        const el = document.getElementById(createCollectionId(collection, frontId));
+        const el = document.getElementById(
+          createCollectionId(collection, frontId)
+        );
         if (el) {
           el.scrollIntoView({
             behavior: 'smooth',

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -37,7 +37,8 @@ import { theme } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import { updateCollection as updateCollectionAction } from '../../actions/Collections';
 
-export const createCollectionId = ({ id }: Collection, frontId: string) => `front-${frontId}-collection-${id}`;
+export const createCollectionId = ({ id }: Collection, frontId: string) =>
+  `front-${frontId}-collection-${id}`;
 
 interface ContainerProps {
   id: string;

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -37,7 +37,7 @@ import { theme } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import { updateCollection as updateCollectionAction } from '../../actions/Collections';
 
-export const createCollectionId = ({ id }: Collection) => `collection-${id}`;
+export const createCollectionId = ({ id }: Collection, frontId: string) => `front-${frontId}-collection-${id}`;
 
 interface ContainerProps {
   id: string;
@@ -231,6 +231,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
     const {
       id,
       collection,
+      frontId,
       articleIds,
       headlineContent,
       metaContent,
@@ -247,7 +248,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
     const { displayName } = this.state;
     return (
       <CollectionContainer
-        id={collection && createCollectionId(collection)}
+        id={collection && createCollectionId(collection, frontId)}
         tabIndex={0}
         onFocus={() => handleFocus(id)}
         onBlur={handleBlur}


### PR DESCRIPTION
## What's changed?

We shouldn't do this:

![incorrect-scroll](https://user-images.githubusercontent.com/7767575/71193392-f7b23b80-2281-11ea-84c7-e3afb6694a5f.gif)

We should do this!

![correct-scroll](https://user-images.githubusercontent.com/7767575/71193397-faad2c00-2281-11ea-8234-76e95a5fc051.gif)

## Implementation notes

A composite key for collections that includes the front id solves the problem.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
