### PR TITLE
Bug: links not working as expected in rich text editor

### DIFF
--- a/client-v2/config/setupTest.js
+++ b/client-v2/config/setupTest.js
@@ -1,5 +1,6 @@
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
+const fc = require('fast-check');
 
 enzyme.configure({ adapter: new Adapter() });
 
@@ -8,3 +9,5 @@ window.gtag = () => {};
 
 // ensures pageConfig data is mocked in all tests
 jest.mock('util/extractConfigFromPage.ts');
+
+fc.configureGlobal({ numRuns: 20, verbose: true, endOnFailure: false });

--- a/client-v2/package.json
+++ b/client-v2/package.json
@@ -51,6 +51,7 @@
     "eslint": "^5.12.0",
     "eslint-plugin-prettier": "^3.0.1",
     "express": "^4.16.4",
+    "fast-check": "^1.20.1",
     "fetch-mock": "^6.4.2",
     "file-loader": "^1.1.11",
     "fork-ts-checker-webpack-plugin": "^0.5.2",

--- a/client-v2/src/components/inputs/richtext/utils/__tests__/link-validator.spec.ts
+++ b/client-v2/src/components/inputs/richtext/utils/__tests__/link-validator.spec.ts
@@ -1,0 +1,57 @@
+import * as fc from 'fast-check';
+import { linkValidator, parseURL } from '../link-validator';
+
+const parse = (url: string, agreeable: boolean) => {
+  return parseURL(url, () => agreeable);
+};
+
+describe('Validate links', () => {
+  it('for any arbitrary valid link (with protocol prefix), return valid', () => {
+    fc.assert(
+      fc.property(fc.webUrl(), url => {
+        expect(linkValidator(url).valid).toBe(true);
+      })
+    );
+  });
+  it('for any arbitrary valid domain (without protocol prefix), return valid', () => {
+    fc.assert(
+      fc.property(fc.domain(), domain => {
+        expect(linkValidator(domain).valid).toBe(true);
+      })
+    );
+  });
+  it('for any arbitrary non-link string, return invalid', () => {
+    fc.assert(
+      fc.property(fc.hexaString(0, 1000), str => {
+        expect(linkValidator(str).valid).toBe(false);
+        expect(linkValidator(str).message).toBe(
+          `"${str}" is not a valid url, please check and try again`
+        );
+      })
+    );
+  });
+});
+
+describe('Parse potential link types', () => {
+  it('should identify and parse email addresses', () => {
+    fc.assert(
+      fc.property(fc.emailAddress(), email => {
+        expect(parse(email, true)).toBe(`mailto:${email}`);
+      })
+    );
+  });
+  it('should identify and parse phone numbers', () => {
+    fc.assert(
+      fc.property(fc.nat(), phoneNumber => {
+        expect(parse(phoneNumber.toString(), true)).toBe(`tel:${phoneNumber}`);
+      })
+    );
+  });
+  it('should identify and parse web domains', () => {
+    fc.assert(
+      fc.property(fc.domain(), domain => {
+        expect(parse(domain, true)).toBe(`http://${domain}`);
+      })
+    );
+  });
+});

--- a/client-v2/yarn.lock
+++ b/client-v2/yarn.lock
@@ -4530,6 +4530,14 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-check@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-1.20.1.tgz#71ababf12038c8f18648233161ef85ea13f2e09a"
+  integrity sha512-VyW+/5QPewaF7EUA6sDp2k6UkBvy8ZlIruXFSEnHJmql8vfc+3PtiP1klo+pvxua1H2mnFhc5xlW4d8nwJjKQg==
+  dependencies:
+    pure-rand "^1.7.0"
+    tslib "^1.10.0"
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
@@ -8353,6 +8361,11 @@ puppeteer@^1.10.0:
     rimraf "^2.6.1"
     ws "^5.1.1"
 
+pure-rand@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-1.7.0.tgz#8b119d05f5f83c409efbede897f1386c4df32313"
+  integrity sha512-Mpghwu8LvQUpr8NRFmGTgX8mFi8WHqor9oE0cCj2Sk5XjA10lBx880qUXtXQPYzrUL8NVQ87nqZvV7LI6gVdOw==
+
 qrcode-terminal@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz#a76a48e2610a18f97fa3a2bd532b682acff86c53"
@@ -10402,6 +10415,11 @@ tsconfig-paths@^3.4.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"


### PR DESCRIPTION
## What's changed?
The rich text editor (in email Fronts) couldn't identify URLs entered without a protocol. 

<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
<img width="469" alt="Screenshot 2019-12-23 at 11 38 02" src="https://user-images.githubusercontent.com/12645938/71361034-a52a9500-2589-11ea-95de-baacdc3abbe3.png">

Now, it can handle them and displays the correct popup, suggesting that the user is entering a link:

<img width="469" alt="Screenshot 2019-12-23 at 13 50 53" src="https://user-images.githubusercontent.com/12645938/71361577-49f9a200-258b-11ea-8111-8cfd6f02079a.png">


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
This appears to be because the call to `url.parse(...)` would not determine `www.google.com` to be a URL, because it lacked a protocol. 

To get around this problem, I've done a second check on the raw input to see whether it contains a full stop, and then if it has a hostname when parsed as a URL (with `https://` prepended to it). If there are other parsers that are able to parse potential URLs without protocols then it would probably be better to use them.

As part of this PR I've added some basic property-based testing of the link validation, using [fast-check](https://github.com/dubzzz/fast-check). 

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
