### PR TITLE
Increase from 3 to 6 the default number of collections for specials

### DIFF
--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -30,7 +30,10 @@ object TemplateHelpers {
     ophanPath,
     collection("Special Container 1").hide.copy(prefill = prefill),
     collection("Special Container 2").hide,
-    collection("Special Container 3").hide
+    collection("Special Container 3").hide,
+    collection("Special Container 4").hide,
+    collection("Special Container 5").hide,
+    collection("Special Container 6").hide
   ).special
     .swatch(swatch)
 


### PR DESCRIPTION
Special sections default to 3 generic containers all hidden.
This change increases that to 6.

