### PR TITLE
Allow renaming of all fronts and containers

### DIFF
--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -34,8 +34,7 @@ case class EditionsClientCollection(
   updatedEmail: Option[String],
   prefill: Option[CapiPrefillQuery],
   contentPrefillTimeWindow: Option[CapiQueryTimeWindow],
-  items: List[EditionsClientArticle],
-  canRename: Boolean
+  items: List[EditionsClientArticle]
 )
 case class EditionsFrontendCollectionWrapper(id: String, collection: EditionsClientCollection)
 
@@ -56,8 +55,7 @@ object EditionsFrontendCollectionWrapper {
         collection.updatedEmail,
         collection.prefill,
         collection.contentPrefillTimeWindow,
-        collection.items.map(EditionsClientArticle.fromArticle),
-        collection.canRename
+        collection.items.map(EditionsClientArticle.fromArticle)
       )
     )
   }
@@ -72,8 +70,7 @@ object EditionsFrontendCollectionWrapper {
       frontendCollection.collection.updatedEmail,
       frontendCollection.collection.prefill,
       frontendCollection.collection.contentPrefillTimeWindow,
-      frontendCollection.collection.items.map(EditionsClientArticle.toArticle),
-      frontendCollection.collection.canRename
+      frontendCollection.collection.items.map(EditionsClientArticle.toArticle)
     )
   }
 }

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -15,8 +15,7 @@ case class EditionsCollection(
                                updatedEmail: Option[String],
                                prefill: Option[CapiPrefillQuery],
                                contentPrefillTimeWindow: Option[CapiQueryTimeWindow],
-                               items: List[EditionsArticle],
-                               canRename: Boolean
+                               items: List[EditionsArticle]
                              ) {
   def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
@@ -42,8 +41,7 @@ object EditionsCollection {
       rs.stringOpt(prefix + "updated_email"),
       capiPrefillQuery,
       contentPrefillTimeWindow,
-      Nil,
-      rs.boolean(prefix + "is_special"),
+      Nil
     )
   }
 
@@ -82,8 +80,7 @@ object EditionsCollection {
         rs.stringOpt(prefix + "updated_email"),
         capiPrefillQuery,
         contentPrefillTimeWindow,
-        Nil,
-        false
+        Nil
       )
     }
   }

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -137,11 +137,10 @@ private[editions] case class CollectionTemplate(
   presentation: CollectionPresentation,
   maybeTimeWindowConfig: Option[CapiTimeWindowConfigInDays] = None,
   hidden: Boolean = false,
-  canRename: Boolean = false,
   articleItemsCap: Int = Defaults.defaultCollectionArticleItemsCap
 ) {
 
-  def hide = copy(hidden = true).copy(canRename = true)
+  def hide = copy(hidden = true)
 
   def withPresentation(presentation: CollectionPresentation) = copy(presentation = presentation)
 

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -224,9 +224,6 @@ trait IssueQueries {
 
             collection
               .copy(items = articles)
-              // Note for the unwary; 'special' fronts can be renamed to create 'special' sections.
-              // Similarly, we permit collections inside special fronts _only_ to be renamed.
-              .copy(canRename = front.isSpecial)
           }
 
         front.copy(collections = collectionsForFront)

--- a/client-v2/src/components/FrontsEdit/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/Collection.tsx
@@ -92,7 +92,6 @@ interface CollectionContextProps {
   handleMove: (move: Move<TCard>) => void;
   handleInsert: (e: React.DragEvent, to: PosSpec) => void;
   selectCard: (id: string, isSupporting: boolean) => void;
-  canRename: boolean;
 }
 
 interface ConnectedCollectionContextProps extends CollectionContextProps {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -15,7 +15,6 @@ import {
   selectHasUnpublishedChanges,
   selectCollectionHasPrefill,
   selectCollectionIsHidden,
-  selectCollectionCanRename,
   selectCollectionDisplayName
 } from 'selectors/frontsSelectors';
 import { selectIsCollectionLocked } from 'selectors/collectionSelectors';
@@ -77,7 +76,6 @@ type CollectionProps = CollectionPropsBeforeState & {
   hasPrefill: boolean;
   setHidden: (id: string, isHidden: boolean) => void;
   isHidden: boolean;
-  canRename: boolean;
   displayName: string;
 };
 
@@ -197,8 +195,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
       hasPrefill,
       isHidden,
       hasContent,
-      hasOpenForms,
-      canRename
+      hasOpenForms
     } = this.props;
 
     const { isPreviouslyOpen, isLaunching } = this.state;
@@ -211,7 +208,6 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
         id={id}
         browsingStage={browsingStage}
         isUneditable={isUneditable}
-        canRename={canRename}
         isLocked={isCollectionLocked}
         isOpen={isOpen}
         hasMultipleFrontsOpen={hasMultipleFrontsOpen}
@@ -342,7 +338,6 @@ const createMapStateToProps = () => {
     }: CollectionPropsBeforeState
   ) => ({
     isHidden: selectCollectionIsHidden(state, collectionId),
-    canRename: selectCollectionCanRename(state, collectionId),
     displayName: selectCollectionDisplayName(state, collectionId),
     hasPrefill: selectCollectionHasPrefill(state, collectionId),
     hasUnpublishedChanges: selectHasUnpublishedChanges(state, {

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -1,6 +1,7 @@
 import { Dispatch } from 'types/Store';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
+import { HeadlineContentButton } from 'shared/components/CollectionDisplay';
 import CollectionDisplay from 'shared/components/CollectionDisplay';
 import CollectionNotification from 'components/CollectionNotification';
 import Button from 'shared/components/input/ButtonDefault';
@@ -217,25 +218,22 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
           canPublish && (
             <Fragment>
               <EditModeVisibility visibleMode="editions">
-                <Button
-                  size="s"
+                <HeadlineContentButton
                   priority="default"
                   onClick={() => this.props.setHidden(id, !isHidden)}
                   title="Toggle the visibility of this container in this issue."
                 >
                   {isHidden ? 'Unhide' : 'Hide'}
-                </Button>
+                </HeadlineContentButton>
                 {hasPrefill && (
-                  <Button
+                  <HeadlineContentButton
                     data-testid="prefill-button"
-                    size="s"
                     priority="default"
                     onClick={() => this.props.fetchPrefill(id)}
                     title="Get suggested articles for this collection"
-                    style={{ marginLeft: '5px' }}
                   >
                     Suggest
-                  </Button>
+                  </HeadlineContentButton>
                 )}
               </EditModeVisibility>
               <ActionButtonsContainer

--- a/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/client-v2/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -218,23 +218,23 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
             <Fragment>
               <EditModeVisibility visibleMode="editions">
                 <Button
-                  size="l"
+                  size="s"
                   priority="default"
                   onClick={() => this.props.setHidden(id, !isHidden)}
                   title="Toggle the visibility of this container in this issue."
                 >
-                  {isHidden ? 'Unhide Container' : 'Hide Container'}
+                  {isHidden ? 'Unhide' : 'Hide'}
                 </Button>
                 {hasPrefill && (
                   <Button
                     data-testid="prefill-button"
-                    size="l"
+                    size="s"
                     priority="default"
                     onClick={() => this.props.fetchPrefill(id)}
                     title="Get suggested articles for this collection"
-                    style={{ marginLeft: '10px' }}
+                    style={{ marginLeft: '5px' }}
                   >
-                    Suggest Articles
+                    Suggest
                   </Button>
                 )}
               </EditModeVisibility>

--- a/client-v2/src/components/FrontsEdit/FrontContainer.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContainer.tsx
@@ -173,7 +173,6 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
               browsingStage={browsingStage}
               handleArticleFocus={this.handleArticleFocus}
               onChangeCurrentCollectionId={this.handleChangeCurrentCollectionId}
-              canRename={false}
             />
           </FrontContentContainer>
           {overviewIsOpen && (

--- a/client-v2/src/components/FrontsEdit/FrontContent.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontContent.tsx
@@ -62,7 +62,6 @@ type FrontProps = FrontPropsBeforeState & {
   ) => void;
   moveCard: typeof moveCard;
   insertCardFromDropEvent: typeof insertCardFromDropEvent;
-  canRename: boolean;
 };
 
 interface FrontState {
@@ -181,7 +180,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
                       )
                     }
                     handleArticleFocus={this.props.handleArticleFocus}
-                    canRename={false}
                   />
                 </CollectionContainer>
               ))}

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -230,15 +230,15 @@ class FrontSection extends React.Component<
                   >
                     {isHidden ? 'Unhide' : 'Hide'}
                   </FrontHeaderButton>
-                  <FrontHeaderButton
-                    data-testid="rename-front-button"
-                    onClick={this.renameFront}
-                    size="l"
-                  >
-                    Rename
-                  </FrontHeaderButton>
                 </>
               )}
+              <FrontHeaderButton
+                data-testid="rename-front-button"
+                onClick={this.renameFront}
+                size="l"
+              >
+                Rename
+              </FrontHeaderButton>
               <FrontHeaderButton onClick={this.handleRemoveFront} size="l">
                 <ClearIcon size="xl" />
               </FrontHeaderButton>

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -25,6 +25,7 @@ import { createFrontId } from 'util/editUtils';
 import EditModeVisibility from 'components/util/EditModeVisibility';
 import { setFrontHiddenState, updateFrontMetadata } from 'actions/Editions';
 import FrontsContainer from './FrontContainer';
+import { isMode } from '../../selectors/pathSelectors';
 
 const FrontHeader = styled(SectionHeader)`
   display: flex;
@@ -119,6 +120,7 @@ type FrontsComponentProps = FrontsContainerProps & {
     ) => void;
     setFrontHiddenState: (id: string, hidden: boolean) => void;
   };
+  isEditions: boolean;
 };
 
 interface ComponentState {
@@ -134,7 +136,7 @@ class FrontSection extends React.Component<
   public state = {
     collectionSet: frontStages.draft,
     frontNameValue: '',
-    editingFrontName: false
+    editingFrontName: false,
   };
 
   public handleCollectionSetSelect(key: string) {
@@ -236,6 +238,7 @@ class FrontSection extends React.Component<
                 data-testid="rename-front-button"
                 onClick={this.renameFront}
                 size="l"
+                style={{ marginLeft: '10px' }}
               >
                 Rename
               </FrontHeaderButton>
@@ -311,7 +314,8 @@ class FrontSection extends React.Component<
 const createMapStateToProps = () => {
   return (state: State, { frontId }: FrontsContainerProps) => ({
     selectedFront: selectFront(state, { frontId }),
-    isOverviewOpen: selectIsFrontOverviewOpen(state, frontId)
+    isOverviewOpen: selectIsFrontOverviewOpen(state, frontId),
+    isEditions: isMode(state, 'editions')
   });
 };
 

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -136,7 +136,7 @@ class FrontSection extends React.Component<
   public state = {
     collectionSet: frontStages.draft,
     frontNameValue: '',
-    editingFrontName: false,
+    editingFrontName: false
   };
 
   public handleCollectionSetSelect(key: string) {

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -87,7 +87,7 @@ const FrontSectionContent = styled(SectionContent)`
   padding-top: 0;
 `;
 
-const FrontHeaderButton = styled(Button).attrs({size: 'l'})`
+const FrontHeaderButton = styled(Button).attrs({ size: 'l' })`
   color: #fff;
   padding: 0 5px;
   display: flex;

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -87,7 +87,7 @@ const FrontSectionContent = styled(SectionContent)`
   padding-top: 0;
 `;
 
-const FrontHeaderButton = styled(Button).attrs({size: l})`
+const FrontHeaderButton = styled(Button).attrs({size: 'l'})`
   color: #fff;
   padding: 0 5px;
   display: flex;

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -237,7 +237,6 @@ class FrontSection extends React.Component<
                 <FrontHeaderButton
                   data-testid="rename-front-button"
                   onClick={this.renameFront}
-                  style={{ marginLeft: '10px' }}
                 >
                   Rename
                 </FrontHeaderButton>

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -87,7 +87,7 @@ const FrontSectionContent = styled(SectionContent)`
   padding-top: 0;
 `;
 
-const FrontHeaderButton = styled(Button)`
+const FrontHeaderButton = styled(Button).attrs({size: "l"})`
   color: #fff;
   padding: 0 5px;
   display: flex;
@@ -155,7 +155,7 @@ class FrontSection extends React.Component<
   };
 
   public render() {
-    const { frontId, isOverviewOpen } = this.props;
+    const { frontId, isOverviewOpen, isEditions } = this.props;
     const title = this.getTitle();
 
     const { frontNameValue, editingFrontName } = this.state;
@@ -203,7 +203,7 @@ class FrontSection extends React.Component<
                   }`}
                   target="preview"
                 >
-                  <FrontHeaderButton size="l">
+                  <FrontHeaderButton>
                     <PreviewEyeIcon size="xl" />
                     <PreviewButtonText>Preview</PreviewButtonText>
                   </FrontHeaderButton>
@@ -228,21 +228,21 @@ class FrontSection extends React.Component<
                   <FrontHeaderButton
                     data-testid="toggle-hidden-front-button"
                     onClick={() => this.setFrontHiddenState(!isHidden)}
-                    size="l"
                   >
                     {isHidden ? 'Unhide' : 'Hide'}
                   </FrontHeaderButton>
                 </>
               )}
-              <FrontHeaderButton
-                data-testid="rename-front-button"
-                onClick={this.renameFront}
-                size="l"
-                style={{ marginLeft: '10px' }}
-              >
-                Rename
-              </FrontHeaderButton>
-              <FrontHeaderButton onClick={this.handleRemoveFront} size="l">
+              {isEditions && (
+                <FrontHeaderButton
+                  data-testid="rename-front-button"
+                  onClick={this.renameFront}
+                  style={{ marginLeft: '10px' }}
+                >
+                  Rename
+                </FrontHeaderButton>
+              )}
+              <FrontHeaderButton onClick={this.handleRemoveFront}>
                 <ClearIcon size="xl" />
               </FrontHeaderButton>
             </FrontHeaderMeta>

--- a/client-v2/src/components/FrontsEdit/FrontSection.tsx
+++ b/client-v2/src/components/FrontsEdit/FrontSection.tsx
@@ -87,7 +87,7 @@ const FrontSectionContent = styled(SectionContent)`
   padding-top: 0;
 `;
 
-const FrontHeaderButton = styled(Button).attrs({size: "l"})`
+const FrontHeaderButton = styled(Button).attrs({size: l})`
   color: #fff;
   padding: 0 5px;
   display: flex;

--- a/client-v2/src/selectors/frontsSelectors.ts
+++ b/client-v2/src/selectors/frontsSelectors.ts
@@ -154,16 +154,6 @@ const selectCollectionDisplayName = (
   return !!collection ? collection.displayName : '';
 };
 
-const selectCollectionCanRename = (
-  state: State,
-  collectionId: string
-): boolean => {
-  const collection = selectCollection(selectSharedState(state), {
-    collectionId
-  });
-  return !!collection && !!collection.canRename;
-};
-
 const selectFrontsIds = createSelector(
   [selectFronts],
   (fronts): string[] => {
@@ -385,7 +375,6 @@ export {
   selectCollectionConfig,
   selectCollectionHasPrefill,
   selectCollectionIsHidden,
-  selectCollectionCanRename,
   selectCollectionDisplayName,
   selectFrontsConfig,
   selectCollectionConfigs,

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -19,9 +19,9 @@ const selectEditMode = <T>(state: { path: string } & T): EditMode => {
 
 const isMode = <T>(state: { path: string } & T, mode: EditMode): boolean => {
   return selectEditMode(state) === mode;
-}
+};
 
-  const selectPriority = <T>(
+const selectPriority = <T>(
   state: { path: string } & T
 ): keyof Priorities | undefined => {
   const path = selectV2SubPath(state);
@@ -32,4 +32,10 @@ const isMode = <T>(state: { path: string } & T, mode: EditMode): boolean => {
   return match.params.priority as keyof Priorities;
 };
 
-export { selectFullPath, selectV2SubPath, selectEditMode, selectPriority, isMode };
+export {
+  selectFullPath,
+  selectV2SubPath,
+  selectEditMode,
+  selectPriority,
+  isMode
+};

--- a/client-v2/src/selectors/pathSelectors.ts
+++ b/client-v2/src/selectors/pathSelectors.ts
@@ -17,7 +17,11 @@ const selectEditMode = <T>(state: { path: string } & T): EditMode => {
   }
 };
 
-const selectPriority = <T>(
+const isMode = <T>(state: { path: string } & T, mode: EditMode): boolean => {
+  return selectEditMode(state) === mode;
+}
+
+  const selectPriority = <T>(
   state: { path: string } & T
 ): keyof Priorities | undefined => {
   const path = selectV2SubPath(state);
@@ -28,4 +32,4 @@ const selectPriority = <T>(
   return match.params.priority as keyof Priorities;
 };
 
-export { selectFullPath, selectV2SubPath, selectEditMode, selectPriority };
+export { selectFullPath, selectV2SubPath, selectEditMode, selectPriority, isMode };

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -36,7 +36,7 @@ import { Dispatch } from 'types/Store';
 import { theme } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import { updateCollection as updateCollectionAction } from '../../actions/Collections';
-import {isMode} from "../../selectors/pathSelectors";
+import { isMode } from '../../selectors/pathSelectors';
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
   `front-${frontId}-collection-${id}`;
@@ -310,7 +310,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
             ) : headlineContent ? (
               <HeadlineContentContainer>
                 {headlineContent}
-                {isEditions &&
+                {isEditions && (
                   <Button
                     size="s"
                     priority="default"
@@ -320,7 +320,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
                   >
                     Rename
                   </Button>
-                }
+                )}
               </HeadlineContentContainer>
             ) : null}
           </CollectionHeadingInner>

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -36,6 +36,7 @@ import { Dispatch } from 'types/Store';
 import { theme } from 'constants/theme';
 import Button from 'shared/components/input/ButtonDefault';
 import { updateCollection as updateCollectionAction } from '../../actions/Collections';
+import {isMode} from "../../selectors/pathSelectors";
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
   `front-${frontId}-collection-${id}`;
@@ -62,6 +63,7 @@ type Props = ContainerProps & {
   handleFocus: (id: string) => void;
   handleBlur: () => void;
   updateCollection: (collection: Collection) => void;
+  isEditions: boolean;
 };
 
 interface CollectionState {
@@ -240,7 +242,8 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       hasMultipleFrontsOpen,
       children,
       handleFocus,
-      handleBlur
+      handleBlur,
+      isEditions
     }: Props = this.props;
     const itemCount = articleIds ? articleIds.length : 0;
     const targetedTerritory = collection ? collection.targetedTerritory : null;
@@ -307,14 +310,17 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
             ) : headlineContent ? (
               <HeadlineContentContainer>
                 {headlineContent}
-                <Button
-                  size="l"
-                  priority="default"
-                  onClick={this.startRenameContainer}
-                  title="Rename this container in this issue."
-                >
-                  Rename
-                </Button>
+                {isEditions &&
+                  <Button
+                    size="s"
+                    priority="default"
+                    onClick={this.startRenameContainer}
+                    title="Rename this container in this issue."
+                    style={{ marginLeft: '5px' }}
+                  >
+                    Rename
+                  </Button>
+                }
               </HeadlineContentContainer>
             ) : null}
           </CollectionHeadingInner>
@@ -410,7 +416,8 @@ const createMapStateToProps = () => {
         collectionId: props.id,
         collectionSet: props.browsingStage,
         includeSupportingArticles: false
-      })
+      }),
+      isEditions: isMode(state, 'editions')
     };
   };
 };

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -96,6 +96,7 @@ export const HeadlineContentButton = styled(Button).attrs({size: 's'})`
   padding: 0 5px;
   display: flex;
   align-items: center;
+  margin-left: 5px;
 `;
 
 const CollectionDisabledTheme = styled.div`

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -91,7 +91,7 @@ const HeadlineContentContainer = styled.span`
   display: flex;
 `;
 
-export const HeadlineContentButton = styled(Button).attrs({size: "s"})`
+export const HeadlineContentButton = styled(Button).attrs({size: s})`
   color: #fff;
   padding: 0 5px;
   display: flex;

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -308,12 +308,12 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               <HeadlineContentContainer>
                 {headlineContent}
                 <Button
-                    size="l"
-                    priority="default"
-                    onClick={this.startRenameContainer}
-                    title="Rename this container in this issue."
+                  size="l"
+                  priority="default"
+                  onClick={this.startRenameContainer}
+                  title="Rename this container in this issue."
                 >
-                    Rename
+                  Rename
                 </Button>
               </HeadlineContentContainer>
             ) : null}

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -91,6 +91,14 @@ const HeadlineContentContainer = styled.span`
   display: flex;
 `;
 
+export const HeadlineContentButton = styled(Button).attrs({size: "s"})`
+  color: #fff;
+  padding: 0 5px;
+  display: flex;
+  align-items: center;
+`;
+
+
 const CollectionDisabledTheme = styled.div`
   position: absolute;
   background-color: hsla(0, 0%, 100%, 0.3);
@@ -311,15 +319,13 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
               <HeadlineContentContainer>
                 {headlineContent}
                 {isEditions && (
-                  <Button
-                    size="s"
+                  <HeadlineContentButton
                     priority="default"
                     onClick={this.startRenameContainer}
                     title="Rename this container in this issue."
-                    style={{ marginLeft: '5px' }}
                   >
                     Rename
-                  </Button>
+                  </HeadlineContentButton>
                 )}
               </HeadlineContentContainer>
             ) : null}

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -91,13 +91,12 @@ const HeadlineContentContainer = styled.span`
   display: flex;
 `;
 
-export const HeadlineContentButton = styled(Button).attrs({size: s})`
+export const HeadlineContentButton = styled(Button).attrs({size: 's'})`
   color: #fff;
   padding: 0 5px;
   display: flex;
   align-items: center;
 `;
-
 
 const CollectionDisabledTheme = styled.div`
   position: absolute;

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -54,7 +54,6 @@ type Props = ContainerProps & {
   metaContent: React.ReactNode;
   children: React.ReactNode;
   isUneditable?: boolean;
-  canRename?: boolean;
   underlyingCollection?: Collection;
   isLocked?: boolean;
   isOpen?: boolean;
@@ -237,7 +236,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       headlineContent,
       metaContent,
       isUneditable,
-      canRename,
       isLocked,
       hasMultipleFrontsOpen,
       children,
@@ -309,16 +307,14 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
             ) : headlineContent ? (
               <HeadlineContentContainer>
                 {headlineContent}
-                {canRename && (
-                  <Button
+                <Button
                     size="l"
                     priority="default"
                     onClick={this.startRenameContainer}
                     title="Rename this container in this issue."
-                  >
+                >
                     Rename
-                  </Button>
-                )}
+                </Button>
               </HeadlineContentContainer>
             ) : null}
           </CollectionHeadingInner>

--- a/client-v2/src/shared/components/CollectionDisplay.tsx
+++ b/client-v2/src/shared/components/CollectionDisplay.tsx
@@ -91,7 +91,7 @@ const HeadlineContentContainer = styled.span`
   display: flex;
 `;
 
-export const HeadlineContentButton = styled(Button).attrs({size: 's'})`
+export const HeadlineContentButton = styled(Button).attrs({ size: 's' })`
   color: #fff;
   padding: 0 5px;
   display: flex;

--- a/client-v2/src/shared/types/Collection.ts
+++ b/client-v2/src/shared/types/Collection.ts
@@ -136,7 +136,6 @@ interface Collection {
   frontsToolSettings?: FrontsToolSettings;
   isHidden?: boolean;
   targetedTerritory?: string;
-  canRename?: boolean;
 }
 
 interface ArticleTag {

--- a/test/logic/EditionsCheckerTest.scala
+++ b/test/logic/EditionsCheckerTest.scala
@@ -69,8 +69,7 @@ class EditionsCheckerTest extends FreeSpec with Matchers {
       None,
       None,
       None,
-      items.toList,
-      false
+      items.toList
     )
   }
 

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -57,8 +57,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       None,
       prefill,
       None,
-      articles.toList,
-      false
+      articles.toList
     )
 
   implicit class RichEditionsCollection(thisCollection: EditionsCollection) {
@@ -269,8 +268,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         None,
         None,
         None,
-        List(article("123")),
-        false
+        List(article("123"))
       )
       val testFront = front("uk-news",
         collection("london", None, article("123")),


### PR DESCRIPTION
## What's changed?
See https://trello.com/c/ZU1l81Bq/159-all-containers-to-be-renamable

All containers and fronts are now editable.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ X] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ X] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [X ] 📷 Screenshots / GIFs of relevant UI changes included
<img width="548" alt="Screenshot 2020-01-09 at 14 05 39" src="https://user-images.githubusercontent.com/5476326/72074097-2eabc800-32e9-11ea-87ad-20678e000dfd.png">

