### PR TITLE
Add clearer styling for breaking news error modal

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -2326,9 +2326,20 @@ hr {
     border: 1px solid #ddd;
     background-color: #fff;
 }
+
+.modalDialog-content--error {
+    border: 3px solid red;
+    background-color: lightcoral;
+}
+
+.modalDialog-content--error hr {
+    background-color: red;
+}
+
 .modalDialog-message {
     padding: 10px 20px 20px;
 }
+
 .modalDialog-message h3 i {
     margin-right: 8px;
 }

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -268,10 +268,11 @@ export default class Collection extends BaseClass {
             reportErrors(new Error(message)); //report to sentry
         })
         .catch(() => {
+            const breakingNewsMsg = 'breaking news alert. The alert has not been sent. Please contact Central Production.';
             const isBreakingNewsAlert = this.front.confirmSendingAlert();
-            const message = `Failed ${action}ing the ${isBreakingNewsAlert ? 'breaking news alert' : 'collection'}`;
+            const message = `Failed ${action}ing the ${isBreakingNewsAlert ? breakingNewsMsg : 'collection'}`;
             this.setPending(false);
-            alert(message);
+            alert(message, 'error');
         });
     }
 

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -268,7 +268,7 @@ export default class Collection extends BaseClass {
             reportErrors(new Error(message)); //report to sentry
         })
         .catch(() => {
-            const breakingNewsMsg = 'breaking news alert. The alert may not have been sent. Please contact Central Production for more information.';
+            const breakingNewsMsg = 'breaking news alert. Please contact Central Production for more information.';
             const isBreakingNewsAlert = this.front.confirmSendingAlert();
             const message = `Failed ${action}ing the ${isBreakingNewsAlert ? breakingNewsMsg : 'collection'}`;
             this.setPending(false);

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -268,7 +268,7 @@ export default class Collection extends BaseClass {
             reportErrors(new Error(message)); //report to sentry
         })
         .catch(() => {
-            const breakingNewsMsg = 'breaking news alert. The alert has not been sent. Please contact Central Production.';
+            const breakingNewsMsg = 'breaking news alert. The alert may not have been sent. Please contact Central Production for more information.';
             const isBreakingNewsAlert = this.front.confirmSendingAlert();
             const message = `Failed ${action}ing the ${isBreakingNewsAlert ? breakingNewsMsg : 'collection'}`;
             this.setPending(false);

--- a/public/src/js/utils/alert.js
+++ b/public/src/js/utils/alert.js
@@ -1,10 +1,17 @@
 import modalDialog from 'modules/modal-dialog';
 
-export default function (message) {
+/**
+ * Launch a modal dialog.
+ *
+ * @param {string} message
+ * @param {'message' | 'error'} type
+ */
+export default function (message, type = 'message') {
     modalDialog.confirm({
         name: 'text_alert',
         data: {
-            message: message
+            message,
+            type
         }
     });
 }

--- a/public/src/js/widgets/modals/modal-dialog.html
+++ b/public/src/js/widgets/modals/modal-dialog.html
@@ -1,6 +1,7 @@
 <!-- ko if: templateName() && isOpen() -->
-    <div class="modalDialog-content" data-bind="component: {
+    <div data-bind="component: {
         name: templateName,
         params: templateData
-    }"></div>
+    }, attr: { class: `modalDialog-content modalDialog-content--${templateData().type}` }"></div>
 <!-- /ko -->
+


### PR DESCRIPTION
## What's changed?

The error modal for breaking-news looks much like the other modals. This has recently led editorial staff to dismiss it, unaware that a problem had occurred.

This PR makes it very clear that something has gone wrong should a breaking-news alert fail to publish.

Before:

<img width="500" alt="Screenshot 2020-01-13 at 08 40 36" src="https://user-images.githubusercontent.com/7767575/72438231-4cbb7180-379c-11ea-8b1b-b827812acea5.png">

After:

<img width="524" alt="Screenshot 2020-01-15 at 13 36 54" src="https://user-images.githubusercontent.com/7767575/72438222-46c59080-379c-11ea-9008-ecce28b71c6b.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
