### PR TITLE
Disable adding snap links for the breaking news front

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -111,6 +111,10 @@ export default {
         'breaking-news'
     ],
 
+    disableSnapLinks: [
+        'breaking-news'
+    ],
+
     restrictedEditor: [
         'breaking-news'
     ],

--- a/public/src/js/widgets/columns/fronts.js
+++ b/public/src/js/widgets/columns/fronts.js
@@ -301,6 +301,10 @@ export default class Front extends ColumnWidget {
         return _.contains(CONST.askForConfirmation, this.front());
     }
 
+    disableSnapLinks() {
+        return _.contains(CONST.disableSnapLinks, this.front());
+    }
+
     showIndicatorsEnabled() {
         return !this.confirmSendingAlert() && this.mode() !== 'treats';
     }
@@ -313,6 +317,10 @@ export default class Front extends ColumnWidget {
         return new Promise((resolve, reject) => {
             if (this.confirmSendingAlert() && !isOnlyArticle(item, this)) {
                 reject('You can only have one article in this collection.');
+            }
+
+            if (item.meta.snapType() && this.disableSnapLinks()) {
+                reject('You cannot use snap links in this collection.')
             }
 
             var defaults = this.baseModel.state().defaults;

--- a/public/src/js/widgets/columns/fronts.js
+++ b/public/src/js/widgets/columns/fronts.js
@@ -320,7 +320,7 @@ export default class Front extends ColumnWidget {
             }
 
             if (item.meta.snapType() && this.disableSnapLinks()) {
-                reject('You cannot use snap links in this collection.')
+                reject('You cannot use snap links in this collection.');
             }
 
             var defaults = this.baseModel.state().defaults;


### PR DESCRIPTION
## What's changed?

There's logic on the server to prevent snap links from being sent as breaking news alerts, but no logic on the client.

This caused a problem last week, when an outage in preview CAPI caused a snaplink to be inadvertently created in the breaking news tool. Because these links look remarkably similar to articles, and there was no error message, the editor attempted to send the alert as usual. They received an error message, but it wasn't clear what had gone wrong.

This PR adds client logic to prevent snap links from being added to the breaking news front. When a user tries, they now see this modal:

<img width="524" alt="Screenshot 2020-01-15 at 13 25 06" src="https://user-images.githubusercontent.com/7767575/72438952-e1729f00-379d-11ea-9508-475bc8e809ab.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
