### PR TITLE
Fail on card creation if the incoming URL is from our website and content is not found

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -2333,6 +2333,10 @@ hr {
     margin-right: 8px;
 }
 
+.modalDialog-message--text {
+    white-space: pre-line;
+}
+
 .modalDialog-confirm,
 .modalDialog-alert {
     height: 42px;

--- a/public/src/js/modules/content-api.js
+++ b/public/src/js/modules/content-api.js
@@ -144,7 +144,11 @@ function validateItem (item) {
 
                     // A snap, of default type 'link'.
                 } else {
-                    item.convertToLinkSnap();
+                    if (!isGuardianUrl(item.id())) {
+                        item.convertToLinkSnap();
+                    } else {
+                        err = 'Content not found. \n \nYou have dropped a Guardian URL, but we could not find the content it refers to in the Content API. Please contact Central Production if this persists.';
+                    }
                 }
 
                 if (err) {

--- a/public/src/js/widgets/modals/text-alert.html
+++ b/public/src/js/widgets/modals/text-alert.html
@@ -1,6 +1,6 @@
 <div class="modalDialog-message">
-    <h3><i class="fa fa-exclamation-circle"></i>Error:</h3>
-    <span data-bind="text: message"></span>
+    <h3><i class="fa fa-exclamation-circle"></i>Error</h3>
+    <span class="modalDialog-message--text" data-bind="text: message"></span>
 </div>
 <hr>
 <div class="buttons modalDialog-alert">


### PR DESCRIPTION
## What's changed?

When we fail to find content in CAPI in V1 (breaking-news) on card creation, we fall back to a snap link if nothing is found.

This isn't appropriate if the incoming URL is from `guardian.co.uk` -- at this point there's clearly a problem with either the content or CAPI itself, and we should fail with a warning to the user that something that's not right.

This PR adds code for this case. Instead of creating a snap link to that article, the tool will now show the user this modal:  

<img width="562" alt="Screenshot 2020-01-15 at 18 06 45" src="https://user-images.githubusercontent.com/7767575/72459414-a46cd380-37c2-11ea-8570-3b1bcff56a3f.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
