### PR TITLE
Revert "Fail on card creation if the incoming URL is from our website and content is not found"

### DIFF
--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -2333,10 +2333,6 @@ hr {
     margin-right: 8px;
 }
 
-.modalDialog-message--text {
-    white-space: pre-line;
-}
-
 .modalDialog-confirm,
 .modalDialog-alert {
     height: 42px;

--- a/public/src/js/modules/content-api.js
+++ b/public/src/js/modules/content-api.js
@@ -144,11 +144,7 @@ function validateItem (item) {
 
                     // A snap, of default type 'link'.
                 } else {
-                    if (!isGuardianUrl(item.id())) {
-                        item.convertToLinkSnap();
-                    } else {
-                        err = 'Content not found. \n \nYou have dropped a Guardian URL, but we could not find the content it refers to in the Content API. Please contact Central Production if this persists.';
-                    }
+                    item.convertToLinkSnap();
                 }
 
                 if (err) {

--- a/public/src/js/widgets/modals/text-alert.html
+++ b/public/src/js/widgets/modals/text-alert.html
@@ -1,6 +1,6 @@
 <div class="modalDialog-message">
-    <h3><i class="fa fa-exclamation-circle"></i>Error</h3>
-    <span class="modalDialog-message--text" data-bind="text: message"></span>
+    <h3><i class="fa fa-exclamation-circle"></i>Error:</h3>
+    <span data-bind="text: message"></span>
 </div>
 <hr>
 <div class="buttons modalDialog-alert">


### PR DESCRIPTION
Reverts guardian/facia-tool#1144.

We've learned that this approach isn't viable, because the v1 tool is still used for treats, and there are URLs that Dotcom understands that aren't available in CAPI -- for example, `https://www.theguardian.com/commentisfree/all`.

Because of this PR, dragging that link into v1 for treats at the moment is impossible.

In the absence of a canonical list of routes which can or can't be mapped onto CAPI queries, the only way around this I can think of is to maintain a whitelist, which would inevitably get out of date.

With #1143 to prevent snap links from being added to the breaking news front, we're still able to alert users in good time if they're doing the wrong thing.

