### PR TITLE
Don't allow creation of 'Invalid atom' cards

### DIFF
--- a/client-v2/src/services/capiQuery.ts
+++ b/client-v2/src/services/capiQuery.ts
@@ -188,6 +188,7 @@ export {
   CAPISearchQueryResultsResponse,
   checkIsResults,
   CAPITagQueryReponse,
-  CAPIInteractiveAtomResponse
+  CAPIInteractiveAtomResponse,
+  CAPIAtomInteractive
 };
 export default capiQuery;

--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -217,8 +217,8 @@ const getArticleEntitiesFromDrop = async (
     } catch (e) {
       dispatch(
         startOptionsModal(
-          'Invalid atom link',
-          "It looks like you've tried to add an interactive atom that doesn't exist. Check the link and try again.",
+          'Invalid link',
+          'It looks like you’ve tried to add something from our content-api that we don’t accept. Only interactive atoms can be added as cards. Check the link is for an interactive atom and that the link is valid and try again.',
           [],
           noop,
           true

--- a/client-v2/src/shared/actions/Cards.ts
+++ b/client-v2/src/shared/actions/Cards.ts
@@ -1,6 +1,10 @@
 import keyBy from 'lodash/keyBy';
 import { actions as externalArticleActions } from 'shared/bundles/externalArticlesBundle';
-import { getContent, transformExternalArticle } from 'services/faciaApi';
+import {
+  getContent,
+  transformExternalArticle,
+  getAtomFromCapi
+} from 'services/faciaApi';
 import { ThunkResult, Dispatch } from 'types/Store';
 import {
   CardsReceived,
@@ -15,13 +19,19 @@ import {
 import { createCard } from 'shared/util/card';
 import { createSnap, createLatestSnap, createAtomSnap } from 'shared/util/snap';
 import { getIdFromURL } from 'util/CAPIUtils';
-import { isValidURL, isGuardianUrl, isCapiUrl } from 'shared/util/url';
+import {
+  isValidURL,
+  isGuardianUrl,
+  isCapiUrl,
+  getAbsolutePath
+} from 'shared/util/url';
 import { MappableDropType } from 'util/collectionUtils';
 import { ExternalArticle } from 'shared/types/ExternalArticle';
 import { CapiArticle } from 'types/Capi';
 import { Card, CardMeta } from '../types/Collection';
 import { selectEditMode } from '../../selectors/pathSelectors';
 import { startOptionsModal } from 'actions/OptionsModal';
+import noop from 'lodash/noop';
 
 export const UPDATE_CARD_META = 'SHARED/UPDATE_CARD_META';
 export const CARDS_RECEIVED = 'SHARED/CARDS_RECEIVED';
@@ -198,8 +208,24 @@ const getArticleEntitiesFromDrop = async (
   const isPlainUrl = isURL && !id && !guMeta;
   const isCAPIUrl = isCapiUrl(resourceIdOrUrl);
   if (isCAPIUrl) {
-    const card = await createAtomSnap(resourceIdOrUrl);
-    return [card];
+    try {
+      const atom = await getAtomFromCapi(
+        getAbsolutePath(resourceIdOrUrl, false)
+      );
+      const card = await createAtomSnap(resourceIdOrUrl, atom);
+      return [card];
+    } catch (e) {
+      dispatch(
+        startOptionsModal(
+          'Invalid atom link',
+          "It looks like you've tried to add an interactive atom that doesn't exist. Check the link and try again.",
+          [],
+          noop,
+          true
+        )
+      );
+      return [];
+    }
   }
   if (isPlainUrl) {
     const card = await createSnap(resourceIdOrUrl);

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -18,6 +18,8 @@ import configureStore from 'util/configureStore';
 import { selectOptionsModalOptions } from 'selectors/modalSelectors';
 import { selectCard, selectSharedState } from 'shared/selectors/shared';
 import capiInteractiveAtomResponse from 'fixtures/capiInteractiveAtomResponse';
+import { startOptionsModal } from 'actions/OptionsModal';
+import noop from 'lodash/noop';
 
 jest.mock('uuid/v4', () => () => 'card1');
 const middlewares = [thunk];
@@ -287,7 +289,7 @@ describe('Snap cards actions', () => {
         })
       );
     });
-    it('takes a content.guardianapis.com URL and returns an invalid atom card if there is no atom', async () => {
+    it('it takes an invalid atom URL, for an atom that cannot be found in CAPI, and displays an error modal', async () => {
       const store = mockStore(initialState);
       const snapUrl =
         'https://content.guardianapis.com/atom/interactive/interactives/2017/06/not-an-atom';
@@ -305,20 +307,15 @@ describe('Snap cards actions', () => {
         idDrop(snapUrl)
       ) as any);
       const actions = store.getActions();
+      expect(actions[0].type).toEqual('MODAL/START_OPTIONS_MODAL');
       expect(actions[0]).toEqual(
-        cardsReceived({
-          card1: {
-            frontPublicationDate: 1487076708000,
-            id: 'snap/1487076708000',
-            meta: {
-              headline: 'Invalid atom',
-              snapType: 'interactive',
-              href:
-                'https://content.guardianapis.com/atom/interactive/interactives/2017/06/not-an-atom'
-            },
-            uuid: 'card1'
-          }
-        })
+        startOptionsModal(
+          'Invalid atom link',
+          "It looks like you've tried to add an interactive atom that doesn't exist. Check the link and try again.",
+          [],
+          noop,
+          true
+        )
       );
     });
   });

--- a/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
+++ b/client-v2/src/shared/actions/__tests__/snapcards.spec.ts
@@ -310,8 +310,8 @@ describe('Snap cards actions', () => {
       expect(actions[0].type).toEqual('MODAL/START_OPTIONS_MODAL');
       expect(actions[0]).toEqual(
         startOptionsModal(
-          'Invalid atom link',
-          "It looks like you've tried to add an interactive atom that doesn't exist. Check the link and try again.",
+          'Invalid link',
+          'It looks like you’ve tried to add something from our content-api that we don’t accept. Only interactive atoms can be added as cards. Check the link is for an interactive atom and that the link is valid and try again.',
           [],
           noop,
           true

--- a/client-v2/src/shared/util/__tests__/snap.spec.ts
+++ b/client-v2/src/shared/util/__tests__/snap.spec.ts
@@ -9,6 +9,10 @@ import tagPageHtml from '../../fixtures/guardianTagPage';
 import fetchMock from 'fetch-mock';
 import bbcSectionPage from 'shared/fixtures/bbcSectionPage';
 import { capiAtom } from 'shared/fixtures/capiAtom.js';
+import {
+  CAPIInteractiveAtomResponse,
+  CAPIAtomInteractive
+} from 'services/capiQuery';
 
 jest.mock('uuid/v4', () => () => 'uuid');
 
@@ -98,8 +102,26 @@ describe('utils/snap', () => {
   describe('convert to Atom snap', async () => {
     it("should create a snap of 'interactive', given a link to an atom in the public content api", async () => {
       fetchMock.once('begin:/api/live', capiAtom);
+      const interactive: CAPIAtomInteractive = {
+        id: '',
+        atomType: '',
+        labels: [],
+        defaultHtml: '',
+        data: { interactive: { title: 'General Election 2017' } },
+        contentChangeDetails: {},
+        commissioningDesks: []
+      };
+      const atom: CAPIInteractiveAtomResponse = {
+        response: {
+          status: 'ok',
+          userTier: capiAtom.response.userTier,
+          total: capiAtom.response.total,
+          interactive
+        }
+      };
       const atomLinkSnap = await createAtomSnap(
-        'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
+        'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election',
+        atom
       );
       expect(atomLinkSnap).toEqual({
         uuid: 'uuid',
@@ -111,10 +133,10 @@ describe('utils/snap', () => {
           showByline: false,
           snapType: 'interactive',
           snapUri:
-            'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter',
+            'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election',
           atomId: 'atom/interactive/interactives/2017/06/general-election',
           href:
-            'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election?api-key=teleporter'
+            'https://content.guardianapis.com/atom/interactive/interactives/2017/06/general-election'
         }
       });
     });

--- a/client-v2/src/shared/util/snap.ts
+++ b/client-v2/src/shared/util/snap.ts
@@ -4,7 +4,6 @@ import { Card, CardMeta } from '../types/Collection';
 import v4 from 'uuid/v4';
 import set from 'lodash/fp/set';
 import { PartialBy } from 'types/Util';
-import { getAtomFromCapi } from 'services/faciaApi';
 import { CAPIInteractiveAtomResponse } from 'services/capiQuery';
 
 function generateId() {
@@ -64,40 +63,28 @@ async function createSnap(url?: string, meta?: CardMeta): Promise<Card> {
   }
 }
 
-async function createAtomSnap(url: string, meta?: CardMeta): Promise<Card> {
-  const uuid = v4();
-  try {
-    const atom: CAPIInteractiveAtomResponse = await getAtomFromCapi(
-      getAbsolutePath(url, false)
-    );
-    const { title } = atom.response.interactive.data.interactive;
-    const atomId = new URL(url).pathname.substr(1);
+async function createAtomSnap(
+  url: string,
+  atom: CAPIInteractiveAtomResponse,
+  meta?: CardMeta
+): Promise<Card> {
+  const { title } = atom.response.interactive.data.interactive;
+  const atomId = new URL(url).pathname.substr(1);
 
-    return convertToSnap({
-      uuid,
-      id: url,
-      frontPublicationDate: Date.now(),
-      meta: {
-        headline: title,
-        byline: 'Guardian Visuals',
-        showByline: false,
-        snapType: 'interactive',
-        snapUri: url,
-        atomId,
-        ...meta
-      }
-    });
-  } catch (e) {
-    return convertToSnap({
-      uuid,
-      id: url,
-      frontPublicationDate: Date.now(),
-      meta: {
-        headline: 'Invalid atom',
-        snapType: 'interactive'
-      }
-    });
-  }
+  return convertToSnap({
+    uuid: v4(),
+    id: url,
+    frontPublicationDate: Date.now(),
+    meta: {
+      headline: title,
+      byline: 'Guardian Visuals',
+      showByline: false,
+      snapType: 'interactive',
+      snapUri: url,
+      atomId,
+      ...meta
+    }
+  });
 }
 
 function createLatestSnap(url: string, kicker: string) {


### PR DESCRIPTION
## What's changed? 

When a user drops a link into the Fronts tool that _looks_ like an interactive atom, we do one of two things: create a card for that atom, or create an 'Invalid Atom' card. The latter happens when the link appears to match the format for an interactive atom but CAPI has indicated that no atom of that ID can be found. In practice, this caused the press to fail if the invalid atom was left in a collection.

Instead of creating an 'Invalid Atom' card, I've added a modal, to let the user know that the atom they tried to add doesn't exist.
 
<img width="749" alt="Screenshot 2020-02-14 at 16 00 45" src="https://user-images.githubusercontent.com/12645938/74546892-304d5900-4f43-11ea-8301-0b6c1da5bc4c.png">

Now when a user drops an interactive atom link into the tool, we either create a card for the atom if it is found in CAPI, or display the modal to let the user know they seem to have pasted/dragged in an invalid link.

Happy to take suggestions on alternate wording for the modal!

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
