### PR TITLE
Add image field for html snap

### DIFF
--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -38,7 +38,7 @@ export const supportingFields = [
   'showKickerCustom'
 ] as FormFields[];
 
-export const htmlSnapFields = ['headline'];
+export const htmlSnapFields = ['headline', 'primaryImage'];
 
 export const emailFieldsToExclude = [
   'isBreaking',


### PR DESCRIPTION
## What's changed?

(Re-)add the image field to the HTML snap. It was removed as it was unnecessary for the current implementation of this snap in Frontend.

Before:
<img width="424" alt="Screenshot 2020-02-14 at 18 29 00" src="https://user-images.githubusercontent.com/7767575/74558174-b2e11300-4f59-11ea-9134-593d5328e0d4.png">

After:

<img width="438" alt="Screenshot 2020-02-14 at 18 27 05" src="https://user-images.githubusercontent.com/7767575/74558178-b5436d00-4f59-11ea-84cc-249b2b8ab064.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
