### PR TITLE
Add image toggles to HTML snaps

### DIFF
--- a/client-v2/src/selectors/formSelectors.ts
+++ b/client-v2/src/selectors/formSelectors.ts
@@ -38,7 +38,14 @@ export const supportingFields = [
   'showKickerCustom'
 ] as FormFields[];
 
-export const htmlSnapFields = ['headline', 'primaryImage'];
+export const htmlSnapFields = [
+  'headline',
+  'primaryImage',
+  'cutoutImage',
+  'imageCutoutReplace',
+  'imageHide',
+  'imageReplace'
+];
 
 export const emailFieldsToExclude = [
   'isBreaking',


### PR DESCRIPTION
## What's changed?
In addition to the changes in #1150 users need to be able to set a cutout image. To make this possible, this PR adds the image toggles to the list of fields that are rendered on the HTML snap type card.

<img width="570" alt="Screenshot 2020-02-18 at 13 40 23" src="https://user-images.githubusercontent.com/12645938/74741277-6ac13980-5254-11ea-8934-8b074b784efd.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
