### PR TITLE
Remove Shared folder FINAL: rename shared cards -> common cards

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -8,7 +8,7 @@ import {
   cardsReceived,
   maybeAddFrontPublicationDate,
   copyCardImageMeta
-} from 'shared/actions/Cards';
+} from 'actions/CardsCommon';
 import { Card } from 'types/Collection';
 import {
   selectSharedState,

--- a/fronts-client/src/actions/CardsCommon.ts
+++ b/fronts-client/src/actions/CardsCommon.ts
@@ -35,8 +35,8 @@ import {
   isValidURL
 } from 'util/url';
 
-import { selectEditMode } from '../../selectors/pathSelectors';
-import { Card, CardMeta } from '../../types/Collection';
+import { selectEditMode } from '../selectors/pathSelectors';
+import { Card, CardMeta } from '../types/Collection';
 
 export const UPDATE_CARD_META = 'UPDATE_CARD_META';
 export const CARDS_RECEIVED = 'CARDS_RECEIVED';

--- a/fronts-client/src/actions/Clipboard.ts
+++ b/fronts-client/src/actions/Clipboard.ts
@@ -2,7 +2,7 @@ import { Dispatch, ThunkResult } from 'types/Store';
 import { saveClipboardStrategy } from 'strategies/save-clipboard';
 import { fetchArticles } from 'actions/Collections';
 import { batchActions } from 'redux-batched-actions';
-import { cardsReceived } from 'shared/actions/Cards';
+import { cardsReceived } from 'actions/CardsCommon';
 import { Card, NestedCard } from 'types/Collection';
 import { normaliseClipboard } from 'util/clipboardUtils';
 import {

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -32,7 +32,7 @@ import {
   normaliseCollectionWithNestedArticles,
   denormaliseCollection
 } from 'util/shared';
-import { cardsReceived, clearCards } from 'shared/actions/Cards';
+import { cardsReceived, clearCards } from 'actions/CardsCommon';
 import { groupsReceived } from 'actions/Groups';
 import {
   recordVisibleArticles,

--- a/fronts-client/src/actions/__tests__/editionscards.spec.ts
+++ b/fronts-client/src/actions/__tests__/editionscards.spec.ts
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import {
   createArticleEntitiesFromDrop,
   cardsReceived
-} from '../../shared/actions/Cards';
+} from '../CardsCommon';
 import initialState from 'fixtures/initialStateForEditions';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'bundles/externalArticlesBundle';

--- a/fronts-client/src/actions/__tests__/editionscards.spec.ts
+++ b/fronts-client/src/actions/__tests__/editionscards.spec.ts
@@ -1,10 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
-import {
-  createArticleEntitiesFromDrop,
-  cardsReceived
-} from '../CardsCommon';
+import { createArticleEntitiesFromDrop, cardsReceived } from '../CardsCommon';
 import initialState from 'fixtures/initialStateForEditions';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'bundles/externalArticlesBundle';

--- a/fronts-client/src/actions/__tests__/frontscards.spec.ts
+++ b/fronts-client/src/actions/__tests__/frontscards.spec.ts
@@ -1,10 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
-import {
-  createArticleEntitiesFromDrop,
-  cardsReceived
-} from '../CardsCommon';
+import { createArticleEntitiesFromDrop, cardsReceived } from '../CardsCommon';
 import initialState from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'bundles/externalArticlesBundle';

--- a/fronts-client/src/actions/__tests__/frontscards.spec.ts
+++ b/fronts-client/src/actions/__tests__/frontscards.spec.ts
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import {
   createArticleEntitiesFromDrop,
   cardsReceived
-} from '../../shared/actions/Cards';
+} from '../CardsCommon';
 import initialState from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'bundles/externalArticlesBundle';

--- a/fronts-client/src/actions/__tests__/snapcards.spec.ts
+++ b/fronts-client/src/actions/__tests__/snapcards.spec.ts
@@ -6,7 +6,7 @@ import {
   cardsReceived,
   snapMetaWhitelist,
   marketingParamsWhiteList
-} from '../../shared/actions/Cards';
+} from '../CardsCommon';
 import initialState from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { createSnap, createLatestSnap } from 'util/snap';

--- a/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -39,7 +39,7 @@ import initialState from 'fixtures/initialState';
 import initialStateForOpenFronts from '../../fixtures/initialStateForOpenFronts';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { Action } from 'types/Action';
-import { removeSupportingCard, removeGroupCard } from 'shared/actions/Cards';
+import { removeSupportingCard, removeGroupCard } from 'actions/CardsCommon';
 import { removeClipboardCard } from 'actions/Clipboard';
 import { State as GlobalState } from 'types/State';
 import { SharedState as GlobalSharedState } from 'types/State';

--- a/fronts-client/src/bundles/frontsUIBundle.ts
+++ b/fronts-client/src/bundles/frontsUIBundle.ts
@@ -37,10 +37,7 @@ import {
   selectFrontsWithPriority,
   selectFront
 } from 'selectors/frontsSelectors';
-import {
-  REMOVE_GROUP_CARD,
-  REMOVE_SUPPORTING_CARD
-} from 'actions/CardsCommon';
+import { REMOVE_GROUP_CARD, REMOVE_SUPPORTING_CARD } from 'actions/CardsCommon';
 import { Stages, CardSets } from 'types/Collection';
 import { selectPriority } from 'selectors/pathSelectors';
 import { CollectionWithArticles } from 'types/PageViewData';

--- a/fronts-client/src/bundles/frontsUIBundle.ts
+++ b/fronts-client/src/bundles/frontsUIBundle.ts
@@ -40,7 +40,7 @@ import {
 import {
   REMOVE_GROUP_CARD,
   REMOVE_SUPPORTING_CARD
-} from 'shared/actions/Cards';
+} from 'actions/CardsCommon';
 import { Stages, CardSets } from 'types/Collection';
 import { selectPriority } from 'selectors/pathSelectors';
 import { CollectionWithArticles } from 'types/PageViewData';

--- a/fronts-client/src/keyboard/index.ts
+++ b/fronts-client/src/keyboard/index.ts
@@ -11,7 +11,7 @@ import { ThunkResult } from 'types/Store';
 import Mousetrap from 'mousetrap';
 import { selectFocusState, setFocusState } from 'bundles/focusBundle';
 import { RefDrop } from 'util/collectionUtils';
-import { createArticleEntitiesFromDrop } from 'shared/actions/Cards';
+import { createArticleEntitiesFromDrop } from 'actions/CardsCommon';
 import { moveUp, moveDown } from './keyboardActionMaps/move';
 import { Card } from '../types/Collection';
 import { thunkInsertClipboardCard } from 'actions/Clipboard';

--- a/fronts-client/src/reducers/__tests__/cardsReducer.spec.ts
+++ b/fronts-client/src/reducers/__tests__/cardsReducer.spec.ts
@@ -1,5 +1,5 @@
 import reducer from 'reducers/cardsReducer';
-import { updateCardMeta } from '../../shared/actions/Cards';
+import { updateCardMeta } from '../../actions/CardsCommon';
 import { stateWithClipboard } from 'fixtures/clipboard';
 
 describe('cardsReducer', () => {

--- a/fronts-client/src/reducers/cardsReducer.ts
+++ b/fronts-client/src/reducers/cardsReducer.ts
@@ -8,7 +8,7 @@ import {
   REMOVE_SUPPORTING_CARD,
   INSERT_SUPPORTING_CARD,
   COPY_CARD_IMAGE_META
-} from 'shared/actions/Cards';
+} from 'actions/CardsCommon';
 import { cloneActiveImageMeta } from 'util/card';
 
 const cards = (state: State['cards'] = {}, action: Action) => {

--- a/fronts-client/src/types/Action.ts
+++ b/fronts-client/src/types/Action.ts
@@ -42,7 +42,7 @@ import { SetHidden } from '../bundles/collectionsBundle';
 import { OptionsModalChoices } from './Modals';
 import { Actions } from 'lib/createAsyncResourceBundle';
 import { ExternalArticle } from 'types/ExternalArticle';
-import { copyCardImageMeta } from 'shared/actions/Cards';
+import { copyCardImageMeta } from 'actions/CardsCommon';
 import { PageViewStory } from 'types/PageViewData';
 
 interface EditorOpenCurrentFrontsMenu {


### PR DESCRIPTION
## What's changed?
This removes the final part of the shared folder as part of our work to make the code base clearer. 

We have moved `shared/actions/Cards.ts` into `actions/CommonCard.ts`. 

NB:
This avoids problems with circular dependencies caused by merging the two Card action files.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
