### PR TITLE
Extensive container renaming to support new navigation

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -285,10 +285,10 @@ object DailyEdition {
   def FrontSportObserver = front(
     "Sport",
     collection("Sport").printSentAnyTag("theobserver/sport/news"),
-    collection("Sport 1"),
-    collection("Sport 2"),
-    collection("Sport 3"),
-    collection("Sport Special").hide,
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport").hide,
   )
     .swatch(Sport)
 

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -78,22 +78,22 @@ object DailyEdition {
 
   def FrontNewsUkGuardian = front(
     "National",
-    collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
-    collection("News Special").hide,
-    collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
+    collection("National").printSentAnyTag("theguardian/mainsection/topstories"),
+    collection("National").hide,
+    collection("National").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2"),
-    collection("News Special 2").hide
+    collection("National").hide
   )
     .swatch(News)
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
-    collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
-    collection("News Special").hide,
-    collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
+    collection("National").printSentAnyTag("theguardian/mainsection/topstories"),
+    collection("National").hide,
+    collection("National").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
     collection("Weather").printSentAnyTag("theguardian/mainsection/weather2"),
-    collection("News Special 2").hide
+    collection("National").hide
   )
     .swatch(News)
 
@@ -102,24 +102,24 @@ object DailyEdition {
   def FrontNewsWorldGuardian = front(
     "World",
     collection("World News").printSentAnyTag("theguardian/mainsection/international"),
-    collection("World Special").hide
+    collection("World").hide
   )
     .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
     collection("Front Page"),
-    collection("UK News").printSentAnyTag("theobserver/news/uknews"),
+    collection("News").printSentAnyTag("theobserver/news/uknews"),
     collection("Focus").printSentAnyTag("theobserver/news/focus").hide,
-    collection("News Special").hide,
-    collection("News Special 2").hide
+    collection("National").hide,
+    collection("National").hide
   )
     .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
     collection("World News").printSentAnyTag("theobserver/news/worldnews"),
-    collection("World Special").hide,
+    collection("World").hide,
   )
     .swatch(News)
 
@@ -131,7 +131,7 @@ object DailyEdition {
     "Financial",
     collection("Financial").printSentAnyTag("theguardian/mainsection/financial3"),
     collection("Money"),printSentAnyTag("theguardian/mainsection/money"),
-    collection("Financial Special").hide,
+    collection("Financial").hide,
   )
     .swatch(News)
 
@@ -139,7 +139,7 @@ object DailyEdition {
     "Financial",
     collection("Financial").printSentAnyTag("theobserver/news/business"),
     collection("Cash").printSentAnyTag("theobserver/news/cash"),
-    collection("Financial Special").hide
+    collection("Financial").hide
   )
     .swatch(News)
 
@@ -151,16 +151,16 @@ object DailyEdition {
     collection("Comment").printSentAnyTag("theguardian/journal/opinion"),
     collection("Letters").printSentAnyTag("theguardian/journal/letters"),
     collection("Obituaries").printSentAnyTag("theguardian/journal/obituaries"),
-    collection("Journal Special").hide,
+    collection("Journal").hide,
   )
     .swatch(Opinion)
 
   def FrontComment = front(
     "Journal",
     collection("Comment").printSentAnyTag("theobserver/news/comment"),
-    collection("Comment 1"),
-    collection("Comment 2"),
-    collection("Comment Special").hide,
+    collection("Comment"),
+    collection("Comment"),
+    collection("Journal").hide,
   )
     .swatch(Opinion)
 
@@ -170,7 +170,7 @@ object DailyEdition {
     "Culture",
     collection("Arts").printSentAnyTag("theguardian/g2/arts"),
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
-    collection("Culture Special").hide,
+    collection("Culture").hide,
   )
     .swatch(Culture)
 
@@ -180,7 +180,7 @@ object DailyEdition {
     collection("Music").printSentAnyTag("theguardian/g2/music"),
     collection("Arts").printSentAnyTag("theguardian/g2/arts"),
     collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
-    collection("Culture Special"),
+    collection("Culture"),
   )
     .swatch(Culture)
 
@@ -188,8 +188,8 @@ object DailyEdition {
     "Culture",
     collection("Features").printSentAnyTag("theguardian/theguide/features"),
     collection("Preview").printSentAnyTag("theguardian/theguide/reviews"),
-    collection("TV and Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
-    collection("Culture Special"),
+    collection("TV & Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
+    collection("Culture"),
   )
     .swatch(Culture)
 
@@ -199,15 +199,15 @@ object DailyEdition {
     collection("Agenda").printSentAnyTag("theobserver/new-review/agenda"),
     collection("Discover").printSentAnyTag("theobserver/new-review/discover"),
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
-    collection("Culture Special").hide,
-    collection("Culture Special 2").hide
+    collection("Culture").hide,
+    collection("Culture").hide
   )
     .swatch(Culture)
 
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
-    collection("Books Special").hide,
+    collection("Books").hide,
   )
     .swatch(Culture)
 
@@ -216,7 +216,7 @@ object DailyEdition {
   def FrontLife = front(
     "Life",
     collection("Features").printSentAnyTag("theguardian/g2/features"),
-    collection("Life Special").hide,
+    collection("Life").hide,
   )
     .swatch(Lifestyle)
 
@@ -234,31 +234,31 @@ object DailyEdition {
     collection("Weekend").printSentAnyTag("theguardian/weekend/starters", "theguardian/weekend/features2", "theguardian/weekend/back"),
     collection("Family").printSentAnyTag("theguardian/weekend/family"),
     collection("Space").printSentAnyTag("theguardian/weekend/space2"),
-    collection("Fashion").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
+    collection("Style").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
     collection("Body").printSentAnyTag("theguardian/weekend/body-and-mind"),
-    collection("Life Special").hide,
+    collection("Life").hide,
   )
     .swatch(Lifestyle)
 
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
-    collection("Travel Special").hide,
+    collection("Travel").hide,
   )
     .swatch(Lifestyle);
 
   def FrontLifeMagazineObserver = front(
     "Life",
     collection("Features").printSentAnyTag("theobserver/magazine/features2"),
-    collection("Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
-    collection("Life Special").printSentAnyTag("theobserver/design/design").hide,
+    collection("Life").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
+    collection("Life").printSentAnyTag("theobserver/design/design").hide,
   )
     .swatch(Lifestyle)
 
   def FrontFood = front(
     "Food",
     collection("Food").printSentAnyTag("theguardian/feast/feast"),
-    collection("Food Special").hide,
+    collection("Food").hide,
   )
     .swatch(Lifestyle)
 
@@ -268,7 +268,7 @@ object DailyEdition {
     collection("Monthly").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").hide,
     collection("Monthly").hide,
     collection("Monthly").hide,
-    collection("Food Special").hide,
+    collection("Food").hide,
   )
     .swatch(Lifestyle)
 

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -129,14 +129,16 @@ object DailyEdition {
 
   def FrontFinancialGuardian = front(
     "Financial",
-    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
+    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3"),
+    collection("Money"),printSentAnyTag("theguardian/mainsection/money"),
     collection("Financial Special").hide,
   )
     .swatch(News)
 
   def FrontFinancialObserver = front(
     "Financial",
-    collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
+    collection("Financial").printSentAnyTag("theobserver/news/business"),
+    collection("Cash").printSentAnyTag("theobserver/news/cash"),
     collection("Financial Special").hide
   )
     .swatch(News)
@@ -195,7 +197,7 @@ object DailyEdition {
     "Culture",
     collection("Features").printSentAnyTag("theobserver/new-review/features"),
     collection("Agenda").printSentAnyTag("theobserver/new-review/agenda"),
-    collection("Science & Technology").printSentAnyTag("theobserver/new-review/discover"),
+    collection("Discover").printSentAnyTag("theobserver/new-review/discover"),
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
     collection("Culture Special").hide,
     collection("Culture Special 2").hide
@@ -220,9 +222,9 @@ object DailyEdition {
 
   def FrontLifeFashion = front(
     "The Fashion",
-    collection("Fashion 1").printSentAnyTag("theguardian/the-fashion/the-fashion"),
-    collection("Fashion 2").hide,
-    collection("Fashion 3").hide,
+    collection("The Fashion").printSentAnyTag("theguardian/the-fashion/the-fashion"),
+    collection("The Fashion").hide,
+    collection("The Fashion").hide,
   )
     .special
     .swatch(Lifestyle)
@@ -232,8 +234,8 @@ object DailyEdition {
     collection("Weekend").printSentAnyTag("theguardian/weekend/starters", "theguardian/weekend/features2", "theguardian/weekend/back"),
     collection("Family").printSentAnyTag("theguardian/weekend/family"),
     collection("Space").printSentAnyTag("theguardian/weekend/space2"),
-    collection("Fashion & Beauty").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
-    collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
+    collection("Fashion").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
+    collection("Body").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life Special").hide,
   )
     .swatch(Lifestyle)
@@ -248,7 +250,7 @@ object DailyEdition {
   def FrontLifeMagazineObserver = front(
     "Life",
     collection("Features").printSentAnyTag("theobserver/magazine/features2"),
-    collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
+    collection("Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
     collection("Life Special").printSentAnyTag("theobserver/design/design").hide,
   )
     .swatch(Lifestyle)
@@ -263,9 +265,9 @@ object DailyEdition {
   def FrontFoodObserver = front(
     "Food",
     collection("Food").printSentAllTags("theobserver/magazine/life-and-style", "food/food"),
-    collection("OFM 1").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").hide,
-    collection("OFM 2").hide,
-    collection("OFM 3").hide,
+    collection("Monthly").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").hide,
+    collection("Monthly").hide,
+    collection("Monthly").hide,
     collection("Food Special").hide,
   )
     .swatch(Lifestyle)
@@ -275,10 +277,10 @@ object DailyEdition {
   def FrontSportGuardian = front(
     "Sport",
     collection("Sport").printSentAnyTag("theguardian/sport/news"),
-    collection("Sport 1"),
-    collection("Sport 2"),
-    collection("Sport 3"),
-    collection("Sport Special").hide,
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport").hide,
   )
     .swatch(Sport)
 

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -67,21 +67,21 @@ object DailyEdition {
     ophanQueryPrefillParams = None
   )
 
-  def FrontSpecial1 = specialFront("Top Special 1", Neutral, None)
+  def FrontSpecial1 = specialFront("Special", Neutral, None)
 
   def FrontTopStories = front(
     "Top stories",
     collection("Top stories")
   )
 
-  def FrontSpecial2 = specialFront("Top Special 2", Neutral, None)
+  def FrontSpecial2 = specialFront("Special", Neutral, None)
 
   def FrontNewsUkGuardian = front(
     "National",
     collection("National").printSentAnyTag("theguardian/mainsection/topstories"),
     collection("National").hide,
     collection("National").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
-    collection("Weather").printSentAnyTag("theguardian/mainsection/weather2"),
+    collection("National").printSentAnyTag("theguardian/mainsection/weather2"),
     collection("National").hide
   )
     .swatch(News)
@@ -92,7 +92,7 @@ object DailyEdition {
     collection("National").hide,
     collection("National").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
-    collection("Weather").printSentAnyTag("theguardian/mainsection/weather2"),
+    collection("National").printSentAnyTag("theguardian/mainsection/weather2"),
     collection("National").hide
   )
     .swatch(News)
@@ -101,15 +101,15 @@ object DailyEdition {
 
   def FrontNewsWorldGuardian = front(
     "World",
-    collection("World News").printSentAnyTag("theguardian/mainsection/international"),
+    collection("World").printSentAnyTag("theguardian/mainsection/international"),
     collection("World").hide
   )
     .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
-    collection("Front Page"),
-    collection("News").printSentAnyTag("theobserver/news/uknews"),
+    collection("National"),
+    collection("National").printSentAnyTag("theobserver/news/uknews"),
     collection("Focus").printSentAnyTag("theobserver/news/focus").hide,
     collection("National").hide,
     collection("National").hide
@@ -118,7 +118,7 @@ object DailyEdition {
 
   def FrontNewsWorldObserver = front(
     "World",
-    collection("World News").printSentAnyTag("theobserver/news/worldnews"),
+    collection("World").printSentAnyTag("theobserver/news/worldnews"),
     collection("World").hide,
   )
     .swatch(News)
@@ -297,12 +297,12 @@ object DailyEdition {
   def FrontSportSpecial = specialFront("Sport Special", Sport)
 
   def FrontSupplementSpecial1 = specialFront(
-    "Special Supplement 1",
+    "Special Supplement",
     swatch = Neutral,
     prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent))
   )
 
-  def FrontSupplementSpecial2 = specialFront("Special Supplement 2", Neutral)
+  def FrontSupplementSpecial2 = specialFront("Special Supplement", Neutral)
 
   def FrontCrosswords = front(
     "Crosswords",


### PR DESCRIPTION
## What's changed?
The current version of the app renders the container name if it differs to the front name.
I've updated extensively the naming of containers to try and ensure the minimum amount of renaming is required by the production team.

## Implementation notes
I've only edited in GitHub, and the prevalence of identically named containers makes me want to test this in code before I merge it. Also need to check it through with Katy Vans.

