### PR TITLE
Container renames for new navigation

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -266,8 +266,8 @@ object DailyEdition {
     "Food",
     collection("Food").printSentAllTags("theobserver/magazine/life-and-style", "food/food"),
     collection("Monthly").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").hide,
-    collection("Monthly").hide,
-    collection("Monthly").hide,
+    collection("Food").hide,
+    collection("Food").hide,
     collection("Food").hide,
   )
     .swatch(Lifestyle)


### PR DESCRIPTION
## What's changed?
The new navigation displays container names when they differ to the front name.
These changes preempt that and attempt to supply useful defaults to the production team.

