### PR TITLE
Removing Shared State: preparatory work 

### DIFF
--- a/fronts-client/src/actions/OptionsModal.ts
+++ b/fronts-client/src/actions/OptionsModal.ts
@@ -15,7 +15,8 @@ const startOptionsModal = (
     description,
     options,
     onCancel,
-    showCancelButton
+    showCancelButton,
+    isOpen: true
   }
 });
 

--- a/fronts-client/src/actions/__tests__/Cards.spec.ts
+++ b/fronts-client/src/actions/__tests__/Cards.spec.ts
@@ -22,7 +22,7 @@ import {
   reducer as collectionsReducer,
   initialState as collectionsState
 } from 'bundles/collectionsBundle';
-import  optionsModal from 'reducers/modalsReducer';
+import optionsModal from 'reducers/modalsReducer';
 import config from 'reducers/configReducer';
 import { enableBatching } from 'redux-batched-actions';
 import { Dispatch } from 'types/Store';

--- a/fronts-client/src/actions/__tests__/Cards.spec.ts
+++ b/fronts-client/src/actions/__tests__/Cards.spec.ts
@@ -22,7 +22,7 @@ import {
   reducer as collectionsReducer,
   initialState as collectionsState
 } from 'bundles/collectionsBundle';
-import { optionsModal } from 'reducers/modalsReducer';
+import  optionsModal from 'reducers/modalsReducer';
 import config from 'reducers/configReducer';
 import { enableBatching } from 'redux-batched-actions';
 import { Dispatch } from 'types/Store';

--- a/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -42,8 +42,6 @@ import { Action } from 'types/Action';
 import { removeSupportingCard, removeGroupCard } from 'actions/CardsCommon';
 import { removeClipboardCard } from 'actions/Clipboard';
 import { State as GlobalState } from 'types/State';
-import { SharedState as GlobalSharedState } from 'types/State';
-import { initialState as initialSharedState } from 'fixtures/shared';
 
 type State = ReturnType<typeof innerReducer>;
 
@@ -52,10 +50,9 @@ type State = ReturnType<typeof innerReducer>;
 const reducer = (
   state: State | undefined,
   action: Action,
-  sharedState: GlobalSharedState = initialSharedState
 ): GlobalState =>
   ({
-    editor: innerReducer(state, action, (sharedState = initialSharedState))
+    editor: innerReducer(state, action)
   } as any);
 
 describe('frontsUIBundle', () => {
@@ -505,8 +502,7 @@ describe('frontsUIBundle', () => {
       it('should do nothing when there is no form for the front', () => {
         const state = innerReducer(
           defaultState,
-          editorCloseFormsForCollection('collectionId', 'frontId'),
-          initialSharedState
+          editorCloseFormsForCollection('collectionId', 'frontId')
         );
         expect(state.selectedCards).toEqual(defaultState.selectedCards);
       });
@@ -535,8 +531,7 @@ describe('frontsUIBundle', () => {
         };
         const state = innerReducer(
           initial,
-          editorCloseFormsForCollection('collectionId', 'frontId'),
-          initialSharedState
+          editorCloseFormsForCollection('collectionId', 'frontId')
         );
         expect(state.selectedCards).toEqual({
           frontId: [

--- a/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -47,10 +47,7 @@ type State = ReturnType<typeof innerReducer>;
 
 // this allows us to put _in_ our own slice of state but receive a _global_
 // state so that we can test out selectors
-const reducer = (
-  state: State | undefined,
-  action: Action,
-): GlobalState =>
+const reducer = (state: State | undefined, action: Action): GlobalState =>
   ({
     editor: innerReducer(state, action)
   } as any);

--- a/fronts-client/src/bundles/focusBundle.ts
+++ b/fronts-client/src/bundles/focusBundle.ts
@@ -31,7 +31,7 @@ export const selectFocusedArticle = (state: GlobalState, focusType: string) => {
   }
 };
 
-interface State {
+export interface State {
   focusState?: ApplicationFocusStates;
 }
 

--- a/fronts-client/src/bundles/frontsUIBundle.ts
+++ b/fronts-client/src/bundles/frontsUIBundle.ts
@@ -30,7 +30,6 @@ import { State as GlobalState } from 'types/State';
 import flatten from 'lodash/flatten';
 import { createSelector } from 'reselect';
 
-import { SharedState as GlobalSharedState } from 'types/State';
 import { events } from 'services/GA';
 import {
   selectFronts,
@@ -628,8 +627,7 @@ const getFrontPosition = (
 
 const reducer = (
   state: State = defaultState,
-  action: Action,
-  sharedState: GlobalSharedState
+  action: Action
 ): State => {
   switch (action.type) {
     case EDITOR_OPEN_CURRENT_FRONTS_MENU: {
@@ -915,7 +913,8 @@ export {
   changedBrowsingStage,
   EditorCloseFormsForCollection,
   editorCloseFormsForCollection,
-  defaultState
+  defaultState,
+  State
 };
 
 export default reducer;

--- a/fronts-client/src/bundles/frontsUIBundle.ts
+++ b/fronts-client/src/bundles/frontsUIBundle.ts
@@ -625,10 +625,7 @@ const getFrontPosition = (
   }
 };
 
-const reducer = (
-  state: State = defaultState,
-  action: Action
-): State => {
+const reducer = (state: State = defaultState, action: Action): State => {
   switch (action.type) {
     case EDITOR_OPEN_CURRENT_FRONTS_MENU: {
       return {

--- a/fronts-client/src/reducers/cardsReducer.ts
+++ b/fronts-client/src/reducers/cardsReducer.ts
@@ -1,6 +1,6 @@
 import { Action } from 'types/Action';
 import { insertAndDedupeSiblings } from '../util/insertAndDedupeSiblings';
-import { State } from 'reducers/sharedReducer';
+import { SharedState } from 'reducers/sharedReducer';
 import {
   UPDATE_CARD_META,
   CARDS_RECEIVED,
@@ -11,7 +11,7 @@ import {
 } from 'actions/CardsCommon';
 import { cloneActiveImageMeta } from 'util/card';
 
-const cards = (state: State['cards'] = {}, action: Action) => {
+const cards = (state: SharedState['cards'] = {}, action: Action) => {
   switch (action.type) {
     case UPDATE_CARD_META: {
       const { id } = action.payload;

--- a/fronts-client/src/reducers/clipboardReducer.ts
+++ b/fronts-client/src/reducers/clipboardReducer.ts
@@ -7,7 +7,7 @@ import {
   CLEAR_CLIPBOARD
 } from 'actions/Clipboard';
 
-type State = string[];
+export type State = string[];
 
 const clipboard = (state: State = [], action: Action): State => {
   switch (action.type) {

--- a/fronts-client/src/reducers/feedStateReducer.ts
+++ b/fronts-client/src/reducers/feedStateReducer.ts
@@ -22,4 +22,5 @@ const feedState = (
   }
 };
 
+export {State};
 export default feedState;

--- a/fronts-client/src/reducers/feedStateReducer.ts
+++ b/fronts-client/src/reducers/feedStateReducer.ts
@@ -22,5 +22,5 @@ const feedState = (
   }
 };
 
-export {State};
+export { State };
 export default feedState;

--- a/fronts-client/src/reducers/groupsReducer.ts
+++ b/fronts-client/src/reducers/groupsReducer.ts
@@ -1,13 +1,13 @@
 import { Action } from '../types/Action';
 import { insertAndDedupeSiblings } from 'util/insertAndDedupeSiblings';
-import { State } from 'reducers/sharedReducer';
+import { SharedState } from 'reducers/sharedReducer';
 import { selectCards, selectGroupSiblings } from 'selectors/shared';
 import { capGroupCards } from 'util/capGroupCards';
 import keyBy from 'lodash/keyBy';
 
 const getUpdatedSiblingGroupsForInsertion = (
-  sharedState: State,
-  groupsState: State['groups'],
+  sharedState: SharedState,
+  groupsState: SharedState['groups'],
   insertionGroupId: string,
   insertionIndex: number,
   cardId: string
@@ -34,14 +34,14 @@ const getUpdatedSiblingGroupsForInsertion = (
         )
       }
     }),
-    {} as State['groups']
+    {} as SharedState['groups']
   );
 };
 
 const groups = (
-  state: State['groups'] = {},
+  state: SharedState['groups'] = {},
   action: Action,
-  prevSharedState: State
+  prevSharedState: SharedState
 ) => {
   switch (action.type) {
     case 'SHARED/GROUPS_RECEIVED': {

--- a/fronts-client/src/reducers/modalsReducer.ts
+++ b/fronts-client/src/reducers/modalsReducer.ts
@@ -1,16 +1,7 @@
 import { Action } from 'types/Action';
-import { OptionsModalChoices } from 'types/Modals';
-import { ReactNode } from 'react';
+import { OptionsModalProps } from 'types/Modals';
 
-type OptionsModalState = null | {
-  title: string;
-  description: string | ReactNode;
-  options: OptionsModalChoices[];
-  onCancel: () => void;
-  showCancelButton: boolean;
-};
-
-const optionsModal = (state: OptionsModalState, action: Action) => {
+const optionsModal = (state: OptionsModalProps, action: Action) => {
   switch (action.type) {
     case 'MODAL/START_OPTIONS_MODAL': {
       return action.payload;
@@ -23,5 +14,4 @@ const optionsModal = (state: OptionsModalState, action: Action) => {
     }
   }
 };
-export { OptionsModalState };
 export default optionsModal;

--- a/fronts-client/src/reducers/modalsReducer.ts
+++ b/fronts-client/src/reducers/modalsReducer.ts
@@ -1,9 +1,10 @@
 import { Action } from 'types/Action';
 import { OptionsModalChoices } from 'types/Modals';
+import { ReactNode } from 'react';
 
-export type OptionsModalState = null | {
+type OptionsModalState = null | {
   title: string;
-  description: string;
+  description: string | ReactNode;
   options: OptionsModalChoices[];
   onCancel: () => void;
   showCancelButton: boolean;
@@ -22,5 +23,5 @@ const optionsModal = (state: OptionsModalState, action: Action) => {
     }
   }
 };
-
+export { OptionsModalState };
 export default optionsModal;

--- a/fronts-client/src/reducers/modalsReducer.ts
+++ b/fronts-client/src/reducers/modalsReducer.ts
@@ -1,7 +1,7 @@
 import { Action } from 'types/Action';
 import { OptionsModalChoices } from 'types/Modals';
 
-type OptionsModalState = null | {
+export type OptionsModalState = null | {
   title: string;
   description: string;
   options: OptionsModalChoices[];
@@ -9,7 +9,7 @@ type OptionsModalState = null | {
   showCancelButton: boolean;
 };
 
-export const optionsModal = (state: OptionsModalState, action: Action) => {
+const optionsModal = (state: OptionsModalState, action: Action) => {
   switch (action.type) {
     case 'MODAL/START_OPTIONS_MODAL': {
       return action.payload;
@@ -23,4 +23,4 @@ export const optionsModal = (state: OptionsModalState, action: Action) => {
   }
 };
 
-export default { optionsModal };
+export default optionsModal;

--- a/fronts-client/src/reducers/pathReducer.ts
+++ b/fronts-client/src/reducers/pathReducer.ts
@@ -1,6 +1,6 @@
 import { Action } from 'types/Action';
 
-type State = string;
+export type State = string;
 
 const path = (state: State = '', action: Action) => {
   switch (action.type) {

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -1,54 +1,62 @@
-import { reducer as form, FormState } from 'redux-form';
-
+import { reducer as form, FormStateMap } from 'redux-form';
 import shared, { SharedState } from 'reducers/sharedReducer';
 import config from './configReducer';
-import fronts, {State as frontsState} from './frontsReducer';
+import fronts, { State as frontsState } from './frontsReducer';
 import error from './errorReducer';
-import path, { State as pathState} from './pathReducer';
-import unpublishedChanges, { State as unpublishedChangesState} from './unpublishedChangesReducer';
-import clipboard, {State as clipboardState } from './clipboardReducer';
-import optionsModal, {OptionsModalState} from './modalsReducer';
-import editor, {State as editorState} from '../bundles/frontsUIBundle';
-import editionsIssue, {EditionsIssueState} from '../bundles/editionsIssueBundle';
+import path, { State as pathState } from './pathReducer';
+import unpublishedChanges, {
+  State as unpublishedChangesState
+} from './unpublishedChangesReducer';
+import clipboard, { State as clipboardState } from './clipboardReducer';
+import optionsModal, { OptionsModalState } from './modalsReducer';
+import editor, { State as editorState } from '../bundles/frontsUIBundle';
+import editionsIssue, {
+  EditionsIssueState
+} from '../bundles/editionsIssueBundle';
 import {
   capiLiveFeed,
   capiPreviewFeed,
   prefillFeed
 } from '../bundles/capiFeedBundle';
-import staleFronts, {State as staleFrontsState} from './staleFrontsReducer';
-import feedState, {State as feedStateType} from './feedStateReducer';
+import staleFronts, { State as staleFrontsState } from './staleFrontsReducer';
+import feedState, { State as feedStateType } from './feedStateReducer';
 
-import { reducer as focusReducer, State as focusState } from '../bundles/focusBundle';
-import { reducer as featureSwitchesReducer, State as featureSwitchesState } from 'redux/modules/featureSwitches';
+import {
+  reducer as focusReducer,
+  State as focusState
+} from '../bundles/focusBundle';
+import {
+  reducer as featureSwitches,
+  State as featureSwitchesState
+} from 'redux/modules/featureSwitches';
 
 import { Config } from 'types/Config';
 import { ActionError } from 'types/Action';
 
 interface FeedState {
-  feedState: feedStateType,
-  capiLiveFeed: ReturnType<typeof capiLiveFeed>,
-  capiPreviewFeed: ReturnType<typeof capiPreviewFeed>
-  prefillFeed: ReturnType<typeof prefillFeed>
+  feedState: feedStateType;
+  capiLiveFeed: ReturnType<typeof capiLiveFeed>;
+  capiPreviewFeed: ReturnType<typeof capiPreviewFeed>;
+  prefillFeed: ReturnType<typeof prefillFeed>;
 }
 
 export interface State {
-  fronts: frontsState,
-  config: Config | null,
-  error: ActionError,
-  path: pathState,
-  shared: SharedState,
-  unpublishedChanges: unpublishedChangesState,
-  clipboard: clipboardState,
-  editor: editorState,
-  staleFronts: staleFrontsState,
-  form: FormState | null,
-  optionsModal: OptionsModalState,
+  fronts: frontsState;
+  config: Config | null;
+  error: ActionError;
+  path: pathState;
+  shared: SharedState;
+  unpublishedChanges: unpublishedChangesState;
+  clipboard: clipboardState;
+  editor: editorState;
+  staleFronts: staleFrontsState;
+  form: FormStateMap;
+  optionsModal: OptionsModalState;
   feed: FeedState;
-  focus: focusState,
-  editionsIssue: EditionsIssueState,
-  featureSwitches: featureSwitchesState
-};
-
+  focus: focusState;
+  editionsIssue: EditionsIssueState;
+  featureSwitches: featureSwitchesState;
+}
 
 const rootReducer = (state: any = { feed: {} }, action: any) => ({
   fronts: fronts(state.fronts, action),
@@ -70,7 +78,7 @@ const rootReducer = (state: any = { feed: {} }, action: any) => ({
   },
   focus: focusReducer(state.focus, action),
   editionsIssue: editionsIssue(state.editionsIssue, action),
-  featureSwitches: featureSwitchesReducer(state.featureSwitches, action)
+  featureSwitches: featureSwitches(state.featureSwitches, action)
 });
 
 export default rootReducer;

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -1,25 +1,54 @@
-import { reducer as form } from 'redux-form';
+import { reducer as form, FormState } from 'redux-form';
 
-import shared from 'reducers/sharedReducer';
+import shared, { SharedState } from 'reducers/sharedReducer';
 import config from './configReducer';
-import fronts from './frontsReducer';
+import fronts, {State as frontsState} from './frontsReducer';
 import error from './errorReducer';
-import path from './pathReducer';
-import unpublishedChanges from './unpublishedChangesReducer';
-import clipboard from './clipboardReducer';
-import { optionsModal } from './modalsReducer';
-import editor from '../bundles/frontsUIBundle';
-import editionsIssue from '../bundles/editionsIssueBundle';
+import path, { State as pathState} from './pathReducer';
+import unpublishedChanges, { State as unpublishedChangesState} from './unpublishedChangesReducer';
+import clipboard, {State as clipboardState } from './clipboardReducer';
+import optionsModal, {OptionsModalState} from './modalsReducer';
+import editor, {State as editorState} from '../bundles/frontsUIBundle';
+import editionsIssue, {EditionsIssueState} from '../bundles/editionsIssueBundle';
 import {
   capiLiveFeed,
   capiPreviewFeed,
   prefillFeed
 } from '../bundles/capiFeedBundle';
-import staleFronts from './staleFrontsReducer';
-import feedState from './feedStateReducer';
+import staleFronts, {State as staleFrontsState} from './staleFrontsReducer';
+import feedState, {State as feedStateType} from './feedStateReducer';
 
-import { reducer as focusReducer } from '../bundles/focusBundle';
-import { reducer as featureSwitchesReducer } from 'redux/modules/featureSwitches';
+import { reducer as focusReducer, State as focusState } from '../bundles/focusBundle';
+import { reducer as featureSwitchesReducer, State as featureSwitchesState } from 'redux/modules/featureSwitches';
+
+import { Config } from 'types/Config';
+import { ActionError } from 'types/Action';
+
+interface FeedState {
+  feedState: feedStateType,
+  capiLiveFeed: ReturnType<typeof capiLiveFeed>,
+  capiPreviewFeed: ReturnType<typeof capiPreviewFeed>
+  prefillFeed: ReturnType<typeof prefillFeed>
+}
+
+export interface State {
+  fronts: frontsState,
+  config: Config | null,
+  error: ActionError,
+  path: pathState,
+  shared: SharedState,
+  unpublishedChanges: unpublishedChangesState,
+  clipboard: clipboardState,
+  editor: editorState,
+  staleFronts: staleFrontsState,
+  form: FormState | null,
+  optionsModal: OptionsModalState,
+  feed: FeedState;
+  focus: focusState,
+  editionsIssue: EditionsIssueState,
+  featureSwitches: featureSwitchesState
+};
+
 
 const rootReducer = (state: any = { feed: {} }, action: any) => ({
   fronts: fronts(state.fronts, action),
@@ -29,7 +58,7 @@ const rootReducer = (state: any = { feed: {} }, action: any) => ({
   shared: shared(state.shared, action),
   unpublishedChanges: unpublishedChanges(state.unpublishedChanges, action),
   clipboard: clipboard(state.clipboard, action),
-  editor: editor(state.editor, action, state.shared),
+  editor: editor(state.editor, action),
   staleFronts: staleFronts(state.staleFronts, action),
   form: form(state.form, action),
   optionsModal: optionsModal(state.optionsModal, action),

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -8,7 +8,8 @@ import unpublishedChanges, {
   State as unpublishedChangesState
 } from './unpublishedChangesReducer';
 import clipboard, { State as clipboardState } from './clipboardReducer';
-import optionsModal, { OptionsModalState } from './modalsReducer';
+import optionsModal from 'reducers/modalsReducer';
+import { OptionsModalProps as OptionsModalState } from 'types/Modals';
 import editor, { State as editorState } from '../bundles/frontsUIBundle';
 import editionsIssue, {
   EditionsIssueState
@@ -51,7 +52,7 @@ export interface State {
   editor: editorState;
   staleFronts: staleFrontsState;
   form: FormStateMap;
-  optionsModal: OptionsModalState;
+  optionsModal: OptionsModalState | null;
   feed: FeedState;
   focus: focusState;
   editionsIssue: EditionsIssueState;

--- a/fronts-client/src/reducers/sharedReducer.ts
+++ b/fronts-client/src/reducers/sharedReducer.ts
@@ -6,7 +6,7 @@ import { reducer as featureSwitches } from 'redux/modules/featureSwitches';
 import { reducer as pageViewData } from '../redux/modules/pageViewData';
 import { Card, Group } from 'types/Collection';
 
-interface State {
+interface SharedState {
   cards: {
     [uuid: string]: Card;
   };
@@ -19,7 +19,7 @@ interface State {
   pageViewData: ReturnType<typeof pageViewData>;
 }
 
-const sharedRootReducer = (state: any = {}, action: any): State => ({
+const sharedRootReducer = (state: any = {}, action: any): SharedState => ({
   cards: cards(state.cards, action),
   groups: groups(state.groups, action, state),
   collections: collections(state.collections, action),
@@ -28,6 +28,6 @@ const sharedRootReducer = (state: any = {}, action: any): State => ({
   pageViewData: pageViewData(state.pageViewData, action)
 });
 
-export { State };
+export { SharedState };
 
 export default sharedRootReducer;

--- a/fronts-client/src/reducers/staleFrontsReducer.ts
+++ b/fronts-client/src/reducers/staleFrontsReducer.ts
@@ -1,6 +1,6 @@
 import { Action } from 'types/Action';
 
-interface State {
+export interface State {
   [id: string]: boolean;
 }
 

--- a/fronts-client/src/reducers/unpublishedChangesReducer.ts
+++ b/fronts-client/src/reducers/unpublishedChangesReducer.ts
@@ -1,6 +1,6 @@
 import { Action } from 'types/Action';
 
-interface State {
+export interface State {
   [id: string]: boolean;
 }
 

--- a/fronts-client/src/redux/modules/featureSwitches/reducer.ts
+++ b/fronts-client/src/redux/modules/featureSwitches/reducer.ts
@@ -2,7 +2,7 @@ import { Action } from 'types/Action';
 import { SET_FEATURE_VALUE } from './actions';
 import { FeatureSwitch } from 'types/Features';
 
-interface State {
+export interface State {
   [key: string]: FeatureSwitch;
 }
 

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -17,14 +17,14 @@ import {
   CardDenormalised,
   ArticleTag
 } from '../types/Collection';
-import { SharedState } from '../types/State';
+import { SharedState, State } from '../types/State';
 import { cardSets } from 'constants/fronts';
 import { createShallowEqualResultSelector } from 'util/selectorUtils';
 import { DerivedArticle } from 'types/Article';
 import { hasMainVideo } from 'util/externalArticle';
 
 // Selects the shared part of the application state mounted at its default point, '.shared'.
-const selectSharedState = (rootState: any): SharedState => rootState.shared;
+const selectSharedState = (rootState: any): State['shared'] => rootState.shared;
 
 const selectGroups = (state: SharedState): { [id: string]: Group } =>
   state.groups;

--- a/fronts-client/src/types/Action.ts
+++ b/fronts-client/src/types/Action.ts
@@ -37,9 +37,8 @@ import {
 } from 'bundles/frontsUIBundle';
 import { setFocusState, resetFocusState } from '../bundles/focusBundle';
 import { ActionSetFeatureValue } from 'redux/modules/featureSwitches';
-import { ReactNode } from 'react';
 import { SetHidden } from '../bundles/collectionsBundle';
-import { OptionsModalChoices } from './Modals';
+import { OptionsModalProps } from 'types/Modals';
 import { Actions } from 'lib/createAsyncResourceBundle';
 import { ExternalArticle } from 'types/ExternalArticle';
 import { copyCardImageMeta } from 'actions/CardsCommon';
@@ -296,13 +295,7 @@ interface FetchVisibleArticlesSuccess {
 
 interface StartOptionsModal {
   type: 'MODAL/START_OPTIONS_MODAL';
-  payload: {
-    title: string;
-    description: string | ReactNode;
-    options: OptionsModalChoices[];
-    onCancel: () => void;
-    showCancelButton: boolean;
-  };
+  payload: OptionsModalProps;
 }
 
 interface EndOptionsModal {

--- a/fronts-client/src/types/State.ts
+++ b/fronts-client/src/types/State.ts
@@ -1,6 +1,5 @@
-import { StateType } from 'typesafe-actions';
-import rootReducer from 'reducers/rootReducer';
+import { State as StateInterface } from 'reducers/rootReducer';
 import sharedRootReducer from 'reducers/sharedReducer';
 
-export type State = StateType<typeof rootReducer>;
+export type State = StateInterface;
 export type SharedState = ReturnType<typeof sharedRootReducer>;


### PR DESCRIPTION
## What's changed?
As part of the work to remove the shared folder - we also want to spread out the shared part of the state into the root. 

This lays some of the ground work for that change by creating a fixed type for the State, on the way to remove the "SharedState" type. 

Next piece of work is to replace all mentions of "SharedState" with `State['shared']` to be changed finally to `State['groups'] or whatever. 


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
