### PR TITLE
Remove reference to shared dir from client README

### DIFF
--- a/fronts-client/README.md
+++ b/fronts-client/README.md
@@ -127,7 +127,6 @@ We are using Typescript for typing in Fronts V2.
 - `constants` store high-level application constants such as theme styles and image paths
 - `services` contains the modules for requests to APIs such as CAPI and FaciaAPI
 - `lib` contains modules designed to be reusable such as the Drag N' Drop (dnd) module
-- `shared` is a library written using React and Redux and Typescript for typing designed to make it easier to develop tools which need to provide the ability to curate collections of content. [Read more.](src/shared/.README)
 - `types` at the top level contains types that have no obvious home: e.g. Action which is a union of things that are split across a few files.
 - `types` and `__tests__` are co-located with their modules at the folder level
 


### PR DESCRIPTION
## What's changed?
The `shared` directory no longer exists, so let's remove it from the client README.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
