### PR TITLE
Navigation change: New front, many container renames

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -45,6 +45,7 @@ object DailyEdition {
       FrontFood -> WeekDays(List(WeekDay.Sat)),
       FrontFoodObserver -> WeekDays(List(WeekDay.Sun)),
       FrontLifeFashion -> WeekDays(List(WeekDay.Sat)),
+      FrontLifeDesign -> WeekDays(List(WeekDay.Sun)),
       FrontLifeSpecial -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Sat, WeekDay.Sun)),
       // Sport fronts and special
       FrontSportGuardian -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs, WeekDay.Fri, WeekDay.Sat)),
@@ -78,22 +79,22 @@ object DailyEdition {
 
   def FrontNewsUkGuardian = front(
     "National",
-    collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
-    collection("News Special").hide,
-    collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
-    collection("Weather").printSentAnyTag("theguardian/mainsection/weather2"),
-    collection("News Special 2").hide
+    collection("National").printSentAnyTag("theguardian/mainsection/topstories"),
+    collection("National").hide,
+    collection("National").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
+    collection("National").printSentAnyTag("theguardian/mainsection/weather2"),
+    collection("National").hide
   )
     .swatch(News)
 
   def FrontNewsUkGuardianSaturday = front(
     "National",
-    collection("Front Page").printSentAnyTag("theguardian/mainsection/topstories"),
-    collection("News Special").hide,
-    collection("UK News").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
+    collection("National").printSentAnyTag("theguardian/mainsection/topstories"),
+    collection("National").hide,
+    collection("National").printSentAnyTag("theguardian/mainsection/uknews", "theguardian/mainsection/education", "theguardian/mainsection/society", "theguardian/mainsection/media", "theguardian/guardian-members/guardian-members"),
     collection("Week in Review").printSentAnyTag("theguardian/mainsection/week-in-review"),
-    collection("Weather").printSentAnyTag("theguardian/mainsection/weather2"),
-    collection("News Special 2").hide
+    collection("National").printSentAnyTag("theguardian/mainsection/weather2"),
+    collection("National").hide
   )
     .swatch(News)
 
@@ -101,25 +102,27 @@ object DailyEdition {
 
   def FrontNewsWorldGuardian = front(
     "World",
-    collection("World News").printSentAnyTag("theguardian/mainsection/international"),
-    collection("World Special").hide
+    collection("World").printSentAnyTag("theguardian/mainsection/international"),
+    collection("World").hide,
+    collection("World").hide
   )
     .swatch(News)
 
   def FrontNewsUkObserver = front(
     "National",
-    collection("Front Page"),
-    collection("UK News").printSentAnyTag("theobserver/news/uknews"),
-    collection("Focus").printSentAnyTag("theobserver/news/focus").hide,
-    collection("News Special").hide,
-    collection("News Special 2").hide
+    collection("National"),
+    collection("National").printSentAnyTag("theobserver/news/uknews"),
+    collection("National").hide,
+    collection("National").hide,
+    collection("National").hide
   )
     .swatch(News)
 
   def FrontNewsWorldObserver = front(
     "World",
-    collection("World News").printSentAnyTag("theobserver/news/worldnews"),
-    collection("World Special").hide,
+    collection("World").printSentAnyTag("theobserver/news/worldnews"),
+    collection("World").hide,
+    collection("World").hide
   )
     .swatch(News)
 
@@ -129,15 +132,18 @@ object DailyEdition {
 
   def FrontFinancialGuardian = front(
     "Financial",
-    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3", "theguardian/mainsection/money"),
-    collection("Financial Special").hide,
+    collection("Financial").printSentAnyTag("theguardian/mainsection/financial3"),
+    collection("Money").printSentAnyTag("theguardian/mainsection/money"),
+    collection("Financial").hide,
+    collection("Financial").hide
   )
     .swatch(News)
 
   def FrontFinancialObserver = front(
     "Financial",
     collection("Financial").printSentAnyTag("theobserver/news/business", "theobserver/news/cash"),
-    collection("Financial Special").hide
+    collection("Financial").hide,
+    collection("Financial").hide
   )
     .swatch(News)
 
@@ -147,18 +153,20 @@ object DailyEdition {
     "Journal",
     collection("Features").printSentAnyTag("theguardian/journal/the-long-read", "theguardian/journal/features"),
     collection("Comment").printSentAnyTag("theguardian/journal/opinion"),
+    collection("Comment").hide,
     collection("Letters").printSentAnyTag("theguardian/journal/letters"),
     collection("Obituaries").printSentAnyTag("theguardian/journal/obituaries"),
-    collection("Journal Special").hide,
+    collection("Journal").hide,
   )
     .swatch(Opinion)
 
   def FrontComment = front(
     "Journal",
     collection("Comment").printSentAnyTag("theobserver/news/comment"),
-    collection("Comment 1"),
-    collection("Comment 2"),
-    collection("Comment Special").hide,
+    collection("Focus").printSentAnyTag("theobserver/news/focus"),
+    collection("Journal"),
+    collection("Journal"),
+    collection("Journal").hide
   )
     .swatch(Opinion)
 
@@ -167,8 +175,9 @@ object DailyEdition {
   def FrontCulture = front(
     "Culture",
     collection("Arts").printSentAnyTag("theguardian/g2/arts"),
-    collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
-    collection("Culture Special").hide,
+    collection("Culture").hide,
+    collection("TV & radio").printSentAnyTag("theguardian/g2/tvandradio"),
+    collection("Culture").hide
   )
     .swatch(Culture)
 
@@ -177,8 +186,9 @@ object DailyEdition {
     collection("Film").printSentAnyTag("theguardian/g2/film"),
     collection("Music").printSentAnyTag("theguardian/g2/music"),
     collection("Arts").printSentAnyTag("theguardian/g2/arts"),
-    collection("TV & Radio").printSentAnyTag("theguardian/g2/tvandradio"),
-    collection("Culture Special"),
+    collection("TV & radio").printSentAnyTag("theguardian/g2/tvandradio"),
+    collection("Culture"),
+    collection("Culture").hide
   )
     .swatch(Culture)
 
@@ -186,8 +196,9 @@ object DailyEdition {
     "Culture",
     collection("Features").printSentAnyTag("theguardian/theguide/features"),
     collection("Preview").printSentAnyTag("theguardian/theguide/reviews"),
-    collection("TV and Radio").printSentAnyTag("theguardian/theguide/tv-radio"),
-    collection("Culture Special"),
+    collection("TV & radio").printSentAnyTag("theguardian/theguide/tv-radio"),
+    collection("Culture"),
+    collection("Culture").hide
   )
     .swatch(Culture)
 
@@ -195,17 +206,19 @@ object DailyEdition {
     "Culture",
     collection("Features").printSentAnyTag("theobserver/new-review/features"),
     collection("Agenda").printSentAnyTag("theobserver/new-review/agenda"),
-    collection("Science & Technology").printSentAnyTag("theobserver/new-review/discover"),
+    collection("Discover").printSentAnyTag("theobserver/new-review/discover"),
     collection("Critics").printSentAnyTag("theobserver/new-review/critics"),
-    collection("Culture Special").hide,
-    collection("Culture Special 2").hide
+    collection("Culture").hide,
+    collection("Culture").hide,
+    collection("Culture").hide
   )
     .swatch(Culture)
 
   def FrontBooks = front(
     "Books",
     collection("Books").printSentAnyTag("theguardian/guardianreview/saturdayreviewsfeatres", "theobserver/new-review/books"),
-    collection("Books Special").hide,
+    collection("Books").hide,
+    collection("Books").hide
   )
     .swatch(Culture)
 
@@ -214,59 +227,83 @@ object DailyEdition {
   def FrontLife = front(
     "Life",
     collection("Features").printSentAnyTag("theguardian/g2/features"),
-    collection("Life Special").hide,
+    collection("Life").hide,
+    collection("Life").hide
   )
     .swatch(Lifestyle)
+  
+  // Hidden by default, a front for the irregular 'The Fashion' supplement
 
   def FrontLifeFashion = front(
     "The Fashion",
-    collection("Fashion 1").printSentAnyTag("theguardian/the-fashion/the-fashion"),
-    collection("Fashion 2").hide,
-    collection("Fashion 3").hide,
+    collection("The Fashion").printSentAnyTag("theguardian/the-fashion/the-fashion"),
+    collection("The Fashion").hide,
+    collection("The Fashion").hide,
+    collection("The Fashion").hide,
+    collection("The Fashion").hide,
+    collection("The Fashion").hide
+  )
+    .special
+    .swatch(Lifestyle)
+  
+  // Hidden by default, a front for the irregular 'Design' supplement
+  
+    def FrontLifeDesign = front(
+    "Design",
+    collection("Design").printSentAnyTag("theobserver/design/design"),
+    collection("Design").hide,
+    collection("Design").hide,
+    collection("Design").hide,
+    collection("Design").hide,
+    collection("Design").hide
   )
     .special
     .swatch(Lifestyle)
 
   def FrontLifeWeekend = front(
     "Life",
-    collection("Weekend").printSentAnyTag("theguardian/weekend/starters", "theguardian/weekend/features2", "theguardian/weekend/back"),
+    collection("Features").printSentAnyTag("theguardian/weekend/starters", "theguardian/weekend/features2", "theguardian/weekend/back"),
     collection("Family").printSentAnyTag("theguardian/weekend/family"),
     collection("Space").printSentAnyTag("theguardian/weekend/space2"),
-    collection("Fashion & Beauty").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
+    collection("Style").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
     collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
-    collection("Life Special").hide,
+    collection("Life").hide,
+    collection("Life").hide
   )
     .swatch(Lifestyle)
 
   def FrontTravelGuardian = front(
     "Travel",
     collection("Travel").printSentAnyTag("theguardian/travel/travel"),
-    collection("Travel Special").hide,
+    collection("Travel").hide,
+    collection("Travel").hide
   )
     .swatch(Lifestyle);
 
   def FrontLifeMagazineObserver = front(
     "Life",
     collection("Features").printSentAnyTag("theobserver/magazine/features2"),
-    collection("Life & Style").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
-    collection("Life Special").printSentAnyTag("theobserver/design/design").hide,
+    collection("Life").printSentAllTags("theobserver/magazine/life-and-style", "-food/food"),
+    collection("Life").printSentAnyTag("theobserver/design/design").hide,
+    collection("Life").hide
   )
     .swatch(Lifestyle)
 
   def FrontFood = front(
     "Food",
     collection("Food").printSentAnyTag("theguardian/feast/feast"),
-    collection("Food Special").hide,
+    collection("Food").hide,
+    collection("Food").hide
   )
     .swatch(Lifestyle)
 
   def FrontFoodObserver = front(
     "Food",
     collection("Food").printSentAllTags("theobserver/magazine/life-and-style", "food/food"),
-    collection("OFM 1").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").hide,
-    collection("OFM 2").hide,
-    collection("OFM 3").hide,
-    collection("Food Special").hide,
+    collection("Monthly").printSentAnyTag("theobserver/foodmonthly/features", "theobserver/foodmonthly").hide,
+    collection("Food").hide,
+    collection("Food").hide,
+    collection("Food").hide
   )
     .swatch(Lifestyle)
 
@@ -275,32 +312,34 @@ object DailyEdition {
   def FrontSportGuardian = front(
     "Sport",
     collection("Sport").printSentAnyTag("theguardian/sport/news"),
-    collection("Sport 1"),
-    collection("Sport 2"),
-    collection("Sport 3"),
-    collection("Sport Special").hide,
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport").hide,
+    collection("Sport").hide
   )
     .swatch(Sport)
 
   def FrontSportObserver = front(
     "Sport",
     collection("Sport").printSentAnyTag("theobserver/sport/news"),
-    collection("Sport 1"),
-    collection("Sport 2"),
-    collection("Sport 3"),
-    collection("Sport Special").hide,
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport"),
+    collection("Sport").hide,
+    collection("Sport").hide
   )
     .swatch(Sport)
 
   def FrontSportSpecial = specialFront("Sport Special", Sport)
 
   def FrontSupplementSpecial1 = specialFront(
-    "Special Supplement 1",
+    "Supplement",
     swatch = Neutral,
     prefill = Some(CapiPrefillQuery("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement", PathType.PrintSent))
   )
 
-  def FrontSupplementSpecial2 = specialFront("Special Supplement 2", Neutral)
+  def FrontSupplementSpecial2 = specialFront("Special Supplement", Neutral)
 
   def FrontCrosswords = front(
     "Crosswords",

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -278,7 +278,7 @@ object DailyEdition {
     collection("Travel").hide,
     collection("Travel").hide
   )
-    .swatch(Lifestyle);
+    .swatch(Lifestyle)
 
   def FrontLifeMagazineObserver = front(
     "Life",


### PR DESCRIPTION
## What's changed?
To support the new navigation we're renaming a lot of container names. NOTE: this now means that many container names now are the same within a front, and also in many cases, the same name as the front itself. This is because the app will not show the container name when it is the same as the front name. 

We've (Katy V and me) tried to make it so the default names, should they split through unchecked, wouldn't be a disaster in production. Production will typically rename containers as necessary on the night should changes be required.

## Implementation notes
Edited in Github by a product manager (👎 )
