### PR TITLE
Removing Shared: Delete selectSharedState selector

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -10,12 +10,7 @@ import {
   copyCardImageMeta
 } from 'actions/CardsCommon';
 import { Card } from 'types/Collection';
-import {
-  selectSharedState,
-  selectCards,
-  selectCard,
-  selectArticleGroup
-} from 'selectors/shared';
+import { selectCards, selectCard, selectArticleGroup } from 'selectors/shared';
 import { ThunkResult, Dispatch } from 'types/Store';
 import { addPersistMetaToAction } from 'util/action';
 import { cloneCard } from 'util/card';
@@ -213,10 +208,10 @@ const insertCardWithCreate = (
   if (!insertActionCreator) {
     return;
   }
-  const sharedState = selectSharedState(getState());
+  const state = getState();
   const toWithRespectToState = getToGroupIndicesWithRespectToState(
     to,
-    sharedState,
+    state,
     false
   );
   if (toWithRespectToState) {
@@ -260,11 +255,7 @@ const removeCard = (
       }
       // The card may belong to an orphaned group -
       // we need to find the actual group the card belongs to
-      const idFromState = selectArticleGroup(
-        selectSharedState(getState()),
-        collectionId,
-        cardId
-      );
+      const idFromState = selectArticleGroup(getState(), collectionId, cardId);
       if (idFromState) {
         return idFromState;
       }
@@ -299,7 +290,7 @@ const moveCard = (
       return;
     }
 
-    const sharedState = selectSharedState(getState());
+    const state = getState();
 
     // If move actions are happening to/from groups which have cards displayed
     // in them which don't belong to these groups we need to adjust the indices of the move
@@ -307,11 +298,11 @@ const moveCard = (
     const fromDetails: {
       fromWithRespectToState: PosSpec | null;
       fromOrphanedGroup: boolean;
-    } = getFromGroupIndicesWithRespectToState(from, sharedState);
+    } = getFromGroupIndicesWithRespectToState(from, state);
 
     const toWithRespectToState: PosSpec | null = getToGroupIndicesWithRespectToState(
       to,
-      sharedState,
+      state,
       fromDetails.fromOrphanedGroup
     );
     if (toWithRespectToState) {
@@ -320,7 +311,7 @@ const moveCard = (
       // if from is not null then assume we're copying a moved card
       // into this new position
       const { parent, supporting } = !fromWithRespectToState
-        ? cloneCard(card, selectCards(sharedState))
+        ? cloneCard(card, selectCards(state))
         : { parent: card, supporting: [] };
 
       if (toWithRespectToState) {
@@ -349,7 +340,7 @@ const cloneCardToTarget = (
 ): ThunkResult<void> => {
   return (dispatch, getState) => {
     const to = { id: toType, type: toType, index: 0 };
-    const card = selectCard(selectSharedState(getState()), uuid);
+    const card = selectCard(getState(), uuid);
     const from = null;
     dispatch(moveCard(to, card, from, toType));
   };

--- a/fronts-client/src/actions/Clipboard.ts
+++ b/fronts-client/src/actions/Clipboard.ts
@@ -13,7 +13,7 @@ import {
 } from 'types/Action';
 import { State } from 'types/State';
 import { addPersistMetaToAction } from 'util/action';
-import { selectCards, selectSharedState } from 'selectors/shared';
+import { selectCards } from 'selectors/shared';
 
 export const REMOVE_CLIPBOARD_CARD = 'REMOVE_CLIPBOARD_CARD';
 export const UPDATE_CLIPBOARD_CONTENT = 'UPDATE_CLIPBOARD_CONTENT';
@@ -96,7 +96,7 @@ const thunkInsertClipboardCard = (
   index: number,
   cardId: string
 ): ThunkResult<void> => (dispatch, getState) => {
-  const currentCards = selectCards(selectSharedState(getState()));
+  const currentCards = selectCards(getState());
   dispatch(
     actionInsertClipboardCardWithPersist(id, index, cardId, currentCards)
   );

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -15,7 +15,6 @@ import {
 } from 'selectors/configSelectors';
 import {
   createSelectGroupArticles,
-  selectSharedState,
   createSelectAllArticlesInCollection
 } from 'selectors/shared';
 import {
@@ -76,7 +75,7 @@ function fetchStaleCollections(
       getCollections(collectionIds, true)
     );
     const prevArticleIds = articlesInCollection(
-      selectSharedState(prevState),
+      prevState,
       fetchedCollectionIds
     );
 
@@ -301,7 +300,7 @@ const fetchArticles = (
     const articles = await getArticlesBatched(articleIdsWithoutSnaps);
     const freshArticles = articles.filter(article =>
       selectIsExternalArticleStale(
-        selectSharedState(getState()),
+        getState(),
         article.id,
         article.fields.lastModified
       )
@@ -339,7 +338,7 @@ const getArticlesForCollections = (
   const articleIds = itemSets.reduce(
     (acc, itemSet) => [
       ...acc,
-      ...selectArticlesInCollections(selectSharedState(getState()), {
+      ...selectArticlesInCollections(getState(), {
         collectionIds,
         itemSet
       })

--- a/fronts-client/src/actions/KeyboardNavigation.ts
+++ b/fronts-client/src/actions/KeyboardNavigation.ts
@@ -3,7 +3,7 @@ import {
   selectNextIndexAndGroup,
   selectNextClipboardIndexSelector
 } from '../selectors/keyboardNavigationSelectors';
-import { selectSharedState, selectIndexInGroup } from 'selectors/shared';
+import { selectIndexInGroup } from 'selectors/shared';
 import { Card } from 'types/Collection';
 import { PosSpec } from 'lib/dnd';
 import { ThunkResult, Dispatch } from 'types/Store';
@@ -25,11 +25,7 @@ const keyboardCardMove = (
     const state = getState();
     const id = card.uuid;
     if (persistTo === 'collection') {
-      const fromIndex = selectIndexInGroup(
-        selectSharedState(state),
-        groupId || '',
-        id
-      );
+      const fromIndex = selectIndexInGroup(state, groupId || '', id);
       const type = 'group';
 
       const from: PosSpec = { type, index: fromIndex, id: groupId || '' };

--- a/fronts-client/src/actions/__tests__/Cards.spec.ts
+++ b/fronts-client/src/actions/__tests__/Cards.spec.ts
@@ -6,9 +6,8 @@ import cardsReducer from 'reducers/cardsReducer';
 import {
   createSelectGroupArticles,
   createSelectSupportingArticles,
-  selectCard,
-  selectSharedState
-} from '../../selectors/shared';
+  selectCard
+} from 'selectors/shared';
 import { selectClipboard as innerClipboardSelector } from '../../selectors/frontsSelectors';
 import { createCardStateFromSpec, CardSpec, specToCard } from './utils';
 import {
@@ -104,18 +103,14 @@ const insert = async (
     [uuid, id, undefined],
     collectionCapInfo ? collectionCapInfo.cap : Infinity
   );
+
+  const stateHere: any = getState();
   await dispatch(insertCardWithCreate(
     { type: parentType, id: parentId, index },
     { type: 'REF', data: parentId },
     'collection',
-    afId => () =>
-      Promise.resolve(selectCard(selectSharedState(getState()), uuid))
+    afId => () => Promise.resolve(selectCard(stateHere, uuid))
   ) as any);
-
-  // TODO: use modal service to mock return from modal
-  // if (collectionCapInfo && collectionCapInfo.accept !== null) {
-  //   dispatch(endConfirmModal(collectionCapInfo.accept));
-  // }
 
   return getState();
 };

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -20,7 +20,7 @@ import {
   updateCollection,
   fetchArticles
 } from '../Collections';
-import { createSelectCollection, selectSharedState } from 'selectors/shared';
+import { createSelectCollection } from 'selectors/shared';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -254,9 +254,9 @@ describe('Collection actions', () => {
       );
       await store.dispatch(getCollections(collectionIds) as any);
       const selector = createSelectCollection();
-      const sharedState = selectSharedState(store.getState());
+      const state = store.getState();
       expect(
-        selector(sharedState, { collectionId: 'testCollection1' }).displayName
+        selector(state, { collectionId: 'testCollection1' }).displayName
       ).toEqual('testCollection');
     });
     it('should send collection id, type and lastUpdated in request body when returnOnlyUpdatedCollection is true', async () => {

--- a/fronts-client/src/actions/__tests__/Fronts.spec.ts
+++ b/fronts-client/src/actions/__tests__/Fronts.spec.ts
@@ -1,11 +1,11 @@
 import configureStore from 'util/configureStore';
 import fetchMock from 'fetch-mock';
-import initialState from 'fixtures/initialState';
+import { state as initialState } from 'fixtures/initialState';
 import { scJohnsonPartnerZoneCollection } from 'fixtures/collectionsEndpointResponse';
 import { articlesForScJohnsonPartnerZone } from 'actions/__tests__/capiEndpointResponse';
 import { selectIsCollectionOpen } from 'bundles/frontsUIBundle';
 import { selectArticlesInCollections } from 'selectors/collection';
-import { selectCard, selectSharedState } from 'selectors/shared';
+import { selectCard } from 'selectors/shared';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 
 describe('Fronts actions', () => {
@@ -37,7 +37,6 @@ describe('Fronts actions', () => {
       ) as any);
 
       const state = store.getState();
-      const sharedState = selectSharedState(state);
       const collectionIds = [
         'e59785e9-ba82-48d8-b79a-0a80b2f9f808',
         '4ab657ff-c105-4292-af23-cda00457b6b7',
@@ -53,10 +52,10 @@ describe('Fronts actions', () => {
       // TODO this selectArticalsInCollections returns internal code pages which means we cannot use it with cardSelector
       //  This worked previously because selectArticles in Collection was returning an empty array which was erroneous - TODO
       expect(
-        selectArticlesInCollections(sharedState, {
+        selectArticlesInCollections(state, {
           collectionIds,
           itemSet: 'draft'
-        }).every(_ => !!selectCard(sharedState, _))
+        }).every(_ => !!selectCard(state, _))
       ).toBe(true);
     });
   });

--- a/fronts-client/src/actions/__tests__/frontscards.spec.ts
+++ b/fronts-client/src/actions/__tests__/frontscards.spec.ts
@@ -2,7 +2,7 @@ import configureMockStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
 import { createArticleEntitiesFromDrop, cardsReceived } from '../CardsCommon';
-import initialState from 'fixtures/initialState';
+import { state as initialState } from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { actionNames as externalArticleActionNames } from 'bundles/externalArticlesBundle';
 import { createCard } from 'util/card';

--- a/fronts-client/src/actions/__tests__/snapcards.spec.ts
+++ b/fronts-client/src/actions/__tests__/snapcards.spec.ts
@@ -7,7 +7,7 @@ import {
   snapMetaWhitelist,
   marketingParamsWhiteList
 } from '../CardsCommon';
-import initialState from 'fixtures/initialState';
+import { state as initialState } from 'fixtures/initialState';
 import { capiArticle } from '../../fixtures/shared';
 import { createSnap, createLatestSnap } from 'util/snap';
 import guardianTagPage from 'fixtures/guardianTagPage';
@@ -15,7 +15,7 @@ import bbcSectionPage from 'fixtures/bbcSectionPage';
 import { RefDrop } from 'util/collectionUtils';
 import configureStore from 'util/configureStore';
 import { selectOptionsModalOptions } from 'selectors/modalSelectors';
-import { selectCard, selectSharedState } from 'selectors/shared';
+import { selectCard } from 'selectors/shared';
 import capiInteractiveAtomResponse from 'fixtures/capiInteractiveAtomResponse';
 import { startOptionsModal } from 'actions/OptionsModal';
 import noop from 'lodash/noop';
@@ -108,7 +108,7 @@ describe('Snap cards actions', () => {
           .forEach(option => option.callback());
       });
       await promise;
-      expect(selectCard(selectSharedState(store.getState()), 'card1')).toEqual(
+      expect(selectCard(store.getState(), 'card1')).toEqual(
         createLatestSnap(
           'https://www.theguardian.com/example/tag/page',
           'Example title'
@@ -138,7 +138,7 @@ describe('Snap cards actions', () => {
       });
 
       await promise;
-      expect(selectCard(selectSharedState(store.getState()), 'card1')).toEqual(
+      expect(selectCard(store.getState(), 'card1')).toEqual(
         await createSnap('https://www.theguardian.com/example/tag/page')
       );
     });

--- a/fronts-client/src/actions/__tests__/utils.ts
+++ b/fronts-client/src/actions/__tests__/utils.ts
@@ -4,6 +4,7 @@ export interface CardMap {
   [uuid: string]: {
     uuid: string;
     id: string;
+    frontPublicationDate: number;
     meta: object;
   };
 }
@@ -37,6 +38,7 @@ export const createCardStateFromSpec = (specs: CardSpec[]) =>
               [suuid]: {
                 uuid: suuid,
                 id: sid,
+                frontPublicationDate: 1234,
                 meta: { ...meta }
               }
             }),

--- a/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/frontsUIBundle.spec.ts
@@ -35,7 +35,7 @@ import {
   selectOpenParentFrontOfCard,
   createSelectDoesCollectionHaveOpenForms
 } from '../frontsUIBundle';
-import initialState from 'fixtures/initialState';
+import { state as initialState } from 'fixtures/initialState';
 import initialStateForOpenFronts from '../../fixtures/initialStateForOpenFronts';
 import { frontsConfig } from 'fixtures/frontsConfig';
 import { Action } from 'types/Action';

--- a/fronts-client/src/bundles/frontsUIBundle.ts
+++ b/fronts-client/src/bundles/frontsUIBundle.ts
@@ -40,11 +40,7 @@ import { REMOVE_GROUP_CARD, REMOVE_SUPPORTING_CARD } from 'actions/CardsCommon';
 import { Stages, CardSets } from 'types/Collection';
 import { selectPriority } from 'selectors/pathSelectors';
 import { CollectionWithArticles } from 'types/PageViewData';
-import {
-  createSelectArticlesInCollection,
-  selectSharedState,
-  createSelectArticleFromCard
-} from 'selectors/shared';
+import { createSelectArticlesInCollection, createSelectArticleFromCard } from 'selectors/shared';
 import { ThunkResult } from 'types/Store';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
@@ -522,7 +518,7 @@ const createSelectOpenCardTitlesForCollection = () => {
     });
     return compact(
       cardIds
-        .map(id => selectArticleFromCard(selectSharedState(state), id))
+        .map(id => selectArticleFromCard(state, id))
         .filter(_ => _)
         .map(
           derivedArticle =>
@@ -551,14 +547,11 @@ const selectOpenFrontsCollectionsAndArticles = (
       frontAndCollections.frontId
     );
     const collections = frontAndCollections.collections.map((cId: string) => {
-      const articleIds: string[] = selectAllArticleIdsForCollection(
-        selectSharedState(state),
-        {
-          collectionId: cId,
+      const articleIds: string[] = selectAllArticleIdsForCollection(state, {
+        collectionId: cId,
           collectionSet: browsingStage,
           includeSupportingArticles: false
-        }
-      );
+      });
       return {
         id: cId,
         articleIds

--- a/fronts-client/src/bundles/frontsUIBundle.ts
+++ b/fronts-client/src/bundles/frontsUIBundle.ts
@@ -40,7 +40,10 @@ import { REMOVE_GROUP_CARD, REMOVE_SUPPORTING_CARD } from 'actions/CardsCommon';
 import { Stages, CardSets } from 'types/Collection';
 import { selectPriority } from 'selectors/pathSelectors';
 import { CollectionWithArticles } from 'types/PageViewData';
-import { createSelectArticlesInCollection, createSelectArticleFromCard } from 'selectors/shared';
+import {
+  createSelectArticlesInCollection,
+  createSelectArticleFromCard
+} from 'selectors/shared';
 import { ThunkResult } from 'types/Store';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
@@ -549,8 +552,8 @@ const selectOpenFrontsCollectionsAndArticles = (
     const collections = frontAndCollections.collections.map((cId: string) => {
       const articleIds: string[] = selectAllArticleIdsForCollection(state, {
         collectionId: cId,
-          collectionSet: browsingStage,
-          includeSupportingArticles: false
+        collectionSet: browsingStage,
+        includeSupportingArticles: false
       });
       return {
         id: cId,

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -18,10 +18,7 @@ import ButtonCircularCaret, {
 } from './inputs/ButtonCircularCaret';
 import { State } from '../types/State';
 
-import {
-  selectSharedState,
-  createSelectArticlesInCollection
-} from '../selectors/shared';
+import { createSelectArticlesInCollection } from '../selectors/shared';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
 import ContentContainer, {
@@ -42,7 +39,6 @@ export const createCollectionId = ({ id }: Collection, frontId: string) =>
 
 interface ContainerProps {
   id: string;
-  selectSharedState?: (state: any) => State;
   browsingStage: CardSets;
   frontId: string;
 }
@@ -412,12 +408,9 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 const createMapStateToProps = () => {
   const selectArticlesInCollection = createSelectArticlesInCollection();
   return (state: State, props: ContainerProps) => {
-    const sharedState = props.selectSharedState
-      ? props.selectSharedState(state)
-      : selectSharedState(state);
     return {
-      collection: collectionSelectors.selectById(sharedState, props.id),
-      articleIds: selectArticlesInCollection(sharedState, {
+      collection: collectionSelectors.selectById(state, props.id),
+      articleIds: selectArticlesInCollection(state, {
         collectionId: props.id,
         collectionSet: props.browsingStage,
         includeSupportingArticles: false

--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -14,7 +14,6 @@ import Button from 'components/inputs/ButtonDefault';
 import ContentContainer from 'components/layout/ContentContainer';
 import {
   createSelectArticleFromCard,
-  selectSharedState,
   selectExternalArticleFromCard,
   selectArticleTag
 } from 'selectors/shared';
@@ -821,29 +820,17 @@ const createMapStateToProps = () => {
   const selectArticle = createSelectArticleFromCard();
   const selectFormFields = createSelectFormFieldsForCard();
   return (state: State, { cardId, isSupporting = false }: InterfaceProps) => {
-    const externalArticle = selectExternalArticleFromCard(
-      selectSharedState(state),
-      cardId
-    );
+    const externalArticle = selectExternalArticleFromCard(state, cardId);
     const valueSelector = formValueSelector(cardId);
-    const article = selectArticle(selectSharedState(state), cardId);
+    const article = selectArticle(state, cardId);
     const parentCollectionId =
-      collectionSelectors.selectParentCollectionOfCard(
-        selectSharedState(state),
-        cardId
-      ) || null;
+      collectionSelectors.selectParentCollectionOfCard(state, cardId) || null;
     const parentCollection = parentCollectionId
-      ? collectionSelectors.selectById(
-          selectSharedState(state),
-          parentCollectionId
-        )
+      ? collectionSelectors.selectById(state, parentCollectionId)
       : null;
 
     function getLastUpdatedBy(collectionId: string) {
-      const collection = collectionSelectors.selectById(
-        selectSharedState(state),
-        collectionId
-      );
+      const collection = collectionSelectors.selectById(state, collectionId);
       if (!collection) {
         return null;
       }
@@ -862,9 +849,7 @@ const createMapStateToProps = () => {
       articleCapiFieldValues: getCapiValuesForArticleFields(externalArticle),
       editableFields:
         article && selectFormFields(state, article.uuid, isSupporting),
-      kickerOptions: article
-        ? selectArticleTag(selectSharedState(state), cardId)
-        : defaultObject,
+      kickerOptions: article ? selectArticleTag(state, cardId) : defaultObject,
       imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
       imageHide: valueSelector(state, 'imageHide'),
       imageReplace: valueSelector(state, 'imageReplace'),

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/ArticleDrag.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import {
-  createSelectArticleFromCard,
-  selectSharedState
-} from 'selectors/shared';
+import { createSelectArticleFromCard } from 'selectors/shared';
 import { State } from 'types/State';
 import { theme, styled } from '../../../constants/theme';
 import documentDragIcon from 'images/icons/document-drag-icon.svg';
@@ -69,7 +66,7 @@ export const DraggingArticleComponent = ({ headline }: ComponentProps) =>
 const createMapStateToProps = () => {
   const selectArticle = createSelectArticleFromCard();
   return (state: State, props: ContainerProps): { headline?: string } => {
-    const article = selectArticle(selectSharedState(state), props.id);
+    const article = selectArticle(state, props.id);
     return { headline: article && article.headline };
   };
 };

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Card.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Card.tsx
@@ -5,7 +5,6 @@ import Article from 'components/article/Article';
 import { State } from 'types/State';
 import { createSelectCardType } from 'selectors/cardSelectors';
 import {
-  selectSharedState,
   selectExternalArticleFromCard,
   selectSupportingArticleCount
 } from 'selectors/shared';
@@ -272,19 +271,13 @@ class Card extends React.Component<ArticleContainerProps> {
 const createMapStateToProps = () => {
   const selectType = createSelectCardType();
   return (state: State, { uuid, frontId }: ContainerProps) => {
-    const maybeExternalArticle = selectExternalArticleFromCard(
-      selectSharedState(state),
-      uuid
-    );
+    const maybeExternalArticle = selectExternalArticleFromCard(state, uuid);
     return {
-      type: selectType(selectSharedState(state), uuid),
+      type: selectType(state, uuid),
       isSelected: selectIsCardFormOpen(state, uuid, frontId),
       isLive: maybeExternalArticle && isArticleLive(maybeExternalArticle),
       pillarId: maybeExternalArticle && maybeExternalArticle.pillarId,
-      numSupportingArticles: selectSupportingArticleCount(
-        selectSharedState(state),
-        uuid
-      ),
+      numSupportingArticles: selectSupportingArticleCount(state, uuid),
       editMode: selectEditMode(state)
     };
   };

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -24,7 +24,6 @@ import { CardSets, Group } from 'types/Collection';
 import {
   createSelectCollectionStageGroups,
   createSelectCollectionEditWarning,
-  selectSharedState,
   createSelectPreviouslyLiveArticlesInCollection
 } from 'selectors/shared';
 import {
@@ -342,19 +341,19 @@ const createMapStateToProps = () => {
       collectionId
     }),
     isCollectionLocked: selectIsCollectionLocked(state, collectionId),
-    groups: selectCollectionStageGroups(selectSharedState(state), {
+    groups: selectCollectionStageGroups(state, {
       collectionSet: browsingStage,
       collectionId
     }),
-    previousGroup: selectPreviously(selectSharedState(state), {
+    previousGroup: selectPreviously(state, {
       collectionId
     }),
-    displayEditWarning: selectEditWarning(selectSharedState(state), {
+    displayEditWarning: selectEditWarning(state, {
       collectionId
     }),
     isOpen: selectIsCollectionOpen(state, collectionId),
     hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
-    hasContent: !!selectors.selectById(selectSharedState(state), collectionId),
+    hasContent: !!selectors.selectById(state, collectionId),
     hasOpenForms: selectHasOpenForms(state, { collectionId, frontId })
   });
 };

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -13,7 +13,6 @@ import { createCollectionId } from 'components/CollectionDisplay';
 import ButtonDefault from 'components/inputs/ButtonCircular';
 import {
   createSelectCollection,
-  selectSharedState,
   createSelectArticlesInCollection
 } from 'selectors/shared';
 import EditModeVisibility from 'components/util/EditModeVisibility';
@@ -172,10 +171,10 @@ const mapStateToProps = () => {
       browsingStage: collectionSet
     }: FrontCollectionOverviewContainerProps
   ) => ({
-    collection: selectCollection(selectSharedState(state), {
+    collection: selectCollection(state, {
       collectionId
     }),
-    articleCount: selectArticlesInCollection(selectSharedState(state), {
+    articleCount: selectArticlesInCollection(state, {
       collectionSet,
       collectionId,
       includeSupportingArticles: false

--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -4,7 +4,7 @@ import {
   getInitialValuesForCardForm
 } from 'util/form';
 import derivedArticle from 'fixtures/derivedArticle';
-import initialState from 'fixtures/initialState';
+import { state as initialState } from 'fixtures/initialState';
 import { State } from 'types/State';
 
 const formValues = {

--- a/fronts-client/src/components/article/Article.tsx
+++ b/fronts-client/src/components/article/Article.tsx
@@ -5,7 +5,6 @@ import noop from 'lodash/noop';
 
 import {
   createSelectArticleFromCard,
-  selectSharedState,
   selectCard
 } from '../../selectors/shared';
 import { selectors } from 'bundles/externalArticlesBundle';
@@ -59,11 +58,7 @@ interface ArticleComponentProps {
   collectionId?: string;
 }
 
-interface ContainerProps extends ArticleComponentProps {
-  selectSharedState?: (state: any) => State;
-}
-
-interface ComponentProps extends ContainerProps {
+interface ComponentProps extends ArticleComponentProps {
   article?: DerivedArticle;
   isLoading?: boolean;
   size?: CardSizes;
@@ -194,22 +189,19 @@ const createMapStateToProps = () => {
   const selectArticle = createSelectArticleFromCard();
   return (
     state: State,
-    props: ContainerProps
+    props: ArticleComponentProps
   ): {
     article?: DerivedArticle;
     isLoading: boolean;
     featureFlagPageViewData: boolean;
   } => {
-    const sharedState = props.selectSharedState
-      ? props.selectSharedState(state)
-      : selectSharedState(state);
-    const article = selectArticle(sharedState, props.id);
-    const card = selectCard(sharedState, props.id);
+    const article = selectArticle(state, props.id);
+    const card = selectCard(state, props.id);
     const getState = (s: any) => s;
 
     return {
       article,
-      isLoading: selectors.selectIsLoadingInitialDataById(sharedState, card.id),
+      isLoading: selectors.selectIsLoadingInitialDataById(state, card.id),
       featureFlagPageViewData: selectFeatureValue(
         getState(state),
         'page-view-data-visualisation'

--- a/fronts-client/src/components/article/DraggableArticleImageContainer.tsx
+++ b/fronts-client/src/components/article/DraggableArticleImageContainer.tsx
@@ -3,7 +3,6 @@ import { styled } from 'constants/theme';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
 import {
-  selectSharedState,
   selectCardHasMediaOverrides,
   createSelectArticleFromCard
 } from 'selectors/shared';
@@ -93,15 +92,12 @@ const mapStateToProps = () => {
   const selectArticle = createSelectArticleFromCard();
 
   return (state: State, { id, canDrag = true }: ContainerProps) => {
-    const article = selectArticle(selectSharedState(state), id);
+    const article = selectArticle(state, id);
 
     return {
       currentImageUrl: article && article.thumbnail,
       canDrag: article ? !!article.thumbnail && canDrag : false,
-      hasImageOverrides: selectCardHasMediaOverrides(
-        selectSharedState(state),
-        id
-      )
+      hasImageOverrides: selectCardHasMediaOverrides(state, id)
     };
   };
 };

--- a/fronts-client/src/components/snapLink/SnapLink.tsx
+++ b/fronts-client/src/components/snapLink/SnapLink.tsx
@@ -17,7 +17,6 @@ import {
 import { HoverActionsAreaOverlay } from '../CollectionHoverItems';
 import { Card, CardSizes } from 'types/Collection';
 import {
-  selectSharedState,
   selectCard,
   createSelectArticleFromCard
 } from '../../selectors/shared';
@@ -53,7 +52,6 @@ const SnapLinkURL = styled.p`
 `;
 
 interface ContainerProps {
-  selectSharedState?: (state: any) => State;
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
   onDelete?: (uuid: string) => void;
@@ -221,14 +219,11 @@ const SnapLink = ({
 const mapStateToProps = () => {
   const selectArticle = createSelectArticleFromCard();
   return (state: State, props: ContainerProps) => {
-    const sharedState = props.selectSharedState
-      ? props.selectSharedState(state)
-      : selectSharedState(state);
-    const article = selectArticle(sharedState, props.id);
+    const article = selectArticle(state, props.id);
     const getState = (s: any) => s;
 
     return {
-      card: selectCard(sharedState, props.id),
+      card: selectCard(state, props.id),
       article,
       featureFlagPageViewData: selectFeatureValue(
         getState(state),

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -714,6 +714,4 @@ const state = {
   }
 } as State;
 
-export { config, state };
-
-// export default state;
+export { state };

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -714,4 +714,6 @@ const state = {
   }
 } as State;
 
-export default state;
+export { config, state };
+
+// export default state;

--- a/fronts-client/src/fixtures/initialStateForEditions.ts
+++ b/fronts-client/src/fixtures/initialStateForEditions.ts
@@ -1,4 +1,4 @@
-import initialState from './initialState';
+import { state as initialState } from 'fixtures/initialState';
 import { State } from 'types/State';
 
 const state = {

--- a/fronts-client/src/fixtures/initialStateForOpenFronts.ts
+++ b/fronts-client/src/fixtures/initialStateForOpenFronts.ts
@@ -1,6 +1,6 @@
 import { defaultState } from 'bundles/frontsUIBundle';
 import { frontsConfig } from 'fixtures/frontsConfig';
-import initialState from './initialState';
+import { state as initialState } from './initialState';
 import { State } from 'types/State';
 
 const state = {

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -50,7 +50,7 @@ interface FeedState {
 export interface State {
   fronts: frontsState;
   config: Config | null;
-  error: ActionError;
+  error: ActionError | null;
   path: pathState;
   unpublishedChanges: unpublishedChangesState;
   clipboard: clipboardState;

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -50,7 +50,7 @@ interface FeedState {
 export interface State {
   fronts: frontsState;
   config: Config | null;
-  error: ActionError | null;
+  error: ActionError;
   path: pathState;
   unpublishedChanges: unpublishedChangesState;
   clipboard: clipboardState;

--- a/fronts-client/src/redux/modules/featureSwitches/__tests__/selectors.spec.ts
+++ b/fronts-client/src/redux/modules/featureSwitches/__tests__/selectors.spec.ts
@@ -1,5 +1,5 @@
 import { selectAllFeatures } from '../selectors';
-import initialState from 'fixtures/initialState';
+import { state as initialState } from 'fixtures/initialState';
 import { State } from 'types/State';
 
 describe('Feature selectors', () => {

--- a/fronts-client/src/redux/modules/pageViewData/__tests__/selectors.spec.ts
+++ b/fronts-client/src/redux/modules/pageViewData/__tests__/selectors.spec.ts
@@ -1,6 +1,6 @@
 import { selectDataForArticle } from '../selectors';
 import { state as pageViewData, data } from './fixtures';
-import globalState from '../../../../fixtures/initialState';
+import { state as globalState } from 'fixtures/initialState';
 import { State } from 'types/State';
 
 const state = {

--- a/fronts-client/src/redux/modules/pageViewData/actions.ts
+++ b/fronts-client/src/redux/modules/pageViewData/actions.ts
@@ -7,7 +7,6 @@ import { PageViewDataFromOphan, PageViewStory } from 'types/PageViewData';
 import { DerivedArticle } from 'types/Article';
 import {
   createSelectArticlesInCollection,
-  selectSharedState,
   createSelectArticleFromCard
 } from 'selectors/shared';
 import { CardSets } from 'types/Collection';
@@ -31,7 +30,7 @@ const getPageViewDataForCollection = (
   return async (dispatch, getState) => {
     dispatch(pageViewDataRequestedAction(frontId));
     try {
-      const state = selectSharedState(getState());
+      const state = getState();
       const articleIds: string[] = selectArticlesInCollection(state, {
         collectionId,
         collectionSet
@@ -48,7 +47,7 @@ const getPageViewData = (
   collectionId: string,
   articleIds: string[]
 ): ThunkResult<void> => async (dispatch, getState) => {
-  const state = selectSharedState(getState());
+  const state = getState();
   const articles = articleIds
     .map(_ => selectArticleFromCard(state, _))
     .filter(_ => _) as DerivedArticle[];

--- a/fronts-client/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/keyboardNavigationSelectors.spec.ts
@@ -2,7 +2,7 @@ import {
   selectNextClipboardIndexSelector,
   selectNextIndexAndGroup
 } from 'selectors/keyboardNavigationSelectors';
-import state from 'fixtures/initialState';
+import { state } from 'fixtures/initialState';
 
 describe('nextClipboardIndexSelector', () => {
   const stateWithClipboard = {

--- a/fronts-client/src/selectors/collectionSelectors.ts
+++ b/fronts-client/src/selectors/collectionSelectors.ts
@@ -1,10 +1,6 @@
 import { State } from 'types/State';
 import { selectCollectionConfig } from './frontsSelectors';
-import {
-  selectSharedState,
-  createSelectCollection,
-  groupsArticleCount
-} from 'selectors/shared';
+import { createSelectCollection, groupsArticleCount } from 'selectors/shared';
 import { getUpdatedSiblingGroupsForInsertion } from 'reducers/groupsReducer';
 
 const selectCollection = createSelectCollection();
@@ -26,7 +22,7 @@ const selectCollectionParams = (
       }
 
       if (returnOnlyUpdatedCollections) {
-        const maybeCollection = selectCollection(selectSharedState(state), {
+        const maybeCollection = selectCollection(state, {
           collectionId: id
         });
         // Some collections are automated and they don't have any content in them.
@@ -51,10 +47,9 @@ const selectWillCollectionHitCollectionCap = (
   cardId: string,
   collectionCap: number
 ) => {
-  const shared = selectSharedState(state);
   const patch = getUpdatedSiblingGroupsForInsertion(
-    shared,
-    shared.groups,
+    state,
+    state.groups,
     groupId,
     index,
     cardId

--- a/fronts-client/src/selectors/formSelectors.ts
+++ b/fronts-client/src/selectors/formSelectors.ts
@@ -1,8 +1,5 @@
 import { selectors } from 'bundles/collectionsBundle';
-import {
-  selectSharedState,
-  createSelectArticleFromCard
-} from 'selectors/shared';
+import { createSelectArticleFromCard } from 'selectors/shared';
 import { selectCollectionConfig } from 'selectors/frontsSelectors';
 import { hasMainVideo } from 'util/externalArticle';
 import { isCollectionConfigDynamic } from '../util/frontsUtils';
@@ -58,17 +55,14 @@ const selectIsSupporting = (_: unknown, __: unknown, isSupporting: boolean) =>
   isSupporting;
 
 const selectParentCollectionConfig = (state: State, cardId: string) => {
-  const collectionId = selectors.selectParentCollectionOfCard(
-    selectSharedState(state),
-    cardId
-  );
+  const collectionId = selectors.selectParentCollectionOfCard(state, cardId);
   return collectionId ? selectCollectionConfig(state, collectionId) : undefined;
 };
 
 export const createSelectFormFieldsForCard = () => {
   const selectDerivedArticle = createSelectArticleFromCard();
   const selectDerivedArticleFromRootState = (state: State, id: string) =>
-    selectDerivedArticle(selectSharedState(state), id);
+    selectDerivedArticle(state, id);
   return createSelector(
     selectDerivedArticleFromRootState,
     selectParentCollectionConfig,

--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -13,8 +13,7 @@ import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
 import { CardSets, Stages } from 'types/Collection';
 import {
   createSelectArticlesInCollection,
-  createSelectCollection,
-  selectSharedState
+  createSelectCollection
 } from 'selectors/shared';
 import { createShallowEqualResultSelector } from 'util/selectorUtils';
 
@@ -138,7 +137,7 @@ const selectCollectionIsHidden = (
   state: State,
   collectionId: string
 ): boolean => {
-  const collection = selectCollection(selectSharedState(state), {
+  const collection = selectCollection(state, {
     collectionId
   });
   return !!collection && !!collection.isHidden;
@@ -148,7 +147,7 @@ const selectCollectionDisplayName = (
   state: State,
   collectionId: string
 ): string => {
-  const collection = selectCollection(selectSharedState(state), {
+  const collection = selectCollection(state, {
     collectionId
   });
   return !!collection ? collection.displayName : '';
@@ -341,7 +340,7 @@ const createSelectArticleVisibilityDetails = () => {
       collectionSet: CardSets;
     }
   ) =>
-    selectArticlesInCollection(selectSharedState(state), {
+    selectArticlesInCollection(state, {
       ...extra,
       includeSupportingArticles: false
     });

--- a/fronts-client/src/selectors/keyboardNavigationSelectors.ts
+++ b/fronts-client/src/selectors/keyboardNavigationSelectors.ts
@@ -1,5 +1,4 @@
 import {
-  selectSharedState,
   selectIndexInGroup,
   selectGroups,
   selectGroupCollection,
@@ -38,19 +37,14 @@ const selectNextIndexAndGroup = (
   action: 'up' | 'down',
   frontId: string
 ) => {
-  const sharedState = selectSharedState(state);
-  const group = selectGroups(sharedState)[groupId];
+  const group = selectGroups(state)[groupId];
   if (!group) {
     return null;
   }
 
   const groupCards = group.cards;
 
-  const currentArticleIndex = selectIndexInGroup(
-    sharedState,
-    groupId,
-    articleId
-  );
+  const currentArticleIndex = selectIndexInGroup(state, groupId, articleId);
 
   // Checking if moving inside the group
   if (action === 'down') {
@@ -68,7 +62,7 @@ const selectNextIndexAndGroup = (
   }
 
   // Checking if moving between groups but inside the collection
-  const { collection, cardSet } = selectGroupCollection(sharedState, groupId);
+  const { collection, cardSet } = selectGroupCollection(state, groupId);
   if (collection) {
     const collectionGroups = collection[cardSet];
 
@@ -84,8 +78,7 @@ const selectNextIndexAndGroup = (
       if (action === 'up') {
         if (groupIndex !== 0) {
           const nextGroupId = collectionGroups[groupIndex - 1];
-          const nextGroupArticles = selectGroups(sharedState)[nextGroupId]
-            .cards;
+          const nextGroupArticles = selectGroups(state)[nextGroupId].cards;
           return { toIndex: nextGroupArticles.length, nextGroupId };
         }
       }
@@ -97,7 +90,7 @@ const selectNextIndexAndGroup = (
     if (action === 'down') {
       if (collectionIndex < frontCollections.length - 1) {
         const selectCollection = createSelectCollection();
-        const coll = selectCollection(sharedState, {
+        const coll = selectCollection(state, {
           collectionId: frontCollections[collectionIndex + 1]
         });
         if (!coll || !coll.draft) {
@@ -111,7 +104,7 @@ const selectNextIndexAndGroup = (
     if (action === 'up') {
       if (collectionIndex !== 0) {
         const selectCollection = createSelectCollection();
-        const coll = selectCollection(sharedState, {
+        const coll = selectCollection(state, {
           collectionId: frontCollections[collectionIndex - 1]
         });
 
@@ -122,7 +115,7 @@ const selectNextIndexAndGroup = (
         const nextIndex = coll.draft.length;
         const nextGroupId = coll.draft[nextIndex - 1];
 
-        const nextGroupArticles = selectGroups(sharedState)[nextGroupId].cards;
+        const nextGroupArticles = selectGroups(state)[nextGroupId].cards;
 
         return {
           toIndex: nextGroupArticles.length,

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -23,21 +23,12 @@ import { createShallowEqualResultSelector } from 'util/selectorUtils';
 import { DerivedArticle } from 'types/Article';
 import { hasMainVideo } from 'util/externalArticle';
 
-// Selects the shared part of the application state mounted at its default point, '.shared'.
-const selectSharedState = (rootState: any): State => rootState;
-
 const selectGroups = (state: State): { [id: string]: Group } => state.groups;
 const selectCards = (state: State) => state.cards;
 
-const selectCardsFromRootState = createSelector(
-  [selectSharedState],
-  (state: State) => selectCards(state)
-);
+const selectCardsFromRootState = (state: State) => selectCards(state);
 
-const selectGroupsFromRootState = createSelector(
-  [selectSharedState],
-  (state: State) => selectGroups(state)
-);
+const selectGroupsFromRootState = (state: State) => selectGroups(state);
 
 const selectCard = (state: State, id: string): Card => state.cards[id];
 
@@ -55,7 +46,7 @@ const selectExternalArticleFromCard = (
 
 const selectSupportingArticleCount = (state: State, uuid: string) => {
   const maybeArticle = selectCard(state, uuid);
-  if (maybeArticle && maybeArticle && maybeArticle.meta.supporting) {
+  if (maybeArticle && maybeArticle.meta.supporting) {
     return maybeArticle.meta.supporting.length;
   }
   return 0;
@@ -524,7 +515,6 @@ export {
   createSelectCollectionStageGroups,
   createSelectPreviouslyLiveArticlesInCollection,
   createDemornalisedCard,
-  selectSharedState,
   selectCard,
   createSelectCollectionEditWarning,
   selectCards,

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -8,7 +8,7 @@ import { CardMeta } from 'types/Collection';
 import { DerivedArticle } from 'types/Article';
 import { CapiArticle } from 'types/Capi';
 import { State } from 'types/State';
-import { selectCard, selectSharedState } from 'selectors/shared';
+import { selectCard } from 'selectors/shared';
 
 export interface CardFormData {
   headline: string;
@@ -209,7 +209,7 @@ export const getCardMetaFromFormValues = (
     return selectIsDirty(state, formToMetaFieldMap[key] || key);
   });
 
-  const existingCard = selectCard(selectSharedState(state), id);
+  const existingCard = selectCard(state, id);
 
   const existingCardMeta = existingCard ? existingCard.meta || {} : {};
 

--- a/fronts-client/src/util/pollingConfig.ts
+++ b/fronts-client/src/util/pollingConfig.ts
@@ -9,10 +9,7 @@ import {
 import { selectPriority } from 'selectors/pathSelectors';
 import { getPageViewDataForCollection } from '../redux/modules/pageViewData/actions';
 import { selectFeatureValue } from 'redux/modules/featureSwitches/selectors';
-import {
-  selectSharedState,
-  selectExternalArticleIdFromCard
-} from 'selectors/shared';
+import { selectExternalArticleIdFromCard } from 'selectors/shared';
 import {
   selectOpenFrontsCollectionsAndArticles,
   selectOpenCardIds
@@ -61,7 +58,7 @@ const createRefreshOpenArticles = (store: Store) => () => {
   const state = store.getState();
   const openCardIds = selectOpenCardIds(state);
   const externalArticleIds = openCardIds
-    .map(_ => selectExternalArticleIdFromCard(selectSharedState(state), _))
+    .map(_ => selectExternalArticleIdFromCard(state, _))
     .filter(_ => _) as string[];
   (store.dispatch as Dispatch)(fetchArticles(externalArticleIds));
 };

--- a/fronts-client/src/util/shared.ts
+++ b/fronts-client/src/util/shared.ts
@@ -5,7 +5,6 @@ import {
   Card
 } from 'types/Collection';
 import { selectors as collectionSelectors } from 'bundles/collectionsBundle';
-import { selectSharedState } from 'selectors/shared';
 import { State } from 'types/State';
 
 import { normalize, denormalize } from './schema';
@@ -167,10 +166,7 @@ function denormaliseCollection(
   state: State,
   id: string
 ): CollectionWithNestedArticles {
-  const collection = collectionSelectors.selectById(
-    selectSharedState(state),
-    id
-  );
+  const collection = collectionSelectors.selectById(state, id);
   if (!collection) {
     throw new Error(
       `Could not denormalise collection - no collection found with id '${id}'`

--- a/fronts-client/src/util/storeMiddleware.ts
+++ b/fronts-client/src/util/storeMiddleware.ts
@@ -8,7 +8,6 @@ import { Action, ActionPersistMeta } from 'types/Action';
 import { selectors } from 'bundles/collectionsBundle';
 import { updateCollection } from 'actions/Collections';
 import { updateClipboard } from 'actions/Clipboard';
-import { selectSharedState } from 'selectors/shared';
 import { saveOpenFrontIds, saveFavouriteFrontIds } from 'services/userDataApi';
 import { NestedCard } from 'types/Collection';
 import { denormaliseClipboard } from 'util/clipboardUtils';
@@ -96,9 +95,9 @@ const persistCollectionOnEdit = (
   let pendingCollectionIds = [] as string[];
   const throttledPersistCollectionEdits = debounce(
     () => {
-      const sharedState = selectSharedState(store.getState());
+      const state = store.getState();
       pendingCollectionIds.forEach(id => {
-        const collection = selectors.selectById(sharedState, id);
+        const collection = selectors.selectById(state, id);
         if (collection) {
           store.dispatch(updateCollectionAction(collection));
         }
@@ -143,7 +142,7 @@ const persistCollectionOnEdit = (
         }
 
         const collectionId = selectors.selectParentCollectionOfCard(
-          selectSharedState(store.getState()),
+          store.getState(),
           id
         );
         if (!collectionId) {


### PR DESCRIPTION
## What's changed?
As part of the bigger project to remove the Shared folder and the shared part of the state, we want to remove the `selectSharedState` selector which is now no longer needed. 

1. Deletes the `selectSharedState` selector
2. Removes all references to it. Properties are now on the state root so it is not needed
3. Lots of tests and fixtures needed to be updated to remove the concept of shared existing on the state. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
