### PR TITLE
Lower case "M" on Body and mind

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -266,7 +266,7 @@ object DailyEdition {
     collection("Family").printSentAnyTag("theguardian/weekend/family"),
     collection("Space").printSentAnyTag("theguardian/weekend/space2"),
     collection("Style").printSentAnyTag("theguardian/weekend/fashion-and-beauty"),
-    collection("Body & Mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
+    collection("Body & mind").printSentAnyTag("theguardian/weekend/body-and-mind"),
     collection("Life").hide,
     collection("Life").hide
   )


### PR DESCRIPTION
Turns the default for the container "Body & Mind" to "Body & mind" which is the style.