### PR TITLE
Fronts cleanup: Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Guardian front pages editor.
 
-## Fronts Client 
+## Fronts Client
 
 You can find the client for the Fronts tool in [fronts-client](/fronts-client).
 
@@ -43,6 +43,56 @@ You can find the client for the Fronts tool in [fronts-client](/fronts-client).
 - Select the front your are trying to view on the config page, click on the edit-metadata link, and deselect the `is hidden`-property.
 
 - If you are developing locally and do not have frontend credentials from janus, the fronts tool won't have permissions to push events to the sqs queue that Facia-Press reads from. To test that a front is pressed, you will have to deploy your changes to code, and test the code from there.
+
+
+## Different tools in this codebase
+
+### The Fronts Tool
+The most important part of this app is the Fronts Tool which is used to curate the web and app front pages of the Guardian. Additionally it is used to manually create emails (each front representing a different email).
+
+Users can move stories from the Content API feed into different front pages. These fronts can then be launched which triggers a set of processes that updates the front pages on dotcom and the iOS and Android apps.
+
+The Fronts Tool uses the most up-to-date front end as stored in [fronts-client](https://github.com/guardian/facia-tool/tree/master/fronts-client)
+
+Useful things to know:
+* An api call to Ophan pulls in page view data to allow users to understand at a glance views for a given story. Normally this is only visible for stories that are actually on a front page. If there is no data, the graph is not shown.
+
+* Containers can be shared between fronts and updates to a container in one place updates it everywhere.
+
+* Certain containers have geolocation properties. This means they can only be seen by users in the location specified.
+
+* Interactive atoms can be pasted into a front as CAPI links. This allows designers and the interactives team to create special content eg banners showing election results. Apart from articles, interactive atoms are the only other type of CAPI content allowed on Fronts
+
+* In the Email editor only - free text boxes can be created. This allows email editors to add introductions to their emails by hijacking the headline field. Rich text editing is enabled for this using Prosemirror.
+
+
+### The Editions creator
+
+The Editions interface is used to curate content on the Editions app (currently known as The Daily iOS and Android). Editions also uses the fronts-client front end, and can be accessed from the Manage Editions menu on the homepage: https://fronts.code.dev-gutools.co.uk/v2
+
+Curation works in the same way as the main fronts tool. But there are these differences:
+
+* Fronts are part of Issues (normally one issue per day). You need to create or open a valid issue to make changes
+
+* Editions are published once instead of being continually updated and launched
+
+* ??? What other differences are there from a user perspective ?
+
+* ??? Are Editions pressed using Fronts press?
+
+
+### The Config Tool
+
+Fronts and collections are configured in the config tool. This allows for the name, geolocation and visual properties of collections to be set. The types and order of collections in a Front is set here too. This tool uses the "old" front end client. Each "type of fronts" has its own config url eg: https://fronts.gutools.co.uk/email/config
+
+
+### The Breaking News Tool
+
+This enables breaking news notifications to be sent to app users who have signed up. This tool also uses the "old" front end client. You need permission from
+Central Production to access this tool. It does not exist in the CODE environment.  https://fronts.gutools.co.uk/breaking-news
+
+** ANYONE GOT ANY MORE INFORMATION ABOUT HOW THIS TOOL WORKS?**
+
 
 #### Troubleshooting
 ##### Postgres

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Curation works in the same way as the main fronts tool. But there are these diff
 
 * Editions are published once instead of being continually updated and launched
 
+* The publication process for Editions is different to the main fronts. We push the json we produce to a lambda - the [backend of the Editions app](https://github.com/guardian/editions), and this combines fronts data with CAPI calls etc to produce the Edition.
+
+Full [Editions codebase and documentation here](https://github.com/guardian/editions).
+
+
+
 
 ### The Config Tool
 
@@ -84,8 +90,11 @@ Fronts and collections are configured in the config tool. This allows for the na
 
 ### The Breaking News Tool
 
-This enables breaking news notifications to be sent to app users who have signed up. This tool also uses the "old" front end client. You need permission from
-Central Production to access this tool. It does not exist in the CODE environment.  https://fronts.gutools.co.uk/breaking-news
+This enables breaking news notifications to be sent to app users who have signed up. This tool also uses the "old" front end client. You need permission from Central Production to access this tool in PROD.  https://fronts.gutools.co.uk/breaking-news
+
+In CODE the breaking news tool sends notifications to the "debug version" of the Android/iOS App.
+
+Breaking News is represented by a front called `breaking-news` which is considered to be a special case. It has a `Send Alert` button rather than a `Launch` button. Only one thing can be added to a collection at a given time. You cannot send the same alert twice, and snap links cannot be added / alerted on. Different collections represent different audience groups (eg by location or by subscription to different topics.) To add a new one, just create a container. New breaking news containers need to have the layout `breaking-news/not-for-other-fronts`.
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ You can find the client for the Fronts tool in [fronts-client](/fronts-client).
 ## Different tools in this codebase
 
 ### The Fronts Tool
-The most important part of this app is the Fronts Tool which is used to curate the web and app front pages of the Guardian. Additionally it is used to manually create emails (each front representing a different email).
+The most important part of this app is the Fronts Tool, used to curate the web and app front pages of the Guardian. Additionally it is used to manually curate emails.
 
-Users can move stories from the Content API feed into different front pages. These fronts can then be launched which triggers a set of processes that updates the front pages on dotcom and the iOS and Android apps.
+In the UI, users can move stories from the Content API feed into different front pages or emails. These fronts can then be launched or published.
 
-The Fronts Tool uses the most up-to-date front end as stored in [fronts-client](https://github.com/guardian/facia-tool/tree/master/fronts-client)
+The Fronts Tool uses the most up-to-date front end, a React-Redux app located in [fronts-client](https://github.com/guardian/facia-tool/tree/master/fronts-client)
 
 Useful things to know:
-* An api call to Ophan pulls in page view data to allow users to understand at a glance views for a given story. Normally this is only visible for stories that are actually on a front page. If there is no data, the graph is not shown.
+* An api call to Ophan pulls in page view data to allow users to understand at a glance that story's performance in the context of the front it is in
 
-* Containers can be shared between fronts and updates to a container in one place updates it everywhere.
+* Containers can be shared between fronts. An update to a container in one place updates it everywhere
 
-* Certain containers have geolocation properties. This means they can only be seen by users in the location specified.
+* Certain containers have geolocation properties. This means they can only be seen by users in the location specified
 
 * Interactive atoms can be pasted into a front as CAPI links. This allows designers and the interactives team to create special content eg banners showing election results. Apart from articles, interactive atoms are the only other type of CAPI content allowed on Fronts
 
@@ -68,17 +68,13 @@ Useful things to know:
 
 ### The Editions creator
 
-The Editions interface is used to curate content on the Editions app (currently known as The Daily iOS and Android). Editions also uses the fronts-client front end, and can be accessed from the Manage Editions menu on the homepage: https://fronts.code.dev-gutools.co.uk/v2
+The Editions interface is used to curate content on the Editions app (currently known as The Daily on iOS and Android). Editions also uses the fronts-client front end, and can be accessed from the Manage Editions menu on the [homepage](https://fronts.code.dev-gutools.co.uk/v2).
 
 Curation works in the same way as the main fronts tool. But there are these differences:
 
 * Fronts are part of Issues (normally one issue per day). You need to create or open a valid issue to make changes
 
 * Editions are published once instead of being continually updated and launched
-
-* ??? What other differences are there from a user perspective ?
-
-* ??? Are Editions pressed using Fronts press?
 
 
 ### The Config Tool
@@ -91,11 +87,9 @@ Fronts and collections are configured in the config tool. This allows for the na
 This enables breaking news notifications to be sent to app users who have signed up. This tool also uses the "old" front end client. You need permission from
 Central Production to access this tool. It does not exist in the CODE environment.  https://fronts.gutools.co.uk/breaking-news
 
-** ANYONE GOT ANY MORE INFORMATION ABOUT HOW THIS TOOL WORKS?**
 
-
-#### Troubleshooting
-##### Postgres
+## Troubleshooting
+### Postgres
 - If you wish to delete everything in the database you can use `docker-compose down -v` which will delete the container's persistent volumes.
 - If you wish to connect to the local database you can run `./scripts/local-psql.sh` which has the user, database and password preconfigured and ready to go.
 - If you need the master passwords for the production postgres instances they are stored as SSM parameters and can be found at:
@@ -105,7 +99,7 @@ Central Production to access this tool. It does not exist in the CODE environmen
 
   `aws ssm get-parameter --name /facia-tool/cms-fronts/CODE/db/password --with-decryption --profile cmsFronts --region eu-west-1`
 
-##### Linting
+### Linting
 
 Fronts tool uses `eslint` to ensure consistent style. Run `eslint` with
 

--- a/app/views/templates/header.scala.html
+++ b/app/views/templates/header.scala.html
@@ -14,7 +14,7 @@
      @if(displayV2Message) {
          <div class="header__group v2-popup">
              <div class="v2-popup_logo"><img src="/assets/images/logo-v2.svg" /></div>
-             <div class="v2-popup_text"><span>There's a new version of the fronts tool. Please&nbsp;<a href="/v2/@priority">try it by clicking here</a>. The new version will be made the default on <strong>Tuesday, 27th August.</strong></span></div>
+             <div class="v2-popup_text"><span>There's a new version of the fronts tool. Please&nbsp;<a href="/v2/@priority">try it by clicking here</a>.</span></div>
          </div>
      }
 

--- a/docs/Deleting.md
+++ b/docs/Deleting.md
@@ -1,3 +1,5 @@
+# Editions: deleting an issue
+
 Open the issue you need to delete, then open the javascript console and paste the following:
 
 ```

--- a/fronts-client/README.md
+++ b/fronts-client/README.md
@@ -181,13 +181,15 @@ At the moment, we normalise on the client. This introduces a degree of complexit
 In normalising on the server, we have an additional advantage -- if the persistence model changes, for example if in the future we move to an RDS to store collection data, we can swap out the models without disturbing the client, avoiding concerns with overlapping versions etc.
 
 
-### Use 3rd party library for Drag and Drop
+### Use a third party library for Drag and Drop
 
 We currently have a custom-made npm module - [Guration](https://www.npmjs.com/package/@guardian/guration) - implementing Drag and Drop specially for the Fronts Tool.
 
-The custom-made NPM module the team wrote is not maintained by anyone else. It is very complex. The HTML drag and drop spec is a bit of a nightmare.
-If this breaks in any way the Fronts tool is basically non-functional and it will take work to figure out what is going on in the module.
-The problem it was written to solve (lists within lists - ie sublinks) is now solved by other npm modules that have a big user-base and are properly maintained. (eg. React Beautiful DnD.) It now has “tree view” and item combination (allowing for sublinks etc)
+This module was written by the team in 2018 and is not maintained by anyone else. It covers the complex area of drag and drop, working with the tricky HTML spec.
 
-This will remove a fair amount of code. Make changes to this area easier. And by using a well-used module with good documentation, it will be easier for new developers to pick up.  We already use the module so it won’t add extra weight.
+If this module breaks the Fronts tool is basically non-functional and it will take work to figure out what is going on inside Guration.
+
+The problem it was written to solve (lists within lists - ie sublinks) is now solved by other npm modules that have a big user-base and are properly maintained. (eg. [React Beautiful DnD](https://www.npmjs.com/package/react-beautiful-dnd).)
+
+By switching to a more popular module with good documentation, it will be easier for new developers to pick up.  We already use React Beautiful DnD for small interactions on the menu so it won’t add extra weight.
 

--- a/fronts-client/README.md
+++ b/fronts-client/README.md
@@ -16,7 +16,7 @@
 
 ## Motivations
 
-Fronts Client V2 looks to rebuild the Fronts tool with modern technologies, develop reusable patterns for content curation and build shareable components for across the tools.
+Fronts Client V2 looks to rebuild the Fronts tool with modern technologies, and develop reusable patterns for content curation.
 
 ## Dev Setup (need to be done once)
 
@@ -32,9 +32,9 @@ Fronts Client V2 looks to rebuild the Fronts tool with modern technologies, deve
 
 ### Technologies
 
-V2 is a ReactRedux Javascript application hooking into the existing Fronts API and CAPI.
+Fronts-Client is a ReactRedux Javascript application hooking into the existing Fronts API and CAPI.
 
-You'll need to understand the concepts of Thunks and Selectors.
+You'll need to understand the Redux concepts of Thunks and Selectors.
 
 | Uses        | For         | Config |
 | ------------|------------- |--- |
@@ -115,7 +115,7 @@ yarn lint-fix
 | [TSLint](https://palantir.github.io/tslint/)      | Typescript Linting | [tslint](tslint.json)|
 
 ## Typescript
-We are using Typescript for typing in Fronts V2.
+We are using Typescript for typing in Fronts-Client.
 
 ## File Structure
 
@@ -123,7 +123,7 @@ We are using Typescript for typing in Fronts V2.
     - The [App component](src/components/App.tsx) is the application entry point
     - All reducers are combined in the [Root Reducer](src/reducers/rootReducer.ts) as per standard convention
 - `bundles`
-    - A bundle exports a reducer and all of the related things a reducer needs to function in an app - selectors, actions and action names. It's a bit like an index.ts for a single redux module. This is especially useful when you're generating the actions, reducer and selectors rather than writing them manually, for example with the `createAsyncResourceBundle` utility in shared/util.
+    - A bundle exports a reducer and all of the related things a reducer needs to function in an app - selectors, actions and action names. It's a bit like an index.ts for a single redux module. This is especially useful when you're generating the actions, reducer and selectors rather than writing them manually, for example with the `createAsyncResourceBundle` utility in shared/util. This is one way of storing Redux code and is [explained here](https://reduxbundler.com/).
 - `constants` store high-level application constants such as theme styles and image paths
 - `services` contains the modules for requests to APIs such as CAPI and FaciaAPI
 - `lib` contains modules designed to be reusable such as the Drag N' Drop (dnd) module
@@ -179,3 +179,15 @@ We already handle all of our persistence calls for collections in one place -- t
 At the moment, we normalise on the client. This introduces a degree of complexity to the client-side code that, although well encapsulated, seems an unnecessary concern for the client domain -- better to have the server pass data in an ideal format and handle the details of modelling for the persistence domain.
 
 In normalising on the server, we have an additional advantage -- if the persistence model changes, for example if in the future we move to an RDS to store collection data, we can swap out the models without disturbing the client, avoiding concerns with overlapping versions etc.
+
+
+### Use 3rd party library for Drag and Drop
+
+We currently have a custom-made npm module - [Guration](https://www.npmjs.com/package/@guardian/guration) - implementing Drag and Drop specially for the Fronts Tool.
+
+The custom-made NPM module the team wrote is not maintained by anyone else. It is very complex. The HTML drag and drop spec is a bit of a nightmare.
+If this breaks in any way the Fronts tool is basically non-functional and it will take work to figure out what is going on in the module.
+The problem it was written to solve (lists within lists - ie sublinks) is now solved by other npm modules that have a big user-base and are properly maintained. (eg. React Beautiful DnD.) It now has “tree view” and item combination (allowing for sublinks etc)
+
+This will remove a fair amount of code. Make changes to this area easier. And by using a well-used module with good documentation, it will be easier for new developers to pick up.  We already use the module so it won’t add extra weight.
+


### PR DESCRIPTION
## What's changed?
As part of the work to improve the Fronts Tool, i am adding more documentation to explain what it does. 

1. Calling out the existence of the editions / config / breaking news parts of this app. Previously and you had to know about them in order to find them.  More details about these (from a user and technical pov) very welcome. 

2. A list of several gotchas/ unexpected behaviors in the Fronts Tool that I'm aware of. 

3. Highlighting the custom drag+drop npm module "Guration" as a potential source of tech debt. 

4. We now no longer need the reference to the 27th August on the redirect banner, this date is long past. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

