### PR TITLE
create a new endpoint for collection renaming

### DIFF
--- a/app/model/forms/CollectionRenameRequest.scala
+++ b/app/model/forms/CollectionRenameRequest.scala
@@ -1,0 +1,12 @@
+package model.forms
+
+import play.api.libs.json.{Json, OFormat}
+
+case class CollectionRenameRequest(
+  id: String,
+  displayName: String
+)
+
+object CollectionRenameRequest {
+  implicit val format: OFormat[CollectionRenameRequest] = Json.format[CollectionRenameRequest]
+}

--- a/conf/routes
+++ b/conf/routes
@@ -114,4 +114,5 @@ PUT         /editions-api/fronts/:frontId/is-hidden/:state       controllers.Edi
 
 POST        /editions-api/collections                            controllers.EditionsController.getCollections
 PUT         /editions-api/collections/:collectionId              controllers.EditionsController.updateCollection(collectionId)
+PATCH       /editions-api/collections/:collectionId/name         controllers.EditionsController.renameCollection(collectionId)
 GET         /editions-api/collections/:collectionId/prefill      controllers.EditionsController.getPrefillForCollection(collectionId)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -297,6 +297,44 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       olderCollections.size shouldBe 0
     }
 
+    "should allow renaming of a collection" taggedAs UsesDatabase in {
+      val id = insertSkeletonIssue(2019, 9, 30,
+        front("news/uk",
+          collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
+            article("12345"),
+            article("23456")
+          ),
+          collection("international", None,
+            article("34567"),
+            article("45678"),
+            article("56789")
+          )
+        )
+      )
+
+      val retrievedIssue = editionsDB.getIssue(id).value
+      val brexshit = retrievedIssue.fronts.head.collections.head
+
+      val newName = "Say My Name, Say My Name..."
+
+      val evenMoreBrexshit = brexshit.copy(
+        displayName = newName,
+        updatedBy = Some("BoJo"),
+        updatedEmail = Some("bojo@piffle.paffle"),
+      )
+
+      editionsDB.updateCollectionName(evenMoreBrexshit)
+
+      val collections = editionsDB.getCollections(List(GetCollectionsFilter(brexshit.id, None)))
+      collections.size shouldBe 1
+      val updatedBrexshit = collections.head
+
+      updatedBrexshit.updatedBy.value shouldBe "BoJo"
+      updatedBrexshit.updatedEmail.value shouldBe "bojo@piffle.paffle"
+      updatedBrexshit.lastUpdated.value should be > brexshit.lastUpdated.value
+      updatedBrexshit.displayName shouldBe newName
+    }
+
     "should allow updating of a collection" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
In making renaming a collection a discrete action, we can avoid the scenario where:
- Person A renames container X from Y to Z
- Person B adds an item to container X
- On refresh, person A will see their rename reverted as person B pushed name Y even though they were not touching the container name

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
This is part of a series of PRs. Next in the series are:
- Update client to use this new endpoint
- Stop updating the name on the current endpoint (that is, only this endpoint can rename a collection)

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
