### PR TITLE
add route to get single collection

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -114,6 +114,17 @@ class EditionsController(db: EditionsDB,
 
   }
 
+  def getCollection(collectionId: String) = EditEditionsAuthAction { req =>
+    val collection = db.getCollections(List(GetCollectionsFilter(id = collectionId, None)))
+
+    if(collection.isEmpty) {
+      logger.warn(s"Collection not found ${collectionId}")
+      NotFound(s"Collection $collectionId not found")
+    } else {
+      Ok(Json.toJson(EditionsFrontendCollectionWrapper.fromCollection(collection.head)))
+    }
+  }
+
   def updateCollection(collectionId: String) = EditEditionsAuthAction(parse.json[EditionsFrontendCollectionWrapper]) { req =>
     val form = req.body
     val collectionToUpdate = EditionsFrontendCollectionWrapper.toCollection(form)

--- a/conf/routes
+++ b/conf/routes
@@ -113,6 +113,7 @@ PUT         /editions-api/fronts/:frontId/metadata               controllers.Edi
 PUT         /editions-api/fronts/:frontId/is-hidden/:state       controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
 
 POST        /editions-api/collections                            controllers.EditionsController.getCollections
+GET         /editions-api/collections/:collectionId              controllers.EditionsController.getCollection(collectionId)
 PUT         /editions-api/collections/:collectionId              controllers.EditionsController.updateCollection(collectionId)
 PATCH       /editions-api/collections/:collectionId/name         controllers.EditionsController.renameCollection(collectionId)
 GET         /editions-api/collections/:collectionId/prefill      controllers.EditionsController.getPrefillForCollection(collectionId)


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Currently, it is only possible to see a collection by making a POST request with a list of collection ids in the request body.

Adding an endpoint to GET a single collection as a debugging error (it's easier to make a GET request in the browser than a POST).

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
Currently, this route is only being used for debugging purposes.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
