### PR TITLE
a standard update to a collection should not rename it

### DIFF
--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -98,7 +98,6 @@ trait CollectionsQueries {
     sql"""
       UPDATE collections
       SET is_hidden = ${collection.isHidden},
-          "name" = ${collection.displayName},
           updated_on = $lastUpdated,
           updated_by = ${collection.updatedBy},
           updated_email = ${collection.updatedEmail}

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -374,6 +374,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       val evenMoreBrexshit = brexshit.copy(
         lastUpdated = Some(futureMillis),
+        displayName = "i=am-ignored",
         updatedBy = Some("BoJo"),
         updatedEmail = Some("bojo@piffle.paffle"),
         items = items
@@ -388,8 +389,8 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
       updatedBrexshit.updatedBy.value shouldBe "BoJo"
       updatedBrexshit.updatedEmail.value shouldBe "bojo@piffle.paffle"
-
       updatedBrexshit.lastUpdated.value shouldBe futureMillis
+      updatedBrexshit.displayName shouldBe "brexshit"
 
       // check we are storing some metadata
       updatedBrexshit.items.find(_.pageCode == "654789").value.addedOn shouldBe future.toInstant.toEpochMilli


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
We have a dedicated endpoint for collection renaming; this change further enforces its presence.

- If you want to rename a collection, request `PATCH /editions-api/collections/:collectionId/name`.
- If you want to perform any other update to the collection, request `PUT /editions-api/collections/:collectionId`.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
Related to https://github.com/guardian/facia-tool/pull/1191 and https://github.com/guardian/facia-tool/pull/1192.

Requires https://github.com/guardian/facia-tool/pull/1192 to ship first.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
