### PR TITLE
Fix image sizing in form trail image

### DIFF
--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -66,7 +66,7 @@ const ImageComponent = styled.div<{ small: boolean }>`
     left: 0;
     width: 100%;
     height: 100%;`
-      : 'position: relative'}
+      : 'position: relative;'}
   background-size: cover;
   flex-grow: 1;
   cursor: grab;


### PR DESCRIPTION
## What's changed?

It looks like the new `styled-components` of #1197 is a bit stricter about the CSS we pass it.

Before –

<img width="207" alt="Screenshot 2020-03-13 at 16 30 02" src="https://user-images.githubusercontent.com/7767575/76640523-02f6c980-6548-11ea-95b0-d21e2519d0e8.png">

After –

<img width="207" alt="Screenshot 2020-03-13 at 16 29 21" src="https://user-images.githubusercontent.com/7767575/76640539-09854100-6548-11ea-8d0e-96e4d49e4898.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
