### PR TITLE
Correct global topic name

### DIFF
--- a/test/updates/BreakingNewsUpdateTest.scala
+++ b/test/updates/BreakingNewsUpdateTest.scala
@@ -1,0 +1,50 @@
+package updates
+
+import org.scalatest.{FreeSpec, Matchers}
+import com.gu.mobile.notifications.client.models.Topic._
+import updates.BreakingNewsUpdate.CovidGlobalTopicName
+
+class BreakingNewsUpdateTest extends FreeSpec with Matchers {
+
+  def createTrail(topic: String) = ClientHydratedTrail(
+    topic = Some(topic),
+    headline = "Example headline",
+    group = None,
+    isArticle = true,
+    thumb = None,
+    image = None,
+    imageHide = None,
+    path = Some("path"),
+    shortUrl = None,
+    alert = None,
+    blockId = None
+  )
+
+  val exampleEmail = "editor@guardian.co.uk"
+
+  "createPayload" - {
+    "should not add titles for topics that don't need them" in {
+      val ukTrail = createTrail(BreakingNewsUk.name)
+      BreakingNewsUpdate.createPayload(ukTrail, exampleEmail).title shouldBe None
+    }
+
+    "should add titles for individual Coronavirus topics" in {
+      val ukTrail = createTrail(BreakingNewsCovid19Uk.name)
+      BreakingNewsUpdate.createPayload(ukTrail, exampleEmail).title shouldBe Some("Coronavirus")
+
+      val usTrail = createTrail(BreakingNewsCovid19Us.name)
+      BreakingNewsUpdate.createPayload(usTrail, exampleEmail).title shouldBe Some("Coronavirus")
+
+      val auTrail = createTrail(BreakingNewsCovid19Au.name)
+      BreakingNewsUpdate.createPayload(auTrail, exampleEmail).title shouldBe Some("Coronavirus")
+
+      val internationalTrail = createTrail(BreakingNewsCovid19International.name)
+      BreakingNewsUpdate.createPayload(internationalTrail, exampleEmail).title shouldBe Some("Coronavirus")
+    }
+
+    "should add titles for global Coronavirus topic" in {
+      val globalTrail = createTrail(CovidGlobalTopicName)
+      BreakingNewsUpdate.createPayload(globalTrail, exampleEmail).title shouldBe Some("Coronavirus")
+    }
+  }
+}


### PR DESCRIPTION
## What's changed?

#1198 had a mistake – by using `++` rather than `:+` in attempting to append a string to a list, it did the wrong thing. As a result, titles weren't present on global covid-19 notifications.

This PR corrects that mistake and adds a test to confirm.

Will be tested on CODE with normal and CV topics.

## Implementation notes

To enable easier testing, I've moved the relevant code – which is stateless – into a companion object.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
