### PR TITLE
Bump typescript

### DIFF
--- a/fronts-client/package.json
+++ b/fronts-client/package.json
@@ -71,7 +71,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "typesafe-actions": "^2.0.4",
-    "typescript": "^3.6.3",
+    "typescript": "^3.8.3",
     "typescript-eslint-parser": "^21.0.2",
     "typescript-plugin-styled-components": "^1.0.0",
     "utility-types": "^2.1.0",

--- a/fronts-client/src/types/Store.ts
+++ b/fronts-client/src/types/Store.ts
@@ -1,4 +1,4 @@
-import { Store as ReduxStore, Dispatch } from 'redux';
+import { Store as ReduxStore } from 'redux';
 import { Action } from './Action';
 import { State } from './State';
 import { ThunkDispatch, ThunkAction } from 'redux-thunk';


### PR DESCRIPTION
## What's changed?

Bumps Typescript to 3.8, enabling optional chaining, amongst other things.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
