### PR TITLE
Add state management for banner notification

### DIFF
--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -1,0 +1,31 @@
+import {
+  reducer,
+  initialState,
+  actionAddNotificationBanner,
+  actionRemoveNotificationBanner,
+  selectBannerMessage
+} from '../notificationsBundle';
+import { state as fixtureState } from 'fixtures/initialState';
+
+describe('Notifications bundle', () => {
+  describe('reducer', () => {
+    it('should add a notification banner message', () => {
+      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      expect(state.banner?.message).toBe('Example message')
+    });
+    it('should remove a notification banner message', () => {
+      const state = reducer(initialState, actionRemoveNotificationBanner())
+      expect(state.banner?.message).toBe(undefined)
+    });
+  });
+  describe('selectors', () => {
+    it('should select the current banner message, if there is one', () => {
+      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      const rootState = {
+        ...fixtureState,
+        notifications: state
+      }
+      expect(selectBannerMessage(rootState)).toBe('Example message')
+    })
+  })
+});

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -3,7 +3,7 @@ import {
   initialState,
   actionAddNotificationBanner,
   actionRemoveNotificationBanner,
-  selectBannerMessage
+  selectBanners
 } from '../notificationsBundle';
 import { state as fixtureState } from 'fixtures/initialState';
 
@@ -11,21 +11,22 @@ describe('Notifications bundle', () => {
   describe('reducer', () => {
     it('should add a notification banner message', () => {
       const state = reducer(initialState, actionAddNotificationBanner('Example message'))
-      expect(state.banner?.message).toBe('Example message')
+      expect(state.banners[0].message).toBe('Example message')
     });
     it('should remove a notification banner message', () => {
-      const state = reducer(initialState, actionRemoveNotificationBanner())
-      expect(state.banner?.message).toBe(undefined)
+      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      const newState = reducer(initialState, actionRemoveNotificationBanner(state.banners[0].id))
+      expect(newState.banners).toEqual([])
     });
   });
   describe('selectors', () => {
-    it('should select the current banner message, if there is one', () => {
+    it('should select the current banners', () => {
       const state = reducer(initialState, actionAddNotificationBanner('Example message'))
       const rootState = {
         ...fixtureState,
         notifications: state
       }
-      expect(selectBannerMessage(rootState)).toBe('Example message')
+      expect(selectBanners(rootState)).toEqual(state.banners)
     })
   })
 });

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -10,23 +10,50 @@ import { state as fixtureState } from 'fixtures/initialState';
 describe('Notifications bundle', () => {
   describe('reducer', () => {
     it('should add a notification banner message', () => {
-      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
-      expect(state.banners[0].message).toBe('Example message')
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
+      expect(state.banners[0].message).toBe('Example message');
     });
+
+    it('should find duplicate messages and bump the duplicate count rather than display a new notification', () => {
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
+      const newState = reducer(
+        state,
+        actionAddNotificationBanner('Example message')
+      );
+      expect(newState.banners.length).toBe(1);
+      expect(newState.banners[0].duplicates).toBe(2);
+    });
+
     it('should remove a notification banner message', () => {
-      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
-      const newState = reducer(initialState, actionRemoveNotificationBanner(state.banners[0].id))
-      expect(newState.banners).toEqual([])
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
+      const newState = reducer(
+        initialState,
+        actionRemoveNotificationBanner(state.banners[0].id)
+      );
+      expect(newState.banners).toEqual([]);
     });
   });
+
   describe('selectors', () => {
     it('should select the current banners', () => {
-      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
       const rootState = {
         ...fixtureState,
         notifications: state
-      }
-      expect(selectBanners(rootState)).toEqual(state.banners)
-    })
-  })
+      };
+      expect(selectBanners(rootState)).toEqual(state.banners);
+    });
+  });
 });

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -1,0 +1,50 @@
+import { Action } from 'types/Action';
+import set from 'lodash/fp/set';
+import { State } from 'types/State';
+
+interface BannerNotification {
+  message: string;
+}
+
+export interface NotificationState {
+  banner: BannerNotification | undefined;
+}
+
+// Actions
+
+export const NOTIFICATION_ADD_BANNER = 'NOTIFICATION_ADD_BANNER' as const;
+
+export const actionAddNotificationBanner = (message: string) => ({
+  type: NOTIFICATION_ADD_BANNER,
+  payload: { message }
+});
+
+export const NOTIFICATION_REMOVE_BANNER = 'NOTIFICATION_REMOVE_BANNER' as const;
+
+export const actionRemoveNotificationBanner = () => ({
+  type: NOTIFICATION_REMOVE_BANNER
+});
+
+export type NotificationActions =
+  | ReturnType<typeof actionAddNotificationBanner>
+  | ReturnType<typeof actionRemoveNotificationBanner>;
+
+// Selectors
+
+export const selectBannerMessage = (state: State) => state.notifications.banner?.message;
+
+// Reducer
+
+export const initialState: NotificationState = { banner: undefined };
+
+export const reducer = (state: NotificationState = initialState, action: Action): NotificationState => {
+  switch (action.type) {
+    case NOTIFICATION_ADD_BANNER: {
+      return set(['banner', 'message'], action.payload.message, state);
+    }
+    case NOTIFICATION_REMOVE_BANNER: {
+      return set(['banner'], undefined, state);
+    }
+  }
+  return state;
+};

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -1,13 +1,15 @@
 import { Action } from 'types/Action';
-import set from 'lodash/fp/set';
+import v4 from 'uuid/v4';
+
 import { State } from 'types/State';
 
 interface BannerNotification {
+  id: string;
   message: string;
 }
 
 export interface NotificationState {
-  banner: BannerNotification | undefined;
+  banners: BannerNotification[];
 }
 
 // Actions
@@ -16,13 +18,14 @@ export const NOTIFICATION_ADD_BANNER = 'NOTIFICATION_ADD_BANNER' as const;
 
 export const actionAddNotificationBanner = (message: string) => ({
   type: NOTIFICATION_ADD_BANNER,
-  payload: { message }
+  payload: { message, id: v4() }
 });
 
 export const NOTIFICATION_REMOVE_BANNER = 'NOTIFICATION_REMOVE_BANNER' as const;
 
-export const actionRemoveNotificationBanner = () => ({
-  type: NOTIFICATION_REMOVE_BANNER
+export const actionRemoveNotificationBanner = (id: string) => ({
+  type: NOTIFICATION_REMOVE_BANNER,
+  payload: { id }
 });
 
 export type NotificationActions =
@@ -31,19 +34,27 @@ export type NotificationActions =
 
 // Selectors
 
-export const selectBannerMessage = (state: State) => state.notifications.banner?.message;
+export const selectBanners = (state: State) => state.notifications.banners;
 
 // Reducer
 
-export const initialState: NotificationState = { banner: undefined };
+export const initialState: NotificationState = { banners: [] };
 
-export const reducer = (state: NotificationState = initialState, action: Action): NotificationState => {
+export const reducer = (
+  state: NotificationState = initialState,
+  action: Action
+): NotificationState => {
   switch (action.type) {
     case NOTIFICATION_ADD_BANNER: {
-      return set(['banner', 'message'], action.payload.message, state);
+      return {
+        banners: [
+          ...state.banners,
+          { id: action.payload.id, message: action.payload.message }
+        ]
+      };
     }
     case NOTIFICATION_REMOVE_BANNER: {
-      return set(['banner'], undefined, state);
+      return { banners: state.banners.filter(_ => _.id !== action.payload.id) };
     }
   }
   return state;

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -6,6 +6,7 @@ import { State } from 'types/State';
 interface BannerNotification {
   id: string;
   message: string;
+  duplicates: number;
 }
 
 export interface NotificationState {
@@ -46,13 +47,33 @@ export const reducer = (
 ): NotificationState => {
   switch (action.type) {
     case NOTIFICATION_ADD_BANNER: {
+      const duplicateNotification = state.banners.find(
+        _ => _.message === action.payload.message
+      );
+      if (duplicateNotification) {
+        return {
+          banners: [
+            ...state.banners.filter(_ => _.id !== duplicateNotification.id),
+            {
+              ...duplicateNotification,
+              duplicates: duplicateNotification.duplicates + 1
+            }
+          ]
+        };
+      }
+
       return {
         banners: [
           ...state.banners,
-          { id: action.payload.id, message: action.payload.message }
+          {
+            id: action.payload.id,
+            message: action.payload.message,
+            duplicates: 1
+          }
         ]
       };
     }
+
     case NOTIFICATION_REMOVE_BANNER: {
       return { banners: state.banners.filter(_ => _.id !== action.payload.id) };
     }

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -711,7 +711,8 @@ const state = {
     loading: false,
     loadingIds: [],
     updatingIds: []
-  }
+  },
+  notifications: { banner: undefined }
 } as State;
 
 export { state };

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -712,7 +712,7 @@ const state = {
     loadingIds: [],
     updatingIds: []
   },
-  notifications: { banner: undefined }
+  notifications: { banners: [] }
 } as State;
 
 export { state };

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -35,6 +35,7 @@ import {
   reducer as featureSwitches,
   State as featureSwitchesState
 } from 'reducers/featureSwitchesReducer';
+import { reducer as notificationsReducer } from 'bundles/notificationsBundle';
 
 import { Config } from 'types/Config';
 import { ActionError } from 'types/Action';
@@ -71,6 +72,7 @@ export interface State {
   collections: ReturnType<typeof collections>;
   externalArticles: ReturnType<typeof externalArticles>;
   pageViewData: ReturnType<typeof pageViewData>;
+  notifications: ReturnType<typeof notificationsReducer>;
 }
 
 const rootReducer = (state: any = { feed: {} }, action: any) => ({
@@ -97,7 +99,8 @@ const rootReducer = (state: any = { feed: {} }, action: any) => ({
   groups: groups(state.groups, action, state),
   collections: collections(state.collections, action),
   externalArticles: externalArticles(state.externalArticles, action),
-  pageViewData: pageViewData(state.pageViewData, action)
+  pageViewData: pageViewData(state.pageViewData, action),
+  notifications: notificationsReducer(state.notifications, action)
 });
 
 export default rootReducer;

--- a/fronts-client/src/types/Action.ts
+++ b/fronts-client/src/types/Action.ts
@@ -43,6 +43,7 @@ import { Actions } from 'lib/createAsyncResourceBundle';
 import { ExternalArticle } from 'types/ExternalArticle';
 import { copyCardImageMeta } from 'actions/CardsCommon';
 import { PageViewStory } from 'types/PageViewData';
+import { NotificationActions } from 'bundles/notificationsBundle';
 
 interface EditorOpenCurrentFrontsMenu {
   type: typeof EDITOR_OPEN_CURRENT_FRONTS_MENU;
@@ -443,7 +444,8 @@ type Action =
   | CapGroupSiblings
   | CopyCardImageMeta
   | PageViewDataRequested
-  | PageViewDataReceived;
+  | PageViewDataReceived
+  | NotificationActions;
 
 export {
   ActionError,

--- a/fronts-client/yarn.lock
+++ b/fronts-client/yarn.lock
@@ -10563,10 +10563,10 @@ typescript@^3.3.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
-typescript@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
## What's changed?

We'd like to display banner notifications in the app. This adds state management for banner notifications, to be used by a component in a downstream PR.

## Implementation notes

I've added duplicate-management code, as there are many things that could display this banner, but we only want one of it. YAGNI?

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
