### PR TITLE
Add a banner notification component

### DIFF
--- a/fronts-client/package.json
+++ b/fronts-client/package.json
@@ -71,7 +71,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "typesafe-actions": "^2.0.4",
-    "typescript": "^3.6.3",
+    "typescript": "^3.8.3",
     "typescript-eslint-parser": "^21.0.2",
     "typescript-plugin-styled-components": "^1.0.0",
     "utility-types": "^2.1.0",

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -1,0 +1,31 @@
+import {
+  reducer,
+  initialState,
+  actionAddNotificationBanner,
+  actionRemoveNotificationBanner,
+  selectBannerMessage
+} from '../notificationsBundle';
+import { state as fixtureState } from 'fixtures/initialState';
+
+describe('Notifications bundle', () => {
+  describe('reducer', () => {
+    it('should add a notification banner message', () => {
+      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      expect(state.banner?.message).toBe('Example message')
+    });
+    it('should remove a notification banner message', () => {
+      const state = reducer(initialState, actionRemoveNotificationBanner())
+      expect(state.banner?.message).toBe(undefined)
+    });
+  });
+  describe('selectors', () => {
+    it('should select the current banner message, if there is one', () => {
+      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      const rootState = {
+        ...fixtureState,
+        notifications: state
+      }
+      expect(selectBannerMessage(rootState)).toBe('Example message')
+    })
+  })
+});

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -3,7 +3,7 @@ import {
   initialState,
   actionAddNotificationBanner,
   actionRemoveNotificationBanner,
-  selectBannerMessage
+  selectBanners
 } from '../notificationsBundle';
 import { state as fixtureState } from 'fixtures/initialState';
 
@@ -11,21 +11,22 @@ describe('Notifications bundle', () => {
   describe('reducer', () => {
     it('should add a notification banner message', () => {
       const state = reducer(initialState, actionAddNotificationBanner('Example message'))
-      expect(state.banner?.message).toBe('Example message')
+      expect(state.banners[0].message).toBe('Example message')
     });
     it('should remove a notification banner message', () => {
-      const state = reducer(initialState, actionRemoveNotificationBanner())
-      expect(state.banner?.message).toBe(undefined)
+      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      const newState = reducer(initialState, actionRemoveNotificationBanner(state.banners[0].id))
+      expect(newState.banners).toEqual([])
     });
   });
   describe('selectors', () => {
-    it('should select the current banner message, if there is one', () => {
+    it('should select the current banners', () => {
       const state = reducer(initialState, actionAddNotificationBanner('Example message'))
       const rootState = {
         ...fixtureState,
         notifications: state
       }
-      expect(selectBannerMessage(rootState)).toBe('Example message')
+      expect(selectBanners(rootState)).toEqual(state.banners)
     })
   })
 });

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -10,23 +10,50 @@ import { state as fixtureState } from 'fixtures/initialState';
 describe('Notifications bundle', () => {
   describe('reducer', () => {
     it('should add a notification banner message', () => {
-      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
-      expect(state.banners[0].message).toBe('Example message')
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
+      expect(state.banners[0].message).toBe('Example message');
     });
+
+    it('should find duplicate messages and bump the duplicate count rather than display a new notification', () => {
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
+      const newState = reducer(
+        state,
+        actionAddNotificationBanner('Example message')
+      );
+      expect(newState.banners.length).toBe(1);
+      expect(newState.banners[0].duplicates).toBe(2);
+    });
+
     it('should remove a notification banner message', () => {
-      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
-      const newState = reducer(initialState, actionRemoveNotificationBanner(state.banners[0].id))
-      expect(newState.banners).toEqual([])
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
+      const newState = reducer(
+        initialState,
+        actionRemoveNotificationBanner(state.banners[0].id)
+      );
+      expect(newState.banners).toEqual([]);
     });
   });
+
   describe('selectors', () => {
     it('should select the current banners', () => {
-      const state = reducer(initialState, actionAddNotificationBanner('Example message'))
+      const state = reducer(
+        initialState,
+        actionAddNotificationBanner('Example message')
+      );
       const rootState = {
         ...fixtureState,
         notifications: state
-      }
-      expect(selectBanners(rootState)).toEqual(state.banners)
-    })
-  })
+      };
+      expect(selectBanners(rootState)).toEqual(state.banners);
+    });
+  });
 });

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -27,7 +27,7 @@ describe('Notifications bundle', () => {
         actionAddNotificationBanner('Example message')
       );
       expect(newState.banners.length).toBe(1);
-      expect(newState.banners[0].duplicates).toBe(2);
+      expect(newState.banners[0].duplicates).toBe(1);
     });
 
     it('should remove a notification banner message', () => {

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -1,0 +1,50 @@
+import { Action } from 'types/Action';
+import set from 'lodash/fp/set';
+import { State } from 'types/State';
+
+interface BannerNotification {
+  message: string;
+}
+
+export interface NotificationState {
+  banner: BannerNotification | undefined;
+}
+
+// Actions
+
+export const NOTIFICATION_ADD_BANNER = 'NOTIFICATION_ADD_BANNER' as const;
+
+export const actionAddNotificationBanner = (message: string) => ({
+  type: NOTIFICATION_ADD_BANNER,
+  payload: { message }
+});
+
+export const NOTIFICATION_REMOVE_BANNER = 'NOTIFICATION_REMOVE_BANNER' as const;
+
+export const actionRemoveNotificationBanner = () => ({
+  type: NOTIFICATION_REMOVE_BANNER
+});
+
+export type NotificationActions =
+  | ReturnType<typeof actionAddNotificationBanner>
+  | ReturnType<typeof actionRemoveNotificationBanner>;
+
+// Selectors
+
+export const selectBannerMessage = (state: State) => state.notifications.banner?.message;
+
+// Reducer
+
+export const initialState: NotificationState = { banner: undefined };
+
+export const reducer = (state: NotificationState = initialState, action: Action): NotificationState => {
+  switch (action.type) {
+    case NOTIFICATION_ADD_BANNER: {
+      return set(['banner', 'message'], action.payload.message, state);
+    }
+    case NOTIFICATION_REMOVE_BANNER: {
+      return set(['banner'], undefined, state);
+    }
+  }
+  return state;
+};

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -1,13 +1,15 @@
 import { Action } from 'types/Action';
-import set from 'lodash/fp/set';
+import v4 from 'uuid/v4';
+
 import { State } from 'types/State';
 
 interface BannerNotification {
+  id: string;
   message: string;
 }
 
 export interface NotificationState {
-  banner: BannerNotification | undefined;
+  banners: BannerNotification[];
 }
 
 // Actions
@@ -16,13 +18,14 @@ export const NOTIFICATION_ADD_BANNER = 'NOTIFICATION_ADD_BANNER' as const;
 
 export const actionAddNotificationBanner = (message: string) => ({
   type: NOTIFICATION_ADD_BANNER,
-  payload: { message }
+  payload: { message, id: v4() }
 });
 
 export const NOTIFICATION_REMOVE_BANNER = 'NOTIFICATION_REMOVE_BANNER' as const;
 
-export const actionRemoveNotificationBanner = () => ({
-  type: NOTIFICATION_REMOVE_BANNER
+export const actionRemoveNotificationBanner = (id: string) => ({
+  type: NOTIFICATION_REMOVE_BANNER,
+  payload: { id }
 });
 
 export type NotificationActions =
@@ -31,19 +34,27 @@ export type NotificationActions =
 
 // Selectors
 
-export const selectBannerMessage = (state: State) => state.notifications.banner?.message;
+export const selectBanners = (state: State) => state.notifications.banners;
 
 // Reducer
 
-export const initialState: NotificationState = { banner: undefined };
+export const initialState: NotificationState = { banners: [] };
 
-export const reducer = (state: NotificationState = initialState, action: Action): NotificationState => {
+export const reducer = (
+  state: NotificationState = initialState,
+  action: Action
+): NotificationState => {
   switch (action.type) {
     case NOTIFICATION_ADD_BANNER: {
-      return set(['banner', 'message'], action.payload.message, state);
+      return {
+        banners: [
+          ...state.banners,
+          { id: action.payload.id, message: action.payload.message }
+        ]
+      };
     }
     case NOTIFICATION_REMOVE_BANNER: {
-      return set(['banner'], undefined, state);
+      return { banners: state.banners.filter(_ => _.id !== action.payload.id) };
     }
   }
   return state;

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -6,6 +6,7 @@ import { State } from 'types/State';
 interface BannerNotification {
   id: string;
   message: string;
+  duplicates: number;
 }
 
 export interface NotificationState {
@@ -46,13 +47,33 @@ export const reducer = (
 ): NotificationState => {
   switch (action.type) {
     case NOTIFICATION_ADD_BANNER: {
+      const duplicateNotification = state.banners.find(
+        _ => _.message === action.payload.message
+      );
+      if (duplicateNotification) {
+        return {
+          banners: [
+            ...state.banners.filter(_ => _.id !== duplicateNotification.id),
+            {
+              ...duplicateNotification,
+              duplicates: duplicateNotification.duplicates + 1
+            }
+          ]
+        };
+      }
+
       return {
         banners: [
           ...state.banners,
-          { id: action.payload.id, message: action.payload.message }
+          {
+            id: action.payload.id,
+            message: action.payload.message,
+            duplicates: 1
+          }
         ]
       };
     }
+
     case NOTIFICATION_REMOVE_BANNER: {
       return { banners: state.banners.filter(_ => _.id !== action.payload.id) };
     }

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -68,7 +68,7 @@ export const reducer = (
           {
             id: action.payload.id,
             message: action.payload.message,
-            duplicates: 1
+            duplicates: 0
           }
         ]
       };

--- a/fronts-client/src/components/App.tsx
+++ b/fronts-client/src/components/App.tsx
@@ -127,6 +127,7 @@ const AppFonts = createGlobalStyle`
 
 const AppContainer = styled.div`
   background-color: ${theme.base.colors.backgroundColorLight};
+  position: relative;
   color: ${theme.base.colors.textDark};
   height: 100%;
   width: 100%;

--- a/fronts-client/src/components/App.tsx
+++ b/fronts-client/src/components/App.tsx
@@ -39,6 +39,7 @@ import ManageView from './Editions/ManageView';
 import FeaturesView from './Features/FeaturesView';
 import { PlaceholderAnimation } from 'components/BasePlaceholder';
 import OptionsModal from './OptionsModal';
+import BannerNotification from './notifications/BannerNotification';
 
 // tslint:disable:no-unused-expression
 // NB the properties described in font-face work as matchers, assigning text to the font imported by the source.
@@ -141,6 +142,7 @@ const BackgroundHeader = styled.div`
 const App = () => (
   <ThemeProvider theme={styleTheme}>
     <DropDisabler>
+      <BannerNotification />
       <AppContainer>
         <BackgroundHeader>
           <SectionHeaderWithLogo greyHeader={true} />

--- a/fronts-client/src/components/inputs/ButtonDefault.ts
+++ b/fronts-client/src/components/inputs/ButtonDefault.ts
@@ -2,7 +2,7 @@ import { styled } from 'constants/theme';
 import { theme } from '../../constants/theme';
 
 type ButtonSizes = 's' | 'm' | 'l';
-type ButtonPriorities = 'primary' | 'default' | 'muted';
+type ButtonPriorities = 'primary' | 'default' | 'muted' | 'transparent';
 
 type SizeMap = { [k in ButtonSizes]: string };
 type PriorityMap = { [k in ButtonPriorities]: string };
@@ -44,17 +44,20 @@ const colorMap = {
   disabled: {
     default: theme.colors.white,
     primary: theme.colors.greyLight,
-    muted: theme.colors.blackLight
+    muted: theme.colors.blackLight,
+    transparent: theme.colors.white
   },
   selected: {
     default: theme.colors.white,
     primary: theme.colors.white,
-    muted: theme.colors.blackLight
+    muted: theme.colors.blackLight,
+    transparent: theme.colors.white
   },
   deselected: {
     default: theme.colors.white,
     primary: theme.colors.blackDark,
-    muted: theme.colors.blackLight
+    muted: theme.colors.blackLight,
+    transparent: theme.colors.white
   }
 };
 
@@ -62,17 +65,20 @@ const backgroundMap = {
   disabled: {
     default: theme.colors.greyMediumLight,
     primary: theme.colors.whiteMedium,
-    muted: theme.colors.greyLight
+    muted: theme.colors.greyLight,
+    transparent: theme.colors.blackTransparent20
   },
   selected: {
     default: theme.colors.greyMediumDark,
     primary: theme.colors.orangeLight,
-    muted: theme.colors.greyLight
+    muted: theme.colors.greyLight,
+    transparent: theme.colors.blackTransparent60
   },
   deselected: {
     default: theme.colors.blackLight,
     primary: theme.colors.orange,
-    muted: theme.colors.greyLightPinkish
+    muted: theme.colors.greyLightPinkish,
+    transparent: theme.colors.blackTransparent40
   }
 };
 
@@ -80,17 +86,20 @@ const backgroundHoverMap = {
   disabled: {
     default: theme.colors.greyMediumLight,
     primary: theme.colors.orangeDark,
-    muted: theme.colors.greyLight
+    muted: theme.colors.greyLight,
+    transparent: theme.colors.blackTransparent20
   },
   selected: {
     default: theme.colors.greyMediumDark,
     primary: theme.colors.orangeLight,
-    muted: theme.colors.greyLight
+    muted: theme.colors.greyLight,
+    transparent: theme.colors.blackTransparent60
   },
   deselected: {
     default: theme.colors.greyMediumDark,
     primary: theme.colors.orangeLight,
-    muted: theme.colors.greyLight
+    muted: theme.colors.greyLight,
+    transparent: theme.colors.blackTransparent60
   }
 };
 

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { styled, theme } from 'constants/theme';
+import { connect } from 'react-redux';
+import { State } from 'types/State';
+import { bindActionCreators } from 'redux';
+
+import {
+  selectBannerMessage,
+  actionRemoveNotificationBanner
+} from 'bundles/notificationsBundle';
+import { Dispatch } from 'types/Store';
+import { ClearIcon } from 'components/icons/Icons';
+import Button from 'components/inputs/ButtonDefault';
+
+type Props = ReturnType<typeof mapStateToProps> &
+  ReturnType<typeof mapDispatchToProps>;
+
+const BannerWrapper = styled.div`
+  background-color: ${theme.base.colors.dangerColor};
+  display: flex;
+  position: relative;
+  padding: 10px;
+  text-align: center;
+  color: white;
+`;
+
+const Message = styled.div`
+  flex-grow: 1;
+`;
+
+const CloseButton = styled(Button).attrs({ size: 'm', priority: 'transparent' })`
+  margin-left: auto;
+  padding: 0;
+  width: 26px;
+`;
+
+const NotificationsBanner = ({
+  message,
+  actionRemoveNotificationBanner: removeNotificationBanner
+}: Props) => (
+  <BannerWrapper>
+    <Message>{message}</Message>
+    <CloseButton onClick={removeNotificationBanner}>
+      <ClearIcon size="fill" />
+    </CloseButton>
+  </BannerWrapper>
+);
+
+const mapStateToProps = (state: State) => ({
+  message: selectBannerMessage(state)
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) =>
+  bindActionCreators({ actionRemoveNotificationBanner }, dispatch);
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NotificationsBanner);

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -5,7 +5,7 @@ import { State } from 'types/State';
 import { bindActionCreators } from 'redux';
 
 import {
-  selectBannerMessage,
+  selectBanners,
   actionRemoveNotificationBanner
 } from 'bundles/notificationsBundle';
 import { Dispatch } from 'types/Store';
@@ -22,6 +22,9 @@ const BannerWrapper = styled.div`
   padding: 10px;
   text-align: center;
   color: white;
+  & + & {
+    border-top: 1px solid ${theme.colors.blackTransparent20};
+  }
 `;
 
 const Message = styled.div`
@@ -39,20 +42,26 @@ const CloseButton = styled(Button).attrs({
 `;
 
 const NotificationsBanner = ({
-  message,
+  banners,
   actionRemoveNotificationBanner: removeNotificationBanner
-}: Props) =>
-  message ? (
-    <BannerWrapper>
-      <Message>{message}</Message>
-      <CloseButton onClick={removeNotificationBanner}>
-        <ClearIcon size="fill" />
-      </CloseButton>
-    </BannerWrapper>
-  ) : null;
+}: Props) => (
+  <>
+    {banners.map(banner => (
+      <BannerWrapper>
+        <Message>
+          {banner.message}
+          {banner.duplicates ? ` (${banner.duplicates + 1})` : ''}
+        </Message>
+        <CloseButton onClick={() => removeNotificationBanner(banner.id)}>
+          <ClearIcon size="fill" />
+        </CloseButton>
+      </BannerWrapper>
+    ))}
+  </>
+);
 
 const mapStateToProps = (state: State) => ({
-  message: selectBannerMessage(state)
+  banners: selectBanners(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) =>

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -28,23 +28,28 @@ const Message = styled.div`
   flex-grow: 1;
 `;
 
-const CloseButton = styled(Button).attrs({ size: 'm', priority: 'transparent' })`
+const CloseButton = styled(Button).attrs({
+  size: 'm',
+  priority: 'transparent'
+})`
   margin-left: auto;
   padding: 0;
   width: 26px;
+  flex-shrink: 0;
 `;
 
 const NotificationsBanner = ({
   message,
   actionRemoveNotificationBanner: removeNotificationBanner
-}: Props) => (
-  <BannerWrapper>
-    <Message>{message}</Message>
-    <CloseButton onClick={removeNotificationBanner}>
-      <ClearIcon size="fill" />
-    </CloseButton>
-  </BannerWrapper>
-);
+}: Props) =>
+  message ? (
+    <BannerWrapper>
+      <Message>{message}</Message>
+      <CloseButton onClick={removeNotificationBanner}>
+        <ClearIcon size="fill" />
+      </CloseButton>
+    </BannerWrapper>
+  ) : null;
 
 const mapStateToProps = (state: State) => ({
   message: selectBannerMessage(state)

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -47,7 +47,7 @@ const NotificationsBanner = ({
 }: Props) => (
   <>
     {banners.map(banner => (
-      <BannerWrapper>
+      <BannerWrapper key={banner.id}>
         <Message>
           {banner.message}
           {banner.duplicates ? ` (${banner.duplicates + 1})` : ''}

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -36,7 +36,8 @@ const colors = {
   greenLight: '#ddead9',
   red: '#d01d00',
   blackTransparent20: 'rgba(0,0,0,0.2)',
-  blackTransparent40: 'rgba(0,0,0,0.4)'
+  blackTransparent40: 'rgba(0,0,0,0.4)',
+  blackTransparent60: 'rgba(0,0,0,0.6)'
 };
 
 const base = {

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -33,7 +33,10 @@ const colors = {
   yellow: '#FFE500',
   green: '#4F9245',
   greenDark: '#36842A',
-  greenLight: '#ddead9'
+  greenLight: '#ddead9',
+  red: '#d01d00',
+  blackTransparent20: 'rgba(0,0,0,0.2)',
+  blackTransparent40: 'rgba(0,0,0,0.4)'
 };
 
 const base = {
@@ -64,7 +67,8 @@ const base = {
     borderColorFocus: colors.greyLight,
     placeholderLight: colors.greyLightPinkish,
     placeholderDark: colors.greyLight,
-    focusColor: colors.orange
+    focusColor: colors.orange,
+    dangerColor: colors.red
   }
 };
 

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -711,7 +711,8 @@ const state = {
     loading: false,
     loadingIds: [],
     updatingIds: []
-  }
+  },
+  notifications: { banner: undefined }
 } as State;
 
 export { state };

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -712,7 +712,7 @@ const state = {
     loadingIds: [],
     updatingIds: []
   },
-  notifications: { banner: undefined }
+  notifications: { banners: [] }
 } as State;
 
 export { state };

--- a/fronts-client/src/reducers/rootReducer.ts
+++ b/fronts-client/src/reducers/rootReducer.ts
@@ -35,6 +35,7 @@ import {
   reducer as featureSwitches,
   State as featureSwitchesState
 } from 'reducers/featureSwitchesReducer';
+import { reducer as notificationsReducer } from 'bundles/notificationsBundle';
 
 import { Config } from 'types/Config';
 import { ActionError } from 'types/Action';
@@ -71,6 +72,7 @@ export interface State {
   collections: ReturnType<typeof collections>;
   externalArticles: ReturnType<typeof externalArticles>;
   pageViewData: ReturnType<typeof pageViewData>;
+  notifications: ReturnType<typeof notificationsReducer>;
 }
 
 const rootReducer = (state: any = { feed: {} }, action: any) => ({
@@ -97,7 +99,8 @@ const rootReducer = (state: any = { feed: {} }, action: any) => ({
   groups: groups(state.groups, action, state),
   collections: collections(state.collections, action),
   externalArticles: externalArticles(state.externalArticles, action),
-  pageViewData: pageViewData(state.pageViewData, action)
+  pageViewData: pageViewData(state.pageViewData, action),
+  notifications: notificationsReducer(state.notifications, action)
 });
 
 export default rootReducer;

--- a/fronts-client/src/types/Action.ts
+++ b/fronts-client/src/types/Action.ts
@@ -43,6 +43,7 @@ import { Actions } from 'lib/createAsyncResourceBundle';
 import { ExternalArticle } from 'types/ExternalArticle';
 import { copyCardImageMeta } from 'actions/CardsCommon';
 import { PageViewStory } from 'types/PageViewData';
+import { NotificationActions } from 'bundles/notificationsBundle';
 
 interface EditorOpenCurrentFrontsMenu {
   type: typeof EDITOR_OPEN_CURRENT_FRONTS_MENU;
@@ -443,7 +444,8 @@ type Action =
   | CapGroupSiblings
   | CopyCardImageMeta
   | PageViewDataRequested
-  | PageViewDataReceived;
+  | PageViewDataReceived
+  | NotificationActions;
 
 export {
   ActionError,

--- a/fronts-client/src/types/Store.ts
+++ b/fronts-client/src/types/Store.ts
@@ -1,4 +1,4 @@
-import { Store as ReduxStore, Dispatch } from 'redux';
+import { Store as ReduxStore } from 'redux';
 import { Action } from './Action';
 import { State } from './State';
 import { ThunkDispatch, ThunkAction } from 'redux-thunk';

--- a/fronts-client/yarn.lock
+++ b/fronts-client/yarn.lock
@@ -10563,10 +10563,10 @@ typescript@^3.3.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
-typescript@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
## What's changed?

Adds a banner notification component to the app. It'll be wired up to error-handling code in a downstream PR.

When more than one notification is launched with the same message, we group it and add the number of iterations in parentheses – see the second notification in the gif below. We might want to add a per-notification type to refine this later on, but this implementation should be fine for the current use case.

![banner](https://user-images.githubusercontent.com/7767575/77641277-b3ef6200-6f53-11ea-9aa6-4fc5a04a3d5c.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
