### PR TITLE
Notify users when auth fails

### DIFF
--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -12,19 +12,31 @@ describe('Notifications bundle', () => {
     it('should add a notification banner message', () => {
       const state = reducer(
         initialState,
-        actionAddNotificationBanner('Example message')
+        actionAddNotificationBanner({
+          message: 'Example message',
+          level: 'error',
+        })
       );
-      expect(state.banners[0].message).toBe('Example message');
+      expect(state.banners[0].message).toBe({
+        message: 'Example message',
+        level: 'error',
+      });
     });
 
     it('should find duplicate messages and bump the duplicate count rather than display a new notification', () => {
       const state = reducer(
         initialState,
-        actionAddNotificationBanner('Example message')
+        actionAddNotificationBanner({
+          message: 'Example message',
+          level: 'error',
+        })
       );
       const newState = reducer(
         state,
-        actionAddNotificationBanner('Example message')
+        actionAddNotificationBanner({
+          message: 'Example message',
+          level: 'error',
+        })
       );
       expect(newState.banners.length).toBe(1);
       expect(newState.banners[0].duplicates).toBe(1);
@@ -33,7 +45,10 @@ describe('Notifications bundle', () => {
     it('should remove a notification banner message', () => {
       const state = reducer(
         initialState,
-        actionAddNotificationBanner('Example message')
+        actionAddNotificationBanner({
+          message: 'Example message',
+          level: 'error',
+        })
       );
       const newState = reducer(
         initialState,
@@ -47,7 +62,10 @@ describe('Notifications bundle', () => {
     it('should select the current banners', () => {
       const state = reducer(
         initialState,
-        actionAddNotificationBanner('Example message')
+        actionAddNotificationBanner({
+          message: 'Example message',
+          level: 'error',
+        })
       );
       const rootState = {
         ...fixtureState,

--- a/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/notificationsBundle.spec.ts
@@ -17,10 +17,7 @@ describe('Notifications bundle', () => {
           level: 'error',
         })
       );
-      expect(state.banners[0].message).toBe({
-        message: 'Example message',
-        level: 'error',
-      });
+      expect(state.banners[0].message).toEqual('Example message');
     });
 
     it('should find duplicate messages and bump the duplicate count rather than display a new notification', () => {

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -2,23 +2,29 @@ import type { Action } from 'types/Action';
 import type { State } from 'types/State';
 import v4 from 'uuid/v4';
 
-interface BannerNotification {
-  id: string;
+type NotificationLevels = 'error';
+
+export interface Notification {
   message: string;
+  level: NotificationLevels
+}
+
+interface InternalBannerNotification extends Notification {
+  id: string;
   duplicates: number;
 }
 
 export interface NotificationState {
-  banners: BannerNotification[];
+  banners: InternalBannerNotification[];
 }
 
 // Actions
 
 export const NOTIFICATION_ADD_BANNER = 'NOTIFICATION_ADD_BANNER' as const;
 
-export const actionAddNotificationBanner = (message: string) => ({
+export const actionAddNotificationBanner = (notification: Notification) => ({
   type: NOTIFICATION_ADD_BANNER,
-  payload: { message, id: v4() },
+  payload: { ...notification, id: v4() },
 });
 
 export const NOTIFICATION_REMOVE_BANNER = 'NOTIFICATION_REMOVE_BANNER' as const;
@@ -67,8 +73,7 @@ export const reducer = (
         banners: [
           ...state.banners,
           {
-            id: action.payload.id,
-            message: action.payload.message,
+            ...action.payload,
             duplicates: 0,
           },
         ],

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -6,7 +6,7 @@ type NotificationLevels = 'error';
 
 export interface Notification {
   message: string;
-  level: NotificationLevels
+  level: NotificationLevels;
 }
 
 interface InternalBannerNotification extends Notification {

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -21,7 +21,7 @@ const BannerWrapper = styled.div`
   position: relative;
   padding: 10px;
   text-align: center;
-  color: white;
+  color: ${theme.base.colors.textLight};
   & + & {
     border-top: 1px solid ${theme.colors.blackTransparent20};
   }
@@ -29,6 +29,10 @@ const BannerWrapper = styled.div`
 
 const Message = styled.div`
   flex-grow: 1;
+  a,
+  a:hover {
+    color: ${theme.base.colors.textLight};
+  }
 `;
 
 const CloseButton = styled(Button).attrs({
@@ -49,7 +53,7 @@ const NotificationsBanner = ({
     {banners.map((banner) => (
       <BannerWrapper key={banner.id}>
         <Message>
-          {banner.message}
+          <span dangerouslySetInnerHTML={{ __html: banner.message }} />
           {banner.duplicates ? ` (${banner.duplicates + 1})` : ''}
         </Message>
         <CloseButton onClick={() => removeNotificationBanner(banner.id)}>

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -22,10 +22,17 @@ import pollingConfig from 'util/pollingConfig';
 import { base } from 'routes/routes';
 import { actionSetFeatureValue } from 'actions/FeatureSwitches';
 import { deleteIssue } from 'util/delete';
+import notifications from 'services/notifications';
+import { actionAddNotificationBanner } from 'bundles/notificationsBundle';
 
 initGA();
 
 const store = configureStore();
+
+// Wire up our notifications service
+notifications.subscribe((notification) =>
+  store.dispatch(actionAddNotificationBanner(notification))
+);
 
 // @ts-ignore -- Unbind is not used yet but can be used for removed all the
 // keyboard events. The keyboardActionMap contains a list of all active keyboard

--- a/fronts-client/src/services/__tests__/notifications.spec.ts
+++ b/fronts-client/src/services/__tests__/notifications.spec.ts
@@ -1,0 +1,20 @@
+import notifications from 'services/notifications';
+
+describe('Notifications service', () => {
+  it('should accept subscriptions and notify them when events are received', () => {
+    const notification = { level: 'error' as const, message: 'message' };
+    const subscriber = jest.fn();
+    notifications.subscribe(subscriber);
+    notifications.notify(notification);
+    expect(subscriber.mock.calls[0][0]).toEqual(notification);
+  });
+
+  it('should allow subscribed services to unsubscribe', () => {
+    const notification = { level: 'error' as const, message: 'message' };
+    const subscriber = jest.fn();
+    notifications.subscribe(subscriber);
+    notifications.unsubscribe(subscriber);
+    notifications.notify(notification);
+    expect(subscriber.mock.calls[0]).toEqual(undefined);
+  });
+});

--- a/fronts-client/src/services/notifications.ts
+++ b/fronts-client/src/services/notifications.ts
@@ -1,0 +1,28 @@
+import { Notification } from 'bundles/notificationsBundle';
+
+type Subscriber = (notification: Notification) => void;
+
+/**
+ * An singleton event bus to decouple parts of the app that need to
+ * create notifications from the store.
+ *
+ * This is necessary because importing the store directly results in
+ * circular dependencies.
+ */
+class NotificationService {
+  private subscribers = [] as Subscriber[];
+
+  public subscribe(subscriber: Subscriber) {
+    this.subscribers.push(subscriber);
+  }
+
+  public unsubscribe(subscriber: Subscriber) {
+    this.subscribers = this.subscribers.filter((_) => _ !== subscriber);
+  }
+
+  public notify(notification: Notification) {
+    this.subscribers.forEach((sub) => sub(notification));
+  }
+}
+
+export default new NotificationService();

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -2,7 +2,7 @@ import { reEstablishSession } from 'panda-session';
 import notifications from './notifications';
 
 const reauthUrl = '/login/status';
-const reauthErrorMessage = `We couldn't log you back in. Please log in again to reauthenticate.`;
+const reauthErrorMessage = `We couldn't log you back in. Your changes may not be saved. Please log in again to reauthenticate.`;
 
 /**
  * Make a fetch request with Panda authentication.
@@ -28,10 +28,10 @@ const pandaFetch = (
           const res2 = await pandaFetch(url, options, count + 1);
           return resolve(res2);
         } catch (e) {
-          notifications.notify({ message: reauthErrorMessage, level: 'error' });
           return reject(e);
         }
       } else if (res.status < 200 || res.status >= 300) {
+        notifications.notify({ message: reauthErrorMessage, level: 'error' });
         return reject(res);
       }
 

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -2,7 +2,7 @@ import { reEstablishSession } from 'panda-session';
 import notifications from './notifications';
 
 const reauthUrl = '/login/status';
-const reauthErrorMessage = `We couldn't log you back in. Your changes may not be saved. Please log in again to reauthenticate.`;
+const reauthErrorMessage = `We couldn't log you back in. Your changes may not be saved. Please  <a href="${window.location.href}" target="_self">log in again</a> to reauthenticate.`;
 
 /**
  * Make a fetch request with Panda authentication.

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -1,6 +1,8 @@
 import { reEstablishSession } from 'panda-session';
+import notifications from './notifications';
 
 const reauthUrl = '/login/status';
+const reauthErrorMessage = `We couldn't log you back in. Please log in again to reauthenticate.`;
 
 /**
  * Make a fetch request with Panda authentication.
@@ -26,6 +28,7 @@ const pandaFetch = (
           const res2 = await pandaFetch(url, options, count + 1);
           return resolve(res2);
         } catch (e) {
+          notifications.notify({ message: reauthErrorMessage, level: 'error' });
           return reject(e);
         }
       } else if (res.status < 200 || res.status >= 300) {


### PR DESCRIPTION
## What's changed?

Notifies users when authentication fails. The number on the right hand side ticks up when things fail, with the reasoning – a) this deduplicates notifications which would otherwise be endless, and b) it provides some feedback that stateful operations aren't being saved as they happen.

![auth](https://user-images.githubusercontent.com/7767575/78015793-cf86ae00-7341-11ea-9fb7-1f743e47640b.gif)

Let me know if the banner could be better worded!

## Implementation notes

We've added an event bus for notifications, as directly importing the store results in circular dependencies which are dangerous and break tests (see #1207 for details). This is the neatest way I and @akash1810 could think of to decouple the store from the code asking for notifications, but any feedback gratefully received.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
