### PR TITLE
Increase the container count in Top Stories to 3

### DIFF
--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -46,6 +46,8 @@ object AustralianEdition {
 
   def FrontTopStoriesAu = front(
     "Top stories",
+    collection("Top Stories"),
+    collection("Top Stories"),
     collection("Top Stories")
   )
     .swatch(News)


### PR DESCRIPTION
Added two more Top stories containers.

## What's changed?
Added a couple more top stories containers. This will let them use three cover cards in a row.

## Implementation notes
Edited in Github.

## Checklist