### PR TITLE
Upped the container count in the first front to 3

### DIFF
--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -49,7 +49,10 @@ object AmericanEdition {
 
   def FrontEssentialReadsUs = front(
     "Essential Reads",
+    collection("Essential Reads"),
+    collection("Essential Reads"),
     collection("Essential Reads")
+
   )
     .swatch(News)
   


### PR DESCRIPTION
To allow multiple covercards in a row

## What's changed?
two additional containers on the first front
## Implementation notes
edited in Github 
