### PR TITLE
Trim collection and front name on rename

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -149,7 +149,7 @@ class EditionsController(db: EditionsDB,
       NotFound(s"Collection $collectionId not found")
     } else {
       val updatingCollection = collection.head.copy(
-        displayName = req.body.collection.displayName,
+        displayName = req.body.collection.displayName.trim(),
         updatedBy = Some(UserUtil.getDisplayName(req.user)),
         updatedEmail = Some(req.user.email)
       )

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -149,7 +149,7 @@ class EditionsController(db: EditionsDB,
       NotFound(s"Collection $collectionId not found")
     } else {
       val updatingCollection = collection.head.copy(
-        displayName = req.body.collection.displayName.trim(),
+        displayName = req.body.collection.displayName,
         updatedBy = Some(UserUtil.getDisplayName(req.user)),
         updatedEmail = Some(req.user.email)
       )

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -76,7 +76,7 @@ trait CollectionsQueries {
     val lastUpdated = LocalDateTime.now()
     sql"""
       UPDATE collections
-      SET "name" = ${collection.displayName},
+      SET "name" = ${collection.displayName.trim()},
           updated_on = $lastUpdated,
           updated_by = ${collection.updatedBy},
           updated_email = ${collection.updatedEmail}

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -7,9 +7,10 @@ import play.api.libs.json._
 
 trait FrontsQueries extends Logging {
   def updateFrontMetadata(id: String, metadata: EditionsFrontMetadata): Option[EditionsFrontMetadata] = DB localTx { implicit session =>
+    val updatedMetadata = metadata.copy(nameOverride = metadata.nameOverride.map(_.trim()))
     sql"""
           UPDATE fronts
-          SET metadata = ${metadata.toPGobject}
+          SET metadata = ${updatedMetadata.toPGobject}
           WHERE id = $id
       """.execute().apply()
 

--- a/fronts-client/integration/tests/editions.spec.js
+++ b/fronts-client/integration/tests/editions.spec.js
@@ -48,6 +48,20 @@ test('Check renaming a front works', async t => {
     .eql('Super neat custom front name');
 });
 
+test('Check renaming a front trims whitespace', async t => {
+  await t
+    .click(frontsMenuButton())
+    .click(frontsMenuItem(1))
+    .expect(frontName(0).textContent)
+    .eql('Special 1')
+    .click(renameFrontButton(0))
+    .selectText(renameFrontInput())
+    .typeText(renameFrontInput(), 'Super neat custom front name        ')
+    .pressKey('enter')
+    .expect(frontName(0).textContent)
+    .eql('Super neat custom front name');
+});
+
 test('Check publish edition button opens modal', async t => {
   await t
     .click(publishEditionButton())

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -261,6 +261,7 @@ function updateCollection(
       batchActions([
         collectionActions.updateStart({
           ...collection,
+          displayName: collection.displayName.trim(),
           updatedEmail: selectUserEmail(getState()) || '',
           updatedBy: `${selectFirstName(state)} ${selectLastName(state)}`,
           lastUpdated: Date.now(),

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -261,7 +261,7 @@ function updateCollection(
       batchActions([
         collectionActions.updateStart({
           ...collection,
-          displayName: collection.displayName.trim(),
+          displayName: collection.displayName && collection.displayName.trim(),
           updatedEmail: selectUserEmail(getState()) || '',
           updatedBy: `${selectFirstName(state)} ${selectLastName(state)}`,
           lastUpdated: Date.now(),

--- a/fronts-client/src/actions/Editions.tsx
+++ b/fronts-client/src/actions/Editions.tsx
@@ -83,7 +83,12 @@ export const updateFrontMetadata = (
   metadata: EditionsFrontMetadata
 ): ThunkResult<Promise<void>> => async (dispatch: Dispatch) => {
   try {
-    const serverMetadata = await putFrontMetadata(id, metadata);
+    const nameOverride = metadata.nameOverride && metadata.nameOverride.trim();
+    const serverMetadata = await putFrontMetadata(id, {
+      ...metadata,
+      nameOverride,
+    });
+
     dispatch({
       type: 'FETCH_UPDATE_METADATA_SUCCESS',
       payload: {


### PR DESCRIPTION
## What's changed?

Whitespace at the end of collection names was causing problems on Android editions.

This PR trims the collection and front names when they're renamed on both the client and server.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
