### PR TITLE
Added two new containers

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -104,6 +104,7 @@ object DailyEdition {
     "World",
     collection("World").printSentAnyTag("theguardian/mainsection/international"),
     collection("World").hide,
+    collection("World").hide,
     collection("World").hide
   )
     .swatch(News)
@@ -121,6 +122,7 @@ object DailyEdition {
   def FrontNewsWorldObserver = front(
     "World",
     collection("World").printSentAnyTag("theobserver/news/worldnews"),
+    collection("World").hide,
     collection("World").hide,
     collection("World").hide
   )


### PR DESCRIPTION
Added on new container each to Guardian World and Observer World.

## What's changed?
There is one new generic world container in both the Guardian and Observer World fronts. This is to give them more options for content grouping as the World sections are larger than normal due to our award winning Corona coverage.

## Implementation notes
Edited by a product manager in Github and untested.
