### PR TITLE
Begin adding metadata to templates

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -7,7 +7,8 @@ import com.gu.contentapi.json.CirceEncoders._
 import io.circe.syntax._
 import logging.Logging
 import logic.EditionsChecker
-import model.editions.{CapiTimeWindowConfigInDays, Edition, EditionsCollection, EditionsFrontMetadata, EditionsFrontendCollectionWrapper, EditionsTemplates}
+import model.editions._
+import model.editions.templates.EditionDefinition
 import model.forms._
 import net.logstash.logback.marker.Markers
 import play.api.Logger
@@ -176,7 +177,7 @@ class EditionsController(db: EditionsDB,
     db.getCollectionPrefill(id).map { prefillUpdate =>
       logger.info(s"getPrefillForCollection id=$id, prefillUpdate")
       import prefillUpdate._
-      val capiDateQueryParam = EditionsTemplates.templates(edition).capiDateQueryParam
+      val capiDateQueryParam = EditionsTemplates.templates(edition).template.capiDateQueryParam
       val capiPrefillTimeParams = CapiPrefillTimeParams(capiQueryTimeWindow, capiDateQueryParam)
       // TODO
       // when we click (suggest articles) for collection we are not using ophan metrics and we are not sorting on them

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import logging.Logging
 import logic.EditionsChecker
 import model.editions._
-import model.editions.templates.EditionDefinition
+import model.editions.templates.{EditionDefinition, EditionType}
 import model.forms._
 import net.logstash.logback.marker.Markers
 import play.api.Logger
@@ -86,9 +86,19 @@ class EditionsController(db: EditionsDB,
       .getOrElse(NotFound(s"Issue $id not found"))
   }
 
-  def getAvailableEditions = EditEditionsAuthAction { _ =>
-    Ok(Json.toJson(EditionsTemplates.getAvailableEditions))
-  }
+  def getAvailableEditions = EditEditionsAuthAction { _ => {
+    val allEditions = EditionsTemplates.getAvailableEditions
+    val regionalEditions = allEditions.filter(e => e.editionType == EditionType.Regional)
+    val specialEditions = allEditions.filter(e => e.editionType == EditionType.Special)
+    val trainingEditions = allEditions.filter(e => e.editionType == EditionType.Training)
+    val editions = Map(
+      "regionalEditions" -> regionalEditions,
+      "specialEditions" -> specialEditions,
+      "trainingEditions" -> trainingEditions
+    )
+    Ok(Json.toJson(editions))
+
+  }}
 
   def checkIssue(id: String) = EditEditionsAuthAction { _ =>
     val maybeIssue = db.getIssue(id)

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -7,21 +7,21 @@ import enumeratum.EnumEntry.{Hyphencase, Uncapitalised}
 import enumeratum.{EnumEntry, PlayEnum}
 import model.editions.PathType.{PrintSent, Search}
 import model.editions.templates.TemplateHelpers.Defaults
-import model.editions.templates.{AmericanEdition, AustralianEdition, DailyEdition, TheDummyEdition, TrainingEdition}
+import model.editions.templates._
 import org.postgresql.util.PGobject
 import play.api.libs.json.Json
 import services.editions.prefills.CapiQueryTimeWindow
 
 object EditionsTemplates {
-  val templates: Map[Edition, EditionTemplate] = Map(
-    Edition.DailyEdition -> DailyEdition.template,
-    Edition.AmericanEdition -> AmericanEdition.template,
-    Edition.AustralianEdition -> AustralianEdition.template,
-    Edition.TrainingEdition -> TrainingEdition.template,
-    Edition.TheDummyEdition -> TheDummyEdition.template
+  val templates: Map[Edition, EditionDefinitionWithTemplate] = Map(
+    Edition.DailyEdition -> DailyEdition,
+    Edition.AmericanEdition -> AmericanEdition,
+    Edition.AustralianEdition -> AustralianEdition,
+    Edition.TrainingEdition -> TrainingEdition,
+    Edition.TheDummyEdition -> TheDummyEdition
   )
 
-  val getAvailableEditions: List[Edition] = templates.keys.toList
+  val getAvailableEditions: List[EditionDefinition] = templates.values.toList
 }
 
 case object WeekDay extends Enumeration(1) {

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -7,7 +7,14 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object AmericanEdition {
+object AmericanEdition extends EditionDefinitionWithTemplate {
+
+  override val title = "The Daily"
+  override val subTitle = "Published every morning by 6am (GMT)"
+  override val edition = "daily-edition"
+  override val headerTitle = "The Daily"
+  override val editionType = EditionType.Regional
+
   lazy val template = EditionTemplate(
     List(
       FrontEssentialReadsUs -> WeekDays(List(WeekDay.Sat)),

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -12,8 +12,7 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
   override val title = "US Weekender"
   override val subTitle = "Published every Saturday morning by 6am (EST)"
   override val edition = "american-edition"
-  override val headerTitle = "US"
-  override val headerSubTitle = "Weekender"
+  override val header = Header("US", Some("Weekender"))
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -9,10 +9,11 @@ import model.editions.templates.TemplateHelpers._
 //noinspection TypeAnnotation
 object AmericanEdition extends EditionDefinitionWithTemplate {
 
-  override val title = "The Daily"
-  override val subTitle = "Published every morning by 6am (GMT)"
-  override val edition = "daily-edition"
-  override val headerTitle = "The Daily"
+  override val title = "US Weekender"
+  override val subTitle = "Published every Saturday morning by 6am (EST)"
+  override val edition = "american-edition"
+  override val headerTitle = "US"
+  override val headerSubTitle = "Weekender"
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -7,7 +7,13 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object AustralianEdition {
+object AustralianEdition extends EditionDefinitionWithTemplate {
+  override val title = "The Daily"
+  override val subTitle = "Published every morning by 6am (GMT)"
+  override val edition = "daily-edition"
+  override val headerTitle = "The Daily"
+  override val editionType = EditionType.Regional
+
   lazy val template = EditionTemplate(
     List(
       FrontTopStoriesAu -> WeekDays(List(WeekDay.Sat)),

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -8,10 +8,12 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object AustralianEdition extends EditionDefinitionWithTemplate {
-  override val title = "The Daily"
-  override val subTitle = "Published every morning by 6am (GMT)"
-  override val edition = "daily-edition"
-  override val headerTitle = "The Daily"
+
+  override val title = "Australia Weekender"
+  override val subTitle = "Published every Saturday morning by 6am (AEST)"
+  override val edition = "australian-edition"
+  override val headerTitle = "Australia"
+  override val headerSubTitle = "Weekender"
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -12,8 +12,7 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
   override val title = "Australia Weekender"
   override val subTitle = "Published every Saturday morning by 6am (AEST)"
   override val edition = "australian-edition"
-  override val headerTitle = "Australia"
-  override val headerSubTitle = "Weekender"
+  override val header = Header("Australia", Some("Weekender"))
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -7,7 +7,13 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object DailyEdition {
+object DailyEdition extends EditionDefinitionWithTemplate {
+  override val title = "The Daily"
+  override val subTitle = "Published every morning by 6am (GMT)"
+  override val edition = "daily-edition"
+  override val headerTitle = "The Daily"
+  override val editionType = EditionType.Regional
+
   lazy val template = EditionTemplate(
     List(
       // Top Stories and Nuclear specials
@@ -348,4 +354,5 @@ object DailyEdition {
     "Crosswords",
     collection("Crosswords").searchPrefill("?tag=type/crossword")
   )
+
 }

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -12,6 +12,7 @@ object DailyEdition extends EditionDefinitionWithTemplate {
   override val subTitle = "Published every morning by 6am (GMT)"
   override val edition = "daily-edition"
   override val headerTitle = "The Daily"
+  override val headerSubTitle = ""
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -11,8 +11,7 @@ object DailyEdition extends EditionDefinitionWithTemplate {
   override val title = "The Daily"
   override val subTitle = "Published every morning by 6am (GMT)"
   override val edition = "daily-edition"
-  override val headerTitle = "The Daily"
-  override val headerSubTitle = ""
+  override val header = Header("The Daily")
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -51,8 +51,7 @@ case object EditionType extends Enumeration() {
 
 case class Header (title: String, subTitle: Option[String] = None)
 object Header {
-  implicit val readsHeader: Reads[Header] = Json.reads[Header]
-  implicit val writesHeader: Writes[Header] = Json.writes[Header]
+  implicit val formatHeader: OFormat[Header] = Json.format[Header]
 }
 
 trait EditionDefinition {
@@ -74,12 +73,10 @@ object EditionDefinition {
     editionType: EditionType
   ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType)
 
-  def unapply(x: EditionDefinition): Option[(String, String, String, Header, EditionType)]
-    = Some(x.title, x.subTitle, x.edition, x.header, x.editionType)
+  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType)]
+    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
-  implicit val writesEditionDefinition: OWrites[EditionDefinition] = Json.writes[EditionDefinition]
-  implicit val readsEditionDefinition: Reads[EditionDefinition] = Json.reads[EditionDefinition]
 }
 
 case class EditionDefinitionRecord(
@@ -92,6 +89,4 @@ case class EditionDefinitionRecord(
 
 object EditionDefinitionRecord{
   implicit val editionDefinitionRecordFormat: OFormat[EditionDefinitionRecord] = Json.format[EditionDefinitionRecord]
-  implicit val editionDefinitionRecordWrites: OWrites[EditionDefinitionRecord] = Json.writes[EditionDefinitionRecord]
-  implicit val editionDefinitionRecordReads: Reads[EditionDefinitionRecord] = Json.reads[EditionDefinitionRecord]
 }

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -1,7 +1,7 @@
 package model.editions.templates
 
 import model.editions.templates.EditionType.EditionType
-import model.editions._
+import model.editions.{templates, _}
 import play.api.libs.json._
 
 object TemplateHelpers {
@@ -45,8 +45,8 @@ case object EditionType extends Enumeration() {
   type EditionType = Value
   val Regional, Special, Training = Value
 
-  implicit val readsMyEnum = Reads.enumNameReads(EditionType)
-  implicit val writesMyEnum = Writes.enumNameWrites
+  implicit val readsMyEnum: Reads[templates.EditionType.Value] = Reads.enumNameReads(EditionType)
+  implicit val writesMyEnum: Writes[templates.EditionType.Value] = Writes.enumNameWrites
 }
 
 trait EditionDefinition {
@@ -54,6 +54,7 @@ trait EditionDefinition {
   val subTitle: String
   val edition: String
   val headerTitle: String
+  val headerSubTitle: String
   val editionType: EditionType
 }
 trait EditionDefinitionWithTemplate extends EditionDefinition {
@@ -65,11 +66,12 @@ object EditionDefinition {
     subTitle: String,
     edition: String,
     headerTitle: String,
+    headerSubTitle: String,
     editionType: EditionType
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, headerTitle, editionType)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, headerTitle, headerSubTitle, editionType)
 
-  def unapply(x: EditionDefinition): Option[(String, String, String, String, EditionType)]
-    = Some(x.title, x.subTitle, x.edition, x.headerTitle, x.editionType)
+  def unapply(x: EditionDefinition): Option[(String, String, String, String, String, EditionType)]
+    = Some(x.title, x.subTitle, x.edition, x.headerTitle, x.headerSubTitle, x.editionType)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
   implicit val writesEditionDefinition: OWrites[EditionDefinition] = Json.writes[EditionDefinition]
@@ -81,11 +83,12 @@ case class EditionDefinitionRecord(
                          override val subTitle: String,
                          override val edition: String,
                          override val headerTitle: String,
+                         override val headerSubTitle: String,
                          override val editionType: EditionType
 ) extends EditionDefinition {}
 
 object EditionDefinitionRecord{
-  implicit val editionDefinitionRecordFormat = Json.format[EditionDefinitionRecord]
-  implicit val editionDefinitionRecordWrites = Json.writes[EditionDefinitionRecord]
-  implicit val editionDefinitionRecordReads = Json.reads[EditionDefinitionRecord]
+  implicit val editionDefinitionRecordFormat: OFormat[EditionDefinitionRecord] = Json.format[EditionDefinitionRecord]
+  implicit val editionDefinitionRecordWrites: OWrites[EditionDefinitionRecord] = Json.writes[EditionDefinitionRecord]
+  implicit val editionDefinitionRecordReads: Reads[EditionDefinitionRecord] = Json.reads[EditionDefinitionRecord]
 }

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -1,6 +1,8 @@
 package model.editions.templates
 
-import model.editions.{CapiPrefillQuery, CapiTimeWindowConfigInDays, CollectionPresentation, CollectionTemplate, FrontPresentation, FrontTemplate, Swatch}
+import model.editions.templates.EditionType.EditionType
+import model.editions._
+import play.api.libs.json._
 
 object TemplateHelpers {
   object Defaults {
@@ -14,8 +16,7 @@ object TemplateHelpers {
       name,
       maybeOphanPath = None,
       prefill = None,
-      presentation = Defaults.defaultCollectionPresentation,
-      hidden = false
+      presentation = Defaults.defaultCollectionPresentation
     )
   }
 
@@ -25,7 +26,7 @@ object TemplateHelpers {
   def front(name: String, collections: CollectionTemplate*): FrontTemplate =
     FrontTemplate(name, collections.toList, Defaults.defaultFrontPresentation, None)
 
-  def specialFront(name: String, swatch: Swatch, ophanPath: Option[String] = None, prefill: Option[CapiPrefillQuery] = None) = front(
+  def specialFront(name: String, swatch: Swatch, ophanPath: Option[String] = None, prefill: Option[CapiPrefillQuery] = None): FrontTemplate = front(
     name,
     ophanPath,
     collection("Special Container 1").hide.copy(prefill = prefill),
@@ -39,3 +40,52 @@ object TemplateHelpers {
 
 }
 
+case object EditionType extends Enumeration() {
+
+  type EditionType = Value
+  val Regional, Special, Training = Value
+
+  implicit val readsMyEnum = Reads.enumNameReads(EditionType)
+  implicit val writesMyEnum = Writes.enumNameWrites
+}
+
+trait EditionDefinition {
+  val title: String
+  val subTitle: String
+  val edition: String
+  val headerTitle: String
+  val editionType: EditionType
+}
+trait EditionDefinitionWithTemplate extends EditionDefinition {
+  val template: EditionTemplate
+}
+object EditionDefinition {
+  def apply(
+    title: String,
+    subTitle: String,
+    edition: String,
+    headerTitle: String,
+    editionType: EditionType
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, headerTitle, editionType)
+
+  def unapply(x: EditionDefinition): Option[(String, String, String, String, EditionType)]
+    = Some(x.title, x.subTitle, x.edition, x.headerTitle, x.editionType)
+
+  implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
+  implicit val writesEditionDefinition: OWrites[EditionDefinition] = Json.writes[EditionDefinition]
+  implicit val readsEditionDefinition: Reads[EditionDefinition] = Json.reads[EditionDefinition]
+}
+
+case class EditionDefinitionRecord(
+                         override val title: String,
+                         override val subTitle: String,
+                         override val edition: String,
+                         override val headerTitle: String,
+                         override val editionType: EditionType
+) extends EditionDefinition {}
+
+object EditionDefinitionRecord{
+  implicit val editionDefinitionRecordFormat = Json.format[EditionDefinitionRecord]
+  implicit val editionDefinitionRecordWrites = Json.writes[EditionDefinitionRecord]
+  implicit val editionDefinitionRecordReads = Json.reads[EditionDefinitionRecord]
+}

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -45,16 +45,21 @@ case object EditionType extends Enumeration() {
   type EditionType = Value
   val Regional, Special, Training = Value
 
-  implicit val readsMyEnum: Reads[templates.EditionType.Value] = Reads.enumNameReads(EditionType)
-  implicit val writesMyEnum: Writes[templates.EditionType.Value] = Writes.enumNameWrites
+  implicit val readsEditionType: Reads[templates.EditionType.Value] = Reads.enumNameReads(EditionType)
+  implicit val writesEditionType: Writes[templates.EditionType.Value] = Writes.enumNameWrites
+}
+
+case class Header (title: String, subTitle: Option[String] = None)
+object Header {
+  implicit val readsHeader: Reads[Header] = Json.reads[Header]
+  implicit val writesHeader: Writes[Header] = Json.writes[Header]
 }
 
 trait EditionDefinition {
   val title: String
   val subTitle: String
   val edition: String
-  val headerTitle: String
-  val headerSubTitle: String
+  val header: Header
   val editionType: EditionType
 }
 trait EditionDefinitionWithTemplate extends EditionDefinition {
@@ -65,13 +70,12 @@ object EditionDefinition {
     title: String,
     subTitle: String,
     edition: String,
-    headerTitle: String,
-    headerSubTitle: String,
+    header: Header,
     editionType: EditionType
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, headerTitle, headerSubTitle, editionType)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType)
 
-  def unapply(x: EditionDefinition): Option[(String, String, String, String, String, EditionType)]
-    = Some(x.title, x.subTitle, x.edition, x.headerTitle, x.headerSubTitle, x.editionType)
+  def unapply(x: EditionDefinition): Option[(String, String, String, Header, EditionType)]
+    = Some(x.title, x.subTitle, x.edition, x.header, x.editionType)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
   implicit val writesEditionDefinition: OWrites[EditionDefinition] = Json.writes[EditionDefinition]
@@ -82,8 +86,7 @@ case class EditionDefinitionRecord(
                          override val title: String,
                          override val subTitle: String,
                          override val edition: String,
-                         override val headerTitle: String,
-                         override val headerSubTitle: String,
+                         override val header: Header,
                          override val editionType: EditionType
 ) extends EditionDefinition {}
 

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -7,7 +7,13 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TheDummyEdition {
+object TheDummyEdition extends EditionDefinitionWithTemplate {
+  override val title = "The Daily"
+  override val subTitle = "Published every morning by 6am (GMT)"
+  override val edition = "daily-edition"
+  override val headerTitle = "The Daily"
+  override val editionType = EditionType.Regional
+
   lazy val template = EditionTemplate(
     List(
       FrontSpecial01 -> Daily(),

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -11,8 +11,7 @@ object TheDummyEdition extends EditionDefinitionWithTemplate {
   override val title = "The Dummy Edition"
   override val subTitle = "Internal usage only, for reproducing issues"
   override val edition = "the-dummy-edition"
-  override val headerTitle = "The Dummy"
-  override val headerSubTitle = "Edition"
+  override val header = Header("The Dummy", Some("Edition"))
   override val editionType = EditionType.Training
 
   lazy val template = EditionTemplate(

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -8,11 +8,12 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object TheDummyEdition extends EditionDefinitionWithTemplate {
-  override val title = "The Daily"
-  override val subTitle = "Published every morning by 6am (GMT)"
-  override val edition = "daily-edition"
-  override val headerTitle = "The Daily"
-  override val editionType = EditionType.Regional
+  override val title = "The Dummy Edition"
+  override val subTitle = "Internal usage only, for reproducing issues"
+  override val edition = "the-dummy-edition"
+  override val headerTitle = "The Dummy"
+  override val headerSubTitle = "Edition"
+  override val editionType = EditionType.Training
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -11,9 +11,8 @@ object TrainingEdition extends EditionDefinitionWithTemplate {
   override val title = "The Training Edition"
   override val subTitle = "Internal usage only, for training and demonstrations"
   override val edition = "training-edition"
-  override val headerTitle = "Training Edition"
-  override val headerSubTitle = ""
-  override val editionType = EditionType.Regional
+  override val header = Header("Training Edition")
+  override val editionType = EditionType.Training
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -7,7 +7,13 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TrainingEdition {
+object TrainingEdition extends EditionDefinitionWithTemplate {
+  override val title = "The Daily"
+  override val subTitle = "Published every morning by 6am (GMT)"
+  override val edition = "daily-edition"
+  override val headerTitle = "The Daily"
+  override val editionType = EditionType.Regional
+
   lazy val template = EditionTemplate(
     List(
       FrontNewsYesterday -> Daily(),

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -8,10 +8,11 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object TrainingEdition extends EditionDefinitionWithTemplate {
-  override val title = "The Daily"
-  override val subTitle = "Published every morning by 6am (GMT)"
-  override val edition = "daily-edition"
-  override val headerTitle = "The Daily"
+  override val title = "The Training Edition"
+  override val subTitle = "Internal usage only, for training and demonstrations"
+  override val edition = "training-edition"
+  override val headerTitle = "Training Edition"
+  override val headerSubTitle = ""
   override val editionType = EditionType.Regional
 
   lazy val template = EditionTemplate(

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -4,9 +4,11 @@ import java.time.ZoneId
 
 import model.editions.templates.TemplateHelpers.Defaults._
 import model.editions._
+import model.editions.templates.{EditionDefinitionWithTemplate, EditionType}
+import model.editions.templates.EditionType.EditionType
 import model.editions.templates.TemplateHelpers.collection
 
-object TestEdition {
+object TestEdition extends EditionDefinitionWithTemplate {
 
   val CapiQueryStartOffsetInDays: Int = -1
   val CapiQueryEndOffsetInDays: Int = 2
@@ -31,7 +33,12 @@ object TestEdition {
     None
   )
 
-  lazy val templates: Map[Edition, EditionTemplate] = Map(Edition.TrainingEdition -> template)
+  lazy val templates: Map[Edition, EditionDefinitionWithTemplate] = Map(Edition.TrainingEdition -> this)
+  override val title: String = "test title"
+  override val subTitle: String = "test subtitle"
+  override val edition: String = "test edition"
+  override val headerTitle: String = "test header title"
+  override val editionType: EditionType = EditionType.Regional
 }
 
 object FrontTopStories {

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -38,6 +38,7 @@ object TestEdition extends EditionDefinitionWithTemplate {
   override val subTitle: String = "test subtitle"
   override val edition: String = "test edition"
   override val headerTitle: String = "test header title"
+  override val headerSubTitle: String = "test header subtitle"
   override val editionType: EditionType = EditionType.Regional
 }
 

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -4,7 +4,7 @@ import java.time.ZoneId
 
 import model.editions.templates.TemplateHelpers.Defaults._
 import model.editions._
-import model.editions.templates.{EditionDefinitionWithTemplate, EditionType}
+import model.editions.templates.{EditionDefinitionWithTemplate, EditionType, Header}
 import model.editions.templates.EditionType.EditionType
 import model.editions.templates.TemplateHelpers.collection
 
@@ -37,8 +37,7 @@ object TestEdition extends EditionDefinitionWithTemplate {
   override val title: String = "test title"
   override val subTitle: String = "test subtitle"
   override val edition: String = "test edition"
-  override val headerTitle: String = "test header title"
-  override val headerSubTitle: String = "test header subtitle"
+  override val header: Header = Header("test header title", Some("test header subtitle"))
   override val editionType: EditionType = EditionType.Regional
 }
 

--- a/test/services/GuardianCapiTest.scala
+++ b/test/services/GuardianCapiTest.scala
@@ -18,7 +18,7 @@ class GuardianCapiTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   private val contentPrefillQuery = CapiPrefillQuery("?tag=theguardian/mainsection/topstories", PathType.PrintSent)
 
-  private val timeWindowCfg = TestEdition.templates(Edition.TrainingEdition).timeWindowConfig
+  private val timeWindowCfg = TestEdition.template.timeWindowConfig
 
   private val contentPrefillTimeWindow: CapiQueryTimeWindow = timeWindowCfg.toCapiQueryTimeWindow(issueDate)
 


### PR DESCRIPTION
## What's changed?

A single source of truth for metadata information about each Edition is required, so that we can generate information for other systems.

Currently this is hard coded in at least three places.

This work starts (there is more metadata to cover) placing metadata on templates and exposing it through an endpoint in JSON format.

https://trello.com/c/qFgFGr6y/265-parent-card-determine-where-new-editions-metadata-will-be-stored-and-how-they-will-be-sent-to-editions-app

## Implementation notes

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
