### PR TITLE
Add notification offset in UTC for each edition

### DIFF
--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -32,6 +32,11 @@ case class EditionsIssue(
     fronts: List[EditionsFront]
 ) {
 
+  // This is a no-op placeholder which matches the UK Daily Edition value.
+  // It should never be needed because the Editions Templates object should always
+  // contain a matching Edition.  It should (TODO) eventually go away.
+  private val defaultOffset = 3
+
   def toPreviewIssue: PublishableIssue = toPublishableIssue("preview", PublishAction.preview)
 
   def toPublishableIssue(version: String, action: PublishAction): PublishableIssue = PublishableIssue(
@@ -49,7 +54,7 @@ case class EditionsIssue(
       .filterNot(_.isHidden) // drop hidden fronts
       .map(_.toPublishedFront) // convert
       .filterNot(_.collections.isEmpty), // drop fronts that contain no collections
-    EditionsTemplates.templates.get(edition).map(_.notificationUTCOffset).getOrElse(3)
+    EditionsTemplates.templates.get(edition).map(_.notificationUTCOffset).getOrElse(defaultOffset)
   )
 }
 

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -48,7 +48,8 @@ case class EditionsIssue(
     else fronts
       .filterNot(_.isHidden) // drop hidden fronts
       .map(_.toPublishedFront) // convert
-      .filterNot(_.collections.isEmpty) // drop fronts that contain no collections
+      .filterNot(_.collections.isEmpty), // drop fronts that contain no collections
+    EditionsTemplates.templates.get(edition).map(_.notificationUTCOffset).getOrElse(3)
   )
 }
 

--- a/app/model/editions/PublishableIssue.scala
+++ b/app/model/editions/PublishableIssue.scala
@@ -1,10 +1,12 @@
 package model.editions
 
-import java.time.{LocalDate, OffsetDateTime}
+import java.time.LocalDate
 
 import enumeratum.EnumEntry.Uncapitalised
 import enumeratum.{EnumEntry, PlayEnum}
 import model.editions.PublishAction.PublishAction
+
+import scala.collection.immutable
 
 // TODO traitify PublishedItem - when we have more than one type of collection item
 
@@ -16,7 +18,7 @@ object PublishedMediaType extends PlayEnum[PublishedMediaType] {
   case object Image extends PublishedMediaType
   case object CoverCard extends PublishedMediaType
 
-  override def values = findValues
+  override def values: immutable.IndexedSeq[PublishedMediaType] = findValues
 }
 
 case class PublishedImage(height: Option[Int], width: Option[Int], src: String)
@@ -56,5 +58,6 @@ case class PublishableIssue(
   edition: Edition,
   issueDate: LocalDate,
   version: String,
-  fronts: List[PublishedFront]
+  fronts: List[PublishedFront],
+  notificationUTCOffset: Int
 )

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -14,6 +14,7 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
   override val edition = "american-edition"
   override val header = Header("US", Some("Weekender"))
   override val editionType = EditionType.Regional
+  override val notificationUTCOffset = 8
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -14,6 +14,7 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
   override val edition = "australian-edition"
   override val header = Header("Australia", Some("Weekender"))
   override val editionType = EditionType.Regional
+  override val notificationUTCOffset = -5
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -13,6 +13,7 @@ object DailyEdition extends EditionDefinitionWithTemplate {
   override val edition = "daily-edition"
   override val header = Header("The Daily")
   override val editionType = EditionType.Regional
+  override val notificationUTCOffset = 3
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -60,6 +60,7 @@ trait EditionDefinition {
   val edition: String
   val header: Header
   val editionType: EditionType
+  val notificationUTCOffset: Int
 }
 trait EditionDefinitionWithTemplate extends EditionDefinition {
   val template: EditionTemplate
@@ -70,11 +71,12 @@ object EditionDefinition {
     subTitle: String,
     edition: String,
     header: Header,
-    editionType: EditionType
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType)
+    editionType: EditionType,
+    notificationUTCOffset: Int
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset)
 
-  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType)]
-    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType)
+  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int)]
+    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType, edition.notificationUTCOffset)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -84,8 +86,10 @@ case class EditionDefinitionRecord(
                          override val subTitle: String,
                          override val edition: String,
                          override val header: Header,
-                         override val editionType: EditionType
+                         override val editionType: EditionType,
+                         override val notificationUTCOffset: Int
 ) extends EditionDefinition {}
+
 
 object EditionDefinitionRecord{
   implicit val editionDefinitionRecordFormat: OFormat[EditionDefinitionRecord] = Json.format[EditionDefinitionRecord]

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -13,6 +13,7 @@ object TheDummyEdition extends EditionDefinitionWithTemplate {
   override val edition = "the-dummy-edition"
   override val header = Header("The Dummy", Some("Edition"))
   override val editionType = EditionType.Training
+  override val notificationUTCOffset = 3
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -13,6 +13,7 @@ object TrainingEdition extends EditionDefinitionWithTemplate {
   override val edition = "training-edition"
   override val header = Header("Training Edition")
   override val editionType = EditionType.Training
+  override val notificationUTCOffset = 3
 
   lazy val template = EditionTemplate(
     List(

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -42,6 +42,7 @@ class EditionsPublishing(publishedBucket: EditionsBucket, previewBucket: Edition
   }
 
   def publish(issue: EditionsIssue, user: User, version: String) = {
+
     val action = PublishAction.proof
 
     val markers = Markers.appendEntries(

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -39,6 +39,7 @@ object TestEdition extends EditionDefinitionWithTemplate {
   override val edition: String = "test edition"
   override val header: Header = Header("test header title", Some("test header subtitle"))
   override val editionType: EditionType = EditionType.Regional
+  override val notificationUTCOffset: Int = 2
 }
 
 object FrontTopStories {

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -33,7 +33,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           |  "edition" : "daily-edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "preview",
-          |  "fronts" : [ ]
+          |  "fronts" : [ ],
+          |  "notificationUTCOffset" : 3
           |}""".stripMargin
 
       val previewIssue = issue.toPreviewIssue
@@ -51,7 +52,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           |  "edition" : "daily-edition",
           |  "issueDate" : "2019-09-30",
           |  "version" : "foo",
-          |  "fronts" : [ ]
+          |  "fronts" : [ ],
+          |  "notificationUTCOffset" : 3
           |}""".stripMargin
 
       val publishedIssue = issue.toPublishableIssue("foo", PublishAction.proof)


### PR DESCRIPTION
## What's changed?

Each Edition definition now has a UTC offset.  This will be used, relative to the edition date in UTC, to decide when the download notification is sent.

## Implementation notes
This is the first part of the process: the offset has been added to the definition and exposed in the published issue json format.  It will be ignored by the step function.  The next step is to make the step function pass this value through to the notification service.

## Checklist

### General
- [ X] 🤖 Relevant tests added
- [ X] ✅ CI checks / tests run locally
- [ X] 🔍 Checked on CODE

### Client
- [ N/A] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ N/A] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ X] 📷 Screenshots / GIFs of relevant UI changes included

This is the file content now exposed via the published-editions-code s3 bucket.  The notification value is currently ignored.

![image](https://user-images.githubusercontent.com/5476326/87320038-4ecf7480-c522-11ea-80a1-9ef6efb44719.png)
