### PR TITLE
Provide front end route for publishing editions list

### DIFF
--- a/app/services/editions/publishing/EditionsBucket.scala
+++ b/app/services/editions/publishing/EditionsBucket.scala
@@ -1,7 +1,7 @@
 package services.editions.publishing
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.amazonaws.util.StringInputStream
 import model.editions.PublishableIssue
 import play.api.libs.json.Json
@@ -28,8 +28,13 @@ object EditionsBucket {
 }
 
 class EditionsBucket(s3Client: AmazonS3, bucketName: String) {
-  def putIssue(issue: PublishableIssue) = {
+  def putIssue(issue: PublishableIssue): PutObjectResult = {
     val request = EditionsBucket.createPutObjectRequest(bucketName, issue)
+    s3Client.putObject(request)
+  }
+
+  def putEditionsList(rawJson: String) = {
+    val request = new PutObjectRequest(bucketName, "editionsList", new StringInputStream(rawJson), EditionsBucket.objectMetadata)
     s3Client.putObject(request)
   }
 }

--- a/app/services/editions/publishing/EditionsPublishing.scala
+++ b/app/services/editions/publishing/EditionsPublishing.scala
@@ -41,6 +41,10 @@ class EditionsPublishing(publishedBucket: EditionsBucket, previewBucket: Edition
     publishedBucket.putIssue(publishedIssue)
   }
 
+  def putEditionsList(rawJson: String) = {
+    publishedBucket.putEditionsList(rawJson)
+  }
+
   def publish(issue: EditionsIssue, user: User, version: String) = {
 
     val action = PublishAction.proof

--- a/conf/routes
+++ b/conf/routes
@@ -101,6 +101,7 @@ POST        /api/usage                               controllers.GridProxy.addUs
 GET         /editions-api/editions                               controllers.EditionsController.getAvailableEditions
 GET         /editions-api/editions/:edition/issues               controllers.EditionsController.listIssues(edition: Edition)
 POST        /editions-api/editions/:name/issues                  controllers.EditionsController.createIssue(name)
+GET         /editions-api/republish-editions                     controllers.EditionsController.republishEditions
 GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
 DELETE      /editions-api/issues/:id                             controllers.EditionsController.deleteIssue(id)
 GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -27,10 +27,14 @@ const Home = () => (
     <h3>Manage edition list</h3>
     <ul>
       <li>
-        <a href='/editions-api/editions'>View Editions json metadata</a>
+        <a href='/editions-api/editions'>
+          View Editions json metadata
+        </a>
       </li>
       <li>
-        <a href='/editions-api/republish-editions'>Republish</a>
+        <a href='/editions-api/republish-editions'>
+          Republish
+        </a>
       </li>
     </ul>
   </HomeContainer>

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -23,6 +23,16 @@ const Home = () => (
 
     <h3>Manage editions</h3>
     <ul>{Object.keys(editionPriorities).map(renderEditionPriority)}</ul>
+
+    <h3>Manage edition list</h3>
+    <ul>
+      <li>
+        <a href='/editions-api/editions'>View Editions json metadata</a>
+      </li>
+      <li>
+        <a href='/editions-api/republish-editions'>Republish</a>
+      </li>
+    </ul>
   </HomeContainer>
 );
 

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -27,10 +27,10 @@ const Home = () => (
     <h3>Manage edition list</h3>
     <ul>
       <li>
-        <a href='/editions-api/editions'>View Editions json metadata</a>
+        <a href="/editions-api/editions">View Editions json metadata</a>
       </li>
       <li>
-        <a href='/editions-api/republish-editions'>Republish</a>
+        <a href="/editions-api/republish-editions">Republish</a>
       </li>
     </ul>
   </HomeContainer>

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -27,14 +27,10 @@ const Home = () => (
     <h3>Manage edition list</h3>
     <ul>
       <li>
-        <a href='/editions-api/editions'>
-          View Editions json metadata
-        </a>
+        <a href='/editions-api/editions'>View Editions json metadata</a>
       </li>
       <li>
-        <a href='/editions-api/republish-editions'>
-          Republish
-        </a>
+        <a href='/editions-api/republish-editions'>Republish</a>
       </li>
     </ul>
   </HomeContainer>


### PR DESCRIPTION
## What's changed?

The main fronts tool front page has a new section: managed editions list.

Tooling is provided for both fetching and sending on ('publishing') the editions list definition json to the editions back end.

## Implementation notes

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [X ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
