### PR TITLE
Fetch editions list from back end

### DIFF
--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -1,6 +1,8 @@
 package controllers
 
 import com.gu.facia.client.models.{Metadata, TargetedTerritory, Trail}
+import model.editions.EditionsTemplates
+import model.editions.templates.EditionDefinition
 import model.{Cached, FeatureSwitch, UserDataForDefaults}
 import permissions.Permissions
 import play.api.libs.json.{JsValue, Json}
@@ -31,7 +33,8 @@ case class Defaults(
                      userData: Option[UserDataForDefaults],
                      capiLiveUrl: String = "",
                      capiPreviewUrl: String = "",
-                     availableTerritories: Iterable[TargetedTerritory] = Nil
+                     availableTerritories: Iterable[TargetedTerritory] = Nil,
+                     availableEditions: List[EditionDefinition]
 )
 
 class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaControllerComponents) extends BaseFaciaController(deps) {
@@ -65,7 +68,8 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
           case (_, meta) => meta
         },
         None,
-        availableTerritories = TargetedTerritory.allTerritories
+        availableTerritories = TargetedTerritory.allTerritories,
+        availableEditions = EditionsTemplates.getAvailableEditions
       )))
     }
   }

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -7,6 +7,7 @@ import model.{FeatureSwitch, UserData, UserDataForDefaults}
 
 import scala.concurrent.ExecutionContext
 import com.gu.facia.client.models.{Metadata, TargetedTerritory}
+import model.editions.EditionsTemplates
 import permissions.Permissions
 import play.api.libs.json.Json
 import switchboard.SwitchManager
@@ -72,7 +73,8 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: AmazonDynamoDB, val deps
       Some(userDataForDefaults),
       routes.FaciaContentApiProxy.capiLive("").absoluteURL(true),
       routes.FaciaContentApiProxy.capiPreview("").absoluteURL(true),
-      TargetedTerritory.allTerritories
+      TargetedTerritory.allTerritories,
+      EditionsTemplates.getAvailableEditions
     )
 
     Ok(views.html.V2App.app(

--- a/docs/AddingAndAlteringTemplates.md
+++ b/docs/AddingAndAlteringTemplates.md
@@ -1,0 +1,31 @@
+# Editions Template Maintainance
+
+Templates for Editions such as 'The Daily Edition' are stored in this application.
+
+These are used to generate both the metadata relied on by the Editions app, and the
+Fronts tool behaviour for creating issues of each Edition.
+
+## Adding a new Template
+
+Create a new file at `app/model/editions/templates/` called `<your-edition-name>.scala`
+
+Ensure your new file is appropriately named and contains a single `object` which
+extends `EditionDefinitionWithTemplate`. Ensure it fulfills all the requirements:
+
+```
+//noinspection TypeAnnotation
+object MyLovelyHorseEdition extends EditionDefinitionWithTemplate {
+  override val title = "My Lovely Horse"
+  override val subTitle = "Published every morning by 6am (GMT)"
+  override val edition = "horse-edition"
+  override val header = Header("Horses!", "Lots of horses!")
+  override val editionType = EditionType.Regional
+  override val notificationUTCOffset = 3
+
+  lazy val template = EditionTemplate(
+  ...
+```
+
+Add the new Edition to _both_ the list of templates and the Edition enum object
+in `app/model/editions/EditionsTemplates.scala`.
+

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import { priorities, editionPriorities } from 'constants/priorities';
+import { priorities } from 'constants/priorities';
+import { EditionPriority } from 'types/Priority';
 import HomeContainer from './layout/HomeContainer';
 import { selectAvailableEditions } from 'selectors/configSelectors';
 import type { State } from 'types/State';
@@ -12,10 +13,10 @@ const renderPriority = (priority: string) => (
     <Link to={`/${priority}`}>{priority}</Link>
   </li>
 );
-const renderEditionPriority = (editionPriority: string) => (
-  <li key={editionPriority}>
-    <Link to={`/manage-editions/${editionPriorities[editionPriority].address}`}>
-      {editionPriorities[editionPriority].description}
+const renderEditionPriority = (editionPriority: EditionPriority) => (
+  <li key={editionPriority.title}>
+    <Link to={`/manage-editions/${editionPriority.edition}`}>
+      {editionPriority.title}
     </Link>
   </li>
 );
@@ -28,7 +29,9 @@ const Home = ({ availableEditions }: IProps) => (
     <ul>{Object.keys(priorities).map(renderPriority)}</ul>
 
     <h3>Manage editions</h3>
-    <ul>{Object.keys(editionPriorities).map(renderEditionPriority)}</ul>
+    <ul>{availableEditions &&
+      availableEditions.sort((a, b) => (a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1))
+        .map(renderEditionPriority)}</ul>
   </HomeContainer>
 );
 

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -29,8 +29,8 @@ const Home = ({ availableEditions }: IProps) => (
     <ul>{Object.keys(priorities).map(renderPriority)}</ul>
 
     <h3>Manage editions</h3>
-    <ul>{
-      availableEditions &&
+    <ul>
+      {availableEditions &&
         availableEditions
           .sort((a, b) =>
             a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1
@@ -41,7 +41,7 @@ const Home = ({ availableEditions }: IProps) => (
 );
 
 const mapStateToProps = (state: State) => ({
-  availableEditions: selectAvailableEditions(state)
+  availableEditions: selectAvailableEditions(state),
 });
 
 export default connect(mapStateToProps)(Home);

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -21,7 +21,7 @@ const renderEditionPriority = (editionPriority: EditionPriority) => (
   </li>
 );
 
-type IProps = ReturnType<typeof mapStateToProps>
+type IProps = ReturnType<typeof mapStateToProps>;
 
 const Home = ({ availableEditions }: IProps) => (
   <HomeContainer>
@@ -29,9 +29,14 @@ const Home = ({ availableEditions }: IProps) => (
     <ul>{Object.keys(priorities).map(renderPriority)}</ul>
 
     <h3>Manage editions</h3>
-    <ul>{availableEditions &&
-      availableEditions.sort((a, b) => (a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1))
-        .map(renderEditionPriority)}</ul>
+    <ul>{
+      availableEditions &&
+        availableEditions
+          .sort((a, b) =>
+            a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1
+          )
+          .map(renderEditionPriority)}
+    </ul>
   </HomeContainer>
 );
 

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { priorities, editionPriorities } from 'constants/priorities';
 import HomeContainer from './layout/HomeContainer';
+import { selectAvailableEditions } from 'selectors/configSelectors';
+import type { State } from 'types/State';
 
 const renderPriority = (priority: string) => (
   <li key={priority}>
@@ -16,7 +19,10 @@ const renderEditionPriority = (editionPriority: string) => (
     </Link>
   </li>
 );
-const Home = () => (
+
+type IProps = ReturnType<typeof mapStateToProps>
+
+const Home = ({ availableEditions }: IProps) => (
   <HomeContainer>
     <h3>Front priorities</h3>
     <ul>{Object.keys(priorities).map(renderPriority)}</ul>
@@ -26,4 +32,8 @@ const Home = () => (
   </HomeContainer>
 );
 
-export default Home;
+const mapStateToProps = (state: State) => ({
+  availableEditions: selectAvailableEditions(state)
+});
+
+export default connect(mapStateToProps)(Home);

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -46,7 +46,6 @@ const Home = ({ availableEditions }: IProps) => (
       <li>
         <a href="/editions-api/republish-editions">Republish</a>
       </li>
->>>>>>> master
     </ul>
   </HomeContainer>
 );

--- a/fronts-client/src/constants/priorities.ts
+++ b/fronts-client/src/constants/priorities.ts
@@ -1,4 +1,4 @@
-import { EditionPriority, Priorities } from 'types/Priority';
+import { Priorities } from 'types/Priority';
 
 export const priorities: Priorities = {
   editorial: {},
@@ -7,25 +7,3 @@ export const priorities: Priorities = {
   email: {},
 };
 
-export const editionPriorities: { [index: string]: EditionPriority } = {
-  dailyEdition: {
-    description: 'Daily Edition',
-    address: 'daily-edition',
-  },
-  americanEdition: {
-    description: 'American Edition',
-    address: 'american-edition',
-  },
-  australianEdition: {
-    description: 'Australian Edition',
-    address: 'australian-edition',
-  },
-  trainingEdition: {
-    description: 'Training Edition',
-    address: 'training-edition',
-  },
-  theDummyEdition: {
-    description: 'The Dummy Edition',
-    address: 'the-dummy-edition',
-  },
-};

--- a/fronts-client/src/constants/priorities.ts
+++ b/fronts-client/src/constants/priorities.ts
@@ -6,4 +6,3 @@ export const priorities: Priorities = {
   training: {},
   email: {},
 };
-

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -258,6 +258,7 @@ const config = {
   },
   capiLiveUrl: 'https://fronts.local.dev-gutools.co.uk/api/live/',
   capiPreviewUrl: 'https://fronts.local.dev-gutools.co.uk/api/preview/',
+  availableEditions: []
 };
 
 const externalArticles = {

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -258,7 +258,7 @@ const config = {
   },
   capiLiveUrl: 'https://fronts.local.dev-gutools.co.uk/api/live/',
   capiPreviewUrl: 'https://fronts.local.dev-gutools.co.uk/api/preview/',
-  availableEditions: []
+  availableEditions: [],
 };
 
 const externalArticles = {

--- a/fronts-client/src/selectors/configSelectors.ts
+++ b/fronts-client/src/selectors/configSelectors.ts
@@ -39,6 +39,11 @@ const selectGridUrl = createSelector(
   (config) => config && config.mediaBaseUrl
 );
 
+const selectAvailableEditions = createSelector(
+  selectConfig,
+  (config) => config && config.availableEditions
+);
+
 export {
   selectCapiLiveURL,
   selectCapiPreviewURL,
@@ -47,4 +52,5 @@ export {
   selectLastName,
   selectCollectionCap,
   selectGridUrl,
+  selectAvailableEditions
 };

--- a/fronts-client/src/selectors/configSelectors.ts
+++ b/fronts-client/src/selectors/configSelectors.ts
@@ -52,5 +52,5 @@ export {
   selectLastName,
   selectCollectionCap,
   selectGridUrl,
-  selectAvailableEditions
+  selectAvailableEditions,
 };

--- a/fronts-client/src/types/Config.ts
+++ b/fronts-client/src/types/Config.ts
@@ -1,5 +1,6 @@
 import type { NestedCard } from 'types/Collection';
 import type { FeatureSwitch } from './Features';
+import type { EditionPriority } from '../types/Priority';
 
 interface Permission {
   [id: string]: boolean;
@@ -46,6 +47,7 @@ interface Config {
     clipboardArticles: NestedCard[];
     featureSwitches: FeatureSwitch[];
   };
+  availableEditions: EditionPriority[];
 }
 
 export { Config };

--- a/fronts-client/src/types/Priority.ts
+++ b/fronts-client/src/types/Priority.ts
@@ -6,8 +6,9 @@ interface Priorities {
 }
 
 interface EditionPriority {
-  address: string;
-  description: string;
+  title: string;
+  edition: string;
+  editionType: string;
 }
 
 export { Priorities, EditionPriority };


### PR DESCRIPTION
## What's changed?
Currently the list of editions available is hard coded into the front end.

This PR provides the list as part of the basic Config so that it can be amended in just one place.  Well, two, but at least it's only two, _and_ that's now documented.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [X ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
