### PR TITLE
Upped the container count in each front, renamed the edition

### DIFF
--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -9,10 +9,10 @@ import model.editions.templates.TemplateHelpers._
 //noinspection TypeAnnotation
 object AmericanEdition extends EditionDefinitionWithTemplate {
 
-  override val title = "US Weekender"
+  override val title = "US Weekend"
   override val subTitle = "Published every Saturday morning by 6am (EST)"
   override val edition = "american-edition"
-  override val header = Header("US", Some("Weekender"))
+  override val header = Header("US", Some("Weekend"))
   override val editionType = EditionType.Regional
   override val notificationUTCOffset = 8
 
@@ -59,8 +59,9 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     "Essential Reads",
     collection("Essential Reads"),
     collection("Essential Reads"),
-    collection("Essential Reads")
-
+    collection("Essential Reads"),
+    collection("Essential Reads").hide,
+    collection("Essential Reads").hide
   )
     .swatch(News)
   
@@ -82,7 +83,9 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
       .withArticleItemsCap(20),
     collection("Q&A")
       .searchPrefill("?tag=type/article,tone/q-and-as")
-      .withArticleItemsCap(20)
+      .withArticleItemsCap(20),
+    collection("People").hide,
+    collection("People").hide
   )
     .swatch(Lifestyle)
   
@@ -97,13 +100,9 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
   def FrontSpotlightUs = front(
     "Spotlight",
     collection("News Features"),
-     // .searchPrefill("?tag=type/article,(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),(tone/features|tone/analysis|tone/explainer),-culture/culture,-lifestyle/lifestyle,-tone/news,-tone/comment,-tone/minutebyminute")
-     // .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-5, 0)))
-     // .withArticleItemsCap(40),
-    collection("Features")
-     // .searchPrefill("?tag=type/article,(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),-(tone/features|tone/analysis|tone/explainer),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/comment,-tone/minutebyminute")
-     // .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-5, 0)))
-     // .withArticleItemsCap(40)
+    collection("Features"),
+    collection("Spotlight").hide,
+    collection("Spotlight").hide
   )
     .swatch(News)
   
@@ -122,7 +121,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
       .withArticleItemsCap(20),
     collection("News")
       .searchPrefill("?tag=type/article,(us-news/us-news|us-news/us-politics|business/business|media/media),-(tone/features|tone/analysis|tone/explainer),-culture/culture,-lifestyle/lifestyle,tone/news,-tone/comment,-tone/minutebyminute")
-      .withArticleItemsCap(20)    
+      .withArticleItemsCap(20),
+    collection("US News").hide,
+    collection("US News").hide,
+    collection("US News").hide
   )
     .swatch(News)
   
@@ -141,7 +143,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
       .withArticleItemsCap(20),
     collection("News")
       .searchPrefill("?tag=type/article,(world/world|australia-news/australia-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),-(tone/features|tone/analysis|tone/explainer),-(us-news/us-news|us-news/us-politics|business/business|media/media),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute")
-      .withArticleItemsCap(20)    
+      .withArticleItemsCap(20) ,
+    collection("World News").hide,
+    collection("World News").hide,
+    collection("World News").hide
   )
     .swatch(News)
 
@@ -155,7 +160,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     .withArticleItemsCap(20),
     collection("World")
     .searchPrefill("?tag=type/article,tone/comment,-(us-news/us-news|us-news/us-politics),-sport/sport,-tone/minutebyminute")
-    .withArticleItemsCap(20)
+    .withArticleItemsCap(20),
+    collection("Opinion").hide,
+    collection("Opinion").hide,
+    collection("Opinion").hide
   )
     .swatch(Opinion)
   
@@ -166,7 +174,11 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     "Environment",
     collection("Environment")
     .searchPrefill("?tag=type/article,environment/environment,-sport/sport,-tone/minutebyminute")
-    .withArticleItemsCap(20)
+    .withArticleItemsCap(20),
+    collection("Environment").hide,
+    collection("Environment").hide,
+    collection("Environment").hide,
+    collection("Environment").hide
   ) 
     .swatch(News)
   
@@ -180,7 +192,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     .withArticleItemsCap(20),
     collection("Reviews")
     .searchPrefill("?tag=type/article,culture/culture,-tone/features,tone/reviews,-tone/news,-tone/minutebyminute")
-    .withArticleItemsCap(20)
+    .withArticleItemsCap(20),
+    collection("Culture").hide,
+    collection("Culture").hide,
+    collection("Culture").hide
   )
     .swatch(News)
 
@@ -193,7 +208,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     .withArticleItemsCap(20),
     collection("Recipes")
     .searchPrefill("?tag=type/article,tone/recipes,food/food,-tone/minutebyminute")
-    .withArticleItemsCap(20)
+    .withArticleItemsCap(20),
+    collection("Lifestyle").hide,
+    collection("Lifestyle").hide,
+    collection("Lifestyle").hide
   )
     .swatch(News)
 
@@ -203,7 +221,11 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     "Sport",
     collection("Sport")
     .searchPrefill("?tag=type/article,sport/sport,(tone/comment|tone/features|tone/analysis),-tone/minutebyminute")
-    .withArticleItemsCap(20)
+    .withArticleItemsCap(20),
+    collection("Sport").hide,
+    collection("Sport").hide,
+    collection("Sport").hide,
+    collection("Sport").hide
   )
     .swatch(Sport)
 


### PR DESCRIPTION
## What's changed?
Name is US Weekend not Weekender.
Upped the container count so there are at least five in each.
Done by adding additional containers which are hidden by default.

## Implementation notes
Edited in Github by a product manager, E&OE.

