### PR TITLE
Pass notification topic

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import logging.Logging
 import logic.EditionsChecker
 import model.editions._
-import model.editions.templates.{EditionDefinition, EditionType}
+import model.editions.templates.EditionType
 import model.forms._
 import net.logstash.logback.marker.Markers
 import play.api.Logger
@@ -92,7 +92,7 @@ class EditionsController(db: EditionsDB,
       publishing.putEditionsList(raw.toString())
       Ok("Published.  Please check processing has succeeded.")
     } catch {
-      case e => InternalServerError(e.getMessage)
+      case e: Exception => InternalServerError(e.getMessage)
     }
   }}
 

--- a/app/model/editions/EditionsIssue.scala
+++ b/app/model/editions/EditionsIssue.scala
@@ -54,7 +54,8 @@ case class EditionsIssue(
       .filterNot(_.isHidden) // drop hidden fronts
       .map(_.toPublishedFront) // convert
       .filterNot(_.collections.isEmpty), // drop fronts that contain no collections
-    EditionsTemplates.templates.get(edition).map(_.notificationUTCOffset).getOrElse(defaultOffset)
+    EditionsTemplates.templates.get(edition).map(_.notificationUTCOffset).getOrElse(defaultOffset),
+    EditionsTemplates.templates.get(edition).map(_.topic)
   )
 }
 

--- a/app/model/editions/PublishableIssue.scala
+++ b/app/model/editions/PublishableIssue.scala
@@ -59,5 +59,6 @@ case class PublishableIssue(
   issueDate: LocalDate,
   version: String,
   fronts: List[PublishedFront],
-  notificationUTCOffset: Int
+  notificationUTCOffset: Int,
+  topic: Option[String]
 )

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -15,6 +15,7 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
   override val header = Header("US", Some("Weekend"))
   override val editionType = EditionType.Regional
   override val notificationUTCOffset = 8
+  override val topic = "us"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -15,6 +15,7 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
   override val header = Header("Australia", Some("Weekend"))
   override val editionType = EditionType.Regional
   override val notificationUTCOffset = -5
+  override val topic = "au"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -14,6 +14,7 @@ object DailyEdition extends EditionDefinitionWithTemplate {
   override val header = Header("The Daily")
   override val editionType = EditionType.Regional
   override val notificationUTCOffset = 3
+  override val topic = "uk"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -61,6 +61,7 @@ trait EditionDefinition {
   val header: Header
   val editionType: EditionType
   val notificationUTCOffset: Int
+  val topic: String
 }
 trait EditionDefinitionWithTemplate extends EditionDefinition {
   val template: EditionTemplate
@@ -72,11 +73,12 @@ object EditionDefinition {
     edition: String,
     header: Header,
     editionType: EditionType,
-    notificationUTCOffset: Int
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset)
+    notificationUTCOffset: Int,
+    topic: String
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic)
 
-  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int)]
-    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType, edition.notificationUTCOffset)
+  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String)]
+    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType, edition.notificationUTCOffset, edition.topic)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -87,7 +89,8 @@ case class EditionDefinitionRecord(
                          override val edition: String,
                          override val header: Header,
                          override val editionType: EditionType,
-                         override val notificationUTCOffset: Int
+                         override val notificationUTCOffset: Int,
+                         override val topic: String
 ) extends EditionDefinition {}
 
 

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -14,6 +14,7 @@ object TheDummyEdition extends EditionDefinitionWithTemplate {
   override val header = Header("The Dummy", Some("Edition"))
   override val editionType = EditionType.Training
   override val notificationUTCOffset = 3
+  override val topic = "dm"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -14,6 +14,7 @@ object TrainingEdition extends EditionDefinitionWithTemplate {
   override val header = Header("Training Edition")
   override val editionType = EditionType.Training
   override val notificationUTCOffset = 3
+  override val topic = "tr"
 
   lazy val template = EditionTemplate(
     List(

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -40,6 +40,7 @@ object TestEdition extends EditionDefinitionWithTemplate {
   override val header: Header = Header("test header title", Some("test header subtitle"))
   override val editionType: EditionType = EditionType.Regional
   override val notificationUTCOffset: Int = 2
+  override val topic: String = "tt"
 }
 
 object FrontTopStories {

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -34,7 +34,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           |  "issueDate" : "2019-09-30",
           |  "version" : "preview",
           |  "fronts" : [ ],
-          |  "notificationUTCOffset" : 3
+          |  "notificationUTCOffset" : 3,
+          |  "topic" : "uk"
           |}""".stripMargin
 
       val previewIssue = issue.toPreviewIssue
@@ -53,7 +54,8 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
           |  "issueDate" : "2019-09-30",
           |  "version" : "foo",
           |  "fronts" : [ ],
-          |  "notificationUTCOffset" : 3
+          |  "notificationUTCOffset" : 3,
+          |  "topic" : "uk"
           |}""".stripMargin
 
       val publishedIssue = issue.toPublishableIssue("foo", PublishAction.proof)


### PR DESCRIPTION
## What's changed?

Currently the notification topic is hard coded as 'uk', which is not very helpful when publishing a US or AU issue of an edition.

This PR requires the topic to be specified as part of the edition, and sends it to the Editions systems as part of the publish notification.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
