### PR TITLE
Add special edition  template type

### DIFF
--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -7,7 +7,7 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object AmericanEdition extends EditionDefinitionWithTemplate {
+object AmericanEdition extends RegionalEdition {
 
   override val title = "US Weekend"
   override val subTitle = "Published from New York every\nSaturday morning by 6am (EST)"
@@ -64,10 +64,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     collection("Essential Reads").hide,
     collection("Essential Reads").hide
   )
-  
+
   // Front: Special Section, News swatch
   // Description: General Special section
-  
+
   def FrontSpecial1Us = specialFront("Front Special 1", News, None)
 
   // Front: People, Lifestyle swatch
@@ -88,10 +88,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     collection("People").hide
   )
     .swatch(Lifestyle)
-  
+
   // Front: Special 2
   // Description: General Special section
-  
+
   def FrontSpecial2Us = specialFront("Front Special 2", Lifestyle, None)
 
   // Front: Spotlight, News swatch
@@ -105,7 +105,7 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     collection("Spotlight").hide
   )
     .swatch(News)
-  
+
   // Front: Special 3, News swatch
   // Description: General Special section
 
@@ -127,7 +127,7 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     collection("US News").hide
   )
     .swatch(News)
-  
+
   // Front: Special 4, News swatch
   // Description: General Special section
 
@@ -166,10 +166,10 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     collection("Opinion").hide
   )
     .swatch(Opinion)
-  
-  // Front: Environment 
+
+  // Front: Environment
   // Description: Environment coverage
-  
+
   def FrontEnvironmentUs = front(
     "Environment",
     collection("Environment")
@@ -179,11 +179,11 @@ object AmericanEdition extends EditionDefinitionWithTemplate {
     collection("Environment").hide,
     collection("Environment").hide,
     collection("Environment").hide
-  ) 
+  )
     .swatch(News)
-  
-  // Front: Culture 
-  // Description: Culture features and reviews 
+
+  // Front: Culture
+  // Description: Culture features and reviews
 
   def FrontCultureUs = front(
     "Culture",

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -13,7 +13,6 @@ object AmericanEdition extends RegionalEdition {
   override val subTitle = "Published from New York every\nSaturday morning by 6am (EST)"
   override val edition = "american-edition"
   override val header = Header("US", Some("Weekend"))
-  override val editionType = EditionType.Regional
   override val notificationUTCOffset = 8
   override val topic = "us"
 

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -7,7 +7,7 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object AustralianEdition extends EditionDefinitionWithTemplate {
+object AustralianEdition extends RegionalEdition {
 
   override val title = "Australia Weekend"
   override val subTitle = "Published from Sydney every\nSaturday by 6 am (AEST)"
@@ -60,9 +60,8 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
     collection("Top stories"),
     collection("Top stories")
   )
-  
+
   // Special 1
-  
   def FrontSpecial1Au = specialFront("Front Special 1", News, None)
 
   // Weekend - Features, Culture, Lifestyle, Comment
@@ -77,9 +76,9 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
     collection("Weekend").hide
   )
     .swatch(Lifestyle)
-  
+
   // Special 2
-  
+
   def FrontSpecial2Au = specialFront("Front Special 2", Lifestyle, None)
 
   //National - News two containers, maybe split out politics into second container?
@@ -98,9 +97,9 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
     collection("National").hide
   )
     .swatch(News)
-  
+
   // Special 3
-  
+
   def FrontSpecial3Au = specialFront("Front Special 3", News, None)
 
   //World - International news content
@@ -119,9 +118,9 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
     collection("World").hide
   )
     .swatch(News)
-  
+
   // Special 4
-  
+
   def FrontSpecial4Au = specialFront("Front Special 4", News, None)
 
   // Opinion
@@ -162,8 +161,8 @@ object AustralianEdition extends EditionDefinitionWithTemplate {
     collection("Culture").hide
   )
     .swatch(Culture)
-  
-    // Life 
+
+    // Life
 
   def FrontLifeAu = front(
     "Lifestyle",

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -13,7 +13,6 @@ object AustralianEdition extends RegionalEdition {
   override val subTitle = "Published from Sydney every\nSaturday by 6 am (AEST)"
   override val edition = "australian-edition"
   override val header = Header("Australia", Some("Weekend"))
-  override val editionType = EditionType.Regional
   override val notificationUTCOffset = -5
   override val topic = "au"
 

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -7,7 +7,7 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object DailyEdition extends EditionDefinitionWithTemplate {
+object DailyEdition extends RegionalEdition {
   override val title = "UK Daily"
   override val subTitle = "Published from London every\nmorning by 6am (GMT)"
   override val edition = "daily-edition"
@@ -243,7 +243,7 @@ object DailyEdition extends EditionDefinitionWithTemplate {
     collection("Life").hide
   )
     .swatch(Lifestyle)
-  
+
   // Hidden by default, a front for the irregular 'The Fashion' supplement
 
   def FrontLifeFashion = front(
@@ -257,9 +257,9 @@ object DailyEdition extends EditionDefinitionWithTemplate {
   )
     .special
     .swatch(Lifestyle)
-  
+
   // Hidden by default, a front for the irregular 'Design' supplement
-  
+
     def FrontLifeDesign = front(
     "Design",
     collection("Design").printSentAnyTag("theobserver/design/design"),

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -12,7 +12,6 @@ object DailyEdition extends RegionalEdition {
   override val subTitle = "Published from London every\nmorning by 6am (GMT)"
   override val edition = "daily-edition"
   override val header = Header("UK", Some("Daily"))
-  override val editionType = EditionType.Regional
   override val notificationUTCOffset = 3
   override val topic = "uk"
 

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -94,17 +94,21 @@ trait EditionDefinition {
   val editionType: EditionType
   val notificationUTCOffset: Int
   val topic: String
+  val image: Option[SpecialEditionImage]
+  val expiry: Option[String]
+  val buttonStyle: Option[SpecialEditionButtonStyles]
+  val headerStyle: Option[SpecialEditionHeaderStyles]
 }
 
 trait EditionDefinitionWithTemplate extends EditionDefinition {
   val template: EditionTemplate
 }
 
-trait SpecialEditionDefinitionWithTemplate extends EditionDefinitionWithTemplate {
-  val image: SpecialEditionImage
-  val expiry: String
-  val buttonStyle: SpecialEditionButtonStyles
-  val headerStyle: SpecialEditionHeaderStyles
+abstract class RegionalEdition extends EditionDefinitionWithTemplate {
+  override val image: Option[SpecialEditionImage] = None
+  override val expiry: Option[String] = None
+  override val buttonStyle: Option[SpecialEditionButtonStyles] = None
+  override val headerStyle: Option[SpecialEditionHeaderStyles] = None
 }
 
 object EditionDefinition {

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -64,7 +64,7 @@ object SpecialEditionHeaderStyles {
   implicit val formatHeader: OFormat[SpecialEditionHeaderStyles] = Json.format[SpecialEditionHeaderStyles]
 }
 
-case class EditionTextFormatting(color: String, font: String, lineHeight: String, size: String)
+case class EditionTextFormatting(color: String, font: String, lineHeight: Int, size: Int)
 object EditionTextFormatting {
   implicit val formatEditionTextFormatting : OFormat[EditionTextFormatting] = Json.format[EditionTextFormatting]
 }

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -54,6 +54,38 @@ object Header {
   implicit val formatHeader: OFormat[Header] = Json.format[Header]
 }
 
+case class SpecialEditionImage(source: String, path: String)
+object SpecialEditionImage {
+  implicit val formatHeader: OFormat[SpecialEditionImage] = Json.format[SpecialEditionImage]
+}
+
+case class SpecialEditionHeaderStyles(backgroundColor: String, textColorPrimary: String, textColorSecondary: String)
+object SpecialEditionHeaderStyles {
+  implicit val formatHeader: OFormat[SpecialEditionHeaderStyles] = Json.format[SpecialEditionHeaderStyles]
+}
+
+case class EditionTextFormatting(color: String, font: String, lineHeight: String, size: String)
+object EditionTextFormatting {
+  implicit val formatEditionTextFormatting : OFormat[EditionTextFormatting] = Json.format[EditionTextFormatting]
+}
+
+case class EditionImageStyle(width: Int, height: Int)
+object EditionImageStyle {
+  implicit val formatEditionImageStyle : OFormat[EditionImageStyle] = Json.format[EditionImageStyle]
+}
+
+case class SpecialEditionButtonStyles(
+  backgroundColor: String,
+  title: EditionTextFormatting,
+  subTitle: EditionTextFormatting,
+  expiry: EditionTextFormatting,
+  image: EditionImageStyle
+)
+
+object SpecialEditionButtonStyles {
+  implicit val formatSpecialEditionButtonStyles : OFormat[SpecialEditionButtonStyles] = Json.format[SpecialEditionButtonStyles]
+}
+
 trait EditionDefinition {
   val title: String
   val subTitle: String
@@ -63,9 +95,18 @@ trait EditionDefinition {
   val notificationUTCOffset: Int
   val topic: String
 }
+
 trait EditionDefinitionWithTemplate extends EditionDefinition {
   val template: EditionTemplate
 }
+
+trait SpecialEditionDefinitionWithTemplate extends EditionDefinitionWithTemplate {
+  val image: SpecialEditionImage
+  val expiry: String
+  val buttonStyle: SpecialEditionButtonStyles
+  val headerStyle: SpecialEditionHeaderStyles
+}
+
 object EditionDefinition {
   def apply(
     title: String,

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -105,10 +105,23 @@ trait EditionDefinitionWithTemplate extends EditionDefinition {
 }
 
 abstract class RegionalEdition extends EditionDefinitionWithTemplate {
+  override val editionType: EditionType =  EditionType.Regional
   override val image: Option[SpecialEditionImage] = None
   override val expiry: Option[String] = None
   override val buttonStyle: Option[SpecialEditionButtonStyles] = None
   override val headerStyle: Option[SpecialEditionHeaderStyles] = None
+}
+
+abstract class InternalEdition extends EditionDefinitionWithTemplate {
+  override val editionType: EditionType = EditionType.Training
+  override val image: Option[SpecialEditionImage] = None
+  override val expiry: Option[String] = None
+  override val buttonStyle: Option[SpecialEditionButtonStyles] = None
+  override val headerStyle: Option[SpecialEditionHeaderStyles] = None
+}
+
+abstract class SpecialEdition extends EditionDefinitionWithTemplate {
+  override val editionType: EditionType = EditionType.Special
 }
 
 object EditionDefinition {

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -119,11 +119,17 @@ object EditionDefinition {
     header: Header,
     editionType: EditionType,
     notificationUTCOffset: Int,
-    topic: String
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic)
+    topic: String,
+   image: Option[SpecialEditionImage],
+   expiry: Option[String],
+   buttonStyle: Option[SpecialEditionButtonStyles],
+   headerStyle: Option[SpecialEditionHeaderStyles]
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, image, expiry, buttonStyle, headerStyle)
 
-  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String)]
-    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType, edition.notificationUTCOffset, edition.topic)
+  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
+    Option[SpecialEditionImage], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
+    = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
+    edition.notificationUTCOffset, edition.topic, edition.image, edition.expiry, edition.buttonStyle, edition.headerStyle)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -135,7 +141,12 @@ case class EditionDefinitionRecord(
                          override val header: Header,
                          override val editionType: EditionType,
                          override val notificationUTCOffset: Int,
-                         override val topic: String
+                         override val topic: String,
+                         override val image: Option[SpecialEditionImage],
+                         override val expiry: Option[String],
+                         override val buttonStyle: Option[SpecialEditionButtonStyles],
+                         override val headerStyle: Option[SpecialEditionHeaderStyles]
+
 ) extends EditionDefinition {}
 
 

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -7,12 +7,11 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TheDummyEdition extends RegionalEdition {
+object TheDummyEdition extends InternalEdition {
   override val title = "The Dummy Edition"
   override val subTitle = "Internal usage only, for reproducing issues"
   override val edition = "the-dummy-edition"
   override val header = Header("The Dummy", Some("Edition"))
-  override val editionType = EditionType.Training
   override val notificationUTCOffset = 3
   override val topic = "dm"
 

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -7,7 +7,7 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TheDummyEdition extends EditionDefinitionWithTemplate {
+object TheDummyEdition extends RegionalEdition {
   override val title = "The Dummy Edition"
   override val subTitle = "Internal usage only, for reproducing issues"
   override val edition = "the-dummy-edition"

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -7,12 +7,11 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TrainingEdition extends RegionalEdition {
+object TrainingEdition extends InternalEdition {
   override val title = "The Training Edition"
   override val subTitle = "Internal usage only, for training and demonstrations"
   override val edition = "training-edition"
   override val header = Header("Training Edition")
-  override val editionType = EditionType.Training
   override val notificationUTCOffset = 3
   override val topic = "tr"
 

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -7,7 +7,7 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TrainingEdition extends EditionDefinitionWithTemplate {
+object TrainingEdition extends RegionalEdition {
   override val title = "The Training Edition"
   override val subTitle = "Internal usage only, for training and demonstrations"
   override val edition = "training-edition"

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -4,11 +4,11 @@ import java.time.ZoneId
 
 import model.editions.templates.TemplateHelpers.Defaults._
 import model.editions._
-import model.editions.templates.{EditionDefinitionWithTemplate, EditionType, Header}
+import model.editions.templates.{EditionDefinitionWithTemplate, EditionType, Header, RegionalEdition}
 import model.editions.templates.EditionType.EditionType
 import model.editions.templates.TemplateHelpers.collection
 
-object TestEdition extends EditionDefinitionWithTemplate {
+object TestEdition extends RegionalEdition {
 
   val CapiQueryStartOffsetInDays: Int = -1
   val CapiQueryEndOffsetInDays: Int = 2


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This PR is more a proposal as I've not been able to test whether this approach will work, but it's an attempt to add the special edition properties expected in the editions app (see here https://github.com/guardian/editions/blob/master/projects/Apps/common/src/index.ts#L607) to a new class type called SpecialEditionDefinitionWithTemplate

This is related to David's work here https://github.com/guardian/facia-tool/pull/1239/files - that test edition could be of this type I think

## Implementation notes
Would be great to get some eyes/opinions on this

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
