### PR TITLE
Added prefills to Weekend

### DIFF
--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -67,7 +67,10 @@ object AustralianEdition extends RegionalEdition {
 
   def FrontWeekendAu = front(
     "Weekend",
-    collection("Weekend"),
+    collection("Weekend")
+      .searchPrefill("?tag=type/article,(tracking/commissioningdesk/australia-features|tracking/commissioningdesk/australia-pictures-),-tone/minutebyminute")
+      .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-5, 0)))
+      .withArticleItemsCap(20),
     collection("Weekend"),
     collection("Weekend"),
     collection("Weekend"),


### PR DESCRIPTION
Note that the trailing hyphen on the pictures tag is, bizarrely, correct.

## What's changed?
This PR adds a prefill to the previously empty first container in Weekend. It's populated by two tracking tags. Merran in Oz wants to give it a try, we can back out if it's not helpful.