### PR TITLE
Am add locale field to editions template

### DIFF
--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -15,8 +15,8 @@ object AmericanEdition extends RegionalEdition {
   override val header = Header("US", Some("Weekend"))
   override val notificationUTCOffset = 8
   override val topic = "us"
-  override val locale = "en_US"
-  override val timezone = "America/New_York"
+  override val locale = Some("en_US")
+  override val timezone = Some("America/New_York")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -15,6 +15,8 @@ object AmericanEdition extends RegionalEdition {
   override val header = Header("US", Some("Weekend"))
   override val notificationUTCOffset = 8
   override val topic = "us"
+  override val locale = "en_US"
+  override val timezone = "America/New_York"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -16,7 +16,6 @@ object AmericanEdition extends RegionalEdition {
   override val notificationUTCOffset = 8
   override val topic = "us"
   override val locale = Some("en_US")
-  override val timezone = Some("America/New_York")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -15,6 +15,8 @@ object AustralianEdition extends RegionalEdition {
   override val header = Header("Australia", Some("Weekend"))
   override val notificationUTCOffset = -5
   override val topic = "au"
+  override val locale = "en_AU"
+  override val timezone = "Australia/Sydney"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -15,8 +15,8 @@ object AustralianEdition extends RegionalEdition {
   override val header = Header("Australia", Some("Weekend"))
   override val notificationUTCOffset = -5
   override val topic = "au"
-  override val locale = "en_AU"
-  override val timezone = "Australia/Sydney"
+  override val locale = Some("en_AU")
+  override val timezone = Some("Australia/Sydney")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -16,7 +16,6 @@ object AustralianEdition extends RegionalEdition {
   override val notificationUTCOffset = -5
   override val topic = "au"
   override val locale = Some("en_AU")
-  override val timezone = Some("Australia/Sydney")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -14,7 +14,7 @@ object DailyEdition extends RegionalEdition {
   override val header = Header("UK", Some("Daily"))
   override val notificationUTCOffset = 3
   override val topic = "uk"
-  override val locale = "en_GB"
+  override val locale = Some("en_GB")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -14,6 +14,7 @@ object DailyEdition extends RegionalEdition {
   override val header = Header("UK", Some("Daily"))
   override val notificationUTCOffset = 3
   override val topic = "uk"
+  override val locale = "en_GB"
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -134,9 +134,7 @@ object EditionDefinition {
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
    headerStyle: Option[SpecialEditionHeaderStyles]
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, 
-                                                 
-                                                 , image, expiry, buttonStyle, headerStyle)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, buttonImageUri, expiry, buttonStyle, headerStyle)
 
   def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
     Option[String], Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -95,7 +95,6 @@ trait EditionDefinition {
   val notificationUTCOffset: Int
   val topic: String
   val locale: Option[String]
-  var timezone: Option[String]
   val image: Option[SpecialEditionImage]
   val expiry: Option[String]
   val buttonStyle: Option[SpecialEditionButtonStyles]
@@ -125,7 +124,6 @@ abstract class InternalEdition extends EditionDefinitionWithTemplate {
 abstract class SpecialEdition extends EditionDefinitionWithTemplate {
   override val editionType: EditionType = EditionType.Special
   override val locale: Option[String] = None
-  override val timezone: Option[String] = None
 }
 
 object EditionDefinition {
@@ -138,17 +136,16 @@ object EditionDefinition {
     notificationUTCOffset: Int,
     topic: String,
     locale: Option[String],
-    timezone: Option[String],
    image: Option[SpecialEditionImage],
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
    headerStyle: Option[SpecialEditionHeaderStyles]
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, timezone, image, expiry, buttonStyle, headerStyle)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, image, expiry, buttonStyle, headerStyle)
 
-  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String, Option[String], Option[String],
+  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String, Option[String],
     Option[SpecialEditionImage], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
-    edition.notificationUTCOffset, edition.topic, edition.locale, edition.timezone, edition.image, edition.expiry, edition.buttonStyle, edition.headerStyle)
+    edition.notificationUTCOffset, edition.topic, edition.locale, edition.image, edition.expiry, edition.buttonStyle, edition.headerStyle)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -162,7 +159,6 @@ case class EditionDefinitionRecord(
                          override val notificationUTCOffset: Int,
                          override val topic: String,
                          override val locale: Option[String], 
-                         override val timezone: Option[String],
                          override val image: Option[SpecialEditionImage],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -94,6 +94,8 @@ trait EditionDefinition {
   val editionType: EditionType
   val notificationUTCOffset: Int
   val topic: String
+  val locale: Option[String]
+  var timezone: Option[String]
   val image: Option[SpecialEditionImage]
   val expiry: Option[String]
   val buttonStyle: Option[SpecialEditionButtonStyles]
@@ -122,6 +124,8 @@ abstract class InternalEdition extends EditionDefinitionWithTemplate {
 
 abstract class SpecialEdition extends EditionDefinitionWithTemplate {
   override val editionType: EditionType = EditionType.Special
+  override val locale: Option[String] = None
+  override val timezone: Option[String] = None
 }
 
 object EditionDefinition {
@@ -133,16 +137,18 @@ object EditionDefinition {
     editionType: EditionType,
     notificationUTCOffset: Int,
     topic: String,
+    locale: Option[String],
+    timezone: Option[String],
    image: Option[SpecialEditionImage],
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
    headerStyle: Option[SpecialEditionHeaderStyles]
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, image, expiry, buttonStyle, headerStyle)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, timezone, image, expiry, buttonStyle, headerStyle)
 
-  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
+  def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String, Option[String], Option[String],
     Option[SpecialEditionImage], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
-    edition.notificationUTCOffset, edition.topic, edition.image, edition.expiry, edition.buttonStyle, edition.headerStyle)
+    edition.notificationUTCOffset, edition.topic, edition.locale, edition.timezone, edition.image, edition.expiry, edition.buttonStyle, edition.headerStyle)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -155,6 +161,8 @@ case class EditionDefinitionRecord(
                          override val editionType: EditionType,
                          override val notificationUTCOffset: Int,
                          override val topic: String,
+                         override val locale: Option[String], 
+                         override val timezone: Option[String],
                          override val image: Option[SpecialEditionImage],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -14,6 +14,7 @@ object TheDummyEdition extends InternalEdition {
   override val header = Header("The Dummy", Some("Edition"))
   override val notificationUTCOffset = 3
   override val topic = "dm"
+  override val locale = Some("dm_DM")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TheDummyEdition.scala
+++ b/app/model/editions/templates/TheDummyEdition.scala
@@ -14,7 +14,7 @@ object TheDummyEdition extends InternalEdition {
   override val header = Header("The Dummy", Some("Edition"))
   override val notificationUTCOffset = 3
   override val topic = "dm"
-  override val locale = Some("dm_DM")
+  override val locale = Some("en_GB")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -14,7 +14,7 @@ object TrainingEdition extends InternalEdition {
   override val header = Header("Training Edition")
   override val notificationUTCOffset = 3
   override val topic = "tr"
-  override val locale = Some("tr_TR")
+  override val locale = Some("en_GB")
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TrainingEdition.scala
+++ b/app/model/editions/templates/TrainingEdition.scala
@@ -14,6 +14,7 @@ object TrainingEdition extends InternalEdition {
   override val header = Header("Training Edition")
   override val notificationUTCOffset = 3
   override val topic = "tr"
+  override val locale = Some("tr_TR")
 
   lazy val template = EditionTemplate(
     List(

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -41,6 +41,7 @@ object TestEdition extends RegionalEdition {
   override val editionType: EditionType = EditionType.Regional
   override val notificationUTCOffset: Int = 2
   override val topic: String = "tt"
+  override val locale: Option[String] = Some("tt_TT")
 }
 
 object FrontTopStories {

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -41,7 +41,7 @@ object TestEdition extends RegionalEdition {
   override val editionType: EditionType = EditionType.Regional
   override val notificationUTCOffset: Int = 2
   override val topic: String = "tt"
-  override val locale: Option[String] = Some("tt_TT")
+  override val locale: Option[String] = Some("en_GB")
 }
 
 object FrontTopStories {


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
In preparation to remove the US edition, we thought that the app shouldn't be dependant on the existence of any particular edition. 
This PR adds a new `locale` field which the editions app can use to decide which default edition to select for a new user based on their selected locale.
**Note** The locale field is only relevant for Regional Editions. 

I have deployed this branch to CODE to check that the field comes through as expected https://fronts.code.dev-gutools.co.uk/editions-api/editions

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
