### PR TITLE
Removed american edition from edition list

### DIFF
--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -15,7 +15,6 @@ import services.editions.prefills.CapiQueryTimeWindow
 object EditionsTemplates {
   val templates: Map[Edition, EditionDefinitionWithTemplate] = Map(
     Edition.DailyEdition -> DailyEdition,
-    Edition.AmericanEdition -> AmericanEdition,
     Edition.AustralianEdition -> AustralianEdition,
     Edition.TrainingEdition -> TrainingEdition,
     Edition.TheDummyEdition -> TheDummyEdition
@@ -59,8 +58,6 @@ sealed abstract class Edition extends EnumEntry with Hyphencase
 object Edition extends PlayEnum[Edition] {
 
   case object DailyEdition extends Edition
-
-  case object AmericanEdition extends Edition
 
   case object AustralianEdition extends Edition
 


### PR DESCRIPTION
## What's changed?
We are excluding the American edition from the edition list


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
