### PR TITLE
Special edition improvements

### DIFF
--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -17,7 +17,8 @@ object EditionsTemplates {
     Edition.DailyEdition -> DailyEdition,
     Edition.AustralianEdition -> AustralianEdition,
     Edition.TrainingEdition -> TrainingEdition,
-    Edition.TheDummyEdition -> TheDummyEdition
+    Edition.TheDummyEdition -> TheDummyEdition,
+    Edition.TestSpecialEdition -> TestSpecialEdition
   )
 
   val getAvailableEditions: List[EditionDefinition] = templates.values.toList
@@ -64,6 +65,8 @@ object Edition extends PlayEnum[Edition] {
   case object TrainingEdition extends Edition
 
   case object TheDummyEdition extends Edition
+  
+  case object TestSpecialEdition extends Edition
 
   override def values = findValues
 }

--- a/app/model/editions/EditionsTemplates.scala
+++ b/app/model/editions/EditionsTemplates.scala
@@ -17,8 +17,7 @@ object EditionsTemplates {
     Edition.DailyEdition -> DailyEdition,
     Edition.AustralianEdition -> AustralianEdition,
     Edition.TrainingEdition -> TrainingEdition,
-    Edition.TheDummyEdition -> TheDummyEdition,
-    Edition.TestSpecialEdition -> TestSpecialEdition
+    Edition.TheDummyEdition -> TheDummyEdition
   )
 
   val getAvailableEditions: List[EditionDefinition] = templates.values.toList
@@ -65,8 +64,6 @@ object Edition extends PlayEnum[Edition] {
   case object TrainingEdition extends Edition
 
   case object TheDummyEdition extends Edition
-  
-  case object TestSpecialEdition extends Edition
 
   override def values = findValues
 }

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -54,11 +54,6 @@ object Header {
   implicit val formatHeader: OFormat[Header] = Json.format[Header]
 }
 
-case class SpecialEditionImage(source: String, path: String)
-object SpecialEditionImage {
-  implicit val formatHeader: OFormat[SpecialEditionImage] = Json.format[SpecialEditionImage]
-}
-
 case class SpecialEditionHeaderStyles(backgroundColor: String, textColorPrimary: String, textColorSecondary: String)
 object SpecialEditionHeaderStyles {
   implicit val formatHeader: OFormat[SpecialEditionHeaderStyles] = Json.format[SpecialEditionHeaderStyles]
@@ -94,7 +89,7 @@ trait EditionDefinition {
   val editionType: EditionType
   val notificationUTCOffset: Int
   val topic: String
-  val image: Option[SpecialEditionImage]
+  val buttonImageUri: Option[String]
   val expiry: Option[String]
   val buttonStyle: Option[SpecialEditionButtonStyles]
   val headerStyle: Option[SpecialEditionHeaderStyles]
@@ -106,7 +101,7 @@ trait EditionDefinitionWithTemplate extends EditionDefinition {
 
 abstract class RegionalEdition extends EditionDefinitionWithTemplate {
   override val editionType: EditionType =  EditionType.Regional
-  override val image: Option[SpecialEditionImage] = None
+  override val buttonImageUri: Option[String] = None
   override val expiry: Option[String] = None
   override val buttonStyle: Option[SpecialEditionButtonStyles] = None
   override val headerStyle: Option[SpecialEditionHeaderStyles] = None
@@ -114,7 +109,7 @@ abstract class RegionalEdition extends EditionDefinitionWithTemplate {
 
 abstract class InternalEdition extends EditionDefinitionWithTemplate {
   override val editionType: EditionType = EditionType.Training
-  override val image: Option[SpecialEditionImage] = None
+  override val buttonImageUri: Option[String] = None
   override val expiry: Option[String] = None
   override val buttonStyle: Option[SpecialEditionButtonStyles] = None
   override val headerStyle: Option[SpecialEditionHeaderStyles] = None
@@ -133,16 +128,16 @@ object EditionDefinition {
     editionType: EditionType,
     notificationUTCOffset: Int,
     topic: String,
-   image: Option[SpecialEditionImage],
+    buttonImageUri: Option[String],
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
    headerStyle: Option[SpecialEditionHeaderStyles]
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, image, expiry, buttonStyle, headerStyle)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, buttonImageUri, expiry, buttonStyle, headerStyle)
 
   def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
-    Option[SpecialEditionImage], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
+    Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
-    edition.notificationUTCOffset, edition.topic, edition.image, edition.expiry, edition.buttonStyle, edition.headerStyle)
+    edition.notificationUTCOffset, edition.topic, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -155,7 +150,7 @@ case class EditionDefinitionRecord(
                          override val editionType: EditionType,
                          override val notificationUTCOffset: Int,
                          override val topic: String,
-                         override val image: Option[SpecialEditionImage],
+                         override val buttonImageUri: Option[String],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],
                          override val headerStyle: Option[SpecialEditionHeaderStyles]

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -93,7 +93,6 @@ trait EditionDefinition {
   val expiry: Option[String]
   val buttonStyle: Option[SpecialEditionButtonStyles]
   val headerStyle: Option[SpecialEditionHeaderStyles]
-  val isLive: Boolean
 }
 
 trait EditionDefinitionWithTemplate extends EditionDefinition {
@@ -105,7 +104,6 @@ abstract class EditionBase extends EditionDefinitionWithTemplate {
   override val expiry: Option[String] = None
   override val buttonStyle: Option[SpecialEditionButtonStyles] = None
   override val headerStyle: Option[SpecialEditionHeaderStyles] = None
-  override val isLive = true
 }
 
 abstract class RegionalEdition extends EditionBase {
@@ -133,13 +131,12 @@ object EditionDefinition {
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
    headerStyle: Option[SpecialEditionHeaderStyles],
-    isLive: Boolean
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, buttonImageUri, expiry, buttonStyle, headerStyle, isLive)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, buttonImageUri, expiry, buttonStyle, headerStyle)
 
   def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
-    Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles], Boolean)]
+    Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
-    edition.notificationUTCOffset, edition.topic, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle, edition.isLive)
+    edition.notificationUTCOffset, edition.topic, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -155,8 +152,7 @@ case class EditionDefinitionRecord(
                          override val buttonImageUri: Option[String],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],
-                         override val headerStyle: Option[SpecialEditionHeaderStyles],
-                         override val isLive: Boolean
+                         override val headerStyle: Option[SpecialEditionHeaderStyles]
 ) extends EditionDefinition {}
 
 

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -93,26 +93,27 @@ trait EditionDefinition {
   val expiry: Option[String]
   val buttonStyle: Option[SpecialEditionButtonStyles]
   val headerStyle: Option[SpecialEditionHeaderStyles]
+  val isLive: Boolean
 }
 
 trait EditionDefinitionWithTemplate extends EditionDefinition {
   val template: EditionTemplate
 }
 
-abstract class RegionalEdition extends EditionDefinitionWithTemplate {
-  override val editionType: EditionType =  EditionType.Regional
+abstract class EditionBase extends EditionDefinitionWithTemplate {
   override val buttonImageUri: Option[String] = None
   override val expiry: Option[String] = None
   override val buttonStyle: Option[SpecialEditionButtonStyles] = None
   override val headerStyle: Option[SpecialEditionHeaderStyles] = None
+  override val isLive = true
 }
 
-abstract class InternalEdition extends EditionDefinitionWithTemplate {
+abstract class RegionalEdition extends EditionBase {
+  override val editionType: EditionType =  EditionType.Regional
+}
+
+abstract class InternalEdition extends EditionBase {
   override val editionType: EditionType = EditionType.Training
-  override val buttonImageUri: Option[String] = None
-  override val expiry: Option[String] = None
-  override val buttonStyle: Option[SpecialEditionButtonStyles] = None
-  override val headerStyle: Option[SpecialEditionHeaderStyles] = None
 }
 
 abstract class SpecialEdition extends EditionDefinitionWithTemplate {

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -132,13 +132,14 @@ object EditionDefinition {
     buttonImageUri: Option[String],
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
-   headerStyle: Option[SpecialEditionHeaderStyles]
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, buttonImageUri, expiry, buttonStyle, headerStyle)
+   headerStyle: Option[SpecialEditionHeaderStyles],
+    isLive: Boolean
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, buttonImageUri, expiry, buttonStyle, headerStyle, isLive)
 
   def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
-    Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
+    Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles], Boolean)]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
-    edition.notificationUTCOffset, edition.topic, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle)
+    edition.notificationUTCOffset, edition.topic, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle, edition.isLive)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -154,8 +155,8 @@ case class EditionDefinitionRecord(
                          override val buttonImageUri: Option[String],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],
-                         override val headerStyle: Option[SpecialEditionHeaderStyles]
-
+                         override val headerStyle: Option[SpecialEditionHeaderStyles],
+                         override val isLive: Boolean
 ) extends EditionDefinition {}
 
 

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -7,7 +7,7 @@ import model.editions._
 import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
-object TrainingEdition extends EditionDefinitionWithTemplate {
+object TestSpecialEdition extends EditionDefinitionWithTemplate {
   override val title = "Specia Edition Test"
   override val subTitle = "Demonstration of special edition"
   override val edition = "special-edition-test"

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -16,7 +16,6 @@ object TestSpecialEdition extends SpecialEdition {
   override val notificationUTCOffset = 3
   override val topic = "s-e-t"
   override val buttonImageUri = Some("https://i.guim.co.uk/img/media/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg?width=200&quality=85&s=a2bb61836c17f02d06173b6bc70034af")
-  override val isLive = false
   override val expiry: Option[String] = Some(
     new DateTime(2020, 10,20,12,0,DateTimeZone.UTC).toString()
   )

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -15,7 +15,7 @@ object TestSpecialEdition extends SpecialEdition {
   override val header = Header(title ="Special", subTitle=Some("Edition Test"))
   override val notificationUTCOffset = 3
   override val topic = "s-e-t"
-  override val buttonImageUri = Some("https://media.guim.co.uk/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg")
+  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg?width=200&quality=85&s=a2bb61836c17f02d06173b6bc70034af")
   override val isLive = false
   override val expiry: Option[String] = Some(
     new DateTime(2020, 10,20,12,0,DateTimeZone.UTC).toString()

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -16,6 +16,7 @@ object TestSpecialEdition extends SpecialEdition {
   override val notificationUTCOffset = 3
   override val topic = "s-e-t"
   override val buttonImageUri = Some("https://media.guim.co.uk/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg")
+  override val isLive = false
   override val expiry: Option[String] = Some(
     new DateTime(2020, 10,20,12,0,DateTimeZone.UTC).toString()
   )

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -11,7 +11,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 object TestSpecialEdition extends SpecialEdition {
   override val title = "Special Edition Test"
   override val subTitle = "Demonstration of special edition"
-  override val edition = "special-edition-test"
+  override val edition = "test-special-edition"
   override val header = Header(title ="Special", subTitle=Some("Edition Test"))
   override val notificationUTCOffset = 3
   override val topic = "s-e-t"

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -5,18 +5,40 @@ import java.time.ZoneId
 import model.editions.Swatch._
 import model.editions._
 import model.editions.templates.TemplateHelpers._
+import org.joda.time.{DateTime, DateTimeZone}
 
 //noinspection TypeAnnotation
-object TestSpecialEdition extends EditionDefinitionWithTemplate {
+object TestSpecialEdition extends SpecialEdition {
   override val title = "Special Edition Test"
   override val subTitle = "Demonstration of special edition"
   override val edition = "special-edition-test"
   override val header = Header(title ="Special", subTitle=Some("Edition Test"))
-  override val editionType = EditionType.Special
   override val notificationUTCOffset = 3
   override val topic = "s-e-t"
-  //override val expiry = ???
-  //override val image = ???
+  override val image: Option[SpecialEditionImage] = Some(SpecialEditionImage(
+    source= "media",
+    path="/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg"
+  ))
+  override val expiry: Option[String] = Some(
+    new DateTime(2020, 9,3,12,0,DateTimeZone.UTC).toString()
+  )
+  override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
+    SpecialEditionButtonStyles(
+      backgroundColor = "",
+      title = EditionTextFormatting(color = "#c1de2b", font="'GHGuardianHeadline-Regular'", lineHeight = 34, size = 34),
+      subTitle = EditionTextFormatting(color = "#284b7d", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
+      expiry = EditionTextFormatting(color = "#5a287d", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),
+      image = EditionImageStyle(87,134)
+    )
+  )
+  override val headerStyle: Option[SpecialEditionHeaderStyles] = Some(
+    SpecialEditionHeaderStyles(
+      backgroundColor = "#de2b67",
+      textColorPrimary = "#de482b",
+      textColorSecondary = "#dea22b"
+    )
+  )
+
 
   lazy val template = EditionTemplate(
     List(

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -15,10 +15,7 @@ object TestSpecialEdition extends SpecialEdition {
   override val header = Header(title ="Special", subTitle=Some("Edition Test"))
   override val notificationUTCOffset = 3
   override val topic = "s-e-t"
-  override val image: Option[SpecialEditionImage] = Some(SpecialEditionImage(
-    source= "media",
-    path="/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg"
-  ))
+  override val buttonImageUri = Some("https://media.guim.co.uk/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg")
   override val expiry: Option[String] = Some(
     new DateTime(2020, 9,3,12,0,DateTimeZone.UTC).toString()
   )

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -17,7 +17,7 @@ object TestSpecialEdition extends SpecialEdition {
   override val topic = "s-e-t"
   override val buttonImageUri = Some("https://media.guim.co.uk/efe173f8944226a06d667869c7f19d072f6807df/541_232_1740_2680/1740.jpg")
   override val expiry: Option[String] = Some(
-    new DateTime(2020, 9,3,12,0,DateTimeZone.UTC).toString()
+    new DateTime(2020, 10,20,12,0,DateTimeZone.UTC).toString()
   )
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -25,7 +25,7 @@ object TestSpecialEdition extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "",
-      title = EditionTextFormatting(color = "#c1de2b", font="'GHGuardianHeadline-Regular'", lineHeight = 34, size = 34),
+      title = EditionTextFormatting(color = "#c1de2b", font="GHGuardianHeadline-Regular", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#284b7d", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#5a287d", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),
       image = EditionImageStyle(87,134)

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -1,0 +1,45 @@
+package model.editions.templates
+
+import java.time.ZoneId
+
+import model.editions.Swatch._
+import model.editions._
+import model.editions.templates.TemplateHelpers._
+
+//noinspection TypeAnnotation
+object TrainingEdition extends EditionDefinitionWithTemplate {
+  override val title = "Specia Edition Test"
+  override val subTitle = "Demonstration of special edition"
+  override val edition = "special-edition-test"
+  override val header = Header("Special", "Edition Test")
+  override val editionType = EditionType.Special
+  //override val expiry = ???
+  //override val image = ???
+
+  lazy val template = EditionTemplate(
+    List(
+      Front1 -> Daily(),
+      Front2 -> Daily(),
+      Front3 -> Daily()
+    )
+  )
+
+  def Front1 = front("Front 1", None,
+    collection("Collection 1"),
+    collection("Collection 2"),
+    collection("Collection 3")
+  ).swatch(News)
+
+  def Front1 = front("Front 2", None,
+    collection("Collection 1"),
+    collection("Collection 2"),
+    collection("Collection 3")
+  ).swatch(Culture)
+  
+  def Front3 = front("Front 3", None,
+    collection("Collection 1"),
+    collection("Collection 2"),
+    collection("Collection 3")
+  ).swatch(Sport)
+
+}

--- a/app/model/editions/templates/TestSpecialEdition.scala
+++ b/app/model/editions/templates/TestSpecialEdition.scala
@@ -8,11 +8,13 @@ import model.editions.templates.TemplateHelpers._
 
 //noinspection TypeAnnotation
 object TestSpecialEdition extends EditionDefinitionWithTemplate {
-  override val title = "Specia Edition Test"
+  override val title = "Special Edition Test"
   override val subTitle = "Demonstration of special edition"
   override val edition = "special-edition-test"
-  override val header = Header("Special", "Edition Test")
+  override val header = Header(title ="Special", subTitle=Some("Edition Test"))
   override val editionType = EditionType.Special
+  override val notificationUTCOffset = 3
+  override val topic = "s-e-t"
   //override val expiry = ???
   //override val image = ???
 
@@ -21,7 +23,16 @@ object TestSpecialEdition extends EditionDefinitionWithTemplate {
       Front1 -> Daily(),
       Front2 -> Daily(),
       Front3 -> Daily()
-    )
+    ),
+    timeWindowConfig = CapiTimeWindowConfigInDays(
+      startOffset = 0,
+      endOffset = 0,
+    ),
+    capiDateQueryParam = CapiDateQueryParam.Published,
+    zoneId = ZoneId.of("Europe/London"),
+    availability = Daily(),
+    maybeOphanPath = None,
+    ophanQueryPrefillParams = None
   )
 
   def Front1 = front("Front 1", None,
@@ -30,12 +41,12 @@ object TestSpecialEdition extends EditionDefinitionWithTemplate {
     collection("Collection 3")
   ).swatch(News)
 
-  def Front1 = front("Front 2", None,
+  def Front2 = front("Front 2", None,
     collection("Collection 1"),
     collection("Collection 2"),
     collection("Collection 3")
   ).swatch(Culture)
-  
+
   def Front3 = front("Front 3", None,
     collection("Collection 1"),
     collection("Collection 2"),

--- a/docs/AddingAndAlteringTemplates.md
+++ b/docs/AddingAndAlteringTemplates.md
@@ -17,7 +17,7 @@ extends `EditionDefinitionWithTemplate`. Ensure it fulfills all the requirements
 object MyLovelyHorseEdition extends EditionDefinitionWithTemplate {
   override val title = "My Lovely Horse"
   override val subTitle = "Published every morning by 6am (GMT)"
-  override val edition = "horse-edition"
+  override val edition = "my-lovely-horse-edition"
   override val header = Header("Horses!", "Lots of horses!")
   override val editionType = EditionType.Regional
   override val notificationUTCOffset = 3
@@ -25,6 +25,9 @@ object MyLovelyHorseEdition extends EditionDefinitionWithTemplate {
   lazy val template = EditionTemplate(
   ...
 ```
+
+NOTE: the `edition` property of your object must be a hypen case version of your object name otherwise the routing won't
+work and you'll get a 404 error when creating an issue
 
 Add the new Edition to _both_ the list of templates and the Edition enum object
 in `app/model/editions/EditionsTemplates.scala`.

--- a/docs/AddingAndAlteringTemplates.md
+++ b/docs/AddingAndAlteringTemplates.md
@@ -26,7 +26,7 @@ object MyLovelyHorseEdition extends EditionDefinitionWithTemplate {
   ...
 ```
 
-NOTE: the `edition` property of your object must be a hypen case version of your object name otherwise the routing won't
+NOTE: the `edition` property of your object must be a kebab case version of your object name otherwise the routing won't
 work and you'll get a 404 error when creating an issue
 
 Add the new Edition to _both_ the list of templates and the Edition enum object


### PR DESCRIPTION
## What's changed?
 - Replaced special edition `image` field with `buttonImageUri` following update in the editions app
 - Introduced new `EditionBase` class for properties that are common between Internal and Regional Editions
 - Updated docs for creating a new edition to warn people that the class name needs to match the edition ID
 - Introduce new `isLive` field for editions - currently ignored by the client - to be used to filter out special editions or regional editions that we need to test in the app with live issues but that we don't want users to see
 - Merge in code changes for special edition @blishen created here https://github.com/guardian/facia-tool/pull/1239 but without actually adding it to the editions list, just so that we have some code in master that won't get into conflicts (once we have introduced `isLive` in the client we could safely merge the test edition)

## Implementation notes
Hopefully it's ok to merge in the test special edition - it's got a bit tedious refactoring it all the time. This way each time we deploy to code it'll be just a 2 line change to add the special edition to the list in `EditionTemplates`

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
