### PR TITLE
Bump fapi client and capi client/models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,8 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.11.293"
-val capiModelsVersion = "15.4"
-val capiClientVersion = "15.4"
+val capiModelsVersion = "15.6"
+val capiClientVersion = "17.1"
 val json4sVersion = "3.6.0-M2"
 val enumeratumPlayVersion = "1.5.13"
 val circeVersion = "0.11.1"
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.5",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.0",
-    "com.gu" %% "fapi-client-play26" % "3.0.22",
+    "com.gu" %% "fapi-client-play26" % "3.2.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.7",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",


### PR DESCRIPTION
## What's changed?

Bumps the Fapi client to 3.2.0, to give access to the new tags provided in the recent version of the [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/241).

Tested on CODE. The new tags are available in the config tool.

<img width="403" alt="Screenshot 2020-09-22 at 12 13 39" src="https://user-images.githubusercontent.com/7767575/93875558-19d36100-fccd-11ea-8261-9c8e561ed7e7.png">

They don't appear to cause problems with the press, which at the moment doesn't yet understand these new tags.
 
<img width="805" alt="Screenshot 2020-09-22 at 12 10 29" src="https://user-images.githubusercontent.com/7767575/93875353-bb0de780-fccc-11ea-8ac2-d370af4015ec.png">

Updating content works from the tool to the pressed front. 

The tool itself displays tags next to the container name, which should make identifying collections with these tags easy for curators.

<img width="432" alt="Screenshot 2020-09-22 at 12 07 03" src="https://user-images.githubusercontent.com/7767575/93875035-27d4b200-fccc-11ea-9642-501b3f1b4ebe.png">

## Implementation notes

Bumping the Capi models and client was necessary, as the new version of the Fapi client depends on the newer versions.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
