### PR TITLE
Update button image for edition earth.

### DIFF
--- a/app/model/editions/templates/EditionEarth.scala
+++ b/app/model/editions/templates/EditionEarth.scala
@@ -15,7 +15,7 @@ object EditionEarth extends SpecialEdition {
   override val header = Header(title ="Edition", subTitle=Some("Earth"))
   override val notificationUTCOffset = 3
   override val topic = "e-e"
-  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/23e97e00b2b0c3277ea6ff8a38068709509d92da/0_0_931_934/931.png?width=134&quality=95&s=5bf4d7e4ea9abd51017379b2dacb1e79")
+  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/23e97e00b2b0c3277ea6ff8a38068709509d92da/462_0_469_934/469.png?width=67&quality=100&s=78dcf02d6978bb0c8885cbe076fcb257")
   override val expiry: Option[String] = Some(
     new DateTime(2020, 11,7,23,59,DateTimeZone.UTC).toString()
   )
@@ -25,7 +25,7 @@ object EditionEarth extends SpecialEdition {
       title = EditionTextFormatting(color = "#121212", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#121212", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#121212", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),
-      image = EditionImageStyle(134,134)
+      image = EditionImageStyle(67,134)
     )
   )
   override val headerStyle: Option[SpecialEditionHeaderStyles] = Some(
@@ -101,7 +101,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special04 = front("Sp Black 2", None,
     collection("Special"),
     collection("Special"),
@@ -125,7 +125,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special07 = front("Sp Black 3", None,
     collection("Special"),
     collection("Special"),
@@ -149,7 +149,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special10 = front("Sp Black 4", None,
     collection("Special"),
     collection("Special"),
@@ -173,7 +173,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special13 = front("Sp Black 5", None,
     collection("Special"),
     collection("Special"),
@@ -197,7 +197,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special16 = front("Sp Black 6", None,
     collection("Special"),
     collection("Special"),
@@ -221,7 +221,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special19 = front("Sp Black 7", None,
     collection("Special"),
     collection("Special"),
@@ -245,7 +245,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special22 = front("Sp Black 8", None,
     collection("Special"),
     collection("Special"),
@@ -269,7 +269,7 @@ object EditionEarth extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Opinion)
-  
+
   def Special25 = front("Sp Black 9", None,
     collection("Special"),
     collection("Special"),
@@ -294,5 +294,5 @@ object EditionEarth extends SpecialEdition {
     collection("Special")
   ).swatch(Opinion)
 
-  
+
 }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This makes the button image for edition earth fit better on the menu. 

Before:
<img width="380" alt="Screenshot 2020-09-28 at 10 27 58" src="https://user-images.githubusercontent.com/3606555/94415422-69a2a400-0175-11eb-8490-5fb5f639ccb4.png">

After:
<img width="408" alt="Screenshot 2020-09-28 at 10 30 31" src="https://user-images.githubusercontent.com/3606555/94415606-aa9ab880-0175-11eb-9ff6-e71190969912.png">

On tablet it looks like this:
<img width="355" alt="Screenshot 2020-09-28 at 10 37 15" src="https://user-images.githubusercontent.com/3606555/94416324-9c996780-0176-11eb-8dc1-b697235bb228.png">



## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ x ] 📷 Screenshots / GIFs of relevant UI changes included
