### PR TITLE
Bump Panda to latest for play 2.6

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -14,6 +14,7 @@ import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest
 import com.amazonaws.services.rds.AmazonRDSClientBuilder
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest
 
@@ -130,6 +131,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     }
     val rdsClient = AmazonRDSClientBuilder.standard().withCredentials(cmsFrontsAccountCredentials).withRegion(region).build()
     val ssmClient = AWSSimpleSystemsManagementClientBuilder.standard().withCredentials(cmsFrontsAccountCredentials).withRegion(region).build()
+    val s3Client = AmazonS3ClientBuilder.standard().withCredentials(cmsFrontsAccountCredentials).withRegion(region).build()
   }
 
   object postgres {
@@ -253,6 +255,8 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
     lazy val domain = getMandatoryString("pandomain.domain")
     lazy val service = getMandatoryString("pandomain.service")
     lazy val roleArn = getMandatoryString("pandomain.roleArn")
+    lazy val bucketName = getMandatoryString("pandomain.bucketName")
+    lazy val settingsFileKey = s"$domain.settings"
     lazy val userGroups = getMandatoryStringPropertiesSplitByComma("pandomain.user.groups")
   }
 

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -23,7 +23,13 @@ abstract class BaseFaciaControllerComponents(context: Context) extends BuiltInCo
   def config: ApplicationConfiguration
 
   lazy val panDomainSettings: PanDomainAuthSettingsRefresher =
-    new PanDomainAuthSettingsRefresher(config.pandomain.domain, config.pandomain.service, actorSystem, config.aws.cmsFrontsAccountCredentials)
+    new PanDomainAuthSettingsRefresher(
+      config.pandomain.domain,
+      config.pandomain.service,
+      config.pandomain.bucketName,
+      config.pandomain.settingsFileKey,
+      config.aws.s3Client
+    )
 
   lazy val permissions = PermissionsProvider(PermissionsConfig(
     stage = config.environment.stage.toUpperCase(Locale.UK),

--- a/app/controllers/PandaAuthController.scala
+++ b/app/controllers/PandaAuthController.scala
@@ -4,7 +4,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PandaAuthController(val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
   def oauthCallback = Action.async { implicit request =>
-    processGoogleCallback()
+    processOAuthCallback()
   }
 
   def logout = Action.async { implicit request =>

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ libraryDependencies ++= Seq(
     filters,
     evolutions,
     jdbc,
+    "com.typesafe.akka" %% "akka-agent" % "2.5.16",
     "com.amazonaws" % "aws-java-sdk-rds" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-core" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
@@ -98,7 +99,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "fapi-client-play26" % "3.2.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.7",
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.2",
+    "com.gu" %% "pan-domain-auth-play_2-6" % "0.9.2",
 
     "com.gu" %% "scanamo" % "1.0.0-M7",
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -89,6 +89,7 @@ PROD.aws.previewEditionsIssuesBucket: "preview-editions-prod"
 pandomain {
   service: "fronts"
   roleArn: "arn:aws:iam::753338109777:role/Fronts-panda-IAM-FaciaToolRole-NKNXCYEGL0F6"
+  bucketName: "pan-domain-auth-settings"
 }
 
 logging {


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This bumps the pan domain library to `0.9.2` which is the latest possible for play 2.6. This is enough to stop fronts setting the legacy cookie though.

### General
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE
