### PR TITLE
fix stale writes by locking collections when auth/connection issue discovered

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -238,10 +238,20 @@ function getCollections(
         getCollectionActions(collectionResponse, getState)
       );
 
+      const actionsToBatch = flatten([
+        ...actions,
+        ...missingActions,
+        ...missingCollectionActions,
+      ]);
+
+      // this is necessary to ensure lastFetch, error etc. are always updated
+      // (as we rely on them elsewhere to lock editing if stale/errored)
+      const noChangesAction = collectionActions.fetchSuccess([]);
+
       dispatch(
-        batchActions(
-          flatten([...actions, ...missingActions, ...missingCollectionActions])
-        )
+        actionsToBatch.length > 0
+          ? batchActions(actionsToBatch)
+          : noChangesAction
       );
       return collectionResponses.map(({ id }) => id);
     } catch (error) {

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -51,8 +51,10 @@ const EditingLockedCollectionsOverlay = styled.div`
   flex-direction: column;
   align-items: center;
   user-select: none;
+  text-align: center;
+  padding: 5px;
   h2 {
-    margin-bottom: 0;
+    margin: 0;
   }
 `;
 

--- a/fronts-client/src/lib/createAsyncResourceBundle/index.ts
+++ b/fronts-client/src/lib/createAsyncResourceBundle/index.ts
@@ -389,9 +389,6 @@ function createAsyncResourceBundle<Resource>(
           ) {
             return state;
           }
-          if (!action.payload.error) {
-            return state;
-          }
           return {
             ...state,
             lastError: action.payload.error,

--- a/fronts-client/src/services/__tests__/pandaFetch.spec.ts
+++ b/fronts-client/src/services/__tests__/pandaFetch.spec.ts
@@ -33,7 +33,7 @@ describe('pandaFetch', () => {
     });
     setReauthedResponse({ ok: true }, '/test');
     const thrown = await pandaFetch('/test').catch((er) => er);
-    expect(thrown).toBe(e);
+    expect(thrown).toBe(`Auth Issue (${e.toString()})`);
   });
 
   it('rejects with non 2XX responses', async () => {

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -41,11 +41,21 @@ const pandaFetch = (
             );
           }
         } else if (res.status < 200 || res.status >= 300) {
+          notifications.notify({
+            message:
+              'Request failed. Your changes may not be saved. Please wait or reload the page.',
+            level: 'error',
+          });
           return reject(res);
         }
 
         return resolve(res);
       } catch (error) {
+        notifications.notify({
+          message:
+            'Connection issue occurred. Your changes may not be saved. Please wait or reload the page.',
+          level: 'error',
+        });
         return reject(`Connection Issue (${error ? error.toString() : ''})`);
       }
     }

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -1,6 +1,7 @@
 import { reEstablishSession } from 'panda-session';
 import notifications from './notifications';
 import { isError } from 'tslint/lib/error';
+import Raven from 'raven-js';
 
 const reauthUrl = '/login/status';
 const reauthErrorMessage =
@@ -36,6 +37,9 @@ const pandaFetch = (
               message: reauthErrorMessage,
               level: 'error',
             });
+            Raven.captureException(e, {
+              extra: `Auth issue banner presented to user`,
+            });
             return reject(
               isError(e) ? `Auth Issue (${e ? e.toString() : ''})` : e
             );
@@ -46,6 +50,10 @@ const pandaFetch = (
               'Request failed. Your changes may not be saved. Please wait or reload the page.',
             level: 'error',
           });
+          Raven.captureException(
+            `'Request failed' banner presented to user, because... ${res.status} ${res.status}`,
+            { extra: res }
+          );
           return reject(res);
         }
 
@@ -55,6 +63,9 @@ const pandaFetch = (
           message:
             'Connection issue occurred. Your changes may not be saved. Please wait or reload the page.',
           level: 'error',
+        });
+        Raven.captureException(error, {
+          extra: `'Connection issue' banner presented to user`,
         });
         return reject(`Connection Issue (${error ? error.toString() : ''})`);
       }


### PR DESCRIPTION
https://trello.com/c/B3dnmNti/2094-its-possible-to-publish-a-stale-collection-in-the-fronts-tool

## What's changed?
As per https://docs.google.com/document/d/14vbdereyeYU8MW6VDdUA_Pbbnv8_tf9ZJciKZMqpd0w/edit# it was possible for stale writes to occur in fronts, due to a combination of the 10second polling and people having auth/connection issues.

This PR seeks to address that by locking the collections when the latest fetch for collections is either errored or is stale by 20 seconds. By locking only the collections we allow users to potentially continue other productive work in the tool such as racking items up in the clipboard.

Before being able to do this there was a bit of re-work required, most notably...

- `FETCH_SUCCESS` events were only fired for collections when the data actually changed, and as such the `lastFetch` and `error` fields were not updated until the next material change to the collections (made by someone else), as such without changing, this the new locking feature would have displayed for much longer than necessary.

- Previously in `pandaFetch` any network failures would've thrown errors which were not caught in the [somewhat convoluted] async/await/Promise construct, and came out like this (Offline is forced on here, notice the `Uncaught` line)....
![image](https://user-images.githubusercontent.com/19289579/100915724-aae46680-34cc-11eb-8186-c52ba708339a.png)
... they're now caught and calls the `reject` of the outer promise (this in turn populates the `error` field under `collections` in the state).

## GIF
![fronts_stale_fix](https://user-images.githubusercontent.com/19289579/101165184-1eea5000-362e-11eb-9887-06ecdcf33359.gif)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
