### PR TITLE
Added first published time to clipboard items

### DIFF
--- a/fronts-client/src/components/article/ArticleBody.tsx
+++ b/fronts-client/src/components/article/ArticleBody.tsx
@@ -77,6 +77,11 @@ const VideoIconContainer = styled(CircularIconContainer)`
   right: 2px;
 `;
 
+const ClipboardFirstPublished = styled.div`
+  font-size: 11px;
+  margin: 4px;
+`;
+
 interface ArticleBodyProps {
   newspaperPageNumber?: number;
 
@@ -263,6 +268,14 @@ const articleBodyDefault = React.memo(
             </CardHeading>
             {displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
           </CardHeadingContainer>
+          {!collectionId && firstPublicationDate && (
+            <ClipboardFirstPublished title="The time elapsed since this article was first published.">
+              {distanceInWordsStrict(
+                Date.now(),
+                new Date(firstPublicationDate)
+              )}
+            </ClipboardFirstPublished>
+          )}
         </CardContent>
         <ImageAndGraphWrapper size={size}>
           {featureFlagPageViewData && canShowPageViewData && collectionId && (

--- a/fronts-client/src/components/article/ArticleBody.tsx
+++ b/fronts-client/src/components/article/ArticleBody.tsx
@@ -79,7 +79,10 @@ const VideoIconContainer = styled(CircularIconContainer)`
 
 const ClipboardFirstPublished = styled.div`
   font-size: 11px;
-  margin: 4px;
+  margin: 4px 4px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
 `;
 
 interface ArticleBodyProps {
@@ -268,14 +271,6 @@ const articleBodyDefault = React.memo(
             </CardHeading>
             {displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
           </CardHeadingContainer>
-          {!collectionId && firstPublicationDate && (
-            <ClipboardFirstPublished title="The time elapsed since this article was first published.">
-              {distanceInWordsStrict(
-                Date.now(),
-                new Date(firstPublicationDate)
-              )}
-            </ClipboardFirstPublished>
-          )}
         </CardContent>
         <ImageAndGraphWrapper size={size}>
           {featureFlagPageViewData && canShowPageViewData && collectionId && (
@@ -313,6 +308,14 @@ const articleBodyDefault = React.memo(
                   imageCutoutReplace={imageCutoutReplace}
                   showMainVideo={showMainVideo}
                 />
+                {!collectionId && firstPublicationDate && (
+                  <ClipboardFirstPublished title="The time elapsed since this article was first published.">
+                    {distanceInWordsStrict(
+                      Date.now(),
+                      new Date(firstPublicationDate)
+                    )}
+                  </ClipboardFirstPublished>
+                )}
               </DraggableArticleImageContainer>
             ))}
         </ImageAndGraphWrapper>


### PR DESCRIPTION
## What's changed?
> When stories appear on the clipboard (on fronts editor), is it possible to see how old the story is (2 hours, 2 days, etc)?

Adds the time elapsed since a story was first published to clipboard items. This is already present on stories in the CAPI feed and stories that have been added into a container. A user suggested it would be helpful to have this on clipboard items too!

After some discussion in the comments below, we've come up with the following design:

<img width="204" alt="Screenshot 2020-12-04 at 06 47 27" src="https://user-images.githubusercontent.com/12645938/101161586-07e03980-35ff-11eb-89eb-1a937dae5c9d.png">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
