### PR TITLE
track stale writes etc. in Sentry

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -238,10 +238,20 @@ function getCollections(
         getCollectionActions(collectionResponse, getState)
       );
 
+      const actionsToBatch = flatten([
+        ...actions,
+        ...missingActions,
+        ...missingCollectionActions,
+      ]);
+
+      // this is necessary to ensure lastFetch, error etc. are always updated
+      // (as we rely on them elsewhere to lock editing if stale/errored)
+      const noChangesAction = collectionActions.fetchSuccess([]);
+
       dispatch(
-        batchActions(
-          flatten([...actions, ...missingActions, ...missingCollectionActions])
-        )
+        actionsToBatch.length > 0
+          ? batchActions(actionsToBatch)
+          : noChangesAction
       );
       return collectionResponses.map(({ id }) => id);
     } catch (error) {

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -183,7 +183,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
   public render() {
     const { front, collectionsError } = this.props;
 
-    const isEditingLocked = this.state.isCollectionsStale || !!collectionsError;
+    // TODO remove the false bit when we're happy to actually lock users editing
+    const isEditingLocked =
+      false && (this.state.isCollectionsStale || !!collectionsError);
 
     return (
       <FrontCollectionsContainer
@@ -249,7 +251,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
     this.setState((prevState) => {
       if (!prevState.isCollectionsStale && isCollectionsStale) {
-        Raven.captureMessage('Collections editing locked due to staleness.');
+        Raven.captureMessage(
+          'Collections editing OUGHT TO BE locked due to staleness.'
+        );
       }
       return { isCollectionsStale };
     });

--- a/fronts-client/src/lib/createAsyncResourceBundle/index.ts
+++ b/fronts-client/src/lib/createAsyncResourceBundle/index.ts
@@ -389,9 +389,6 @@ function createAsyncResourceBundle<Resource>(
           ) {
             return state;
           }
-          if (!action.payload.error) {
-            return state;
-          }
           return {
             ...state,
             lastError: action.payload.error,

--- a/fronts-client/src/services/__tests__/pandaFetch.spec.ts
+++ b/fronts-client/src/services/__tests__/pandaFetch.spec.ts
@@ -33,7 +33,7 @@ describe('pandaFetch', () => {
     });
     setReauthedResponse({ ok: true }, '/test');
     const thrown = await pandaFetch('/test').catch((er) => er);
-    expect(thrown).toBe(e);
+    expect(thrown).toBe(`Auth Issue (${e.toString()})`);
   });
 
   it('rejects with non 2XX responses', async () => {

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -1,8 +1,12 @@
 import { reEstablishSession } from 'panda-session';
 import notifications from './notifications';
+import { isError } from 'tslint/lib/error';
+import Raven from 'raven-js';
 
 const reauthUrl = '/login/status';
-const reauthErrorMessage = `We couldn't log you back in. Your changes may not be saved. Please  <a href="${window.location.href}" target="_self">log in again</a> to reauthenticate.`;
+const reauthErrorMessage =
+  "We couldn't log you back in. Your changes may not be saved. " +
+  `Please <a href="${window.location.href}" target="_self">log in again</a> to reauthenticate.`;
 
 /**
  * Make a fetch request with Panda authentication.
@@ -16,26 +20,59 @@ const pandaFetch = (
   count: number = 0
 ): Promise<Response> =>
   new Promise(
-    async (resolve: (r: Response) => any, reject: (r: Response) => any) => {
-      const res = await fetch(url, {
-        ...options,
-        credentials: 'same-origin',
-      });
+    async (resolve: (r: Response) => any, reject: (e: any) => any) => {
+      try {
+        const res = await fetch(url, {
+          ...options,
+          credentials: 'same-origin',
+        });
 
-      if ((res.status === 419 || res.status === 401) && count < 1) {
-        try {
-          await reEstablishSession(reauthUrl, 5000);
-          const res2 = await pandaFetch(url, options, count + 1);
-          return resolve(res2);
-        } catch (e) {
-          notifications.notify({ message: reauthErrorMessage, level: 'error' });
-          return reject(e);
+        if ((res.status === 419 || res.status === 401) && count < 1) {
+          try {
+            await reEstablishSession(reauthUrl, 5000);
+            const res2 = await pandaFetch(url, options, count + 1);
+            return resolve(res2);
+          } catch (e) {
+            notifications.notify({
+              message: reauthErrorMessage,
+              level: 'error',
+            });
+            Raven.captureException(e, {
+              extra: {
+                message: `'Auth issue' banner presented to user`,
+              },
+            });
+            return reject(
+              isError(e) ? `Auth Issue (${e ? e.toString() : ''})` : e
+            );
+          }
+        } else if (res.status < 200 || res.status >= 300) {
+          notifications.notify({
+            message:
+              'Request failed. Your changes may not be saved. Please wait or reload the page.',
+            level: 'error',
+          });
+          Raven.captureException(
+            `'Request failed' banner presented to user, because... ${res.status} ${res.status}`,
+            { extra: res }
+          );
+          return reject(res);
         }
-      } else if (res.status < 200 || res.status >= 300) {
-        return reject(res);
-      }
 
-      return resolve(res);
+        return resolve(res);
+      } catch (error) {
+        notifications.notify({
+          message:
+            'Connection issue occurred. Your changes may not be saved. Please wait or reload the page.',
+          level: 'error',
+        });
+        Raven.captureException(error, {
+          extra: {
+            message: `'Connection issue' banner presented to user`,
+          },
+        });
+        return reject(`Connection Issue (${error ? error.toString() : ''})`);
+      }
     }
   );
 

--- a/fronts-client/src/services/pandaFetch.ts
+++ b/fronts-client/src/services/pandaFetch.ts
@@ -47,13 +47,13 @@ const pandaFetch = (
             );
           }
         } else if (res.status < 200 || res.status >= 300) {
-          notifications.notify({
-            message:
-              'Request failed. Your changes may not be saved. Please wait or reload the page.',
-            level: 'error',
-          });
+          // notifications.notify({
+          //   message:
+          //     'Request failed. Your changes may not be saved. Please wait or reload the page.',
+          //   level: 'error',
+          // });
           Raven.captureException(
-            `'Request failed' banner presented to user, because... ${res.status} ${res.status}`,
+            `'Request failed' banner OUGHT TO BE presented to user, because... ${res.status} ${res.status}`,
             { extra: res }
           );
           return reject(res);
@@ -61,14 +61,14 @@ const pandaFetch = (
 
         return resolve(res);
       } catch (error) {
-        notifications.notify({
-          message:
-            'Connection issue occurred. Your changes may not be saved. Please wait or reload the page.',
-          level: 'error',
-        });
+        // notifications.notify({
+        //   message:
+        //     'Connection issue occurred. Your changes may not be saved. Please wait or reload the page.',
+        //   level: 'error',
+        // });
         Raven.captureException(error, {
           extra: {
-            message: `'Connection issue' banner presented to user`,
+            message: `'Connection issue' banner OUGHT TO BE presented to user`,
           },
         });
         return reject(`Connection Issue (${error ? error.toString() : ''})`);


### PR DESCRIPTION
Reinstates most of #1277 (after reverting in #1279 - due to users complaining).

Can't actually replicate the 'false positives' myself, which suggests to me they are true positives and the user was actually seeing stale collections and should probably be prevented from make changes that could lead onto a stale write...

... but rather than bluntly reinstating as it was, the changes that actually locked editing (with the overlay) as well as the additional banners are commented out, so we can monitor for while with Sentry and perhaps ask to observe affected users when this happens.