### PR TITLE
capture the calculated staleness value in Sentry

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -244,15 +244,22 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
   }
 
   private updateCollectionsStalenessFlag = () => {
-    const isCollectionsStale =
+    const collectionsStalenessInMillis =
       !!this.props.collectionsLastFetch &&
-      Date.now() - this.props.collectionsLastFetch >
-        STALENESS_THRESHOLD_IN_MILLIS;
+      Date.now() - this.props.collectionsLastFetch;
+
+    const isCollectionsStale =
+      collectionsStalenessInMillis > STALENESS_THRESHOLD_IN_MILLIS;
 
     this.setState((prevState) => {
       if (!prevState.isCollectionsStale && isCollectionsStale) {
         Raven.captureMessage(
-          'Collections editing OUGHT TO BE locked due to staleness.'
+          'Collections editing OUGHT TO BE locked due to staleness.',
+          {
+            extra: {
+              collectionsStalenessInMillis,
+            },
+          }
         );
       }
       return { isCollectionsStale };


### PR DESCRIPTION
Minor tweak on https://github.com/guardian/facia-tool/pull/1280, to actually capture the calculated staleness value, in case...
- 30s isn't quite enough
- or, the retrieval of `collectionsLastFetch` is bound to when the function gets created (i.e. some sort of scoping mishap)
- or, some other dark magic 🧙 