### PR TITLE
set the environment property of the `sentryOptions` for easier filtering in the Sentry UI

### DIFF
--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -28,12 +28,14 @@ function checkEnabled (res) {
 
 function registerRaven (res) {
     if (res.defaults.env.toUpperCase() !== 'DEV' && res.defaults.sentryPublicDSN) {
+        const stage = res.defaults.env.toUpperCase();
         const sentryOptions = {
             tags: {
                 stack: 'cms-fronts',
-                stage: res.defaults.env.toUpperCase(),
+                stage,
                 app: 'facia-tool'
-            }
+            },
+            environment: stage
         };
 
         Raven.config(res.defaults.sentryPublicDSN, sentryOptions).install();


### PR DESCRIPTION
Minor one but wanted to make use of the `environment` property of the sentry configuration, such that we get nice filtering in Sentry UI (and potentially can set up notifications differently for different environments)...