### PR TITLE
Update icon url

### DIFF
--- a/app/model/editions/templates/EditionBadYear.scala
+++ b/app/model/editions/templates/EditionBadYear.scala
@@ -15,7 +15,7 @@ object EditionBadYear extends SpecialEdition {
   override val header = Header(title ="The best of", subTitle=Some("a bad year"))
   override val notificationUTCOffset = 3
   override val topic = "e-by"
-  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/581b334dc0d3a2c61cabafeee5744eb61171e9f2/0_0_180_356/180.png?width=134&quality=100&s=5ea13373e15fdc35a3f3c8114f4f2184")
+  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/9183f03557872759bde51b1ffa52e7952a45cb20/0_0_525_1050/250.png?width=134&quality=100&s=34d3e831560a25f5b7abb164187ab53f")
   override val expiry: Option[String] = Some(
     new DateTime(2021, 1,23,23,59,DateTimeZone.UTC).toString()
   )


### PR DESCRIPTION
This is an updated icon for the forthcoming special edition. The icon has been passed through the Fastly image resizer that can be found (on dc1 vpn only) here: http://image-url-signer.s3-website-eu-west-1.amazonaws.com/ - the width is identical to the last icon, but it is 3px taller which we're not expecting to be a problem.

## What's changed?
New icon