### PR TITLE
Do not rerender child collections unnecessarily

### DIFF
--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -91,7 +91,7 @@ interface CollectionContextProps {
   size?: 'medium' | 'default' | 'wide';
   handleMove: (move: Move<TCard>) => void;
   handleInsert: (e: React.DragEvent, to: PosSpec) => void;
-  selectCard: (id: string, isSupporting: boolean) => void;
+  selectCard: (id: string, collectionId: string, isSupporting: boolean) => void;
 }
 
 interface ConnectedCollectionContextProps extends CollectionContextProps {
@@ -174,7 +174,7 @@ class CollectionContext extends React.Component<
                         size={size}
                         canShowPageViewData={true}
                         getNodeProps={() => getAfNodeProps(isUneditable)}
-                        onSelect={() => selectCard(card.uuid, false)}
+                        onSelect={() => selectCard(card.uuid, id, false)}
                         onDelete={() => removeCard(group.uuid, card.uuid)}
                       >
                         <CardLevel
@@ -189,7 +189,9 @@ class CollectionContext extends React.Component<
                               uuid={supporting.uuid}
                               parentId={card.uuid}
                               canShowPageViewData={false}
-                              onSelect={() => selectCard(supporting.uuid, true)}
+                              onSelect={() =>
+                                selectCard(supporting.uuid, id, true)
+                              }
                               isUneditable={isUneditable}
                               getNodeProps={() =>
                                 getSupportingProps(isUneditable)

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -232,14 +232,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
                         ? 'default'
                         : 'medium'
                     }
-                    selectCard={(cardId, isSupporting) =>
-                      this.props.selectCard(
-                        cardId,
-                        collectionId,
-                        this.props.id,
-                        isSupporting
-                      )
-                    }
+                    selectCard={this.onSelectCard}
                     handleArticleFocus={this.props.handleArticleFocus}
                   />
                 </CollectionContainer>
@@ -250,6 +243,12 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
       </FrontCollectionsContainer>
     );
   }
+
+  private onSelectCard = (
+    cardId: string,
+    collectionId: string,
+    isSupporting: boolean
+  ) => this.props.selectCard(cardId, collectionId, this.props.id, isSupporting);
 
   private updateCollectionsStalenessFlag = () => {
     const collectionsStalenessInMillis =


### PR DESCRIPTION
## What's changed?

When debugging slow fronts performance w/ @twrichards, we noticed collections were receiving an inline function as a prop, which is causing child collections to rerender every time their parent front rerenders.

This PR moves that function into a private method on the associated class, ensuring that it's stable between rerenders. As a result, containers no longer rerender every time their parent front renders.

This is unlikely to be the cause of the general performance issues facing Fronts in Chrome (that's a separate issue, likely due to a browser rendering performance regression), but is a nice get anyhow, and may improve the performance issues we've had when introducing the last fetch time as a prop to this component (via #1288) 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
