### PR TITLE
Remove v1 build from teamcity

### DIFF
--- a/scripts/teamcity-ci.sh
+++ b/scripts/teamcity-ci.sh
@@ -43,7 +43,7 @@ riffRaffUpload() {
 main() {
     setupNvm
     globalJsDependencies
-    javascriptV1
+    # javascriptV1
     javascriptV2
     riffRaffUpload
 }


### PR DESCRIPTION
it looks like the teamcity build failures are coming from the v1 build script, which don't seem to be used- this comments out the line in `teamcity-ci.sh` to validate this