### PR TITLE
Swapping the last two container on the covid front

### DIFF
--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -113,11 +113,11 @@ object AustralianEdition extends RegionalEdition {
       .searchPrefill("?tag=type/article,(world/world|us-news/us-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),-(tone/features|tone/analysis|tone/explainer),-(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute,world/coronavirus-outbreak")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
       .withArticleItemsCap(10),
+     collection("Coronavirus"),
      collection("Coronavirus")
       .searchPrefill("?tag=type/article,tone/comment,-sport/sport,-tone/minutebyminute,world/coronavirus-outbreak")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
-      .withArticleItemsCap(10),
-     collection("Coronavirus").hide
+      .withArticleItemsCap(10)
   )
     .swatch(News)
 


### PR DESCRIPTION
## What's changed?
Moves the opinion prefilled container to 4th position.
Ensures there are always four containers visible, by removing .hide.

## Implementation notes
Small change, edited in Github.

