### PR TITLE
Extended EditionDefinition and SpecialEditionButtonStyles

### DIFF
--- a/app/model/editions/templates/EditionBadYear.scala
+++ b/app/model/editions/templates/EditionBadYear.scala
@@ -22,7 +22,7 @@ object EditionBadYear extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "#6B5840",
-      titleColor = ???,
+      titleColor = "#A1845C",
       title = EditionTextFormatting(color = "#FFFFFF", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),

--- a/app/model/editions/templates/EditionBadYear.scala
+++ b/app/model/editions/templates/EditionBadYear.scala
@@ -22,6 +22,7 @@ object EditionBadYear extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "#6B5840",
+      titleColor = ???,
       title = EditionTextFormatting(color = "#FFFFFF", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),
@@ -79,7 +80,7 @@ object EditionBadYear extends SpecialEdition {
       Special38 -> Daily(),
       Special39 -> Daily(),
       Special40 -> Daily()
-      
+
     ),
     timeWindowConfig = CapiTimeWindowConfigInDays(
       startOffset = 0,
@@ -307,7 +308,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special28 = front("Sp Brown 3", None,
     collection("Special"),
     collection("Special"),
@@ -315,7 +316,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special29 = front("Sp Brown 4", None,
     collection("Special"),
     collection("Special"),
@@ -323,7 +324,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special30 = front("Sp Brown 5", None,
     collection("Special"),
     collection("Special"),
@@ -331,7 +332,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special31 = front("Sp Brown 6", None,
     collection("Special"),
     collection("Special"),
@@ -339,7 +340,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special32 = front("Sp Brown 7", None,
     collection("Special"),
     collection("Special"),
@@ -347,7 +348,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special33 = front("Sp Brown 8", None,
     collection("Special"),
     collection("Special"),
@@ -355,7 +356,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special34 = front("Sp Brown 9", None,
     collection("Special"),
     collection("Special"),
@@ -363,7 +364,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special35 = front("Sp Brown 10", None,
     collection("Special"),
     collection("Special"),
@@ -371,7 +372,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special36 = front("Sp Black 6", None,
     collection("Special"),
     collection("Special"),
@@ -379,7 +380,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special37 = front("Sp Black 7", None,
     collection("Special"),
     collection("Special"),
@@ -387,7 +388,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special38 = front("Sp Black 8", None,
     collection("Special"),
     collection("Special"),
@@ -395,7 +396,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special39 = front("Sp Black 9", None,
     collection("Special"),
     collection("Special"),
@@ -403,7 +404,7 @@ object EditionBadYear extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special40 = front("Sp Black 10", None,
     collection("Special"),
     collection("Special"),
@@ -412,5 +413,5 @@ object EditionBadYear extends SpecialEdition {
     collection("Special")
   ).swatch(Neutral)
 
-
+  override val pickerButtonImageUri: Option[String] = None
 }

--- a/app/model/editions/templates/EditionBooks.scala
+++ b/app/model/editions/templates/EditionBooks.scala
@@ -22,6 +22,7 @@ object EditionBooks extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "#6B5840",
+      titleColor = ???,
       title = EditionTextFormatting(color = "#FFFFFF", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),
@@ -79,7 +80,7 @@ object EditionBooks extends SpecialEdition {
       Special38 -> Daily(),
       Special39 -> Daily(),
       Special40 -> Daily()
-      
+
     ),
     timeWindowConfig = CapiTimeWindowConfigInDays(
       startOffset = 0,
@@ -307,7 +308,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special28 = front("Sp Brown 3", None,
     collection("Special"),
     collection("Special"),
@@ -315,7 +316,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special29 = front("Sp Brown 4", None,
     collection("Special"),
     collection("Special"),
@@ -323,7 +324,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special30 = front("Sp Brown 5", None,
     collection("Special"),
     collection("Special"),
@@ -331,7 +332,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special31 = front("Sp Brown 6", None,
     collection("Special"),
     collection("Special"),
@@ -339,7 +340,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special32 = front("Sp Brown 7", None,
     collection("Special"),
     collection("Special"),
@@ -347,7 +348,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special33 = front("Sp Brown 8", None,
     collection("Special"),
     collection("Special"),
@@ -355,7 +356,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special34 = front("Sp Brown 9", None,
     collection("Special"),
     collection("Special"),
@@ -363,7 +364,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special35 = front("Sp Brown 10", None,
     collection("Special"),
     collection("Special"),
@@ -371,7 +372,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Culture)
-  
+
   def Special36 = front("Sp Black 6", None,
     collection("Special"),
     collection("Special"),
@@ -379,7 +380,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special37 = front("Sp Black 7", None,
     collection("Special"),
     collection("Special"),
@@ -387,7 +388,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special38 = front("Sp Black 8", None,
     collection("Special"),
     collection("Special"),
@@ -395,7 +396,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special39 = front("Sp Black 9", None,
     collection("Special"),
     collection("Special"),
@@ -403,7 +404,7 @@ object EditionBooks extends SpecialEdition {
     collection("Special"),
     collection("Special")
   ).swatch(Neutral)
-  
+
   def Special40 = front("Sp Black 10", None,
     collection("Special"),
     collection("Special"),
@@ -412,5 +413,5 @@ object EditionBooks extends SpecialEdition {
     collection("Special")
   ).swatch(Neutral)
 
-
+  override val pickerButtonImageUri: Option[String] = None
 }

--- a/app/model/editions/templates/EditionBooks.scala
+++ b/app/model/editions/templates/EditionBooks.scala
@@ -22,7 +22,7 @@ object EditionBooks extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "#6B5840",
-      titleColor = ???,
+      titleColor = "#A1845C",
       title = EditionTextFormatting(color = "#FFFFFF", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#FFFFFF", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),

--- a/app/model/editions/templates/EditionEarth.scala
+++ b/app/model/editions/templates/EditionEarth.scala
@@ -22,7 +22,7 @@ object EditionEarth extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "#ededed",
-      titleColor = ???,
+      titleColor = "#A1845C",
       title = EditionTextFormatting(color = "#121212", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#121212", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#121212", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),

--- a/app/model/editions/templates/EditionEarth.scala
+++ b/app/model/editions/templates/EditionEarth.scala
@@ -22,6 +22,7 @@ object EditionEarth extends SpecialEdition {
   override val buttonStyle: Option[SpecialEditionButtonStyles] = Some(
     SpecialEditionButtonStyles(
       backgroundColor = "#ededed",
+      titleColor = ???,
       title = EditionTextFormatting(color = "#121212", font="GHGuardianHeadline-Light", lineHeight = 34, size = 34),
       subTitle = EditionTextFormatting(color = "#121212", font="GuardianTextSans-Bold", lineHeight = 20, size = 17),
       expiry = EditionTextFormatting(color = "#121212", font="GuardianTextSans-Regular", lineHeight = 16, size = 15),
@@ -294,5 +295,5 @@ object EditionEarth extends SpecialEdition {
     collection("Special")
   ).swatch(Opinion)
 
-
+  override val pickerButtonImageUri: Option[String] = None
 }

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -134,9 +134,9 @@ object EditionDefinition {
     locale: Option[String],
     buttonImageUri: Option[String],
     pickerButtonImageUri: Option[String],
-   expiry: Option[String],
-   buttonStyle: Option[SpecialEditionButtonStyles],
-   headerStyle: Option[SpecialEditionHeaderStyles]
+    expiry: Option[String],
+    buttonStyle: Option[SpecialEditionButtonStyles],
+    headerStyle: Option[SpecialEditionHeaderStyles]
   ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, buttonImageUri, expiry, buttonStyle, headerStyle)
 
   def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -72,6 +72,7 @@ object EditionImageStyle {
 case class SpecialEditionButtonStyles(
   backgroundColor: String,
   title: EditionTextFormatting,
+  titleColor: String,
   subTitle: EditionTextFormatting,
   expiry: EditionTextFormatting,
   image: EditionImageStyle
@@ -91,6 +92,7 @@ trait EditionDefinition {
   val topic: String
   val locale: Option[String]
   val buttonImageUri: Option[String]
+  val pickerButtonImageUri: Option[String]
   val expiry: Option[String]
   val buttonStyle: Option[SpecialEditionButtonStyles]
   val headerStyle: Option[SpecialEditionHeaderStyles]
@@ -131,6 +133,7 @@ object EditionDefinition {
     topic: String,
     locale: Option[String],
     buttonImageUri: Option[String],
+    pickerButtonImageUri: Option[String],
    expiry: Option[String],
    buttonStyle: Option[SpecialEditionButtonStyles],
    headerStyle: Option[SpecialEditionHeaderStyles]

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -111,10 +111,12 @@ abstract class EditionBase extends EditionDefinitionWithTemplate {
 
 abstract class RegionalEdition extends EditionBase {
   override val editionType: EditionType =  EditionType.Regional
+  override val pickerButtonImageUri: Option[String] = None
 }
 
 abstract class InternalEdition extends EditionBase {
   override val editionType: EditionType = EditionType.Training
+  override val pickerButtonImageUri: Option[String] = None
 }
 
 abstract class SpecialEdition extends EditionDefinitionWithTemplate {
@@ -137,12 +139,12 @@ object EditionDefinition {
     expiry: Option[String],
     buttonStyle: Option[SpecialEditionButtonStyles],
     headerStyle: Option[SpecialEditionHeaderStyles]
-  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, buttonImageUri, expiry, buttonStyle, headerStyle)
+  ): EditionDefinition = EditionDefinitionRecord(title, subTitle, edition, header, editionType, notificationUTCOffset, topic, locale, buttonImageUri, pickerButtonImageUri, expiry, buttonStyle, headerStyle)
 
   def unapply(edition: EditionDefinition): Option[(String, String, String, Header, EditionType, Int, String,
-    Option[String], Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
+    Option[String], Option[String], Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
-    edition.notificationUTCOffset, edition.topic, edition.locale, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle)
+    edition.notificationUTCOffset, edition.topic, edition.locale, edition.buttonImageUri, edition.pickerButtonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle)
 
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
@@ -157,10 +159,10 @@ case class EditionDefinitionRecord(
                          override val topic: String,
                          override val locale: Option[String],
                          override val buttonImageUri: Option[String],
+                         override val pickerButtonImageUri: Option[String],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],
-                         override val headerStyle: Option[SpecialEditionHeaderStyles],
-                         override val pickerButtonImageUri: Option[String]
+                         override val headerStyle: Option[SpecialEditionHeaderStyles]
 ) extends EditionDefinition {}
 
 object EditionDefinitionRecord{

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -143,7 +143,7 @@ object EditionDefinition {
     Option[String], Option[String], Option[String], Option[SpecialEditionButtonStyles], Option[SpecialEditionHeaderStyles])]
     = Some(edition.title, edition.subTitle, edition.edition, edition.header, edition.editionType,
     edition.notificationUTCOffset, edition.topic, edition.locale, edition.buttonImageUri, edition.expiry, edition.buttonStyle, edition.headerStyle)
-  
+
   implicit val formatEditionDefinition: OFormat[EditionDefinition] = Json.format[EditionDefinition]
 }
 
@@ -155,13 +155,13 @@ case class EditionDefinitionRecord(
                          override val editionType: EditionType,
                          override val notificationUTCOffset: Int,
                          override val topic: String,
-                         override val locale: Option[String], 
+                         override val locale: Option[String],
                          override val buttonImageUri: Option[String],
                          override val expiry: Option[String],
                          override val buttonStyle: Option[SpecialEditionButtonStyles],
-                         override val headerStyle: Option[SpecialEditionHeaderStyles]
+                         override val headerStyle: Option[SpecialEditionHeaderStyles],
+                         override val pickerButtonImageUri: Option[String]
 ) extends EditionDefinition {}
-
 
 object EditionDefinitionRecord{
   implicit val editionDefinitionRecordFormat: OFormat[EditionDefinitionRecord] = Json.format[EditionDefinitionRecord]


### PR DESCRIPTION
This is a stab in the dark a bit - but the Editions team need some new values passed to support their new Edition picker design.
We've attempted to add them here, and if this was the right thing to do, we'd update the next special edition template to include the new values as well as the old.
There will be two versions of the app in the wild, those that support the existing values, and one that will expect the new ones. In time we'd remove: buttonImageUri as it is essentially replaced by pickerButtonImageUri

## What's changed?
David has possibly broken everything - will this change break existing editions? Will these changes flow happily through to the editions back end? These and more questions you can help with!

## Implementation notes
Edited in Github beware linting.

## Checklist
We checked nothing!