### PR TITLE
Convert Coronavirus front to a special

### DIFF
--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -101,25 +101,17 @@ object AustralianEdition extends RegionalEdition {
   )
     .swatch(News)
 
-  // Coronavirus, it's not going away right?
+  // Coronavirus, getting bored of it now, removed prefills converted to 'special'
 
   def FrontCoronavirusAu = front(
     "Coronavirus",
-     collection("Coronavirus")
-      .searchPrefill("?tag=type/article,(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),-(tone/features|tone/analysis|tone/explainer),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/comment,-tone/minutebyminute,world/coronavirus-outbreak")
-      .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
-      .withArticleItemsCap(10),
-     collection("Coronavirus")
-      .searchPrefill("?tag=type/article,(world/world|us-news/us-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),-(tone/features|tone/analysis|tone/explainer),-(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute,world/coronavirus-outbreak")
-      .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
-      .withArticleItemsCap(10),
      collection("Coronavirus"),
-     collection("Coronavirus")
-      .searchPrefill("?tag=type/article,tone/comment,-sport/sport,-tone/minutebyminute,world/coronavirus-outbreak")
-      .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
-      .withArticleItemsCap(10)
+     collection("Coronavirus"),
+     collection("Coronavirus"),
+     collection("Coronavirus"),
   )
-    .swatch(News)
+  .special  
+  .swatch(News)
 
   //World - International news content
 


### PR DESCRIPTION
Removed Coronavirus prefills and converted to a special.

## What's changed?
Four prefills and article caps removed for the four containers with the CV front.
Added .special to make this front hidden by default.

## Implementation notes
Edited by an unvaccinated PM in Github. Caveat Emptor.

