### PR TITLE
Bumps AWS SDK version to 1.11.999

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ TwirlKeys.templateImports ++= Seq(
 // include the enum path bindables
 routesImport += "model.editions._"
 
-val awsVersion = "1.11.293"
+val awsVersion = "1.11.999"
 val capiModelsVersion = "15.6"
 val capiClientVersion = "17.1"
 val json4sVersion = "3.6.6"


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Bumps the AWS SDK version to be compatible with IMDSv2. This will reduce our exposure to various vulnerabilities, more details can be found [here](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2).

## How to tests?
Deploy this to CODE alongside the [updating the stack](https://github.com/guardian/editorial-tools-platform/pull/526), this should be a NO-OP.