### PR TITLE
Moved Xenial AMI to Bionic as it is no longer supported

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: facia-tool
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## Has it been successfully deployed?

Yes, [here](https://riffraff.gutools.co.uk/deployment/view/0c9d933d-f779-44ac-9bc3-c064aa298583). 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to [CODE](https://fronts.code.dev-gutools.co.uk/) via RiffRaff (it's under `cms-fronts::facia-tool`), and ensure it deploys and runs correctly.