### PR TITLE
Prevent form from being dragged when selecting text in sublinks

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -362,6 +362,15 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           (e: React.MouseEvent) =>
             e.stopPropagation() /* Prevent clicks passing through the form */
         }
+        // Making this component draggable, but preventing drag events from
+        // propagating, ensures we don't leak drag events through to the parent
+        // element. This stops the form being accidentally dragged when people
+        // e.g. attempt to select text in inputs.
+        draggable={true}
+        onDragStart={(e: React.MouseEvent) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
       >
         {!articleExists && (
           <CollectionEditedError>


### PR DESCRIPTION
## What's changed?

Prevents the form initiating a drag event. This was problematic when users were e.g. clicking and dragging to select text in inputs (card [here](https://trello.com/c/46B9iYGV/2362-fronts-ui-bug)):

![no-drag-ko](https://user-images.githubusercontent.com/7767575/119028472-69267a00-b99f-11eb-853f-2a54edfebd45.gif)

Now, things behave as they should:

![no-drag-ok](https://user-images.githubusercontent.com/7767575/119028480-6b88d400-b99f-11eb-8b5b-3b9976a4aa79.gif)

## How to test

Difficult to write an automated test for this – best to try the above locally, or in CODE, to see that it works as expected.