### PR TITLE
Move card sublinks out of drag container

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -362,15 +362,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
           (e: React.MouseEvent) =>
             e.stopPropagation() /* Prevent clicks passing through the form */
         }
-        // Making this component draggable, but preventing drag events from
-        // propagating, ensures we don't leak drag events through to the parent
-        // element. This stops the form being accidentally dragged when people
-        // e.g. attempt to select text in inputs.
-        draggable={true}
-        onDragStart={(e: React.MouseEvent) => {
-          e.preventDefault();
-          e.stopPropagation();
-        }}
       >
         {!articleExists && (
           <CollectionEditedError>

--- a/fronts-client/src/components/article/Article.tsx
+++ b/fronts-client/src/components/article/Article.tsx
@@ -19,6 +19,7 @@ import DragIntentContainer from '../DragIntentContainer';
 import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import { theme } from 'constants/theme';
 import { getPillarColor } from 'util/getPillarColor';
+import { dragEventHasImageData } from 'util/validateImageSrc';
 
 const ArticleBodyContainer = styled(CardBody)<{
   pillarId: string | undefined;
@@ -64,25 +65,20 @@ interface ComponentProps extends ArticleComponentProps {
   size?: CardSizes;
   textSize?: CardSizes;
   children: React.ReactNode;
-  imageDropTypes?: string[];
   onImageDrop?: (e: React.DragEvent<HTMLElement>) => void;
 }
 
 interface ComponentState {
   isDraggingImageOver: boolean;
-  isDraggingArticleOver: boolean;
 }
 
 class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
   public state = {
     isDraggingImageOver: false,
-    isDraggingArticleOver: false,
   };
 
   public setIsImageHovering = (isDraggingImageOver: boolean) =>
     this.setState({ isDraggingImageOver });
-  public setIsArticleHovering = (isDraggingArticleOver: boolean) =>
-    this.setState({ isDraggingArticleOver });
 
   public render() {
     const {
@@ -101,7 +97,6 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
       onAddToClipboard,
       children,
       isUneditable,
-      imageDropTypes = [],
       onImageDrop,
       showMeta,
       canDragImage,
@@ -111,11 +106,6 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
       collectionId,
     } = this.props;
 
-    const dragEventHasImageData = (e: React.DragEvent) =>
-      e.dataTransfer.types.some((dataTransferType) =>
-        imageDropTypes.includes(dataTransferType)
-      );
-
     const getArticleData = () =>
       article || {
         uuid: id,
@@ -123,14 +113,9 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
       };
 
     return (
-      <DragIntentContainer
-        filterRegisterEvent={(e) => !dragEventHasImageData(e)}
-        onDragIntentStart={() => this.setIsArticleHovering(true)}
-        onDragIntentEnd={() => this.setIsArticleHovering(false)}
-      >
+      <>
         <CardContainer
           draggable={draggable}
-          isDraggingArticleOver={this.state.isDraggingArticleOver}
           onDragStart={onDragStart}
           onDragOver={onDragOver}
           onDrop={onDrop}
@@ -178,9 +163,9 @@ class ArticleComponent extends React.Component<ComponentProps, ComponentState> {
               />
             </ArticleBodyContainer>
           </DragIntentContainer>
-          {children}
         </CardContainer>
-      </DragIntentContainer>
+        {children}
+      </>
     );
   }
 }

--- a/fronts-client/src/components/card/CardContainer.tsx
+++ b/fronts-client/src/components/card/CardContainer.tsx
@@ -1,13 +1,5 @@
-import { styled, css } from 'constants/theme';
-import { DefaultDropIndicator } from 'components/DropZone';
+import { styled } from 'constants/theme';
 
-export default styled.div<{ isDraggingArticleOver?: boolean }>`
+export default styled.div`
   position: relative;
-  ${({ isDraggingArticleOver }) =>
-    isDraggingArticleOver &&
-    css`
-      ${DefaultDropIndicator} {
-        opacity: 1;
-      }
-    `}
 `;

--- a/fronts-client/src/util/validateImageSrc.ts
+++ b/fronts-client/src/util/validateImageSrc.ts
@@ -5,7 +5,11 @@ import deepGet from 'lodash/get';
 import grid, { recordUsage } from './grid';
 import fetchImage from './fetchImage';
 import { Crop, Criteria } from 'types/Grid';
-import { DRAG_DATA_GRID_IMAGE_URL } from 'constants/image';
+import {
+  DRAG_DATA_CARD_IMAGE_OVERRIDE,
+  DRAG_DATA_GRID_IMAGE_URL,
+} from 'constants/image';
+import { gridDropTypes } from 'constants/fronts';
 
 interface ImageDescription {
   height?: number;
@@ -294,6 +298,17 @@ function validateImageEvent(
     new Error('Invalid image source, are you dragging from the grid?')
   );
 }
+
+const imageDropTypes = [
+  ...gridDropTypes,
+  DRAG_DATA_CARD_IMAGE_OVERRIDE,
+  DRAG_DATA_GRID_IMAGE_URL,
+];
+
+export const dragEventHasImageData = (e: React.DragEvent) =>
+  e.dataTransfer.types.some((dataTransferType) =>
+    imageDropTypes.includes(dataTransferType)
+  );
 
 export {
   ImageDescription,


### PR DESCRIPTION
## What's changed?

Another attempt to solve the problem described in #1341 (see that card for gifs and detail). Instead of attempting to intercept drag events (which had problems with cross-browser behaviour, hence the revert #1342), this PR moves sublinks out of the draggable container entirely – AFAICS there's no reason to nest these elements.

## Implementation notes

In doing this, we needed a bit of a refactor to move the code around, hence the slightly larger diff – we've shuffled the drag intent detection up from the `Article` component to its parent, the `Card` component.

This also fixes a previously unnoticed bug where `Snaplink`s (a kind of `Card`, along with `Article`) did not show hint hover states when cards were hovering over them – as we've moved the hover detection out of `Article` to a place that handles both kinds of card.

Before:

![snap-link-hover-ko](https://user-images.githubusercontent.com/7767575/119329454-23a6cd00-bc7d-11eb-83dc-852092b74423.gif)

After:

![snap-link-hover-ok](https://user-images.githubusercontent.com/7767575/119329461-26a1bd80-bc7d-11eb-8a98-379e4125102c.gif)

Tested in Chrome and Firefox.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
