### PR TITLE
Firefox banner

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -24,8 +24,14 @@ object PageViewDataVisualisation extends FeatureSwitch(
   enabled = true
 )
 
+object ShowFirefoxPrompt extends FeatureSwitch(
+  key = "show-firefox-prompt",
+  title = "Show the prompt to use Firefox if applicable",
+  enabled = true
+)
+
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation)
+  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     val newSwitches = userDataSwitches match {
@@ -38,7 +44,7 @@ object FeatureSwitches {
     removeUnknownSwitches(newSwitches)
   }
 
-  def removeUnknownSwitches(featureSwitches: List[FeatureSwitch]) = 
+  def removeUnknownSwitches(featureSwitches: List[FeatureSwitch]) =
     featureSwitches.filter(featureSwitch =>
       FeatureSwitches.all.exists(_.key == featureSwitch.key))
 }

--- a/app/model/UserData.scala
+++ b/app/model/UserData.scala
@@ -43,7 +43,8 @@ object UserDataForDefaults {
 
   def fromUserData(userData: UserData, clipboardArticles: Option[List[Trail]]): UserDataForDefaults = {
     val featureSwitches = userData.featureSwitches.fold(FeatureSwitches.all) { userFeatureSwitches =>
-      val unsetFeatureSwitches = FeatureSwitches.all.diff(userFeatureSwitches)
+      val userFeatureSwitchKeys = userFeatureSwitches.map(_.key)
+      val unsetFeatureSwitches = FeatureSwitches.all.filter(featureSwitch => !userFeatureSwitchKeys.contains(featureSwitch.key))
       unsetFeatureSwitches ++ FeatureSwitches.removeUnknownSwitches(userFeatureSwitches)
     }
     UserDataForDefaults(

--- a/fronts-client/src/bundles/notificationsBundle.ts
+++ b/fronts-client/src/bundles/notificationsBundle.ts
@@ -7,6 +7,7 @@ type NotificationLevels = 'error';
 export interface Notification {
   message: string;
   level: NotificationLevels;
+  dismissalCallback?: () => void;
 }
 
 interface InternalBannerNotification extends Notification {

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -56,10 +56,12 @@ const NotificationsBanner = ({
           <span dangerouslySetInnerHTML={{ __html: banner.message }} />
           {banner.duplicates ? ` (${banner.duplicates + 1})` : ''}
         </Message>
-        <CloseButton onClick={() => {
-          banner.dismissalCallback?.();
-          removeNotificationBanner(banner.id)
-        }}>
+        <CloseButton
+          onClick={() => {
+            banner.dismissalCallback?.();
+            removeNotificationBanner(banner.id);
+          }}
+        >
           <ClearIcon size="fill" />
         </CloseButton>
       </BannerWrapper>

--- a/fronts-client/src/components/notifications/BannerNotification.tsx
+++ b/fronts-client/src/components/notifications/BannerNotification.tsx
@@ -56,7 +56,10 @@ const NotificationsBanner = ({
           <span dangerouslySetInnerHTML={{ __html: banner.message }} />
           {banner.duplicates ? ` (${banner.duplicates + 1})` : ''}
         </Message>
-        <CloseButton onClick={() => removeNotificationBanner(banner.id)}>
+        <CloseButton onClick={() => {
+          banner.dismissalCallback?.();
+          removeNotificationBanner(banner.id)
+        }}>
           <ClearIcon size="fill" />
         </CloseButton>
       </BannerWrapper>

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -36,14 +36,16 @@ notifications.subscribe((notification) =>
 
 // Recommend Chrome 87 users to use Firefox instead, due to drag-and drop
 // performance issue.
-if (navigator.userAgent){
+if (navigator.userAgent && pageConfig.userData){
   const getChromeVersion = () => {
     const chromeString = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
     return chromeString ? parseInt(chromeString[2], 10) : false;
   }
   const chromeVersion = getChromeVersion();
 
-  if (chromeVersion >= 87){
+  const featureSwitch = pageConfig.userData.featureSwitches.find(featureSwitch => featureSwitch.key === "show-firefox-prompt");
+  console.log(pageConfig.userData.featureSwitches);
+  if (chromeVersion >= 87 && featureSwitch?.enabled){
     notifications.notify({
       message: `There are known performance issues in Chrome ${chromeVersion}. We recommend the use of Firefox.`,
       level: 'error',

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -34,6 +34,23 @@ notifications.subscribe((notification) =>
   store.dispatch(actionAddNotificationBanner(notification))
 );
 
+// Recommend Chrome 87 users to use Firefox instead, due to drag-and drop
+// performance issue.
+if (navigator.userAgent){
+  const getChromeVersion = () => {
+    const chromeString = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    return chromeString ? parseInt(chromeString[2], 10) : false;
+  }
+  const chromeVersion = getChromeVersion();
+
+  if (chromeVersion >= 87){
+    notifications.notify({
+      message: `There are known performance issues in Chrome ${chromeVersion}. We recommend the use of Firefox.`,
+      level: 'error',
+    });
+  }
+}
+
 // @ts-ignore -- Unbind is not used yet but can be used for removed all the
 // keyboard events. The keyboardActionMap contains a list of all active keyboard
 // shortcuts, which can eventually be displayed to the user.

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -38,12 +38,14 @@ notifications.subscribe((notification) =>
 // Recommend Chrome 87 users to use Firefox instead, due to drag-and drop
 // performance issue.
 const maybeWarnChromeUsers = () => {
-  if (!navigator.userAgent || !pageConfig.userData) return;
+  if (!navigator.userAgent || !pageConfig.userData) {
+    return;
+  }
   const chromeString = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
   const chromeVersion = chromeString ? parseInt(chromeString[2], 10) : false;
 
   const featureSwitch = pageConfig.userData.featureSwitches.find(
-    (featureSwitch) => featureSwitch.key === 'show-firefox-prompt'
+    (feature) => feature.key === 'show-firefox-prompt'
   );
 
   if (chromeVersion < 87 || !featureSwitch?.enabled) {

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -53,7 +53,8 @@ const maybeWarnChromeUsers = () => {
   }
 
   notifications.notify({
-    message: `There are known performance issues in Chrome ${chromeVersion}. If Fronts feels slow, try using Firefox.`,
+    message: `There are known performance issues in Chrome ${chromeVersion} for this tool. If it feels slow, try using Firefox. \
+<br>For further information, please contact <a href="mailto:central.production@guardian.co.uk">Central Production.</a>`,
     level: 'error',
     dismissalCallback: () => {
       const newSwitchValue = {

--- a/test/model/UserDataTest.scala
+++ b/test/model/UserDataTest.scala
@@ -1,0 +1,40 @@
+package model
+
+import model.{FeatureSwitch, FeatureSwitches, ObscureFeed, UserData, UserDataForDefaults}
+import org.scalatest.{FunSuite, Matchers}
+
+class UserDataTest extends FunSuite with Matchers {
+  val testUserData = UserData(email = "hello@example.com")
+
+  test("There are no duplicate switches when switches are changed") {
+    val userWithSwitches = testUserData.copy(featureSwitches = Some(List(
+      ObscureFeed.copy(enabled = !ObscureFeed.enabled)
+    )))
+    UserDataForDefaults.fromUserData(userWithSwitches, None).featureSwitches.get.length shouldEqual FeatureSwitches.all.length
+  }
+
+  test("Fills out switches that aren't present in user data") {
+    val userWithSwitches = testUserData.copy(featureSwitches = Some(List(
+      ObscureFeed.copy(enabled = !ObscureFeed.enabled)
+    )))
+    val allSwitchKeys = FeatureSwitches.all.map(_.key)
+    val userSwitchKeys = UserDataForDefaults.fromUserData(userWithSwitches, None).featureSwitches.get.map(_.key)
+
+    userSwitchKeys should contain allElementsOf allSwitchKeys
+  }
+
+  test("Removes features switches that aren't present in the code") {
+    object BadSwitch extends FeatureSwitch(
+      key = "bad-switch",
+      title = "A switch that shouldn't be here",
+      enabled = true
+    )
+    val userWithBadSwitch = testUserData.copy(featureSwitches = Some(List(
+      BadSwitch
+    )))
+
+    val switches = UserDataForDefaults.fromUserData(userWithBadSwitch, None).featureSwitches.get.map(_.key)
+
+    switches should not contain "bad-switch"
+  }
+}


### PR DESCRIPTION
_co-authored with: @rhystmills_ 

## What's changed?

Adds a banner to the Fronts tool, alerting users to use Firefox if the tool feels slow and they're using a browser that we know is affected by the bug detailed in [this card](https://trello.com/c/iII6siii/2154-fronts-tool-perf-issues-in-chrome):

<img width="999" alt="Screenshot 2021-07-14 at 08 42 55" src="https://user-images.githubusercontent.com/7767575/125586771-907ec70c-721d-4617-a269-da257af0d2de.png">

The banner will not reappear after the use dismisses it. The data is stored against the user profile in Dynamo, so it's tied to the Google account's e-mail, not e.g. local storage.

To reset the message, flip the relevant switch in `<tool>/v2/features`

## Implementation notes

In doing this, we've also fixed a bug in the feature switches code that would give the frontend more feature switches than existed in user data. We've added tests for that.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
