### PR TITLE
Improves the V1 image validation process

### DIFF
--- a/public/src/js/models/article/editor.js
+++ b/public/src/js/models/article/editor.js
@@ -154,6 +154,8 @@ export default class Editor extends BaseClass {
             image = imageSrc(),
             opts = params.options;
 
+        this.assignImageToSpreadElement(params, null);
+
         if (image) {
             let {src, origin} = extractImageElements(image);
             const frontId = this.article.front ? this.article.front.front() : 'clipboard';
@@ -163,8 +165,6 @@ export default class Editor extends BaseClass {
                 }, err => {
                     this.assignImageToSpreadElement(params, err);
                 });
-        } else {
-            this.assignImageToSpreadElement(params, null);
         }
     }
 

--- a/public/src/js/utils/validate-image-src.js
+++ b/public/src/js/utils/validate-image-src.js
@@ -144,7 +144,7 @@ function validateActualImage (image, frontId) {
         } else {
             if (image.origin) {
                 return recordUsage(image.origin.split('/').slice(-1)[0], frontId)
-                .then(() => { resolve({ path, origin, thumb, width, height }); });
+                .finally(() => { resolve({ path, origin, thumb, width, height }); });
             }
             resolve( { path, origin, thumb, width, height } );
         }

--- a/public/src/js/utils/validate-image-src.js
+++ b/public/src/js/utils/validate-image-src.js
@@ -142,11 +142,13 @@ function validateActualImage (image, frontId) {
         } else if (criteriaRatio && criteriaRatio - ratio > 0.01) {
             reject(new Error('Images must have a ' + widthAspectRatio + ':' + heightAspectRatio + ' aspect ratio'));
         } else {
+            const resolveWithImage = () => { resolve({ path, origin, thumb, width, height });};
             if (image.origin) {
                 return recordUsage(image.origin.split('/').slice(-1)[0], frontId)
-                .finally(() => { resolve({ path, origin, thumb, width, height }); });
+                .then(resolveWithImage)
+                .catch(resolveWithImage);
             }
-            resolve( { path, origin, thumb, width, height } );
+            resolve(resolveWithImage);
         }
     });
 }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This PR aims to fixes occurrences of internal Grid URL being distributed with a breaking news alert. Examples of which can be [seen in the logs](https://logs.gutools.co.uk/s/editorial-tools/goto/dc17b298da75d48f88241d3c9a9f5986). 

This issue appears to be related to how grid internal links are processed into links to S3. This process can be latent and result in the original URL not being replaced before the image is used in a front. The GIF below replicates a possible cause of the issue:

Before
![Fronts_issue_2](https://user-images.githubusercontent.com/4633246/125776041-d9b3987b-daee-46c4-88a6-75d6a43959b8.gif)

After
![Fronts_issue_1](https://user-images.githubusercontent.com/4633246/125776011-6676bd5c-ea1b-4a43-98f1-584e6869eb09.gif)

This fix attempt proactively removes the entered src and assumes it's wrong until the images is retrieved via the image validate process. This should mean the src is only ever set correctly.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
This functionally isn't 100% faithful to the current behaviour, setting a rejected src now doesn't clear the input for reason I can't discern due to the complexity of the codebase. This might also highlight other potential unknowns. Certain units tests are now also failing.

EDIT: The image source will now only be set once the chain of promises completes successfully, this will mean the thumbnail image accurately represents the image attached to the piece, even if the source url is invalid and left in place. This should provide a clear indication to the user what image will  be launched and highlight any issues. It may be the case we have reports of images not updating properly, this will highlight existing issues in a more obvious way and could justify further investigation.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
