### PR TITLE
Addition of new showcase Priority to fronts tool

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -24,6 +24,7 @@ GET         /editorial                               controllers.ViewsController
 GET         /commercial                              controllers.ViewsController.collectionEditor(priority="commercial")
 GET         /training                                controllers.ViewsController.collectionEditor(priority="training")
 GET         /email                                   controllers.ViewsController.collectionEditor(priority="email")
+GET         /showcase                                controllers.ViewsController.collectionEditor(priority="showcase")
 
 GET         /editorial/config                        controllers.ViewsController.configEditor()
 GET         /commercial/config                       controllers.ViewsController.configEditor()

--- a/conf/routes
+++ b/conf/routes
@@ -29,6 +29,7 @@ GET         /editorial/config                        controllers.ViewsController
 GET         /commercial/config                       controllers.ViewsController.configEditor()
 GET         /training/config                         controllers.ViewsController.configEditor()
 GET         /email/config                            controllers.ViewsController.configEditor()
+GET         /showcase/config                         controllers.ViewsController.configEditor()
 GET         /edition/config                          controllers.ViewsController.configEditor()
 
 POST        /collection/publish/*collectionId        controllers.FaciaToolController.publishCollection(collectionId)

--- a/fronts-client/src/constants/priorities.ts
+++ b/fronts-client/src/constants/priorities.ts
@@ -5,4 +5,5 @@ export const priorities: Priorities = {
   commercial: {},
   training: {},
   email: {},
+  showcase: {},
 };

--- a/fronts-client/src/types/Priority.ts
+++ b/fronts-client/src/types/Priority.ts
@@ -3,6 +3,7 @@ interface Priorities {
   commercial: unknown;
   training: unknown;
   email: unknown;
+  showcase: unknown;
 }
 
 interface EditionPriority {

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -149,6 +149,12 @@ export default {
             hasGroups: true,
             isTypeLocked: true,
             isHiddenLocked: true
+        },
+        'showcase': {
+            maxFronts: 50,
+            hasGroups: false,
+            isTypeLocked: false,
+            isHiddenLocked: false
         }
 
     },


### PR DESCRIPTION
## What's changed?

Adds a new `showcase` Priority to the fronts tool.

<img width="589" alt="Screenshot 2021-08-18 at 14 15 59" src="https://user-images.githubusercontent.com/150238/129904874-42693833-6313-4854-8308-198ab75b6ec0.png">

The priority will be used to house the fronts which will be the sources for our Google Showcase feeds.


## Implementation notes

Tests ok in CODE.
CODE frontend seems happy to render fronts with this new priority.

Merging this PR makes the Showcase integration general knowledge to all fronts users.


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
