### PR TITLE
update fapi-client library to 3.3.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,8 +60,8 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.11.999"
-val capiModelsVersion = "15.6"
-val capiClientVersion = "17.1"
+val capiModelsVersion = "17.1.0"
+val capiClientVersion = "17.21"
 val json4sVersion = "3.6.6"
 val enumeratumPlayVersion = "1.6.0"
 val circeVersion = "0.13.0"

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play27" % "3.2.0",
+    "com.gu" %% "fapi-client-play27" % "3.3.7",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-7" % "1.0.4",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,7 +75,7 @@ download_config() {
 
 fetch_config(){
     if [[ -w ${CONFIG_DIR} ]]; then
-        downloadConfig
+        download_config
         echo -e "${GREEN}Done ${NOCOLOUR}"
     else
       echo "Cannot write to ${CONFIG_DIR}. It either doesn't exist or is not owned by $(whoami)."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,7 +75,7 @@ download_config() {
 
 fetch_config(){
     if [[ -w ${CONFIG_DIR} ]]; then
-        download_config
+        downloadConfig
         echo -e "${GREEN}Done ${NOCOLOUR}"
     else
       echo "Cannot write to ${CONFIG_DIR}. It either doesn't exist or is not owned by $(whoami)."


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This is a simple PR to update to `"com.gu" %% "fapi-client-play27" % "3.3.7",`.
This will allow the client to be able to add the Podcast item to the list of tags.
## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
I significant jump from 3.2.0 to 3.3.7

This has been initially tested using SNAPSHOT locally and from facia-tool to ensure the logic change in the library works.

In addition:
-  CAPI libs bumped `capiModelsVersion = "17.1.0"`   `capiClientVersion = "17.21"`
-  Updates the models used in fronts to be in line with latest CAPI models. 
-  This results in all test passing


| Before  | After |
| --- | --- |
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/49187886/132672841-fa4f7210-d7dd-4ac3-959b-bebfd995f95a.png">| <img width="300" alt="image" src="https://user-images.githubusercontent.com/49187886/132671922-67a37892-841b-46e7-9c69-5a994b861533.png">|

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

Tested by adding `Podcast` from tags dropdown in ` https://fronts.code.dev-gutools.co.uk/editorial/config`
### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
