### PR TITLE
New large capacity Container Layout to hold Showcase live panels

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -13,6 +13,7 @@ class FixedContainers(val config: ApplicationConfiguration) {
   val fixedMediumFastXI = slices(HalfQQ, Ql2Ql2Ql2Ql2)
   val fixedMediumFastXII = slices(QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)
 
+  val showcase = slices(ShowcaseSingleStories)
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
   val video = slices(TTT).copy(customCssClasses = Set("fc-container--video"))
 
@@ -31,7 +32,8 @@ class FixedContainers(val config: ApplicationConfiguration) {
     ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/video", video),
-    ("fixed/thrasher", thrasher)
+    ("fixed/thrasher", thrasher),
+    ("fixed/showcase", showcase)
   ) ++ (if (config.faciatool.showTestContainers) Map(
     ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))
   ) else Map.empty)

--- a/app/slices/Slice.scala
+++ b/app/slices/Slice.scala
@@ -885,3 +885,21 @@ case object TTlMpu extends Slice {
     )
   )
 }
+
+// Large single column collection hold all currently live Showcase single stories; not intended to be render as HTML
+case object ShowcaseSingleStories extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "q-q-q-ql",
+    columns = Seq(
+      Rows(
+        colSpan = 1,
+        columns = 1,
+        rows = 30,
+        ItemClasses(
+          mobile = ListItem,
+          tablet = ListItem,
+        ),
+      ),
+    ),
+  )
+}

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -58,7 +58,8 @@ export default {
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },
-        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] }
+        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
+        { 'name': 'fixed/showcase' },
     ],
 
     emailTypes: [


### PR DESCRIPTION
## What's changed?

Add a new large capacity Container Layout named showcase to hold currently live Showcase single story panels.
Showcase editors will need ~ 10 - 20 live slots in `.curated` content; this collection gives them that.

This needs to be duplicated in Frontend or else the we'll be assigned a default 4 slot layout when we launch.
https://github.com/guardian/frontend/pull/24186



<img width="607" alt="Screenshot 2021-09-23 at 12 18 10" src="https://user-images.githubusercontent.com/150238/134498551-7eba68f7-6785-4b18-8dc2-3c1b46b0c51b.png">

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
