### PR TITLE
Geo-targeted containers - Australia

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play27" % "3.3.7",
+    "com.gu" %% "fapi-client-play27" % "3.3.8",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-7" % "1.0.4",
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -34,3 +34,4 @@ deployments:
         map: text/plain
         json: application/json
       prefixStack: false
+      publicReadAcl: true


### PR DESCRIPTION
## What's changed?

This will add New South Wales, Victoria and Queensland to the list of regions for targeted containers.

See also:
https://github.com/guardian/facia-scala-client/pull/254/files
https://github.com/guardian/frontend/pull/24251
https://github.com/guardian/fastly-edge-cache/pull/926
https://github.com/guardian/mobile-apps-api/pull/1755
https://github.com/guardian/fastly-edge-cache/pull/926


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
