### PR TITLE
Add new email permission

### DIFF
--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -61,7 +61,6 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
 
   def getCollectionPermissionFilterByPriority(priority: String, acl: Acl)(implicit ec: ExecutionContext): ActionBuilder[UserRequest, AnyContent] = {
     val permissionsPriority = PermissionsPriority.stringToPermissionPriority(priority)
-    println(permissionsPriority)
     permissionsPriority match {
       case Some(EditorialPermission) => AccessAuthAction andThen new EditEditorialFrontsPermissionCheck(acl)
       case Some(CommercialPermission) => AccessAuthAction andThen new LaunchCommercialFrontsPermissionCheck(acl)

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -61,10 +61,11 @@ abstract class BaseFaciaController(deps: BaseFaciaControllerComponents) extends 
 
   def getCollectionPermissionFilterByPriority(priority: String, acl: Acl)(implicit ec: ExecutionContext): ActionBuilder[UserRequest, AnyContent] = {
     val permissionsPriority = PermissionsPriority.stringToPermissionPriority(priority)
+    println(permissionsPriority)
     permissionsPriority match {
       case Some(EditorialPermission) => AccessAuthAction andThen new EditEditorialFrontsPermissionCheck(acl)
       case Some(CommercialPermission) => AccessAuthAction andThen new LaunchCommercialFrontsPermissionCheck(acl)
-      case Some(EmailPermission) => AccessAuthAction andThen new EditEditorialFrontsPermissionCheck(acl)
+      case Some(EmailPermission) => AccessAuthAction andThen new EditEmailFrontsPermissionCheck(acl)
       case Some(EditionsPermission) => AccessAuthAction andThen new AccessEditionsPermissionCheck(acl)
       case _ => AccessAuthAction
     }

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -10,4 +10,5 @@ object Permissions {
   val LaunchEditorialFronts = PermissionDefinition("launch_editorial_fronts", "fronts")
   val EditEditorialFronts = PermissionDefinition("edit_editorial_fronts", "fronts")
   val EditEditions = PermissionDefinition("edit_editions", "fronts")
+  val LaunchAndEditEmailFronts = PermissionDefinition("edit_and_launch_email_fronts", "fronts")
 }

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -63,7 +63,6 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
     isLaunch: Boolean = false)(block: => Future[Result])
   (implicit request: UserRequest[A],
   executionContext: ExecutionContext): Future[Result] = {
-
     (testAccess(request.user.email, priorities, isLaunch), testAccess(request.user.email, secondaryPriorities, isLaunch)) match {
       case (AccessGranted, AccessGranted) => block
       case _ => Future.successful(Results.Unauthorized)
@@ -87,6 +86,18 @@ class EditEditorialFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionCon
   override implicit val executionContext: ExecutionContext = ec
   override val testAccess: String => Authorization = acl.testUser(Permissions.EditEditorialFronts, "facia-tool-allow-edit-editorial-fronts-for-all")
   override val restrictedAction: String = "Edit editorial fronts."
+}
+
+class EditEmailFrontsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {
+  override implicit val executionContext: ExecutionContext = ec
+  override val testAccess: String => Authorization = (email: String) => {
+    val emailAccess = acl.testUser(Permissions.LaunchAndEditEmailFronts, "facia-tool-allow-edit-email-fronts-for-all")(email)
+    emailAccess match {
+      case AccessGranted => emailAccess
+      case AccessDenied => new EditEditorialFrontsPermissionCheck(acl)(executionContext).testAccess(email)
+    }
+  }
+  override val restrictedAction: String = "Edit email fronts."
 }
 
 class AccessEditionsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext) extends PermissionActionFilter {

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -46,13 +46,17 @@ trait ModifyCollectionsPermissionsCheck extends Logging { self: BaseFaciaControl
     if (priorities.isEmpty) AccessGranted
     else if (isLaunch)
       acl.testUserGroupsAndCollections(
-        Permissions.LaunchEditorialFronts, Permissions.LaunchCommercialFronts,
-        Permissions.FrontsAccess, "facia-tool-allow-launch-editorial-fronts-for-all")(email, priorities)
+        Permissions.LaunchEditorialFronts,
+        Permissions.LaunchCommercialFronts,
+        Permissions.FrontsAccess,
+        Permissions.LaunchAndEditEmailFronts,
+        "facia-tool-allow-launch-editorial-fronts-for-all")(email, priorities)
     else
       acl.testUserGroupsAndCollections(
         Permissions.EditEditorialFronts,
         Permissions.LaunchCommercialFronts,
-        Permissions.FrontsAccess, "facia-tool-allow-edit-editorial-fronts-for-all")(email, priorities)
+        Permissions.FrontsAccess,
+        Permissions.LaunchAndEditEmailFronts, "facia-tool-allow-edit-editorial-fronts-for-all")(email, priorities)
   }
 
   def withModifyGroupPermissionForCollections[A](priorities: Set[PermissionsPriority], secondaryPriorities: Set[PermissionsPriority],

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -100,11 +100,11 @@ object PermissionsChecker {
       else if (commercialPermissionIsValid) {
         hasCommercialPermissions
       }
+      else if (editorialPermissionIsValid)
+        hasEditorialPermissions
       else if (emailPermissionIsValid) {
         hasEmailPermissions
       }
-      else if (editorialPermissionIsValid)
-        hasEditorialPermissions
       else AccessDenied
     }
   }

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -50,14 +50,15 @@ class Acl(permissions: PermissionsProvider) extends Logging {
   }
 
   def testUserGroupsAndCollections(editorialPermission: PermissionDefinition, commercialPermission: PermissionDefinition,
-                                   trainingPermission: PermissionDefinition, editorialSwitch: String)
+                                   trainingPermission: PermissionDefinition, emailPermission: PermissionDefinition, editorialSwitch: String)
                                   (email: String, priorities: Set[PermissionsPriority]): Authorization = {
 
     val hasCommercialPermissions = testUser(commercialPermission, "facia-tool-allow-launch-commercial-fronts-for-all")(email)
     val hasEditorialPermissions = testUser(editorialPermission, editorialSwitch)(email)
     val hasTrainingPermissions = testUser(trainingPermission, "facia-tool-permissions-access")(email)
+    val hasEmailPermissions = testUser(emailPermission, "facia-tool-email-access")(email)
 
-    PermissionsChecker.check(hasCommercialPermissions, hasEditorialPermissions, hasTrainingPermissions, priorities) match {
+    PermissionsChecker.check(hasCommercialPermissions, hasEditorialPermissions, hasTrainingPermissions, hasEmailPermissions, priorities) match {
       case AccessGranted => AccessGranted
       case AccessDenied => {
         logger.warn(s"User with e-mail ${email} and with the following permissions commercial: $hasCommercialPermissions, " +
@@ -76,12 +77,14 @@ object PermissionsChecker {
              hasCommercialPermissions: Authorization,
              hasEditorialPermissions: Authorization,
              hasTrainingPermissions: Authorization,
+             hasEmailPermissions: Authorization,
              priorities: Set[PermissionsPriority]
            ): Authorization =  {
 
     val trainingPermissionIsValid = priorities.contains(TrainingPermission)
     val editorialPermissionIsValid = priorities.contains(EditorialPermission) || priorities.contains(EmailPermission)
     val commercialPermissionIsValid = priorities.contains(CommercialPermission)
+    val emailPermissionIsValid = priorities.contains(EmailPermission)
 
     if (trainingPermissionIsValid)
       hasTrainingPermissions
@@ -96,6 +99,9 @@ object PermissionsChecker {
 
       else if (commercialPermissionIsValid) {
         hasCommercialPermissions
+      }
+      else if (emailPermissionIsValid) {
+        hasEmailPermissions
       }
       else if (editorialPermissionIsValid)
         hasEditorialPermissions

--- a/test/util/AclTest.scala
+++ b/test/util/AclTest.scala
@@ -13,6 +13,7 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessGranted,
         hasEditorialPermissions = AccessDenied,
         hasTrainingPermissions = AccessDenied,
+        hasEmailPermissions = AccessDenied,
         Set(CommercialPermission)
       ) should be(AccessGranted)
     }
@@ -23,6 +24,7 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessDenied,
         hasEditorialPermissions = AccessGranted,
         hasTrainingPermissions = AccessDenied,
+        hasEmailPermissions = AccessDenied,
         Set(EditorialPermission)
       ) should be(AccessGranted)
     }
@@ -32,6 +34,17 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessDenied,
         hasEditorialPermissions = AccessGranted,
         hasTrainingPermissions = AccessDenied,
+        hasEmailPermissions = AccessDenied,
+        Set(EmailPermission)
+      ) should be(AccessGranted)
+    }
+
+    "Allow access to email fronts if email permissions"  in {
+      PermissionsChecker.check(
+        hasCommercialPermissions = AccessDenied,
+        hasEditorialPermissions = AccessGranted,
+        hasTrainingPermissions = AccessDenied,
+        hasEmailPermissions = AccessGranted,
         Set(EmailPermission)
       ) should be(AccessGranted)
     }
@@ -42,6 +55,7 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessDenied,
         hasEditorialPermissions = AccessDenied,
         hasTrainingPermissions = AccessGranted,
+        hasEmailPermissions = AccessDenied,
         Set(TrainingPermission)
       ) should be(AccessGranted)
     }
@@ -52,6 +66,7 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessGranted,
         hasEditorialPermissions = AccessDenied,
         hasTrainingPermissions = AccessDenied,
+        hasEmailPermissions = AccessDenied,
         Set(EditorialPermission, CommercialPermission)
       ) should be(AccessGranted)
     }
@@ -62,6 +77,7 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessDenied,
         hasEditorialPermissions = AccessGranted,
         hasTrainingPermissions = AccessDenied,
+        hasEmailPermissions = AccessDenied,
         Set(EditorialPermission, CommercialPermission)
       ) should be(AccessGranted)
   }
@@ -72,6 +88,7 @@ class AclTest extends FreeSpec with Matchers {
         hasCommercialPermissions = AccessDenied,
         hasEditorialPermissions = AccessDenied,
         hasTrainingPermissions = AccessGranted,
+        hasEmailPermissions = AccessDenied,
         Set(EditorialPermission, CommercialPermission)
       ) should be(AccessDenied)
 


### PR DESCRIPTION
## What's changed?

Following on from [this PR in the permissions tool](https://github.com/guardian/permissions/pull/141), this PR makes use of a new email permission to restrict users with just that permission to accessing email fronts only.

We've preserved the logic that allows users with editorial permissions to edit email fronts.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE