### PR TITLE
Updating documentation to forbid numbers in edition object names.

### DIFF
--- a/docs/AddingAndAlteringTemplates.md
+++ b/docs/AddingAndAlteringTemplates.md
@@ -29,7 +29,7 @@ object MyLovelyHorseEdition extends EditionDefinitionWithTemplate {
 NOTE: the `edition` property of your object must be a kebab case version of your object name otherwise the routing won't
 work and you'll get a 404 error when creating an issue. 
 
-NOTE: the `edition` property of your object should not contain numbers, you will also get a 404 error when creating an issue.
+NOTE: the `edition` property of your object should not contain numbers or you will also get a 404 error when creating an issue.
 
 Add the new Edition to _both_ the list of templates and the Edition enum object
 in `app/model/editions/EditionsTemplates.scala`.

--- a/docs/AddingAndAlteringTemplates.md
+++ b/docs/AddingAndAlteringTemplates.md
@@ -27,7 +27,9 @@ object MyLovelyHorseEdition extends EditionDefinitionWithTemplate {
 ```
 
 NOTE: the `edition` property of your object must be a kebab case version of your object name otherwise the routing won't
-work and you'll get a 404 error when creating an issue
+work and you'll get a 404 error when creating an issue. 
+
+NOTE: the `edition` property of your object should not contain numbers, you will also get a 404 error when creating an issue.
 
 Add the new Edition to _both_ the list of templates and the Edition enum object
 in `app/model/editions/EditionsTemplates.scala`.


### PR DESCRIPTION
## What's changed?
Making it clear numbers in the object name will make it fail.