### PR TITLE
Update EditionEndOfYear.scala

### DIFF
--- a/app/model/editions/templates/EditionEndOfYear.scala
+++ b/app/model/editions/templates/EditionEndOfYear.scala
@@ -15,7 +15,7 @@ object EditionEndOfYear extends SpecialEdition {
   override val header = Header(title ="2021", subTitle=Some("Highs, hits, hopes"))
   override val notificationUTCOffset = 3
   override val topic = "e-eoy"
-  override val buttonImageUri = Some("https://media.guim.co.uk/04682faa0ac6d5665ce31f4a7c4bf8d8c0a5e54e/0_0_86_163/86.png?width=86&height=163")
+  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/04682faa0ac6d5665ce31f4a7c4bf8d8c0a5e54e/0_0_86_163/86.png?width=86&height=163&quality=85&s=a10d08a2df25b72e67bdf61b943f3b823")
   override val expiry: Option[String] = Some(
     new DateTime(2022, 1,31,23,59,DateTimeZone.UTC).toString()
   )

--- a/app/model/editions/templates/EditionEndOfYear.scala
+++ b/app/model/editions/templates/EditionEndOfYear.scala
@@ -15,7 +15,7 @@ object EditionEndOfYear extends SpecialEdition {
   override val header = Header(title ="2021", subTitle=Some("Highs, hits, hopes"))
   override val notificationUTCOffset = 3
   override val topic = "e-eoy"
-  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/04682faa0ac6d5665ce31f4a7c4bf8d8c0a5e54e/0_0_86_163/86.png?width=86&height=163&quality=85&s=a10d08a2df25b72e67bdf61b943f3b823")
+  override val buttonImageUri = Some("https://i.guim.co.uk/img/media/04682faa0ac6d5665ce31f4a7c4bf8d8c0a5e54e/0_0_86_163/86.png?width=86&height=163&quality=85&s=a10d08a2df25b72e67bdf61b943f3b82")
   override val expiry: Option[String] = Some(
     new DateTime(2022, 1,31,23,59,DateTimeZone.UTC).toString()
   )


### PR DESCRIPTION
## What's changed?
Swapped the 'grid' image for a signed url

## Implementation notes
Used this
http://image-url-signer.s3-website-eu-west-1.amazonaws.com/

