### PR TITLE
Set timestamp in output jars from SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,14 @@ resolvers ++= Seq(
 
 PlayKeys.devSettings := Seq("play.akka.dev-mode.akka.http.parsing.max-uri-length" -> "20480")
 
+// We need to keep the timestamps to allow caching headers to work as expected on assets.
+// The below should work, but some problem in one of the plugins (possible the play plugin? or sbt-web?) causes
+// the option not to be passed correctly
+//   ThisBuild / packageTimestamp := Package.keepTimestamps
+// Setting as a packageOption seems to bypass that problem, wherever it lies
+import sbt.Package.FixedTimestamp
+ThisBuild / packageOptions += FixedTimestamp(Package.keepTimestamps)
+
 libraryDependencies ++= Seq(
     ws,
     filters,


### PR DESCRIPTION
Since SBT 1.4.0, SBT has edited the last modified dates in packaged
JARs, which include web assets (css, js, etc.); Grid's current version
sets the date to 1 Jan 2010. Play framework uses these dates to
calculate the ETag and Last-Modified headers. Since the headers are now
based upon a static date, caching (especially via Cloudfront) is broken,
returning outdated assets.

This commit restores the previous behaviour, so cloudfront should now
notice and pick up new assets upon deployment.

See also <playframework/playframework#10572>
See also <sbt/sbt#6237>

## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
