### PR TITLE
Explicitly set publicReadAcl

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -34,3 +34,4 @@ deployments:
         map: text/plain
         json: application/json
       prefixStack: false
+      publicReadAcl: true


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Set publicReadAcl: true to resolve riff-raff deployment warnings, and keeping the previous behaviour explicitly.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
