### PR TITLE
[Troubleshoot tool]: Do not crash when troubleshooting fronts with no backfill

### DIFF
--- a/public/src/js/troubleshoot/views/stale.js
+++ b/public/src/js/troubleshoot/views/stale.js
@@ -200,7 +200,6 @@ function diagnoseCapiQueries(container, front, config, scheduler) {
         innerElement.querySelector('.capiQueriesList').appendChild(generateCapiList(listOfQueries, scheduler));
         capiQueriesPlaceholder.appendChild(innerElement);
     } else {
-        capiQueriesPlaceholder.querySelector('.capiQueriesResult').classList.remove('loading');
         capiQueriesPlaceholder.appendChild(clone('emptyCapiQueriesList'));
     }
 


### PR DESCRIPTION
## What's changed?

Do not crash when troubleshooting fronts with no backfill.

This was caused by assuming that the `.capiQueriesResult` element was present. It's created by `clone('capiQueries');`, which never runs if there's no backfill (IIUC there are no queries, there's no backfill!), so just removing this should solve.

|Before|After|
|--|--|
|<img width="715" alt="Screenshot 2022-02-11 at 08 55 09" src="https://user-images.githubusercontent.com/7767575/153563506-c22a868c-e80d-464f-85f7-c9561cc96b84.png">|<img width="715" alt="Screenshot 2022-02-11 at 08 54 57" src="https://user-images.githubusercontent.com/7767575/153563569-b06ea419-b637-4740-9834-21e273ba858f.png">|

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
