### PR TITLE
Bump FAPI-client and add new tags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "3.3.10-SNAPSHOT",
+    "com.gu" %% "fapi-client-play28" % "3.3.10",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
 

--- a/build.sbt
+++ b/build.sbt
@@ -94,9 +94,9 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play27" % "3.3.8",
+    "com.gu" %% "fapi-client-play28" % "3.3.8",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
-    "com.gu" %% "pan-domain-auth-play_2-7" % "1.0.4",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
 
     "org.scanamo" %% "scanamo" % "1.0.0-M15" exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),
     "com.github.blemale" %% "scaffeine" % "4.1.0" % "compile",

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,8 @@ val enumeratumPlayVersion = "1.6.0"
 val circeVersion = "0.13.0"
 
 resolvers ++= Seq(
-    Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
+    Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+    "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 )
 
 
@@ -94,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "3.3.9",
+    "com.gu" %% "fapi-client-play28" % "3.3.10-SNAPSHOT",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
 

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ routesImport += "model.editions._"
 val awsVersion = "1.11.999"
 val capiModelsVersion = "17.1.0"
 val capiClientVersion = "17.21"
-val json4sVersion = "3.6.6"
+val json4sVersion = "4.0.3"
 val enumeratumPlayVersion = "1.6.0"
 val circeVersion = "0.13.0"
 
@@ -94,7 +94,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "3.3.8",
+    "com.gu" %% "fapi-client-play28" % "3.3.9",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -92,7 +92,7 @@ fetch_config(){
     fi
 }
 main() {
-  fetch_config
+  fetch_config "$@"
   install_yarn
   set_node_version
   install_v2_deps_and_build
@@ -101,4 +101,4 @@ main() {
   printf "\n\rDone.\n\r\n\r"
 }
 
-main
+main "$@"


### PR DESCRIPTION
## What's changed?

Bump the FAPI client lib to the latest version, increasing json4s version to resolve version conflicts. Also move it and panda libs to their play 2.8 variants, missed in the previous upgrade to play 2.8. Also fixes the setup script to pass command line arguments to where they're consumed.

FAPI client lib 3.3.10 includes the two new tags, "SombreAltPalette" and "LongRunningAltPalette"

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
