### PR TITLE
Always show a length for slideshow caption validation

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -321,7 +321,7 @@ const RenderSlideshow = ({ fields, frontId, change }: RenderSlideshowProps) => {
                 <WarningIcon size="s" fill={error.warningDark} />
               ) : null}
               <CaptionLength invalid={isInvalidCaptionLength(slideshowIndex)}>
-                {fields.get(slideshowIndex)?.caption?.length} / 100
+                {fields.get(slideshowIndex)?.caption?.length ?? 0} / 100
               </CaptionLength>
             </CaptionLengthContainer>
           </CaptionControls>


### PR DESCRIPTION
## What's changed?

At the moment, a pristine slideshow caption field does not show a length. This PR corrects that.

|Before|After|
|--|--|
|<img width="329" alt="Screenshot 2022-03-28 at 15 09 14" src="https://user-images.githubusercontent.com/7767575/160450505-177f1cd3-0637-46e6-85f0-2326d74befa6.png">|<img width="604" alt="Screenshot 2022-03-28 at 16 10 25" src="https://user-images.githubusercontent.com/7767575/160450515-e0256b64-b214-4735-9c84-a3a454d2a5e7.png">|

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
