### PR TITLE
Revert "Correct the preview link for non-PROD environments"

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontSection.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontSection.tsx
@@ -12,7 +12,6 @@ import {
 } from 'bundles/frontsUI';
 import Button from 'components/inputs/ButtonDefault';
 import { frontStages } from 'constants/fronts';
-import urls from 'constants/url';
 import { FrontConfig, EditionsFrontMetadata } from 'types/FaciaApi';
 import type { State } from 'types/State';
 import { selectFront } from 'selectors/frontsSelectors';
@@ -27,7 +26,6 @@ import EditModeVisibility from 'components/util/EditModeVisibility';
 import { setFrontHiddenState, updateFrontMetadata } from 'actions/Editions';
 import FrontsContainer from './FrontContainer';
 import { isMode } from '../../selectors/pathSelectors';
-import { selectShouldUsePreviewCODE } from '../../selectors/configSelectors';
 
 const FrontHeader = styled(SectionHeader)`
   display: flex;
@@ -111,7 +109,6 @@ interface FrontsContainerProps {
 type FrontsComponentProps = FrontsContainerProps & {
   selectedFront: FrontConfig;
   isOverviewOpen: boolean;
-  shouldUsePreviewCODE: boolean;
   frontsActions: {
     fetchLastPressed: (frontId: string) => void;
     editorCloseFront: (frontId: string) => void;
@@ -158,12 +155,7 @@ class FrontSection extends React.Component<
   };
 
   public render() {
-    const {
-      frontId,
-      isOverviewOpen,
-      isEditions,
-      shouldUsePreviewCODE,
-    } = this.props;
+    const { frontId, isOverviewOpen, isEditions } = this.props;
     const title = this.getTitle();
 
     const { frontNameValue, editingFrontName } = this.state;
@@ -206,11 +198,7 @@ class FrontSection extends React.Component<
             <FrontHeaderMeta>
               <EditModeVisibility visibleMode="fronts">
                 <a
-                  href={`${
-                    shouldUsePreviewCODE
-                      ? urls.previewUrlCODE
-                      : urls.previewUrlPROD
-                  }${this.props.frontId}`}
+                  href={`https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/${this.props.frontId}`}
                   target="preview"
                 >
                   <FrontHeaderButton>
@@ -325,7 +313,6 @@ const createMapStateToProps = () => {
     selectedFront: selectFront(state, { frontId }),
     isOverviewOpen: selectIsFrontOverviewOpen(state, frontId),
     isEditions: isMode(state, 'editions'),
-    shouldUsePreviewCODE: selectShouldUsePreviewCODE(state),
   });
 };
 

--- a/fronts-client/src/constants/url.ts
+++ b/fronts-client/src/constants/url.ts
@@ -1,13 +1,10 @@
 import pageConfig from 'util/extractConfigFromPage';
-
-const previewDomain = 'preview.gutools.co.uk';
-
 export default {
   base: {
     mainDomain: 'www.theguardian.com',
     mainDomainShort: 'theguardian.com',
     frontendDomain: 'frontend.gutools.co.uk',
-    previewDomain,
+    previewDomain: 'preview.gutools.co.uk',
     shortDomain: 'gu.com',
     capi: 'content.guardianapis.com',
   },
@@ -25,6 +22,4 @@ export default {
   manageEditions: '/manage-editions/',
   appRoot: 'v2',
   editionsCardBuilder: 'https://editions-card-builder.gutools.co.uk',
-  previewUrlPROD: `https://${previewDomain}/responsive-viewer/${previewDomain}/`,
-  previewUrlCODE: 'https://m.code.dev-theguardian.com/',
 };

--- a/fronts-client/src/selectors/configSelectors.ts
+++ b/fronts-client/src/selectors/configSelectors.ts
@@ -44,11 +44,6 @@ const selectAvailableEditions = createSelector(
   (config) => config && config.availableEditions
 );
 
-const selectShouldUsePreviewCODE = createSelector(
-  selectConfig,
-  (config) => !!config && (config.dev || config.env === 'code')
-);
-
 export {
   selectCapiLiveURL,
   selectCapiPreviewURL,
@@ -58,5 +53,4 @@ export {
   selectCollectionCap,
   selectGridUrl,
   selectAvailableEditions,
-  selectShouldUsePreviewCODE,
 };

--- a/fronts-client/src/types/Config.ts
+++ b/fronts-client/src/types/Config.ts
@@ -20,13 +20,14 @@ interface Config {
   env: string;
   editions: string[];
   email: string;
-  avatarUrl?: string;
+  avararUrl?: string;
   firstName: string;
   lastName: string;
   sentryPublicDSN: string;
   mediaBaseUrl: string;
   apiBaseUrl: string;
   switches: { [key: string]: boolean };
+  stage: string;
   acl: Acl;
   collectionCap: number;
   navListCap: number;


### PR DESCRIPTION
Reverts guardian/facia-tool#1424, which caused problems with the PROD preview link.