### PR TITLE
Restrict slideshows with less than two images

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -85,8 +85,7 @@ type Props = ComponentProps &
 type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
   frontId: string;
   change: (field: string, value: any) => void;
-  hasAtLeastTwoImages: boolean;
-  setHasAtLeastTwoImages: (state: boolean) => void;
+  slideshowHasAtLeastTwoImages: boolean;
 };
 
 const FormContainer = styled(ContentContainer.withComponent('form'))`
@@ -238,7 +237,7 @@ const RenderSlideshow = ({
   fields,
   frontId,
   change,
-  setHasAtLeastTwoImages,
+  slideshowHasAtLeastTwoImages,
 }: RenderSlideshowProps) => {
   const [slideshowIndex, setSlideshowIndex] = React.useState(0);
 
@@ -247,14 +246,6 @@ const RenderSlideshow = ({
       navigateToNearestIndex();
     }
   }, [fields.get(slideshowIndex)]);
-
-  const hasAtLeastTwoImages =
-    fields.map((_, index) => fields.get(index) !== null).filter((_) => _)
-      .length >= 2;
-
-  React.useEffect(() => {
-    setHasAtLeastTwoImages(hasAtLeastTwoImages);
-  }, [hasAtLeastTwoImages]);
 
   const isInvalidCaptionLength = (index: number) =>
     !!maxLength100(fields.get(index));
@@ -360,7 +351,7 @@ const RenderSlideshow = ({
           />
         </div>
       ) : null}
-      {!hasAtLeastTwoImages ? (
+      {!slideshowHasAtLeastTwoImages ? (
         <InvalidSlideshowWarning>
           <WarningIcon size="s" fill={error.warningDark} />
           <InvalidSlideshowText>
@@ -433,7 +424,6 @@ const getInputId = (cardId: string, label: string) => `${cardId}-${label}`;
 
 interface FormComponentState {
   lastKnownCollectionId: string | null;
-  slideshowHasAtLeastTwoImages: boolean;
 }
 
 class FormComponent extends React.Component<Props, FormComponentState> {
@@ -445,7 +435,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
   public state: FormComponentState = {
     lastKnownCollectionId: null,
-    slideshowHasAtLeastTwoImages: false,
   };
 
   public render() {
@@ -467,6 +456,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
       imageCutoutReplace,
       cutoutImage,
       imageSlideshowReplace,
+      slideshow,
       isBreaking,
       editMode,
       primaryImage,
@@ -481,8 +471,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
     const imageDefined = (img: ImageData | undefined) => img && img.src;
 
-    const setSlideshowHasAtLeastTwoImages = (state: boolean) =>
-      this.setState({ slideshowHasAtLeastTwoImages: state });
+    const slideshowHasAtLeastTwoImages =
+      (slideshow ?? []).filter((field) => field !== null).length >= 2;
 
     const invalidCardReplacement = coverCardImageReplace
       ? !imageDefined(coverCardMobileImage) ||
@@ -812,8 +802,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
                   frontId={frontId}
                   component={RenderSlideshow}
                   change={change}
-                  hasAtLeastTwoImages={this.state.slideshowHasAtLeastTwoImages}
-                  setHasAtLeastTwoImages={setSlideshowHasAtLeastTwoImages}
+                  slideshowHasAtLeastTwoImages={slideshowHasAtLeastTwoImages}
                 />
               </SlideshowRowContainer>
             )}
@@ -881,8 +870,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
               !articleExists ||
               invalidCardReplacement ||
               !valid ||
-              (imageSlideshowReplace &&
-                !this.state.slideshowHasAtLeastTwoImages)
+              (imageSlideshowReplace && !slideshowHasAtLeastTwoImages)
             }
             size="l"
             data-testid="edit-form-save-button"
@@ -981,6 +969,7 @@ interface ContainerProps {
   collectionId: string | null;
   snapType: string | undefined;
   getLastUpdatedBy: (collectionId: string) => string | null;
+  slideshow: any[] | undefined;
   imageSlideshowReplace: boolean;
   imageCutoutReplace: boolean;
   imageHide: boolean;
@@ -1047,6 +1036,7 @@ const createMapStateToProps = () => {
         article && selectFormFields(state, article.uuid, isSupporting),
       kickerOptions: article ? selectArticleTag(state, cardId) : defaultObject,
       imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
+      slideshow: valueSelector(state, 'slideshow'),
       imageHide: valueSelector(state, 'imageHide'),
       imageReplace: valueSelector(state, 'imageReplace'),
       imageCutoutReplace: valueSelector(state, 'imageCutoutReplace'),

--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -472,7 +472,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     const imageDefined = (img: ImageData | undefined) => img && img.src;
 
     const slideshowHasAtLeastTwoImages =
-      (slideshow ?? []).filter((field) => field !== null).length >= 2;
+      (slideshow ?? []).filter((field) => !!field).length >= 2;
 
     const invalidCardReplacement = coverCardImageReplace
       ? !imageDefined(coverCardMobileImage) ||
@@ -969,7 +969,7 @@ interface ContainerProps {
   collectionId: string | null;
   snapType: string | undefined;
   getLastUpdatedBy: (collectionId: string) => string | null;
-  slideshow: any[] | undefined;
+  slideshow: Array<ImageData | undefined | null> | undefined;
   imageSlideshowReplace: boolean;
   imageCutoutReplace: boolean;
   imageHide: boolean;

--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -219,7 +219,7 @@ const FlexContainer = styled.div`
 
 const InvalidSlideshowWarning = styled(FlexContainer)`
   margin-top: 4px;
-`
+`;
 
 const InvalidSlideshowText = styled.div`
   color: ${error.primary};
@@ -234,7 +234,12 @@ const maxCaptionLength = (max: number) => (value: ImageData) =>
 
 const maxLength100 = maxCaptionLength(100);
 
-const RenderSlideshow = ({ fields, frontId, change, setHasAtLeastTwoImages }: RenderSlideshowProps) => {
+const RenderSlideshow = ({
+  fields,
+  frontId,
+  change,
+  setHasAtLeastTwoImages,
+}: RenderSlideshowProps) => {
   const [slideshowIndex, setSlideshowIndex] = React.useState(0);
 
   React.useEffect(() => {
@@ -243,14 +248,13 @@ const RenderSlideshow = ({ fields, frontId, change, setHasAtLeastTwoImages }: Re
     }
   }, [fields.get(slideshowIndex)]);
 
-  const hasAtLeastTwoImages = (fields
-    .map((_, index) => fields.get(index) !== null)
-    .filter(_ => _)
-    .length >= 2)
+  const hasAtLeastTwoImages =
+    fields.map((_, index) => fields.get(index) !== null).filter((_) => _)
+      .length >= 2;
 
   React.useEffect(() => {
-    setHasAtLeastTwoImages(hasAtLeastTwoImages)
-  }, [hasAtLeastTwoImages])
+    setHasAtLeastTwoImages(hasAtLeastTwoImages);
+  }, [hasAtLeastTwoImages]);
 
   const isInvalidCaptionLength = (index: number) =>
     !!maxLength100(fields.get(index));
@@ -359,9 +363,10 @@ const RenderSlideshow = ({ fields, frontId, change, setHasAtLeastTwoImages }: Re
       {!hasAtLeastTwoImages ? (
         <InvalidSlideshowWarning>
           <WarningIcon size="s" fill={error.warningDark} />
-          <InvalidSlideshowText>You need at least two images to make a slideshow</InvalidSlideshowText>
+          <InvalidSlideshowText>
+            You need at least two images to make a slideshow
+          </InvalidSlideshowText>
         </InvalidSlideshowWarning>
-
       ) : null}
     </>
   );
@@ -428,7 +433,7 @@ const getInputId = (cardId: string, label: string) => `${cardId}-${label}`;
 
 interface FormComponentState {
   lastKnownCollectionId: string | null;
-  slideshowHasAtLeastTwoImages: boolean
+  slideshowHasAtLeastTwoImages: boolean;
 }
 
 class FormComponent extends React.Component<Props, FormComponentState> {
@@ -440,7 +445,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
   public state: FormComponentState = {
     lastKnownCollectionId: null,
-    slideshowHasAtLeastTwoImages: false
+    slideshowHasAtLeastTwoImages: false,
   };
 
   public render() {
@@ -476,7 +481,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
     const imageDefined = (img: ImageData | undefined) => img && img.src;
 
-    const setSlideshowHasAtLeastTwoImages = (state: boolean) => this.setState({slideshowHasAtLeastTwoImages: state})
+    const setSlideshowHasAtLeastTwoImages = (state: boolean) =>
+      this.setState({ slideshowHasAtLeastTwoImages: state });
 
     const invalidCardReplacement = coverCardImageReplace
       ? !imageDefined(coverCardMobileImage) ||
@@ -871,7 +877,12 @@ class FormComponent extends React.Component<Props, FormComponentState> {
             priority="primary"
             onClick={this.handleSubmit}
             disabled={
-              pristine || !articleExists || invalidCardReplacement || !valid || (imageSlideshowReplace && !this.state.slideshowHasAtLeastTwoImages)
+              pristine ||
+              !articleExists ||
+              invalidCardReplacement ||
+              !valid ||
+              (imageSlideshowReplace &&
+                !this.state.slideshowHasAtLeastTwoImages)
             }
             size="l"
             data-testid="edit-form-save-button"

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -169,7 +169,7 @@ const CloseIcon = ({
     <title>{title}</title>
     <path
       fill={fill}
-      fill-rule="evenodd"
+      fillRule="evenodd"
       d="M6.485 4.571L9.314 7.4 7.899 8.814 5.071 5.985 2.243 8.814.828 7.399l2.829-2.828L.828 1.743 2.243.328 5.07 3.157 7.9.328l1.415 1.415L6.485 4.57z"
     />
   </svg>
@@ -310,8 +310,8 @@ const WarningIcon = ({ fill = theme.colors.white, size = 'm' }: IconProps) => (
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M5.70536 0L0.5 8.52857L0.833929 9H11.1661L11.5 8.52857L6.29464 0H5.70536ZM5.67346 6.08888H6.32656L6.63705 2.63068L6.20879 2.26666H5.79124L5.36298 2.63068L5.67346 6.08888ZM6.00001 6.72593C6.35038 6.72593 6.63705 7.0126 6.63705 7.36297C6.63705 7.71334 6.35038 8 6.00001 8C5.64964 8 5.36298 7.71334 5.36298 7.36297C5.36298 7.0126 5.64964 6.72593 6.00001 6.72593Z"
       fill={fill}
     />


### PR DESCRIPTION
## What's changed?

We have always allowed slideshows containing one image. Until now, we think very few, if any, have been made. 

However, now we have released captions, there is a (bizarre) incentive to publish a slideshow with only one image. Slideshows are the only fronts media to have captions, so if you want a single image with a caption, you can create a slideshow with that one image.

This looks bad, and isn't the intended behaviour. This PR adds a simple restriction in the tooling to prevent this. Now you can only publish a slideshow with more than one image.

https://user-images.githubusercontent.com/40991816/163005580-3b4c81d8-5f27-445a-9d82-52bad6262a44.mov

The form is disabled if (a) slideshow is enabled and (b) the slideshow has fewer than two images present.

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
