### PR TITLE
Restore 'preview' target

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontSection.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontSection.tsx
@@ -211,7 +211,7 @@ class FrontSection extends React.Component<
                       ? urls.previewUrlCODE
                       : urls.previewUrlPROD
                   }${this.props.frontId}`}
-                  target="_blank"
+                  target="preview"
                 >
                   <FrontHeaderButton>
                     <PreviewEyeIcon size="xl" />


### PR DESCRIPTION
## What's changed?

From a user:

> I wonder if anyone can help me with this. On the fronts tool it has suddenly started opening a new tab every time I preview, rather than overlaying on the previous preview. Consequently i spend my life closing tabs, which is obviously quite annoying. A couple of my colleagues say they have been living with this same glitch for a while now so I wonder if you could fix it, or point me in the right direction.

Likely introduced by the `target="_blank"` attribute in #1430.

This restores the previous behaviour. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
