### PR TITLE
Ophan promotions scores used to prefill Editions are mapped to conten…

### DIFF
--- a/app/logic/CapiPrefiller.scala
+++ b/app/logic/CapiPrefiller.scala
@@ -27,7 +27,7 @@ object CapiPrefiller {
     val internalPageCode = content.fields.flatMap(_.internalPageCode).getOrElse(-1)
     val newspaperPageNumber = content.fields.flatMap(_.newspaperPageNumber)
     val webUrl = content.webUrl
-
+    val capiId = content.id
     val cardStyle = CardStyle(content, TrailMetaData.empty)
     val metadata = ResolvedMetaData.fromContent(content, cardStyle)
 
@@ -58,7 +58,9 @@ object CapiPrefiller {
       cardStyle.toneString,
       mediaType,
       pickedKicker,
-      None)
+      None,
+      capiId
+    )
   }
 
   def getFirstContributorWithCutoutOption(content: Content): Option[String] =

--- a/app/services/Ophan.scala
+++ b/app/services/Ophan.scala
@@ -10,14 +10,14 @@ import java.util.concurrent.TimeUnit
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import com.gu.contentapi.client.model.HttpResponse
 import model.editions.{OphanQueryPrefillParams}
-import okhttp3.{Call, Callback, ConnectionPool, OkHttpClient, Request, Response}
+import okhttp3.{Call, Callback, ConnectionPool, OkHttpClient, Response}
 import okhttp3.Request.Builder
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-case class OphanScore(val webUrl: String, val promotionScore: Double)
+case class OphanScore(val promotionScore: Double, val capiId: String)
 
 class GuardianOphan(config: ApplicationConfiguration)(implicit ex: ExecutionContext) extends Ophan with Logging {
 
@@ -63,7 +63,7 @@ class GuardianOphan(config: ApplicationConfiguration)(implicit ex: ExecutionCont
       .maximumSize(50)
       .build((url: String) => getRequest(url))
 
-  def get(host: String, path: String, startDate: LocalDate, endDate: LocalDate, ophanApiKey: String)(implicit context: ExecutionContext): Future[HttpResponse] = {
+  private def get(host: String, path: String, startDate: LocalDate, endDate: LocalDate, ophanApiKey: String)(implicit context: ExecutionContext): Future[HttpResponse] = {
     val fromParam = startDate.toString // iso 8601
     val toParam = endDate.toString // iso 8601
     val url = s"$host$promotionPath$path?from=${fromParam}&to=${toParam}&api-key=${ophanApiKey}"

--- a/app/services/editions/prefills/package.scala
+++ b/app/services/editions/prefills/package.scala
@@ -17,7 +17,8 @@ package object prefills {
                       tone: String,
                       mediaType: Option[MediaType],
                       pickedKicker: Option[String], // Note: algorithmically-picked, not human-picked.
-                      promotionMetric: Option[Double]
+                      promotionMetric: Option[Double],
+                      capiId: String
                     )
 
   case class CapiQueryTimeWindow(fromDate: Instant, toDate: Instant)

--- a/test/fixtures/FakeCapiAndOphan.scala
+++ b/test/fixtures/FakeCapiAndOphan.scala
@@ -36,7 +36,9 @@ trait FakeCapiAndOphan {
             "tone1",
             None,
             None,
-            None),
+            None,
+            "capiId123456",
+          ),
           Prefill(
             222222,
             None,
@@ -50,7 +52,9 @@ trait FakeCapiAndOphan {
             "tone2",
             None,
             None,
-            None),
+            None,
+            "capiId222222",
+          ),
           Prefill(
             333333,
             None,
@@ -64,7 +68,9 @@ trait FakeCapiAndOphan {
             "tone3",
             None,
             None,
-            None)
+            None,
+            "capiId333333"
+          )
         )
         case "?tag=theguardian/g2/arts" => List(
           Prefill(
@@ -80,7 +86,9 @@ trait FakeCapiAndOphan {
             "tone1",
             Some(MediaType.Cutout),
             None,
-            None),
+            None,
+            "capiId345678"
+          ),
           Prefill(
             574893,
             None,
@@ -94,7 +102,9 @@ trait FakeCapiAndOphan {
             "tone2",
             Some(MediaType.UseArticleTrail),
             None,
-            None),
+            None,
+            "capiId574893"
+          ),
           Prefill(
             674893,
             None,
@@ -108,7 +118,9 @@ trait FakeCapiAndOphan {
             "tone3",
             Some(MediaType.UseArticleTrail),
             None,
-            None)
+            None,
+            "capiId674893"
+          )
         )
         case "?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement" => List(
           Prefill(
@@ -124,7 +136,9 @@ trait FakeCapiAndOphan {
             "tone1",
             Some(MediaType.Cutout),
             None,
-            None),
+            None,
+            "capiId112211",
+          ),
           Prefill(
             122211,
             None,
@@ -138,7 +152,9 @@ trait FakeCapiAndOphan {
             "tone1",
             Some(MediaType.Cutout),
             None,
-            None),
+            None,
+            "capiId122211"
+          ),
           Prefill(
             132211,
             None,
@@ -152,7 +168,8 @@ trait FakeCapiAndOphan {
             "tone1",
             Some(MediaType.Cutout),
             None,
-            None),
+            None,
+            "capiId132211"),
           Prefill(
             142211,
             None,
@@ -166,7 +183,8 @@ trait FakeCapiAndOphan {
             "tone1",
             Some(MediaType.Cutout),
             None,
-            None),
+            None,
+            "capiId132211"),
           Prefill(
             152211,
             None,
@@ -180,7 +198,8 @@ trait FakeCapiAndOphan {
             "tone1",
             Some(MediaType.Cutout),
             None,
-            None)
+            None,
+            "capiId132211")
         )
       }
     }
@@ -195,9 +214,9 @@ trait FakeCapiAndOphan {
   val forwardOphan = new Ophan {
     override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
       Array(
-        OphanScore("webUrl123456", 3d),
-        OphanScore("webUrl345678", 2d),
-        OphanScore("webUrl574893", 1d)
+        OphanScore(3d, "capiId123456"),
+        OphanScore(2d, "capiId345678"),
+        OphanScore(1d, "capiId574893"),
       )
     ))
   }
@@ -205,16 +224,16 @@ trait FakeCapiAndOphan {
   val reverseOphan = new Ophan {
     override def getOphanScores(maybeUrl: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] = Future.successful(Some(
       Array(
-        OphanScore("webUrl123456", 1d),
-        OphanScore("webUrl345678", 2d),
-        OphanScore("webUrl574893", 3d)
+        OphanScore(1d, "capiId123456"),
+        OphanScore(2d, "capiId345678"),
+        OphanScore(3d, "capiId574893")
       )
     ))
   }
 
   val fakeOphan = new Ophan() {
     override def getOphanScores(maybePath: Option[String], baseDate: LocalDate, maybeOphanQueryPrefillParams: Option[OphanQueryPrefillParams]): Future[Option[Array[OphanScore]]] =
-      Future.successful(Some(Array(OphanScore("banana", 33d))))
+      Future.successful(Some(Array(OphanScore(33d, "banana"))))
   }
 
 }


### PR DESCRIPTION
…t by capiId rather than webUrl.

Better accomodates content with evolving urls. Allows ophan to deprecate the webUrl field from their API response.

Adds a capiId field to the Prefill class; this looks safe because it doesn't look like a persisted object.

## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
