### PR TITLE
Bump panda to 1.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.9",
     "com.gu" %% "fapi-client-play28" % "4.0.1",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
 
     "org.scanamo" %% "scanamo" % "1.0.0-M15" exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),
     "com.github.blemale" %% "scaffeine" % "4.1.0" % "compile",


### PR DESCRIPTION
## What does this change?

Bumps pan-domain-auth to 1.0.6 to patch some security vulnerabilities.

## How to test

The app should continue to accept authenticated requests, and reject unauthenticated ones.

Deploy to CODE and log in. Does the tool continue to authenticate you? Remove your pan-domain cookies, and try again. Does it force you to log in?