### PR TITLE
allow samesite=none

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,6 +61,7 @@ play {
   http {
     session {
       secure=true
+      sameSite="none"
     }
   }
 


### PR DESCRIPTION
## What's changed?

Firefox won't allow the panda reauth flow to complete, because it requires the PLAY_SESSION cookie to be sent during the redirect back to 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
