### PR TITLE
Upgrade to panda v1.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "2.9",
     "com.gu" %% "fapi-client-play28" % "4.0.1",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.0",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.1",
 
     "org.scanamo" %% "scanamo" % "1.0.0-M15" exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),
     "com.github.blemale" %% "scaffeine" % "4.1.0" % "compile",


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Upgrade to pan-domain-auth v1.1.1. This fixes a bug that meant reauth could not be performed if the origin page url contained a `,`, as Play refuses to issue cookies containing comma characters.

## How to test

- Deploy to CODE, navigate to breaking news tool (contains a comma in url). Open devtools and delete the gutoolsAuth-assym cookie, then reload. Do you see a generic 500 message, or do you get authenticated and back into the breaking news tool?

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
