### PR TITLE
Up max slideshow images from 5 to 10

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -38,6 +38,7 @@ import {
   getInitialValuesForCardForm,
   getCapiValuesForArticleFields,
   shouldRenderField,
+  maxSlideshowImages,
 } from 'util/form';
 import { CapiFields } from 'util/form';
 import { Dispatch } from 'types/Store';
@@ -142,9 +143,23 @@ const ButtonContainer = styled.div`
   margin-bottom: -10px;
 `;
 
+const slideshowGutter = 5;
+const slidesPerRow = 5;
+
 const SlideshowRow = styled(Row)`
+  flex-wrap: wrap;
+  margin-left: 0;
+  margin-right: 0;
   margin-top: 10px;
   margin-bottom: 5px;
+  gap: ${slideshowGutter}px;
+`;
+
+const SlideshowCol = styled(Col)`
+  flex: 0 1 auto;
+  padding: 0;
+  width: calc(${100 / slidesPerRow}% - ${slideshowGutter}px);
+  max-width: 100px;
 `;
 
 const SlideshowLabel = styled.div`
@@ -170,11 +185,6 @@ const FieldsContainerWrap = styled(Row)`
   flex-wrap: wrap;
   padding-bottom: 4px;
   border-bottom: 1px solid ${theme.base.colors.borderColor};
-`;
-
-const SlideshowCol = styled(Col)`
-  max-width: 100px;
-  min-width: 0;
 `;
 
 const ToggleCol = styled(Col)`
@@ -306,7 +316,7 @@ const RenderSlideshow = ({
           </SlideshowCol>
         ))}
       </SlideshowRow>
-      <SlideshowLabel>Drag and drop up to five images</SlideshowLabel>
+      <SlideshowLabel>Drag and drop up to {maxSlideshowImages} images</SlideshowLabel>
       {fields.get(slideshowIndex) ? (
         <div>
           <CaptionControls>

--- a/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
+++ b/fronts-client/src/components/FrontsEdit/CardFormInline.tsx
@@ -316,7 +316,9 @@ const RenderSlideshow = ({
           </SlideshowCol>
         ))}
       </SlideshowRow>
-      <SlideshowLabel>Drag and drop up to {maxSlideshowImages} images</SlideshowLabel>
+      <SlideshowLabel>
+        Drag and drop up to {maxSlideshowImages} images
+      </SlideshowLabel>
       {fields.get(slideshowIndex) ? (
         <div>
           <CaptionControls>

--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -2,6 +2,7 @@ import { reducer, initialize, change } from 'redux-form';
 import {
   getCardMetaFromFormValues,
   getInitialValuesForCardForm,
+  maxSlideshowImages,
 } from 'util/form';
 import derivedArticle from 'fixtures/derivedArticle';
 import { state as initialState } from 'fixtures/initialState';
@@ -37,7 +38,7 @@ const formValues = {
   showLargeHeadline: false,
   showByline: false,
   showQuotedHeadline: false,
-  slideshow: [undefined, undefined, undefined, undefined, undefined],
+  slideshow: Array(maxSlideshowImages).fill(undefined),
   showKickerTag: false,
   showKickerSection: false,
   trailText:
@@ -82,7 +83,7 @@ describe('CardForm transform functions', () => {
         origin: 'origin',
         thumb: 'thumb',
       };
-      const slideshow = Array(6).fill(exampleImage);
+      const slideshow = Array(maxSlideshowImages + 5).fill(exampleImage);
       const slideshowArticle = {
         ...derivedArticle,
         slideshow,
@@ -154,9 +155,7 @@ describe('CardForm transform functions', () => {
             origin: 'exampleOrigin',
             thumb: 'exampleThumb',
           },
-          undefined,
-          undefined,
-          undefined,
+          ...Array(maxSlideshowImages - 2).fill(undefined),
         ],
       });
     });

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -80,7 +80,7 @@ export const getCapiValuesForArticleFields = (
   };
 };
 
-const maxSlideshowImages = 10;
+export const maxSlideshowImages = 10;
 
 export const getInitialValuesForCardForm = (
   article: DerivedArticle | void

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -80,6 +80,8 @@ export const getCapiValuesForArticleFields = (
   };
 };
 
+const maxSlideshowImages = 10;
+
 export const getInitialValuesForCardForm = (
   article: DerivedArticle | void
 ): CardFormData | void => {
@@ -94,7 +96,7 @@ export const getInitialValuesForCardForm = (
       height: strToInt(image.height),
     })
   );
-  slideshowBackfill.length = clamp(5 - slideshow.length, 0, 5);
+  slideshowBackfill.length = clamp(maxSlideshowImages - slideshow.length, 0, maxSlideshowImages);
   slideshowBackfill.fill(undefined);
   return article
     ? {

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -96,7 +96,11 @@ export const getInitialValuesForCardForm = (
       height: strToInt(image.height),
     })
   );
-  slideshowBackfill.length = clamp(maxSlideshowImages - slideshow.length, 0, maxSlideshowImages);
+  slideshowBackfill.length = clamp(
+    maxSlideshowImages - slideshow.length,
+    0,
+    maxSlideshowImages
+  );
   slideshowBackfill.fill(undefined);
   return article
     ? {


### PR DESCRIPTION
## What's changed?

What's better than 5 slideshow images? 10 slideshow images![^1]

This PR pushes the envelope of facia-tool slideshow image counts, _literally doubling_ the number of images you can put in a slideshow, in a card, on a front.

This is a temporary change, which we should roll back after the 19th.

[^1]: not actually better

|Before|After|
|-|-|
|<img width="953" alt="Screenshot_2022-09-15_at_10 52 28" src="https://user-images.githubusercontent.com/7767575/190397452-593986eb-eb2a-4711-a82d-b235ee9d2227.png">|<img width="848" alt="Screenshot 2022-09-15 at 12 53 55" src="https://user-images.githubusercontent.com/7767575/190397290-b71a64dc-87a2-419f-8159-73e30481cfdb.png">|

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
