### PR TITLE
amend setup for node and yarn

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,19 +11,18 @@ NOCOLOUR='\033[0m'
 
 
 CONFIG_DIR=/etc/gu
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=${DIR}/..
 
 printf "\n\rSetting up Fronts Tool V2 dependencies... \n\r\n\r"
 
-installed() {
-  hash "$1" 2>/dev/null
- }
 
 fileExists() {
   test -e "$1"
 }
 
-install_yarn() {
-  if ! installed yarn; then
+check_yarn_installed() {
+  if ! [ -x "$(command -v yarn)" ]; then
     echo -e "\r\n\r\n${red}yarn not found: please install yarn from https://yarnpkg.com/${plain}\r\n"
     echo -e "Yarn is required to ensure developers use consistent JS dependencies"
 
@@ -32,15 +31,12 @@ install_yarn() {
 }
 
 set_node_version() {
+  runningNodeVersion=$(node -v)
+  requiredNodeVersion=$(cat "$ROOT_DIR/.nvmrc")
 
-  if ! fileExists "$NVM_DIR/nvm.sh"; then
-    node_version=`cat .nvmrc`
-    echo -e "${YELLOW}nvm not found: please ensure you're using node $node_version\r\n"
-    echo -e "${nocolour}NVM is not required to run this project, but we recommend using it to easily manage node versions"
-    echo -e "Install it from https://github.com/creationix/nvm#installation\r\n\r\n"
-  else
-    source "$NVM_DIR/nvm.sh"
-    nvm use
+  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
+    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}"
+    exit 1
   fi
 }
 
@@ -93,7 +89,7 @@ fetch_config(){
 }
 main() {
   fetch_config "$@"
-  install_yarn
+  check_yarn_installed
   set_node_version
   install_v2_deps_and_build
   install_v1_deps


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Currently the setup bash script does not accurately account for the use of asdf to manage Node Versions. Currently it only checks for `nvm`. 
Several developers have moved over to asdf as a result of the new M1 laptops, and in any case seeks to make the repo more wide using. 

In addition this does not allow for the accurate checking whether `yarn` is intalled.

Both of these functions have been amended to mitigate for this.
## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
paired with: @akash1810 