### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+## code changes will send PR to following users. See https://help.github.com/articles/about-codeowners/
+* @guardian/digital-cms


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Add CODEOWNERS file to automatically add digital-cms in the list of required reviewers