### PR TITLE
Adds What's On as a front

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -230,12 +230,12 @@ object DailyEdition extends RegionalEdition {
     .swatch(Culture)
   
   def FrontWhatsOn = front(
-    "What's On",
-    collection("What's On").printSentAnyTag("theguardian/whatson/whatson"),
-    collection("What's On"),
-    collection("What's On"),
-    collection("What's On"),
-    collection("What's On").hide
+    "What's on",
+    collection("What's on").printSentAnyTag("theguardian/whatson/whatson"),
+    collection("What's on"),
+    collection("What's on"),
+    collection("What's on"),
+    collection("What's on").hide
   )
     .swatch(Culture)
 

--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -40,6 +40,8 @@ object DailyEdition extends RegionalEdition {
       FrontOpinionSpecial -> Daily(),
       // Culture fronts and special
       FrontCulture -> WeekDays(List(WeekDay.Mon, WeekDay.Tues, WeekDay.Wed, WeekDay.Thurs)),
+      // What's on
+      FrontWhatsOn -> WeekDays(List(WeekDay.Sat)),
       FrontCultureFilmMusic -> WeekDays(List(WeekDay.Fri)),
       // New for Saturday Magazine
       FrontLifeSaturdayMagazineFeatures -> WeekDays(List(WeekDay.Sat)),
@@ -224,6 +226,16 @@ object DailyEdition extends RegionalEdition {
     collection("Culture").hide,
     collection("TV & radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture").hide
+  )
+    .swatch(Culture)
+  
+  def FrontWhatsOn = front(
+    "What's On",
+    collection("What's On").printSentAnyTag("theguardian/whatson/whatson"),
+    collection("What's On"),
+    collection("What's On"),
+    collection("What's On"),
+    collection("What's On").hide
   )
     .swatch(Culture)
 


### PR DESCRIPTION
I've assumed that  single quotes don't need escaping:  https://stackoverflow.com/questions/30079501/why-does-scala-allow-single-quotes-in-strings-to-be-escaped

## What's changed?
Add's "What's On" as a front, with five containers.

## Implementation notes
Edited in Github

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
