### PR TITLE
Revert "Bump capi, facia clients and capi-models to latest versions"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,8 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.11.999"
-val capiModelsVersion = "17.4.2"
-val capiClientVersion = "19.2.1"
+val capiModelsVersion = "17.1.0"
+val capiClientVersion = "19.0.5"
 val json4sVersion = "4.0.3"
 val enumeratumPlayVersion = "1.6.0"
 val circeVersion = "0.13.0"
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "4.0.5",
+    "com.gu" %% "fapi-client-play28" % "4.0.3",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.1",
 


### PR DESCRIPTION
Reverts guardian/facia-tool#1493, which has caused problems in PROD.