### PR TITLE
Do not alter names of fronts in UI when editing Editions

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontSection.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontSection.tsx
@@ -295,11 +295,12 @@ class FrontSection extends React.Component<
       return nameOverride;
     }
 
-    const name = this.props.selectedFront.displayName || this.props.selectedFront.id;
+    const name =
+      this.props.selectedFront.displayName || this.props.selectedFront.id;
     return this.props.isEditions
       ? name
-      // Some fronts are missing a title, and are named by their id. This makes them more legible to editorial staff.
-      : startCase(name);
+      : // Some fronts are missing a title, and are named by their id. This makes them more legible to editorial staff.
+        startCase(name);
   };
 
   private setName = () => {

--- a/fronts-client/src/components/FrontsEdit/FrontSection.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontSection.tsx
@@ -286,17 +286,20 @@ class FrontSection extends React.Component<
   private getTitle = () => {
     const { selectedFront } = this.props;
 
-    if (selectedFront) {
-      if (selectedFront.metadata && selectedFront.metadata.nameOverride) {
-        return selectedFront.metadata.nameOverride;
-      } else {
-        return startCase(
-          this.props.selectedFront.displayName || this.props.selectedFront.id
-        );
-      }
+    if (!selectedFront) {
+      return;
     }
 
-    return;
+    const nameOverride = selectedFront.metadata?.nameOverride;
+    if (nameOverride) {
+      return nameOverride;
+    }
+
+    const name = this.props.selectedFront.displayName || this.props.selectedFront.id;
+    return this.props.isEditions
+      ? name
+      // Some fronts are missing a title, and are named by their id. This makes them more legible to editorial staff.
+      : startCase(name);
   };
 
   private setName = () => {

--- a/fronts-client/src/components/FrontsEdit/__tests__/FrontSection.spec.tsx
+++ b/fronts-client/src/components/FrontsEdit/__tests__/FrontSection.spec.tsx
@@ -4,7 +4,7 @@ import state from 'fixtures/initialStateForOpenFronts';
 import React from 'react';
 import 'jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import {getByTestId, getByText, render} from 'react-testing-library';
+import { getByTestId, getByText, render } from 'react-testing-library';
 import { ThemeProvider } from 'styled-components';
 import configureStore from 'util/configureStore';
 import FrontSection from '../FrontSection';
@@ -97,11 +97,11 @@ describe('FrontSection component', () => {
     );
   });
 
-  describe("Front titles", () => {
+  describe('Front titles', () => {
     const sectionProps = {
       ...defaultProps,
-      frontId: "editorial-front-3",
-      selectedFront: frontsConfig.data.fronts["editorial-front-3"]
+      frontId: 'editions-front-3',
+      selectedFront: frontsConfig.data.fronts['editions-front-3'],
     };
 
     it('should make front names more legible when derived from ids', () => {
@@ -111,7 +111,7 @@ describe('FrontSection component', () => {
           ...state.config,
           dev: false,
           env: 'prod',
-        }
+        },
       });
 
       const { container } = render(
@@ -123,19 +123,22 @@ describe('FrontSection component', () => {
       );
 
       expect(getByTestId(container, 'front-name')).toHaveTextContent(
-        "Editorial Front 3",
+        'Editions Front 3'
       );
     });
 
     it('should not alter front names for editions', () => {
-      const store = configureStore({
-        ...state,
-        config: {
-          ...state.config,
-          dev: false,
-          env: 'prod',
-        }
-      }, "/v2/issues/9120723d-7d0d-4598-a22d-d9cf4dc7cbe6");
+      const store = configureStore(
+        {
+          ...state,
+          config: {
+            ...state.config,
+            dev: false,
+            env: 'prod',
+          },
+        },
+        '/v2/issues/9120723d-7d0d-4598-a22d-d9cf4dc7cbe6'
+      );
 
       const { container } = render(
         <Provider store={store}>
@@ -146,7 +149,7 @@ describe('FrontSection component', () => {
       );
 
       expect(getByTestId(container, 'front-name')).toHaveTextContent(
-        "editorial-front-3",
+        'editions-front-3'
       );
     });
   });

--- a/fronts-client/src/components/FrontsEdit/__tests__/FrontSection.spec.tsx
+++ b/fronts-client/src/components/FrontsEdit/__tests__/FrontSection.spec.tsx
@@ -4,7 +4,7 @@ import state from 'fixtures/initialStateForOpenFronts';
 import React from 'react';
 import 'jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import { getByText, render } from 'react-testing-library';
+import {getByTestId, getByText, render} from 'react-testing-library';
 import { ThemeProvider } from 'styled-components';
 import configureStore from 'util/configureStore';
 import FrontSection from '../FrontSection';
@@ -95,5 +95,59 @@ describe('FrontSection component', () => {
       'href',
       'https://preview.gutools.co.uk/responsive-viewer/https://preview.gutools.co.uk/editorialFront'
     );
+  });
+
+  describe("Front titles", () => {
+    const sectionProps = {
+      ...defaultProps,
+      frontId: "editorial-front-3",
+      selectedFront: frontsConfig.data.fronts["editorial-front-3"]
+    };
+
+    it('should make front names more legible when derived from ids', () => {
+      const store = configureStore({
+        ...state,
+        config: {
+          ...state.config,
+          dev: false,
+          env: 'prod',
+        }
+      });
+
+      const { container } = render(
+        <Provider store={store}>
+          <ThemeProvider theme={theme}>
+            <FrontSection {...sectionProps} />
+          </ThemeProvider>
+        </Provider>
+      );
+
+      expect(getByTestId(container, 'front-name')).toHaveTextContent(
+        "Editorial Front 3",
+      );
+    });
+
+    it('should not alter front names for editions', () => {
+      const store = configureStore({
+        ...state,
+        config: {
+          ...state.config,
+          dev: false,
+          env: 'prod',
+        }
+      }, "/v2/issues/9120723d-7d0d-4598-a22d-d9cf4dc7cbe6");
+
+      const { container } = render(
+        <Provider store={store}>
+          <ThemeProvider theme={theme}>
+            <FrontSection {...sectionProps} />
+          </ThemeProvider>
+        </Provider>
+      );
+
+      expect(getByTestId(container, 'front-name')).toHaveTextContent(
+        "editorial-front-3",
+      );
+    });
   });
 });

--- a/fronts-client/src/fixtures/frontsConfig.ts
+++ b/fronts-client/src/fixtures/frontsConfig.ts
@@ -13,8 +13,8 @@ const frontsConfig: { data: FrontsConfig } = {
         collections: ['collection6'],
         priority: 'editorial',
       },
-      "editorial-front-3": {
-        id: 'editorial-front-3',
+      'editions-front-3': {
+        id: 'editions-front-3',
         collections: ['collection6'],
         priority: '9120723d-7d0d-4598-a22d-d9cf4dc7cbe6',
       },

--- a/fronts-client/src/fixtures/frontsConfig.ts
+++ b/fronts-client/src/fixtures/frontsConfig.ts
@@ -13,6 +13,11 @@ const frontsConfig: { data: FrontsConfig } = {
         collections: ['collection6'],
         priority: 'editorial',
       },
+      "editorial-front-3": {
+        id: 'editorial-front-3',
+        collections: ['collection6'],
+        priority: '9120723d-7d0d-4598-a22d-d9cf4dc7cbe6',
+      },
       commercialFront: {
         id: 'commercialFront',
         collections: ['collection1'],

--- a/fronts-client/src/selectors/collectionSelectors.ts
+++ b/fronts-client/src/selectors/collectionSelectors.ts
@@ -37,8 +37,7 @@ const selectCollectionParams = (
     []
   );
 
-const selectIsCollectionLocked = (state: State, id: string): boolean =>
-  !!selectCollectionConfig(state, id).uneditable;
+const selectIsCollectionLocked = (state: State, id: string): boolean => !!selectCollectionConfig(state, id)?.uneditable;
 
 const selectWillCollectionHitCollectionCap = (
   state: State,

--- a/fronts-client/src/selectors/collectionSelectors.ts
+++ b/fronts-client/src/selectors/collectionSelectors.ts
@@ -37,7 +37,8 @@ const selectCollectionParams = (
     []
   );
 
-const selectIsCollectionLocked = (state: State, id: string): boolean => !!selectCollectionConfig(state, id)?.uneditable;
+const selectIsCollectionLocked = (state: State, id: string): boolean =>
+  !!selectCollectionConfig(state, id)?.uneditable;
 
 const selectWillCollectionHitCollectionCap = (
   state: State,


### PR DESCRIPTION
## What's changed?

Removes the startCasing of front names when working with Editions. This fixes a problem where the Editions front, `What's on`, is displayed as `Whats On`.

Keeps it in all other cases – renaming other fronts in this way could be quite disorienting for editorial users!

In future, it'd be nice to backfill the sugared names into `displayName` properties on Fronts, and make that property required for new fronts, to ensure we've always got a user-facing name and remove this code.

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
