### PR TITLE
Support Europe edition notifications

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -25,14 +25,6 @@ import scala.util.{Failure, Success, Try}
 class InvalidNotificationContentType(msg: String) extends Throwable(msg) {}
 
 object BreakingNewsUpdate {
-  val CovidGlobalTopicName = "global-covid-19"
-  val CovidBreakingNewsTopics = List(
-    BreakingNewsCovid19Uk,
-    BreakingNewsCovid19Us,
-    BreakingNewsCovid19Au,
-    BreakingNewsCovid19International
-  )
-
   val SportGlobalTopicName = "global-sport"
   val SportBreakingNewsTopics = List(
     BreakingNewsSportUk,
@@ -45,7 +37,6 @@ object BreakingNewsUpdate {
   def createPayload(trail: ClientHydratedTrail, email: String): BreakingNewsPayload = {
     val title = trail.topic match {
       case Some("uk-general-election") => Some("General election 2019")
-      case Some(topic) if (CovidBreakingNewsTopics.map(_.name) :+ CovidGlobalTopicName).contains(topic) => Some("Coronavirus")
       case Some(topic) if (SportBreakingNewsTopics.map(_.name) :+ SportGlobalTopicName).contains(topic) => Some("Sport breaking news")
       case _ => None
     }
@@ -92,11 +83,6 @@ object BreakingNewsUpdate {
       case Some("international-sport") => List(BreakingNewsSportInternational)
       case Some(SportGlobalTopicName) => SportBreakingNewsTopics
       case Some("uk-general-election") => List(BreakingNewsElection)
-      case Some("uk-covid-19") => List(BreakingNewsCovid19Uk)
-      case Some("us-covid-19") => List(BreakingNewsCovid19Us)
-      case Some("au-covid-19") => List(BreakingNewsCovid19Au)
-      case Some("international-covid-19") => List(BreakingNewsCovid19International)
-      case Some(CovidGlobalTopicName) => CovidBreakingNewsTopics
       case Some("") => throw new InvalidParameterException(s"Invalid empty string topic")
       case Some(notYetImplementedTopic) => List(Topic(Breaking, notYetImplementedTopic))
       case None => throw new InvalidParameterException(s"Invalid empty topic")

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -38,7 +38,8 @@ object BreakingNewsUpdate {
     BreakingNewsSportUk,
     BreakingNewsSportUs,
     BreakingNewsSportAu,
-    BreakingNewsSportInternational
+    BreakingNewsSportInternational,
+    BreakingNewsSportEurope,
   )
 
   def createPayload(trail: ClientHydratedTrail, email: String): BreakingNewsPayload = {
@@ -78,14 +79,16 @@ object BreakingNewsUpdate {
 
   private def parseTopic(topic: Option[String]): List[Topic] = {
     topic match {
-      case Some("global") => List(BreakingNewsUk, BreakingNewsUs, BreakingNewsAu, BreakingNewsInternational)
+      case Some("global") => List(BreakingNewsUk, BreakingNewsUs, BreakingNewsAu, BreakingNewsInternational, BreakingNewsEurope)
       case Some("au") => List(BreakingNewsAu)
       case Some("international") => List(BreakingNewsInternational)
       case Some("uk") => List(BreakingNewsUk)
       case Some("us") => List(BreakingNewsUs)
+      case Some("europe") => List(BreakingNewsEurope)
       case Some("uk-sport") => List(BreakingNewsSportUk)
       case Some("us-sport") => List(BreakingNewsSportUs)
       case Some("au-sport") => List(BreakingNewsSportAu)
+      case Some("europe-sport") => List(BreakingNewsSportEurope)
       case Some("international-sport") => List(BreakingNewsSportInternational)
       case Some(SportGlobalTopicName) => SportBreakingNewsTopics
       case Some("uk-general-election") => List(BreakingNewsElection)

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -39,7 +39,7 @@ object BreakingNewsUpdate {
     BreakingNewsSportUs,
     BreakingNewsSportAu,
     BreakingNewsSportInternational,
-    BreakingNewsSportEurope,
+    BreakingNewsSportEurope
   )
 
   def createPayload(trail: ClientHydratedTrail, email: String): BreakingNewsPayload = {

--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
     "com.gu" %% "fapi-client-play28" % "4.0.3",
-    "com.gu" %% "mobile-notifications-api-models" % "1.0.15-001-SNAPSHOT",
+    "com.gu" %% "mobile-notifications-api-models" % "1.0.15-002-SNAPSHOT",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.1",
 
     "org.scanamo" %% "scanamo" % "1.0.0-M15" exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
     "com.gu" %% "fapi-client-play28" % "4.0.3",
-    "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
+    "com.gu" %% "mobile-notifications-api-models" % "1.0.15-001-SNAPSHOT",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.1",
 
     "org.scanamo" %% "scanamo" % "1.0.0-M15" exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
     "com.gu" %% "fapi-client-play28" % "4.0.3",
-    "com.gu" %% "mobile-notifications-api-models" % "1.0.15-002-SNAPSHOT",
+    "com.gu" %% "mobile-notifications-api-models" % "1.0.16",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.1",
 
     "org.scanamo" %% "scanamo" % "1.0.0-M15" exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/test/updates/BreakingNewsUpdateTest.scala
+++ b/test/updates/BreakingNewsUpdateTest.scala
@@ -2,7 +2,6 @@ package updates
 
 import org.scalatest.{FreeSpec, Matchers}
 import com.gu.mobile.notifications.client.models.Topic._
-import updates.BreakingNewsUpdate.CovidGlobalTopicName
 
 class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
@@ -26,25 +25,6 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
     "should not add titles for topics that don't need them" in {
       val ukTrail = createTrail(BreakingNewsUk.name)
       BreakingNewsUpdate.createPayload(ukTrail, exampleEmail).title shouldBe None
-    }
-
-    "should add titles for individual Coronavirus topics" in {
-      val ukTrail = createTrail(BreakingNewsCovid19Uk.name)
-      BreakingNewsUpdate.createPayload(ukTrail, exampleEmail).title shouldBe Some("Coronavirus")
-
-      val usTrail = createTrail(BreakingNewsCovid19Us.name)
-      BreakingNewsUpdate.createPayload(usTrail, exampleEmail).title shouldBe Some("Coronavirus")
-
-      val auTrail = createTrail(BreakingNewsCovid19Au.name)
-      BreakingNewsUpdate.createPayload(auTrail, exampleEmail).title shouldBe Some("Coronavirus")
-
-      val internationalTrail = createTrail(BreakingNewsCovid19International.name)
-      BreakingNewsUpdate.createPayload(internationalTrail, exampleEmail).title shouldBe Some("Coronavirus")
-    }
-
-    "should add titles for global Coronavirus topic" in {
-      val globalTrail = createTrail(CovidGlobalTopicName)
-      BreakingNewsUpdate.createPayload(globalTrail, exampleEmail).title shouldBe Some("Coronavirus")
     }
   }
 }


### PR DESCRIPTION
## What's changed?
In order to support delivery of notifications for the Europe edition, we need to make changes to the Breaking News Tool.

## Implementation notes

- We have added _europe_ and _europe-sport_ to the list of breaking notification topics
- These have also been included in the list of global topics
- We have removed the covid-19-related topics (per request from editorial)
- We have removed several unit tests that were performing checks for covid-19 topics
- We have bumped the version of `mobile-notifications-api-models`


## UI Changes
- We have manually created containers for _europe_ and _europe-sport_ topics
- Once this PR is merged, we will remove containers for the covid-19-related topics

## Testing
- The changes were tested in CODE, by sending europe and global breaking news notifications and confirming that the debug app received the relevant notifications.
- We also sent a uk breaking news notification to make sure the existing code was still working, and the notification was received successfully.

## Screenshots
| UI | Debug App |
|---|---|
| ![Screenshot 2023-03-14 at 12 34 48](https://user-images.githubusercontent.com/55602675/225880694-f4e69359-58c3-4919-835f-c791f185f59a.png) | <img width="412" alt="Screenshot 2023-03-17 at 10 36 45" src="https://user-images.githubusercontent.com/55602675/225881596-6570f171-3108-4449-a87a-8553398c05d2.png"> |

## Checklist

### General
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
