### PR TITLE
Bump capi, facia clients and content-api-models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.11.999"
-val capiModelsVersion = "17.1.0"
+val capiModelsVersion = "17.5.1"
 val capiClientVersion = "19.2.1"
 val json4sVersion = "4.0.3"
 val enumeratumPlayVersion = "1.6.0"

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ routesImport += "model.editions._"
 
 val awsVersion = "1.11.999"
 val capiModelsVersion = "17.1.0"
-val capiClientVersion = "19.0.5"
+val capiClientVersion = "19.2.1"
 val json4sVersion = "4.0.3"
 val enumeratumPlayVersion = "1.6.0"
 val circeVersion = "0.13.0"
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "4.0.3",
+    "com.gu" %% "fapi-client-play28" % "4.0.5",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.14",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.1.1",
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
As part of the upcoming `SpecialReportAlt` we had to [change the report's tag](https://github.com/guardian/content-api-scala-client/pull/380). CAPI client [decides `content.theme` based on content's tags and pillar](https://github.com/guardian/content-api-scala-client/blob/main/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala#L171-L186) and FAPI client [decides the `CardStyle` based on the theme](https://github.com/guardian/facia-scala-client/blob/main/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala#L33-L34). The main purpose of this PR is to bring the new tag change.

I have to bump 3 dependencies a few versions up for this to work smoothly. Here are links to all the changes:
* [CAPI client](https://github.com/guardian/content-api-scala-client/compare/v19.0.5...main)
* [facia client](https://github.com/guardian/facia-scala-client/compare/v4.0.3...v4.0.5)
* [content-api-models](https://github.com/guardian/content-api-models/compare/v17.1.0...v17.5.1)

I have tested my branch in CODE and it works:

![image](https://user-images.githubusercontent.com/19683595/224986398-3fc6f32c-7c4e-4128-ba1e-d68d0c79d78f.png)

### Why this didn't work the previous time?
There was a previous attempt with [#1493](https://github.com/guardian/facia-tool/pull/1493) to update these dependencies but this gave the following error:

![image](https://user-images.githubusercontent.com/19683595/224988462-426a69bb-2bbf-4612-8d92-e6719077b703.png)


I am not 100% familiar with all the changes the CAPI client update brings in but I suspect [v19.2.0](https://github.com/guardian/content-api-scala-client/compare/v19.1.2...v19.2.0) requires CAPI client and facia-tool to be on the same version of `content-api-models`. My previous PR was setting those to `17.4.2` instead of the correct latest `17.5.1`, which is also [the one currently used by the current CAPI client (v19.2.1)](https://github.com/guardian/content-api-scala-client/blob/main/project/Dependencies.scala#L5). I mistakenly thought [GH releases](https://github.com/guardian/content-api-models/releases) has the latest version but [a closer look to the commit history points to the right version](https://github.com/guardian/content-api-models/commits/master).


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [X] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
