### PR TITLE
Update RiffRaff deploy to use ARM AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
     app: facia-tool
     parameters:
       amiTags:
-        Recipe: editorial-tools-focal-java8
+        Recipe: editorial-tools-focal-java8-ARM
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What's changed?
Update RiffRaff deploy to use ARM-based AMI. This is in support of migrating our apps to EC2 instance types with ARM-based Graviton processors, which are cheaper to run.
