### PR TITLE
Allow 10 image slideshows (behind a feature switch)

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,7 +33,7 @@ object ShowFirefoxPrompt extends FeatureSwitch(
 object TenImageSlideshows extends FeatureSwitch(
   key = "ten-image-slideshows",
   title = "Allow slideshows to contain 10 images rather than 5",
-  enabled = true
+  enabled = false
 )
 
 object FeatureSwitches {

--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -30,8 +30,14 @@ object ShowFirefoxPrompt extends FeatureSwitch(
   enabled = true
 )
 
+object TenImageSlideshows extends FeatureSwitch(
+  key = "ten-image-slideshows",
+  title = "Allow slideshows to contain 10 images rather than 5",
+  enabled = true
+)
+
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt)
+  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt, TenImageSlideshows)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     val newSwitches = userDataSwitches match {

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -4,6 +4,7 @@ import compact from 'lodash/compact';
 import clamp from 'lodash/clamp';
 import pickBy from 'lodash/pickBy';
 import { isDirty } from 'redux-form';
+import pageConfig from 'util/extractConfigFromPage';
 import { CardMeta } from 'types/Collection';
 import { DerivedArticle } from 'types/Article';
 import { CapiArticle } from 'types/Capi';
@@ -80,7 +81,12 @@ export const getCapiValuesForArticleFields = (
   };
 };
 
-export const maxSlideshowImages = 5;
+
+const tenImagesFeatureSwitch = pageConfig?.userData?.featureSwitches.find(
+  (feature) => feature.key === 'ten-image-slideshows'
+);
+
+export const maxSlideshowImages = tenImagesFeatureSwitch?.enabled ? 10 : 5;
 
 export const getInitialValuesForCardForm = (
   article: DerivedArticle | void

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -81,7 +81,6 @@ export const getCapiValuesForArticleFields = (
   };
 };
 
-
 const tenImagesFeatureSwitch = pageConfig?.userData?.featureSwitches.find(
   (feature) => feature.key === 'ten-image-slideshows'
 );


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Allows up to 10 images in a slideshow, when the Feature is enabled

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
Editorial are keen for longer slideshows (as for the queens funeral) but we don't have any tracking or stats on how many users see the later images, or any info on how the additional images affect load time for the side.

We're implementing 10 image slideshows behind an AB test, so we can get some data and advise on this before the Kings Coronation (when editorial would like another 10 image slideshow)

| Description | Screenshot |
|--------|--------|
| Fronts tool | <img width="673" alt="image" src="https://user-images.githubusercontent.com/26366706/234631170-a3e82ded-6a88-4e5a-be28-a7e8df67ae4c.png"> |
| Facia feature switches | <img width="424" alt="image" src="https://user-images.githubusercontent.com/26366706/234631311-025ebd23-efe1-4e70-b94c-bce13b0b0009.png"> |
| Testing with Frontend | See video below |

https://user-images.githubusercontent.com/26366706/234637380-39d9f097-9e2d-4305-8323-72fc5a7b4fa4.mov



## Checklist

### General

- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
