### PR TITLE
Revert "Tests should pass in UTC"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
             - name: build
               env:
                   JSPM_GITHUB_AUTH_SECRET: ${{ secrets.GITHUB_TOKEN }}
+                  TZ: Europe/London # todo: tix tests to pass in UTC
               run: |
                   set -e
                   # Ensure we don't overwrite existing (Teamcity) builds.

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -20,7 +20,7 @@ ALTER TABLE edition_issues ADD COLUMN temp TIMESTAMPTZ;
 
 --- Do the work to migrate back
 -- noinspection SqlWithoutWhere
-UPDATE edition_issues SET temp = CONCAT(issue_date, ' 00:00:00 Europe/London')::TIMESTAMPTZ;
+UPDATE edition_issues SET temp = CONCAT(issue_date, ' 00:00:00 Europe/London')::TIMESTAMP;
 
 ALTER TABLE edition_issues ALTER COLUMN temp SET NOT NULL;
 DROP INDEX edition_issues_issue_date_index;

--- a/test/services/editions/db/EditionsDBEvolutionsTest.scala
+++ b/test/services/editions/db/EditionsDBEvolutionsTest.scala
@@ -81,8 +81,8 @@ class EditionsDBEvolutionsTest extends FreeSpec with Matchers with EditionsDBSer
       val summerDateTime = getIssueDateTime(summerId)
       val winterDateTime = getIssueDateTime(winterId)
 
-      summerDateTime.toInstant.toString shouldBe "2019-08-20T23:00:00Z"
-      winterDateTime.toInstant.toString shouldBe "2019-02-21T00:00:00Z"
+      summerDateTime.toString shouldBe "2019-08-21T00:00+01:00"
+      winterDateTime.toString shouldBe "2019-02-21T00:00Z"
 
     }
   }


### PR DESCRIPTION
Reverts guardian/facia-tool#1513

This PR changed a DB evolution, and since play cares about the hash of the evolution, it thinks that the evolution hasn't been applied