### PR TITLE
Simplify snyk action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,45 +1,19 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
-name: Snyk
+# This action submits a report to snyk on every push
 
+name: Snyk
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
-        - main
+      - main
+      - nt/snyk
   workflow_dispatch:
+
 
 jobs:
   security:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v2
-
-      - name: Run Snyk to check for V1 Node vulnerabilities
-        uses: snyk/actions/node@0.3.0
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --org=guardian --project-name=${{ github.repository }}/V1 --file=./package-lock.json
-          command: monitor
-
-      - name: Run Snyk to check for V2 Node vulnerabilities
-        if: ${{ always() }} # always ensures we run this regardless of failed steps
-        uses: snyk/actions/node@0.3.0
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --org=guardian --project-name=${{ github.repository }}/V2 --file=./fronts-client/yarn.lock
-          command: monitor
-
-      - name: Run Snyk to check for Scala vulnerabilities
-        uses: snyk/actions/scala@0.3.0
-        if: ${{ always() }} # always ensures we run this regardless of failed steps
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --org=guardian --project-name=${{ github.repository }}/Scala --file=./build.sbt
-          command: monitor
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    with:
+      ORG: guardian-test
+      JAVA_VERSION: 8
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - nt/snyk
   workflow_dispatch:
 
 
@@ -13,7 +12,7 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      ORG: guardian-test
+      ORG: guardian
       JAVA_VERSION: 8
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What's changed?

The snyk workflow has been significantly simplified by migrating it to the Guardian's [centralised snyk action](https://github.com/guardian/.github/blob/main/.github/workflows/sbt-node-snyk.yml).

The old project on snyk needs to be deleted after this PR is merged.

## Implementation notes

The cron job that ran at 6am every morning has been removed. This is not needed as snyk only needs to be notified when dependencies change, and will run regular checks on existing projects independently (usually daily)

## Testing

run the action using the github UI, verify it shows up in snyk
