### PR TITLE
Add vertical video layout container

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -32,6 +32,7 @@ class FixedContainers(val config: ApplicationConfiguration) {
     ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/video", video),
+    ("fixed/video/vertical", video),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcase)
   ) ++ (if (config.faciatool.showTestContainers) Map(

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -19,7 +19,7 @@ export default {
         { 'name': 'fixed/medium/slow-XII-mpu' },
         { 'name': 'fixed/thrasher' },
         { 'name': 'fixed/video' },
-        { 'name': 'fixed/vertical/video' },
+        { 'name': 'fixed/video/vertical' },
         { 'name': 'fixed/medium/slow-VII' },
         { 'name': 'fixed/small/fast-VIII' },
         { 'name': 'fixed/small/slow-V-mpu' },

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -19,7 +19,7 @@ export default {
         { 'name': 'fixed/medium/slow-XII-mpu' },
         { 'name': 'fixed/thrasher' },
         { 'name': 'fixed/video' },
-        { 'name': 'fixed/verticalVideo' },
+        { 'name': 'fixed/vertical/video' },
         { 'name': 'fixed/medium/slow-VII' },
         { 'name': 'fixed/small/fast-VIII' },
         { 'name': 'fixed/small/slow-V-mpu' },

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -19,6 +19,7 @@ export default {
         { 'name': 'fixed/medium/slow-XII-mpu' },
         { 'name': 'fixed/thrasher' },
         { 'name': 'fixed/video' },
+        { 'name': 'fixed/verticalVideo' },
         { 'name': 'fixed/medium/slow-VII' },
         { 'name': 'fixed/small/fast-VIII' },
         { 'name': 'fixed/small/slow-V-mpu' },


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
This PR adds the adds a vertical video (`fixed/video/vertical`) container layout so that we can differentiate between standard and vertical video containers on the rendering platforms.

![Screenshot 2023-06-14 at 15 21 16](https://github.com/guardian/facia-tool/assets/20416599/9bbd0812-eaa2-4589-b541-71c56d58d2c7)


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
