### PR TITLE
Update to fapi-client v4.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "4.0.5",
+    "com.gu" %% "fapi-client-play28" % "4.0.6",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.16",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.2",
 


### PR DESCRIPTION
This is a small upgrade, catching up with the recent dependency updates of https://github.com/guardian/facia-scala-client/releases/tag/v4.0.6, before the more extensive update in https://github.com/guardian/facia-scala-client/pull/287 is introduced.

This update has already been tested in Ophan's PromotionPoller with https://github.com/guardian/ophan/pull/5540, successfully deployed to Prodution.
