### PR TITLE
Revert "Update to fapi-client v4.0.6"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "2.9",
-    "com.gu" %% "fapi-client-play28" % "4.0.6",
+    "com.gu" %% "fapi-client-play28" % "4.0.5",
     "com.gu" %% "mobile-notifications-api-models" % "1.0.16",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.2",
 


### PR DESCRIPTION
Reverts guardian/facia-tool#1526 as it leads to `NoSuchMethodError` and a failing service.

https://github.com/guardian/facia-tool/pull/1526#issuecomment-1718905559