### PR TITLE
Facia tool dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ In CODE the breaking news tool sends notifications to the "debug version" of the
 
 Breaking News is represented by a front called `breaking-news` which is considered to be a special case. It has a `Send Alert` button rather than a `Launch` button. Only one thing can be added to a collection at a given time. You cannot send the same alert twice, and snap links cannot be added / alerted on. Different collections represent different audience groups (eg by location or by subscription to different topics.) To add a new one, just create a container. New breaking news containers need to have the layout `breaking-news/not-for-other-fronts`.
 
+## Client-side vulnerabilities: Synk and JSPM
+
+The older client side tools (those with source code at /public/src - not the [Fronts-tool](#the-fronts-tool)) are bundled using [JSPM](https://jspm.org/). Instead of dependencies for the application being listed in the package.json file in the normal way, they are listed under "jspm" and compiled by JSPM using an import map.
+
+A side effect of this is that the vulnerabilities are not surfaced by Synk. To address this, there is a workaround to construct a "regular" package.json file out real one, and a custom action so that Synk can report on vulnerabilities (see [PR#1521](https://github.com/guardian/facia-tool/pull/1521)).
+
+To audit vulernabilities locally:
+ - `cd v1_jsmp_synk_workaround`
+ - `npm run preinstall` - generates the package.json file in the gitignored '/result' subfolder
+ - `npm run audit` - generates a lockfile in '/result' and runs the npm audit command - note you can append parameters for pn audit - eg `npm run audit --production > ./result/audit.txt`
 
 ## Troubleshooting
 ### Postgres

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "raven-js": "npm:raven-js@2.3.0",
       "sinon": "npm:sinon@1.17.3",
       "text": "github:systemjs/plugin-text@0.0.7",
-      "underscore": "npm:underscore@1.8.3"
+      "underscore": "npm:underscore@1.13.6"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "fastselect": "github:dbrekalo/fastselect@0.2.0",
       "font-awesome": "npm:font-awesome@4.5.0",
       "grid-util-js": "npm:grid-util-js@1.0.5",
-      "highcharts": "npm:highcharts@7.2.2",
+      "highcharts": "npm:highcharts@9.2.1",
       "jquery": "npm:jquery@2.2.3",
       "jquery-mockjax": "npm:jquery-mockjax@2.1.1",
       "jquery-ui": "github:jquery/jquery-ui@1.11.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       "jquery": "npm:jquery@2.2.3",
       "jquery-mockjax": "npm:jquery-mockjax@2.1.1",
       "jquery-ui": "github:jquery/jquery-ui@1.11.3",
-      "knockout": "npm:knockout@3.4.0",
+      "knockout": "npm:knockout@3.5.1",
       "numeral": "npm:numeral@1.5.3",
       "panda-session": "github:guardian/panda-session@0.1.6",
       "raven-js": "npm:raven-js@2.3.0",

--- a/public/src/js/jspm-config.js
+++ b/public/src/js/jspm-config.js
@@ -33,7 +33,7 @@ System.config({
     "fastselect": "github:dbrekalo/fastselect@0.2.0",
     "font-awesome": "npm:font-awesome@4.5.0",
     "grid-util-js": "npm:grid-util-js@1.0.5",
-    "highcharts": "npm:highcharts@4.2.3",
+    "highcharts": "npm:highcharts@9.2.1",
     "jquery": "npm:jquery@2.2.3",
     "jquery-mockjax": "npm:jquery-mockjax@2.1.1",
     "jquery-ui": "github:jquery/jquery-ui@1.11.3",
@@ -45,10 +45,10 @@ System.config({
     "text": "github:systemjs/plugin-text@0.0.7",
     "underscore": "npm:underscore@1.13.6",
     "github:jspm/nodelibs-assert@0.1.0": {
-      "assert": "npm:assert@1.3.0"
+      "assert": "npm:assert@1.5.1"
     },
-    "github:jspm/nodelibs-buffer@0.1.0": {
-      "buffer": "npm:buffer@3.6.0"
+    "github:jspm/nodelibs-buffer@0.1.1": {
+      "buffer": "npm:buffer@5.7.1"
     },
     "github:jspm/nodelibs-constants@0.1.0": {
       "constants-browserify": "npm:constants-browserify@0.0.1"
@@ -77,7 +77,7 @@ System.config({
       "path-browserify": "npm:path-browserify@0.0.0"
     },
     "github:jspm/nodelibs-process@0.1.2": {
-      "process": "npm:process@0.11.2"
+      "process": "npm:process@0.11.10"
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"
@@ -89,7 +89,7 @@ System.config({
       "url": "npm:url@0.10.3"
     },
     "github:jspm/nodelibs-util@0.1.0": {
-      "util": "npm:util@0.10.3"
+      "util": "npm:util@0.10.4"
     },
     "github:jspm/nodelibs-vm@0.1.0": {
       "vm-browserify": "npm:vm-browserify@0.0.4"
@@ -103,23 +103,27 @@ System.config({
     "npm:asn1.js@4.5.2": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "bn.js": "npm:bn.js@4.11.3",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "inherits": "npm:inherits@2.0.1",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
-    "npm:assert@1.3.0": {
-      "util": "npm:util@0.10.3"
+    "npm:assert@1.5.1": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
+      "object.assign": "npm:object.assign@4.1.4",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "util": "npm:util@0.10.4"
     },
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:bn.js@4.11.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1"
     },
     "npm:browserify-aes@1.0.6": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "buffer-xor": "npm:buffer-xor@1.0.3",
       "cipher-base": "npm:cipher-base@1.0.2",
       "create-hash": "npm:create-hash@1.1.2",
@@ -132,12 +136,12 @@ System.config({
     "npm:browserify-cipher@1.0.0": {
       "browserify-aes": "npm:browserify-aes@1.0.6",
       "browserify-des": "npm:browserify-des@1.0.0",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "evp_bytestokey": "npm:evp_bytestokey@1.0.0"
     },
     "npm:browserify-des@1.0.0": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "des.js": "npm:des.js@1.0.0",
@@ -145,7 +149,7 @@ System.config({
     },
     "npm:browserify-rsa@4.0.1": {
       "bn.js": "npm:bn.js@4.11.3",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "constants": "github:jspm/nodelibs-constants@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "randombytes": "npm:randombytes@2.0.3"
@@ -153,7 +157,7 @@ System.config({
     "npm:browserify-sign@4.0.0": {
       "bn.js": "npm:bn.js@4.11.3",
       "browserify-rsa": "npm:browserify-rsa@4.0.1",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "create-hash": "npm:create-hash@1.1.2",
       "create-hmac": "npm:create-hmac@1.1.4",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
@@ -163,25 +167,26 @@ System.config({
       "stream": "github:jspm/nodelibs-stream@0.1.0"
     },
     "npm:buffer-xor@1.0.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
-    "npm:buffer@3.6.0": {
-      "base64-js": "npm:base64-js@0.0.8",
-      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "ieee754": "npm:ieee754@1.1.6",
-      "isarray": "npm:isarray@1.0.0",
-      "process": "github:jspm/nodelibs-process@0.1.2"
+    "npm:buffer@5.7.1": {
+      "base64-js": "npm:base64-js@1.5.1",
+      "ieee754": "npm:ieee754@1.2.1"
+    },
+    "npm:call-bind@1.0.5": {
+      "function-bind": "npm:function-bind@1.1.2",
+      "get-intrinsic": "npm:get-intrinsic@1.2.2",
+      "set-function-length": "npm:set-function-length@1.1.1"
     },
     "npm:cipher-base@1.0.2": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "inherits": "npm:inherits@2.0.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
       "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
     },
     "npm:clean-css@3.4.12": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "commander": "npm:commander@2.8.1",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "http": "github:jspm/nodelibs-http@1.7.1",
@@ -211,16 +216,16 @@ System.config({
       "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:core-util-is@1.0.2": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1"
     },
     "npm:create-ecdh@4.0.0": {
       "bn.js": "npm:bn.js@4.11.3",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "elliptic": "npm:elliptic@6.2.3"
     },
     "npm:create-hash@1.1.2": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
@@ -229,7 +234,7 @@ System.config({
       "sha.js": "npm:sha.js@2.4.5"
     },
     "npm:create-hmac@1.1.4": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "create-hash": "npm:create-hash@1.1.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "inherits": "npm:inherits@2.0.1",
@@ -247,14 +252,24 @@ System.config({
       "public-encrypt": "npm:public-encrypt@4.0.0",
       "randombytes": "npm:randombytes@2.0.3"
     },
+    "npm:define-data-property@1.1.1": {
+      "get-intrinsic": "npm:get-intrinsic@1.2.2",
+      "gopd": "npm:gopd@1.0.1",
+      "has-property-descriptors": "npm:has-property-descriptors@1.0.1"
+    },
+    "npm:define-properties@1.2.1": {
+      "define-data-property": "npm:define-data-property@1.1.1",
+      "has-property-descriptors": "npm:has-property-descriptors@1.0.1",
+      "object-keys": "npm:object-keys@1.1.1"
+    },
     "npm:des.js@1.0.0": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "inherits": "npm:inherits@2.0.1",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0"
     },
     "npm:diffie-hellman@5.0.2": {
       "bn.js": "npm:bn.js@4.11.3",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "miller-rabin": "npm:miller-rabin@4.0.0",
       "randombytes": "npm:randombytes@2.0.3",
@@ -268,7 +283,7 @@ System.config({
       "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:evp_bytestokey@1.0.0": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "create-hash": "npm:create-hash@1.1.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0"
     },
@@ -279,13 +294,29 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "samsam": "npm:samsam@1.1.2"
     },
+    "npm:get-intrinsic@1.2.2": {
+      "function-bind": "npm:function-bind@1.1.2",
+      "has-proto": "npm:has-proto@1.0.1",
+      "has-symbols": "npm:has-symbols@1.0.3",
+      "hasown": "npm:hasown@2.0.0"
+    },
+    "npm:gopd@1.0.1": {
+      "get-intrinsic": "npm:get-intrinsic@1.2.2"
+    },
     "npm:graceful-readlink@1.0.1": {
       "fs": "github:jspm/nodelibs-fs@0.1.2"
+    },
+    "npm:has-property-descriptors@1.0.1": {
+      "get-intrinsic": "npm:get-intrinsic@1.2.2"
     },
     "npm:hash.js@1.0.3": {
       "inherits": "npm:inherits@2.0.1"
     },
-    "npm:highcharts@4.2.3": {
+    "npm:hasown@2.0.0": {
+      "function-bind": "npm:function-bind@1.1.2"
+    },
+    "npm:highcharts@9.2.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:https-browserify@0.0.0": {
@@ -294,8 +325,8 @@ System.config({
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:isarray@1.0.0": {
-      "systemjs-json": "github:systemjs/plugin-json@0.1.1"
+    "npm:inherits@2.0.3": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:jquery-mockjax@2.1.1": {
       "jquery": "npm:jquery@2.2.3",
@@ -317,13 +348,19 @@ System.config({
     "npm:numeral@1.5.3": {
       "fs": "github:jspm/nodelibs-fs@0.1.2"
     },
+    "npm:object.assign@4.1.4": {
+      "call-bind": "npm:call-bind@1.0.5",
+      "define-properties": "npm:define-properties@1.2.1",
+      "has-symbols": "npm:has-symbols@1.0.3",
+      "object-keys": "npm:object-keys@1.1.1"
+    },
     "npm:os-browserify@0.1.2": {
       "os": "github:jspm/nodelibs-os@0.1.0"
     },
     "npm:parse-asn1@5.0.0": {
       "asn1.js": "npm:asn1.js@4.5.2",
       "browserify-aes": "npm:browserify-aes@1.0.6",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "create-hash": "npm:create-hash@1.1.2",
       "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
       "pbkdf2": "npm:pbkdf2@3.0.4",
@@ -333,7 +370,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:pbkdf2@3.0.4": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "child_process": "github:jspm/nodelibs-child_process@0.1.0",
       "create-hmac": "npm:create-hmac@1.1.4",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
@@ -341,13 +378,15 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
-    "npm:process@0.11.2": {
-      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    "npm:process@0.11.10": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
     "npm:public-encrypt@4.0.0": {
       "bn.js": "npm:bn.js@4.11.3",
       "browserify-rsa": "npm:browserify-rsa@4.0.1",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "create-hash": "npm:create-hash@1.1.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "parse-asn1": "npm:parse-asn1@5.0.0",
@@ -357,7 +396,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:randombytes@2.0.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -366,7 +405,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:readable-stream@1.1.14": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "core-util-is": "npm:core-util-is@1.0.2",
       "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
@@ -376,11 +415,17 @@ System.config({
       "string_decoder": "npm:string_decoder@0.10.31"
     },
     "npm:ripemd160@1.0.1": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:set-function-length@1.1.1": {
+      "define-data-property": "npm:define-data-property@1.1.1",
+      "get-intrinsic": "npm:get-intrinsic@1.2.2",
+      "gopd": "npm:gopd@1.0.1",
+      "has-property-descriptors": "npm:has-property-descriptors@1.0.1"
+    },
     "npm:sha.js@2.4.5": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "inherits": "npm:inherits@2.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -392,7 +437,7 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "samsam": "npm:samsam@1.1.2",
-      "util": "npm:util@0.10.3"
+      "util": "npm:util@0.10.4"
     },
     "npm:source-map@0.4.4": {
       "amdefine": "npm:amdefine@1.0.0",
@@ -404,7 +449,7 @@ System.config({
       "readable-stream": "npm:readable-stream@1.1.14"
     },
     "npm:string_decoder@0.10.31": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1"
     },
     "npm:url@0.10.3": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
@@ -412,8 +457,8 @@ System.config({
       "querystring": "npm:querystring@0.2.0",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:util@0.10.3": {
-      "inherits": "npm:inherits@2.0.1",
+    "npm:util@0.10.4": {
+      "inherits": "npm:inherits@2.0.3",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:vm-browserify@0.0.4": {

--- a/public/src/js/jspm-config.js
+++ b/public/src/js/jspm-config.js
@@ -37,7 +37,7 @@ System.config({
     "jquery": "npm:jquery@2.2.3",
     "jquery-mockjax": "npm:jquery-mockjax@2.1.1",
     "jquery-ui": "github:jquery/jquery-ui@1.11.3",
-    "knockout": "npm:knockout@3.4.0",
+    "knockout": "npm:knockout@3.5.1",
     "numeral": "npm:numeral@1.5.3",
     "panda-session": "github:guardian/panda-session@0.1.6",
     "raven-js": "npm:raven-js@2.3.0",
@@ -62,7 +62,7 @@ System.config({
     "github:jspm/nodelibs-http@1.7.1": {
       "Base64": "npm:Base64@0.2.1",
       "events": "github:jspm/nodelibs-events@0.1.1",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
       "url": "github:jspm/nodelibs-url@0.1.0",
       "util": "github:jspm/nodelibs-util@0.1.0"
@@ -105,7 +105,7 @@ System.config({
       "bn.js": "npm:bn.js@4.11.3",
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
@@ -130,7 +130,7 @@ System.config({
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:browserify-cipher@1.0.0": {
@@ -145,7 +145,7 @@ System.config({
       "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "des.js": "npm:des.js@1.0.0",
-      "inherits": "npm:inherits@2.0.1"
+      "inherits": "npm:inherits@2.0.3"
     },
     "npm:browserify-rsa@4.0.1": {
       "bn.js": "npm:bn.js@4.11.3",
@@ -162,7 +162,7 @@ System.config({
       "create-hmac": "npm:create-hmac@1.1.4",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "elliptic": "npm:elliptic@6.2.3",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "parse-asn1": "npm:parse-asn1@5.0.0",
       "stream": "github:jspm/nodelibs-stream@0.1.0"
     },
@@ -181,7 +181,7 @@ System.config({
     },
     "npm:cipher-base@1.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
       "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
     },
@@ -229,7 +229,7 @@ System.config({
       "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "ripemd160": "npm:ripemd160@1.0.1",
       "sha.js": "npm:sha.js@2.4.5"
     },
@@ -237,7 +237,7 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "create-hash": "npm:create-hash@1.1.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "stream": "github:jspm/nodelibs-stream@0.1.0"
     },
     "npm:crypto-browserify@3.11.0": {
@@ -247,7 +247,7 @@ System.config({
       "create-hash": "npm:create-hash@1.1.2",
       "create-hmac": "npm:create-hmac@1.1.4",
       "diffie-hellman": "npm:diffie-hellman@5.0.2",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "pbkdf2": "npm:pbkdf2@3.0.4",
       "public-encrypt": "npm:public-encrypt@4.0.0",
       "randombytes": "npm:randombytes@2.0.3"
@@ -264,7 +264,7 @@ System.config({
     },
     "npm:des.js@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "minimalistic-assert": "npm:minimalistic-assert@1.0.0"
     },
     "npm:diffie-hellman@5.0.2": {
@@ -279,7 +279,7 @@ System.config({
       "bn.js": "npm:bn.js@4.11.3",
       "brorand": "npm:brorand@1.0.5",
       "hash.js": "npm:hash.js@1.0.3",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "systemjs-json": "github:systemjs/plugin-json@0.1.1"
     },
     "npm:evp_bytestokey@1.0.0": {
@@ -310,7 +310,7 @@ System.config({
       "get-intrinsic": "npm:get-intrinsic@1.2.2"
     },
     "npm:hash.js@1.0.3": {
-      "inherits": "npm:inherits@2.0.1"
+      "inherits": "npm:inherits@2.0.3"
     },
     "npm:hasown@2.0.0": {
       "function-bind": "npm:function-bind@1.1.2"
@@ -322,9 +322,6 @@ System.config({
     "npm:https-browserify@0.0.0": {
       "http": "github:jspm/nodelibs-http@1.7.1"
     },
-    "npm:inherits@2.0.1": {
-      "util": "github:jspm/nodelibs-util@0.1.0"
-    },
     "npm:inherits@2.0.3": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
@@ -332,7 +329,7 @@ System.config({
       "jquery": "npm:jquery@2.2.3",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:knockout@3.4.0": {
+    "npm:knockout@3.5.1": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:miller-rabin@4.0.0": {
@@ -408,7 +405,7 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "core-util-is": "npm:core-util-is@1.0.2",
       "events": "github:jspm/nodelibs-events@0.1.1",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "isarray": "npm:isarray@0.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "stream-browserify": "npm:stream-browserify@1.0.0",
@@ -427,7 +424,7 @@ System.config({
     "npm:sha.js@2.4.5": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:sinon@1.17.3": {
@@ -445,7 +442,7 @@ System.config({
     },
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",
-      "inherits": "npm:inherits@2.0.1",
+      "inherits": "npm:inherits@2.0.3",
       "readable-stream": "npm:readable-stream@1.1.14"
     },
     "npm:string_decoder@0.10.31": {

--- a/public/src/js/jspm-config.js
+++ b/public/src/js/jspm-config.js
@@ -43,7 +43,7 @@ System.config({
     "raven-js": "npm:raven-js@2.3.0",
     "sinon": "npm:sinon@1.17.3",
     "text": "github:systemjs/plugin-text@0.0.7",
-    "underscore": "npm:underscore@1.8.3",
+    "underscore": "npm:underscore@1.13.6",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },

--- a/public/test/spec/knockout.utils.spec.js
+++ b/public/test/spec/knockout.utils.spec.js
@@ -20,7 +20,7 @@ describe('utils/as-observable-props', function () {
 describe('utils/find-first-by-id', function () {
     it('find by id', function () {
         var array = ko.observableArray();
-        expect(firstById(array, 'banana')).toBe(null);
+        expect(firstById(array, 'banana')).toBeFalsy();
 
         array([{
             id: 'some',

--- a/v1_jspm_snyk_workaround/package.json
+++ b/v1_jspm_snyk_workaround/package.json
@@ -1,5 +1,6 @@
 {
     "scripts": {
-        "preinstall": "node jspm-snyk-workaround.js"
+        "preinstall": "node jspm-snyk-workaround.js",
+        "audit": "cd ./result && npm i --package-lock-only && npm audit"
     }
 }


### PR DESCRIPTION
## What's changed?

Upgrades to packages bundled by jspm for the facia-tool application:
      "highcharts": @7.2.2 -> @9.2.1",
      "knockout": @3.4.0 ->  @3.5.1
      "underscore": @1.8.3 -> @1.13.6"

Adds some notes to the readme about the workaround to surface jspm vulnerabilities in Synk., and a new script command for running npm audit locally on the generated package.json.  


## Implementation notes

Left alone some medium severity warnings that would require upgrading jquery from v2 to v3 and updating jquery ui.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
