### PR TITLE
Add prod SNSTopic

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -123,6 +123,9 @@ PROD {
 }
 
 faciatool.sns.tool_topic_arn="arn:aws:sns:eu-west-1:163592447864:facia-CODE-FrontsUpdateSNSTopic-RepwK3g95V3w"
+PROD {
+    faciatool.sns.tool_topic_arn="arn:aws:sns:eu-west-1:163592447864:facia-PROD-FrontsUpdateSNSTopic-kWN6oX2kvOmI"
+}
 
 faciatool.show_test_containers=true
 


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @silvacb 

## What's changed?
Now that this [platform PR](https://github.com/guardian/editorial-tools-platform/pull/707) is in prod, creating an SNS Topic, as a follow-up to this [previous PR](https://github.com/guardian/facia-tool/pull/1528) which enabled the fronts tool to publish to an sns topic, this PR specifies the prod SNS topic for the tool to point at. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
