### PR TITLE
Display front priority in the troubleshooting tool

### DIFF
--- a/public/src/js/troubleshoot/templates/stale.html
+++ b/public/src/js/troubleshoot/templates/stale.html
@@ -37,7 +37,7 @@
     <div class="messageIcon successfulResult">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -256 1792 1792"><g transform="matrix(1,0,0,-1,7.5932203,1217.0847)"><path d="m1671 970q0-40-28-68L919 178 783 42Q755 14 715 14 675 14 647 42L511 178 149 540q-28 28-28 68 0 40 28 68l136 136q28 28 68 28 40 0 68-28l294-295 656 657q28 28 68 28 40 0 68-28l136-136q28-28 28-68z" fill="currentColor"/></g></svg>
     </div>
-    <span>The front &ldquo;<span class="frontName"></span>&rdquo; was pressed correctly <span class="lastModifyDate"></span>.</span>
+    <span>The front &ldquo;<span class="frontName"></span>&rdquo; (<span class="frontPriority"></span>) was pressed correctly <span class="lastModifyDate"></span>.</span>
     <span class="errorStatus">
         Last press attempt <span class="actionTime">time</span> failed for the <span class="errorCount">count</span> time because of <pre class="errorMessage">error</pre>
     </span>
@@ -48,7 +48,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M436.5 75.5c-100-100-262.1-100-362 0 -100 100-100 262.1 0 362 99.9 100 262.1 100 362 0C536.5 337.6 536.5 175.4 436.5 75.5zM119.8 120.7c67.1-67.1 171.7-73.6 246.6-20.3L99.4 367.3C46.2 292.4 52.6 187.8 119.8 120.7zM391.3 392.2c-67.1 67.1-171.7 73.6-246.6 20.3l266.9-266.9C464.8 220.6 458.4 325.1 391.3 392.2z" fill="currentColor"/></svg>
     </div>
     <span>
-        The front &ldquo;<span class="frontName"></span>&rdquo; was last pressed <span class="lastModifyDate"></span>.
+        The front &ldquo;<span class="frontName"></span>&rdquo; (<span class="frontPriority"></span>) was last pressed <span class="lastModifyDate"></span>.
         <button class="formField rePress">Press now</button>
     </span>
     <span class="errorStatus">

--- a/public/src/js/troubleshoot/views/stale.js
+++ b/public/src/js/troubleshoot/views/stale.js
@@ -174,7 +174,7 @@ function diagnoseStaleFront (container, front, priority, config, when, status) {
     const troubleshootResults = clone('staleFront');
     troubleshootResults.querySelector('.lastModifyDate').textContent = when || 'never';
     troubleshootResults.querySelector('.frontName').textContent = front;
-    troubleshootResults.querySelector('.frontPrioity').textContent = priority;
+    troubleshootResults.querySelector('.frontPriority').textContent = priority;
 
     diagnoseCapiQueries(troubleshootResults, front, config, createScheduler());
     diagnoseLatestSnaps(troubleshootResults, front, config, createScheduler());
@@ -232,7 +232,7 @@ function frontNotStale (container, front, priority, when, status) {
     const validMessage = clone('frontNotStale');
     validMessage.querySelector('.lastModifyDate').textContent = when;
     validMessage.querySelector('.frontName').textContent = front;
-    validMessage.querySelector('.frontPrioity').textContent = priority;
+    validMessage.querySelector('.frontPriority').textContent = priority;
     populatePressErrorMessage(validMessage, status);
 
     inject(container, validMessage);

--- a/public/src/js/troubleshoot/views/stale.js
+++ b/public/src/js/troubleshoot/views/stale.js
@@ -134,7 +134,7 @@ function fetchLastPressed (front) {
 }
 
 function checkPressedState (front, config, container, lastPress) {
-    const priority = config.fronts[front].priority;
+    const priority = config.fronts[front].priority || "editorial";
     if (lastPress) {
         const date = new Date(lastPress.pressedTime);
         const now = new Date();

--- a/public/src/js/troubleshoot/views/stale.js
+++ b/public/src/js/troubleshoot/views/stale.js
@@ -134,17 +134,18 @@ function fetchLastPressed (front) {
 }
 
 function checkPressedState (front, config, container, lastPress) {
+    const priority = config.fronts[front].priority;
     if (lastPress) {
         const date = new Date(lastPress.pressedTime);
         const now = new Date();
 
         if (now - date > staleInterval(front, config) || lastPress.statusCode !== 'ok') {
-            return diagnoseStaleFront(container, front, config, humanTime(date, now), lastPress);
+            return diagnoseStaleFront(container, front, priority, config, humanTime(date, now), lastPress);
         } else {
-            return frontNotStale(container, front, humanTime(date, now), lastPress);
+            return frontNotStale(container, front, priority, humanTime(date, now), lastPress);
         }
     } else {
-        return diagnoseStaleFront(container, front, config, null);
+        return diagnoseStaleFront(container, front, priority, config, null);
     }
 }
 
@@ -169,10 +170,11 @@ function inject (container, ...elements) {
     elements.filter(Boolean).forEach(element => placeholder.appendChild(element));
 }
 
-function diagnoseStaleFront (container, front, config, when, status) {
+function diagnoseStaleFront (container, front, priority, config, when, status) {
     const troubleshootResults = clone('staleFront');
     troubleshootResults.querySelector('.lastModifyDate').textContent = when || 'never';
     troubleshootResults.querySelector('.frontName').textContent = front;
+    troubleshootResults.querySelector('.frontPrioity').textContent = priority;
 
     diagnoseCapiQueries(troubleshootResults, front, config, createScheduler());
     diagnoseLatestSnaps(troubleshootResults, front, config, createScheduler());
@@ -226,10 +228,11 @@ function diagnoseLatestSnaps(container, front, config, scheduler) {
     });
 }
 
-function frontNotStale (container, front, when, status) {
+function frontNotStale (container, front, priority, when, status) {
     const validMessage = clone('frontNotStale');
     validMessage.querySelector('.lastModifyDate').textContent = when;
     validMessage.querySelector('.frontName').textContent = front;
+    validMessage.querySelector('.frontPrioity').textContent = priority;
     populatePressErrorMessage(validMessage, status);
 
     inject(container, validMessage);


### PR DESCRIPTION
## What's changed?

Adds the front priority in parenthesis after the front name in the troubleshooting tool so that it is more apparent if you are diagnosing a lower priority issue (i.e. training front)

<img width="867" alt="Screenshot 2024-01-03 at 12 54 48" src="https://github.com/guardian/facia-tool/assets/2619836/904c1018-e10c-40bb-aa87-6f8f98361033">

<img width="685" alt="Screenshot 2024-01-03 at 12 53 30" src="https://github.com/guardian/facia-tool/assets/2619836/a1cd62c2-b4e2-4285-bd04-c16b7acd538e">

