### PR TITLE
Update DailyEdition.scala

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -439,7 +439,7 @@ object DailyEdition extends RegionalEdition {
 
   def FrontCrosswords = front(
     "Crosswords",
-    collection("Crosswords").searchPrefill("?tag=type/crossword")
+    collection("Crosswords").searchPrefill("?tag=type/crossword,-crosswords/series/quick-cryptic")
   )
 
 }


### PR DESCRIPTION
Removes the forthcoming quick-cryptic from the prefill for daily edition.

## What's changed?
We've excluded the tag [crosswords/series/quick-cryptic](https://theguardian.com/crosswords/series/quick-cryptic)
As the Editions puzzle player is unlikely to support it from launch.

## Implementation notes
It's a simple CAPI query. 
https://content.guardianapis.com/search?tag=type/crossword,-crosswords/series/quick-cryptic&api-key=your-key
There is form in that the AmericanEdition.scala in this directory successfully used tag exclusions like this.

## Testing
It would be ideal to test this on code and check that all the other crosswords still appear, a task beyond this humble product manager.
