### PR TITLE
add two more containers to friday culture edition front

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -248,7 +248,9 @@ object DailyEdition extends RegionalEdition {
     collection("Arts").printSentAnyTag("theguardian/g2/arts"),
     collection("TV & radio").printSentAnyTag("theguardian/g2/tvandradio"),
     collection("Culture"),
-    collection("Culture").hide
+    collection("Culture").hide,
+    collection("Culture").hide,
+    collection("Culture").hide,
   )
     .swatch(Culture)
 


### PR DESCRIPTION
## What's changed?
Add 2x extra containers to the "culture" front for editions on friday (`FrontCultureFilmMusic`)

(previous similar request for reference https://github.com/guardian/facia-tool/pull/1538/files)

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
