### PR TITLE
Migrate Editions article to card, and add 'card_type' property to card model

### DIFF
--- a/app/model/editions/EditionsAppTemplates.scala
+++ b/app/model/editions/EditionsAppTemplates.scala
@@ -182,13 +182,13 @@ object PathType extends PlayEnum[PathType] {
 }
 
 private[editions] case class CollectionTemplate(
-  name: String,
-  maybeOphanPath: Option[String] = None,
-  prefill: Option[CapiPrefillQuery],
-  presentation: CollectionPresentation,
-  maybeTimeWindowConfig: Option[CapiTimeWindowConfigInDays] = None,
-  hidden: Boolean = false,
-  articleItemsCap: Int = Defaults.defaultCollectionArticleItemsCap
+                                                 name: String,
+                                                 maybeOphanPath: Option[String] = None,
+                                                 prefill: Option[CapiPrefillQuery],
+                                                 presentation: CollectionPresentation,
+                                                 maybeTimeWindowConfig: Option[CapiTimeWindowConfigInDays] = None,
+                                                 hidden: Boolean = false,
+                                                 cardCap: Int = Defaults.defaultCollectionCardsCap
 ) {
 
   def hide = copy(hidden = true)
@@ -203,7 +203,7 @@ private[editions] case class CollectionTemplate(
 
   def searchPrefill(prefillQuery: String) = copy(prefill = Some(CapiPrefillQuery(prefillQuery, Search)))
 
-  def withArticleItemsCap(articleItemsCap: Int) = copy(articleItemsCap = articleItemsCap)
+  def withCardItemsCap(articleItemsCap: Int) = copy(cardCap = articleItemsCap)
 
   def withTimeWindowConfig(maybeTimeWindowConfig: Option[CapiTimeWindowConfigInDays]) = copy(maybeTimeWindowConfig = maybeTimeWindowConfig)
 }
@@ -299,5 +299,5 @@ case class EditionsCollectionSkeleton(
 
 case class EditionsArticleSkeleton(
                                     id: String,
-                                    metadata: ArticleMetadata
+                                    metadata: CardMetadata
 )

--- a/app/model/editions/EditionsAppTemplates.scala
+++ b/app/model/editions/EditionsAppTemplates.scala
@@ -298,6 +298,6 @@ case class EditionsCollectionSkeleton(
 )
 
 case class EditionsArticleSkeleton(
-  pageCode: String,
-  metadata: ArticleMetadata
+                                    id: String,
+                                    metadata: ArticleMetadata
 )

--- a/app/model/editions/EditionsArticle.scala
+++ b/app/model/editions/EditionsArticle.scala
@@ -50,7 +50,7 @@ object ArticleMetadata {
   val default = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
 }
 
-case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[ArticleMetadata]) extends Logging {
+case class EditionsArticle(id: String, addedOn: Long, metadata: Option[ArticleMetadata]) extends Logging {
   def toPublishedArticle: PublishedArticle = {
     var mediaType: Option[MediaType] = metadata.flatMap(_.mediaType)
 
@@ -80,7 +80,7 @@ case class EditionsArticle(pageCode: String, addedOn: Long, metadata: Option[Art
     })
 
     PublishedArticle(
-      pageCode.toLong,
+      id.toLong,
       PublishedFurniture(
         kicker = metadata.flatMap(_.customKicker),
         headlineOverride = metadata.flatMap(_.headline),
@@ -103,7 +103,7 @@ object EditionsArticle extends Logging {
 
   def fromRow(rs: WrappedResultSet, prefix: String = ""): EditionsArticle = {
     EditionsArticle(
-      rs.string(prefix + "page_code"),
+      rs.string(prefix + "id"),
       rs.zonedDateTime(prefix + "added_on").toInstant.toEpochMilli,
       rs.stringOpt(prefix + "metadata").map(s => Json.parse(s).validate[ArticleMetadata].get)
     )
@@ -111,11 +111,11 @@ object EditionsArticle extends Logging {
 
   def fromRowOpt(rs: WrappedResultSet, prefix: String = ""): Option[EditionsArticle] = {
     for {
-      pageCode <- rs.stringOpt(prefix + "page_code")
+      id <- rs.stringOpt(prefix + "id")
       addedOn <- rs.zonedDateTimeOpt(prefix + "added_on").map(_.toInstant.toEpochMilli)
     } yield
       EditionsArticle(
-        pageCode,
+        id,
         addedOn,
         rs.stringOpt(prefix + "metadata").map(
           s => Json.parse(s).validate[ArticleMetadata] match {

--- a/app/model/editions/EditionsCard.scala
+++ b/app/model/editions/EditionsCard.scala
@@ -24,7 +24,7 @@ object CoverCardImages {
   implicit val format = Json.format[CoverCardImages]
 }
 
-case class ArticleMetadata (
+case class CardMetadata(
   headline: Option[String],
   customKicker: Option[String],
   trailText: Option[String],
@@ -44,14 +44,14 @@ case class ArticleMetadata (
   promotionMetric: Option[Double]
 )
 
-object ArticleMetadata {
-  implicit val format = Json.format[ArticleMetadata]
+object CardMetadata {
+  implicit val format = Json.format[CardMetadata]
 
-  val default = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
+  val default = CardMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
 }
 
-case class EditionsArticle(id: String, addedOn: Long, metadata: Option[ArticleMetadata]) extends Logging {
-  def toPublishedArticle: PublishedArticle = {
+case class EditionsCard(id: String, addedOn: Long, metadata: Option[CardMetadata]) extends Logging {
+  def toPublishedCard: PublishedArticle = {
     var mediaType: Option[MediaType] = metadata.flatMap(_.mediaType)
 
     val coverCardImages = metadata.flatMap { meta =>
@@ -98,30 +98,30 @@ case class EditionsArticle(id: String, addedOn: Long, metadata: Option[ArticleMe
   }
 }
 
-object EditionsArticle extends Logging {
-  implicit val writes = Json.format[EditionsArticle]
+object EditionsCard extends Logging {
+  implicit val writes = Json.format[EditionsCard]
 
-  def fromRow(rs: WrappedResultSet, prefix: String = ""): EditionsArticle = {
-    EditionsArticle(
+  def fromRow(rs: WrappedResultSet, prefix: String = ""): EditionsCard = {
+    EditionsCard(
       rs.string(prefix + "id"),
       rs.zonedDateTime(prefix + "added_on").toInstant.toEpochMilli,
-      rs.stringOpt(prefix + "metadata").map(s => Json.parse(s).validate[ArticleMetadata].get)
+      rs.stringOpt(prefix + "metadata").map(s => Json.parse(s).validate[CardMetadata].get)
     )
   }
 
-  def fromRowOpt(rs: WrappedResultSet, prefix: String = ""): Option[EditionsArticle] = {
+  def fromRowOpt(rs: WrappedResultSet, prefix: String = ""): Option[EditionsCard] = {
     for {
       id <- rs.stringOpt(prefix + "id")
       addedOn <- rs.zonedDateTimeOpt(prefix + "added_on").map(_.toInstant.toEpochMilli)
     } yield
-      EditionsArticle(
+      EditionsCard(
         id,
         addedOn,
         rs.stringOpt(prefix + "metadata").map(
-          s => Json.parse(s).validate[ArticleMetadata] match {
+          s => Json.parse(s).validate[CardMetadata] match {
             case result if (result.isError) => {
-              logger.error(s"Unable to parse article from database: \n${s}")
-              ArticleMetadata.default
+              logger.error(s"Unable to parse card from database: \n${s}")
+              CardMetadata.default
             }
             case result@_ => result.get
           }

--- a/app/model/editions/EditionsCard.scala
+++ b/app/model/editions/EditionsCard.scala
@@ -111,15 +111,6 @@ case class EditionsCard(id: String, cardType: CardType, addedOn: Long, metadata:
 object EditionsCard extends Logging {
   implicit val writes = Json.format[EditionsCard]
 
-  def fromRow(rs: WrappedResultSet, prefix: String = ""): EditionsCard = {
-    EditionsCard(
-      rs.string(prefix + "id"),
-      CardType.withName(rs.string(prefix + "card_type")),
-      rs.zonedDateTime(prefix + "added_on").toInstant.toEpochMilli,
-      rs.stringOpt(prefix + "metadata").map(s => Json.parse(s).validate[CardMetadata].get)
-    )
-  }
-
   def fromRowOpt(rs: WrappedResultSet, prefix: String = ""): Option[EditionsCard] = {
     for {
       id <- rs.stringOpt(prefix + "id")

--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -6,12 +6,13 @@ import services.editions.prefills.CapiQueryTimeWindow
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
 
-case class EditionsClientCard(id: String, frontPublicationDate: Long, meta: Option[ClientCardMetadata])
+case class EditionsClientCard(id: String, cardType: CardType, frontPublicationDate: Long, meta: Option[ClientCardMetadata])
 
 object EditionsClientCard {
   def fromCard(card: EditionsCard): EditionsClientCard = {
     EditionsClientCard(
       "internal-code/page/" + card.id,
+      card.cardType,
       card.addedOn,
       card.metadata.map(ClientCardMetadata.fromCardMetadata)
     )
@@ -19,6 +20,7 @@ object EditionsClientCard {
   def toCard(card: EditionsClientCard): EditionsCard = {
     EditionsCard(
       card.id.split("/").last,
+      card.cardType,
       card.frontPublicationDate,
       card.meta.map(_.toCardMetadata)
     )

--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -11,7 +11,7 @@ case class EditionsClientArticle(id: String, frontPublicationDate: Long, meta: O
 object EditionsClientArticle {
   def fromArticle(article: EditionsArticle): EditionsClientArticle = {
     EditionsClientArticle(
-      "internal-code/page/" + article.pageCode,
+      "internal-code/page/" + article.id,
       article.addedOn,
       article.metadata.map(ClientArticleMetadata.fromArticleMetadata)
     )

--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -1,26 +1,26 @@
 package model.editions
 
-import model.editions.client.ClientArticleMetadata
+import model.editions.client.ClientCardMetadata
 import play.api.libs.json.Json
 import services.editions.prefills.CapiQueryTimeWindow
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
 
-case class EditionsClientArticle(id: String, frontPublicationDate: Long, meta: Option[ClientArticleMetadata])
+case class EditionsClientCard(id: String, frontPublicationDate: Long, meta: Option[ClientCardMetadata])
 
-object EditionsClientArticle {
-  def fromArticle(article: EditionsArticle): EditionsClientArticle = {
-    EditionsClientArticle(
-      "internal-code/page/" + article.id,
-      article.addedOn,
-      article.metadata.map(ClientArticleMetadata.fromArticleMetadata)
+object EditionsClientCard {
+  def fromCard(card: EditionsCard): EditionsClientCard = {
+    EditionsClientCard(
+      "internal-code/page/" + card.id,
+      card.addedOn,
+      card.metadata.map(ClientCardMetadata.fromCardMetadata)
     )
   }
-  def toArticle(article: EditionsClientArticle): EditionsArticle = {
-    EditionsArticle(
-      article.id.split("/").last,
-      article.frontPublicationDate,
-      article.meta.map(_.toArticleMetadata)
+  def toCard(card: EditionsClientCard): EditionsCard = {
+    EditionsCard(
+      card.id.split("/").last,
+      card.frontPublicationDate,
+      card.meta.map(_.toCardMetadata)
     )
   }
 }
@@ -34,12 +34,12 @@ case class EditionsClientCollection(
   updatedEmail: Option[String],
   prefill: Option[CapiPrefillQuery],
   contentPrefillTimeWindow: Option[CapiQueryTimeWindow],
-  items: List[EditionsClientArticle]
+  items: List[EditionsClientCard]
 )
 case class EditionsFrontendCollectionWrapper(id: String, collection: EditionsClientCollection)
 
 object EditionsFrontendCollectionWrapper {
-  implicit def articleFormat = Json.format[EditionsClientArticle]
+  implicit def cardFormat = Json.format[EditionsClientCard]
   implicit def collectionFormat = Json.format[EditionsClientCollection]
   implicit def collectionWrapperFormat = Json.format[EditionsFrontendCollectionWrapper]
 
@@ -55,7 +55,7 @@ object EditionsFrontendCollectionWrapper {
         collection.updatedEmail,
         collection.prefill,
         collection.contentPrefillTimeWindow,
-        collection.items.map(EditionsClientArticle.fromArticle)
+        collection.items.map(EditionsClientCard.fromCard)
       )
     )
   }
@@ -70,7 +70,7 @@ object EditionsFrontendCollectionWrapper {
       frontendCollection.collection.updatedEmail,
       frontendCollection.collection.prefill,
       frontendCollection.collection.contentPrefillTimeWindow,
-      frontendCollection.collection.items.map(EditionsClientArticle.toArticle)
+      frontendCollection.collection.items.map(EditionsClientCard.toCard)
     )
   }
 }

--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -6,13 +6,13 @@ import services.editions.prefills.CapiQueryTimeWindow
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
 
-case class EditionsClientCard(id: String, cardType: CardType, frontPublicationDate: Long, meta: Option[ClientCardMetadata])
+case class EditionsClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long, meta: Option[ClientCardMetadata])
 
 object EditionsClientCard {
   def fromCard(card: EditionsCard): EditionsClientCard = {
     EditionsClientCard(
       "internal-code/page/" + card.id,
-      card.cardType,
+      Some(card.cardType),
       card.addedOn,
       card.metadata.map(ClientCardMetadata.fromCardMetadata)
     )
@@ -20,7 +20,7 @@ object EditionsClientCard {
   def toCard(card: EditionsClientCard): EditionsCard = {
     EditionsCard(
       card.id.split("/").last,
-      card.cardType,
+      card.cardType.getOrElse(CardType.Article),
       card.frontPublicationDate,
       card.meta.map(_.toCardMetadata)
     )

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -15,12 +15,12 @@ case class EditionsCollection(
                                updatedEmail: Option[String],
                                prefill: Option[CapiPrefillQuery],
                                contentPrefillTimeWindow: Option[CapiQueryTimeWindow],
-                               items: List[EditionsArticle]
+                               items: List[EditionsCard]
                              ) {
   def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
     displayName,
-    items.map(_.toPublishedArticle)
+    items.map(_.toPublishedCard)
   )
 }
 

--- a/app/model/editions/client/ClientCardMetadata.scala
+++ b/app/model/editions/client/ClientCardMetadata.scala
@@ -1,11 +1,11 @@
 package model.editions.client
 
 import ai.x.play.json.Jsonx
-import model.editions.{ArticleMetadata, CoverCardImages, Image, MediaType}
+import model.editions.{CardMetadata, CoverCardImages, Image, MediaType}
 
 // This is a subset of the shared model here - https://github.com/guardian/facia-scala-client/blob/master/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala#L18
 // Why not reuse that model? We only want to surface the fields necessary for editions
-case class ClientArticleMetadata (
+case class ClientCardMetadata(
   headline: Option[String],
   customKicker: Option[String],
   showKickerCustom: Option[Boolean],
@@ -37,7 +37,7 @@ case class ClientArticleMetadata (
   coverCardTabletImage: Option[Image],
   promotionMetric: Option[Double]
 ) {
-  def toArticleMetadata: ArticleMetadata = {
+  def toCardMetadata: CardMetadata = {
     val cutoutImage: Option[Image] = (imageCutoutSrcHeight, imageCutoutSrcWidth, imageCutoutSrc, imageCutoutSrcOrigin) match {
       case (height, width, Some(src), Some(origin)) => Some(Image(height.map(_.toInt), width.map(_.toInt), origin, src))
       // If we don't have an origin, duplicate the src into the origin
@@ -63,7 +63,7 @@ case class ClientArticleMetadata (
       case _ => Some(CoverCardImages(coverCardMobileImage, coverCardTabletImage))
     }
 
-    ArticleMetadata(
+    CardMetadata(
       headline,
       customKicker,
       trailText,
@@ -81,43 +81,43 @@ case class ClientArticleMetadata (
   }
 }
 
-object ClientArticleMetadata {
-  implicit val format = Jsonx.formatCaseClassUseDefaults[ClientArticleMetadata]
+object ClientCardMetadata {
+  implicit val format = Jsonx.formatCaseClassUseDefaults[ClientCardMetadata]
 
-  def fromArticleMetadata(articleMetadata: ArticleMetadata): ClientArticleMetadata = {
-    val mediaType: MediaType = articleMetadata.mediaType.getOrElse(MediaType.UseArticleTrail)
+  def fromCardMetadata(cardMetadata: CardMetadata): ClientCardMetadata = {
+    val mediaType: MediaType = cardMetadata.mediaType.getOrElse(MediaType.UseArticleTrail)
 
-    ClientArticleMetadata(
-      articleMetadata.headline,
-      articleMetadata.customKicker,
-      articleMetadata.customKicker.map(_ => true),
-      articleMetadata.trailText,
-      articleMetadata.showQuotedHeadline,
-      articleMetadata.showByline,
-      articleMetadata.byline,
-      articleMetadata.sportScore,
+    ClientCardMetadata(
+      cardMetadata.headline,
+      cardMetadata.customKicker,
+      cardMetadata.customKicker.map(_ => true),
+      cardMetadata.trailText,
+      cardMetadata.showQuotedHeadline,
+      cardMetadata.showByline,
+      cardMetadata.byline,
+      cardMetadata.sportScore,
 
-      articleMetadata.mediaType.collect({case MediaType.Hide => true}),
+      cardMetadata.mediaType.collect({case MediaType.Hide => true}),
 
-      articleMetadata.replaceImage.map(_ => mediaType == MediaType.Image),
-      articleMetadata.replaceImage.map(_.src),
-      articleMetadata.replaceImage.flatMap(_.height).map(_.toString),
-      articleMetadata.replaceImage.flatMap(_.width).map(_.toString),
-      articleMetadata.replaceImage.map(_.origin),
-      articleMetadata.replaceImage.flatMap(_.thumb),
+      cardMetadata.replaceImage.map(_ => mediaType == MediaType.Image),
+      cardMetadata.replaceImage.map(_.src),
+      cardMetadata.replaceImage.flatMap(_.height).map(_.toString),
+      cardMetadata.replaceImage.flatMap(_.width).map(_.toString),
+      cardMetadata.replaceImage.map(_.origin),
+      cardMetadata.replaceImage.flatMap(_.thumb),
 
-      articleMetadata.mediaType.map(_ == MediaType.Cutout),
-      articleMetadata.cutoutImage.map(_.src),
-      articleMetadata.cutoutImage.flatMap(_.height).map(_.toString),
-      articleMetadata.cutoutImage.flatMap(_.width).map(_.toString),
-      articleMetadata.cutoutImage.map(_.origin),
+      cardMetadata.mediaType.map(_ == MediaType.Cutout),
+      cardMetadata.cutoutImage.map(_.src),
+      cardMetadata.cutoutImage.flatMap(_.height).map(_.toString),
+      cardMetadata.cutoutImage.flatMap(_.width).map(_.toString),
+      cardMetadata.cutoutImage.map(_.origin),
 
-      articleMetadata.overrideArticleMainMedia,
+      cardMetadata.overrideArticleMainMedia,
 
-      articleMetadata.mediaType.map {_ => mediaType == MediaType.CoverCard},
-      articleMetadata.coverCardImages.flatMap(_.mobile),
-      articleMetadata.coverCardImages.flatMap(_.tablet),
-      articleMetadata.promotionMetric
+      cardMetadata.mediaType.map { _ => mediaType == MediaType.CoverCard},
+      cardMetadata.coverCardImages.flatMap(_.mobile),
+      cardMetadata.coverCardImages.flatMap(_.tablet),
+      cardMetadata.promotionMetric
     )
   }
 }

--- a/app/model/editions/templates/AmericanEdition.scala
+++ b/app/model/editions/templates/AmericanEdition.scala
@@ -77,13 +77,13 @@ object AmericanEdition extends RegionalEdition {
     "People",
     collection("Interviews")
       .searchPrefill("?tag=type/article,(tone/interview|lifeandstyle/series/experience)")
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("Profiles")
       .searchPrefill("?tag=type/article,tone/profiles")
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("Q&A")
       .searchPrefill("?tag=type/article,tone/q-and-as")
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("People").hide,
     collection("People").hide
   )
@@ -118,10 +118,10 @@ object AmericanEdition extends RegionalEdition {
     "US News",
     collection("News Features")
       .searchPrefill("?tag=type/article,(us-news/us-news|us-news/us-politics|business/business|media/media|news/series/the-long-read),(tone/features|tone/analysis|tone/explainer),-culture/culture,-lifestyle/lifestyle,tone/news,-tone/comment,-tone/minutebyminute")
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("News")
       .searchPrefill("?tag=type/article,(us-news/us-news|us-news/us-politics|business/business|media/media),-(tone/features|tone/analysis|tone/explainer),-culture/culture,-lifestyle/lifestyle,tone/news,-tone/comment,-tone/minutebyminute")
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("US News").hide,
     collection("US News").hide,
     collection("US News").hide
@@ -140,10 +140,10 @@ object AmericanEdition extends RegionalEdition {
     "World News",
     collection("News Features")
       .searchPrefill("?tag=type/article,(world/world|australia-news/australia-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),(tone/features|tone/analysis|tone/explainer),-(us-news/us-news|us-news/us-politics|business/business|media/media),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute")
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("News")
       .searchPrefill("?tag=type/article,(world/world|australia-news/australia-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),-(tone/features|tone/analysis|tone/explainer),-(us-news/us-news|us-news/us-politics|business/business|media/media),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute")
-      .withArticleItemsCap(20) ,
+      .withCardItemsCap(20) ,
     collection("World News").hide,
     collection("World News").hide,
     collection("World News").hide
@@ -157,10 +157,10 @@ object AmericanEdition extends RegionalEdition {
     "Opinion",
     collection("US")
     .searchPrefill("?tag=type/article,tone/comment,(us-news/us-news|us-news/us-politics),-sport/sport,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("World")
     .searchPrefill("?tag=type/article,tone/comment,-(us-news/us-news|us-news/us-politics),-sport/sport,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Opinion").hide,
     collection("Opinion").hide,
     collection("Opinion").hide
@@ -174,7 +174,7 @@ object AmericanEdition extends RegionalEdition {
     "Environment",
     collection("Environment")
     .searchPrefill("?tag=type/article,environment/environment,-sport/sport,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Environment").hide,
     collection("Environment").hide,
     collection("Environment").hide,
@@ -189,10 +189,10 @@ object AmericanEdition extends RegionalEdition {
     "Culture",
     collection("Features")
     .searchPrefill("?tag=type/article,culture/culture,tone/features,-tone/reviews,-tone/news,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Reviews")
     .searchPrefill("?tag=type/article,culture/culture,-tone/features,tone/reviews,-tone/news,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Culture").hide,
     collection("Culture").hide,
     collection("Culture").hide
@@ -205,10 +205,10 @@ object AmericanEdition extends RegionalEdition {
     "Lifestyle",
     collection("Lifestyle")
     .searchPrefill("?tag=type/article,lifeandstyle/lifeandstyle,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Recipes")
     .searchPrefill("?tag=type/article,tone/recipes,food/food,-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Lifestyle").hide,
     collection("Lifestyle").hide,
     collection("Lifestyle").hide
@@ -221,7 +221,7 @@ object AmericanEdition extends RegionalEdition {
     "Sport",
     collection("Sport")
     .searchPrefill("?tag=type/article,sport/sport,(tone/comment|tone/features|tone/analysis),-tone/minutebyminute")
-    .withArticleItemsCap(20),
+    .withCardItemsCap(20),
     collection("Sport").hide,
     collection("Sport").hide,
     collection("Sport").hide,
@@ -234,6 +234,6 @@ object AmericanEdition extends RegionalEdition {
   def FrontCrosswordsUs = front(
     "Puzzles",
     collection("Crosswords").searchPrefill("?tag=type/crossword")
-      .withArticleItemsCap(10)
+      .withCardItemsCap(10)
   )
 }

--- a/app/model/editions/templates/AustralianEdition.scala
+++ b/app/model/editions/templates/AustralianEdition.scala
@@ -70,7 +70,7 @@ object AustralianEdition extends RegionalEdition {
     collection("Weekend")
       .searchPrefill("?tag=type/article,(tracking/commissioningdesk/australia-features|tracking/commissioningdesk/australia-pictures-),-tone/minutebyminute")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-5, 0)))
-      .withArticleItemsCap(20),
+      .withCardItemsCap(20),
     collection("Weekend"),
     collection("Weekend"),
     collection("Weekend"),
@@ -90,11 +90,11 @@ object AustralianEdition extends RegionalEdition {
     collection("News Features")
       .searchPrefill("?tag=type/article,(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),(tone/features|tone/analysis|tone/explainer),-culture/culture,-lifestyle/lifestyle,-tone/news,-tone/comment,-tone/minutebyminute")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-5, 0)))
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("News")
       .searchPrefill("?tag=type/article,(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),-(tone/features|tone/analysis|tone/explainer),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/comment,-tone/minutebyminute")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("National").hide,
     collection("National").hide
   )
@@ -107,11 +107,11 @@ object AustralianEdition extends RegionalEdition {
     collection("News Features")
       .searchPrefill("?tag=type/article,(world/world|us-news/us-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),(tone/features|tone/analysis|tone/explainer),-(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),-tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-5, 0)))
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("News")
       .searchPrefill("?tag=type/article,(world/world|us-news/us-news|uk/uk|world/europe-news|world/africa|world/americas|world/asia-pacific|world/middleeast),-(tone/features|tone/analysis|tone/explainer),-(australia-news/australia-news|australia-news/australian-politics|australia-news/business-australia|media/australia-media),tone/news,-culture/culture,-lifestyle/lifestyle,-tone/minutebyminute")
       .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 0)))
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("World").hide,
     collection("World").hide
   )
@@ -127,11 +127,11 @@ object AustralianEdition extends RegionalEdition {
     "Opinion",
     collection("Opinion")
       .searchPrefill("?tag=type/article,tone/comment,(australia-news/australia-news|australia-news/australian-politics|media/australia-media),-sport/sport,-tone/minutebyminute")
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("Opinion").hide,
     collection("World Opinion")
       .searchPrefill("?tag=type/article,tone/comment,-(australia-news/australia-news|australia-news/australian-politics|media/australia-media),-sport/sport,-tone/minutebyminute")
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("World Opinion").hide
   )
     .swatch(Opinion)
@@ -142,20 +142,20 @@ object AustralianEdition extends RegionalEdition {
     "Culture",
     collection("Culture")
       .searchPrefill("?tag=type/article,culture/culture,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-books/books,-music/music,-film/film,-culture/television,-artanddesign/artanddesign,-tv-and-radio/tv-and-radio")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Culture").hide,
     collection("Film and TV")
       .searchPrefill("?tag=type/article,culture/culture,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-books/books,-music/music,(film/film|culture/television|tv-and-radio/tv-and-radio),-artanddesign/artanddesign")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Music")
       .searchPrefill("?tag=type/article,culture/culture,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-books/books,music/music,-film/film,-culture/television,-artanddesign/artanddesign,-tv-and-radio/tv-and-radio")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Books")
       .searchPrefill("?tag=type/article,culture/culture,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,books/books,-music/music,-film/film,-culture/television,-artanddesign/artanddesign,-tv-and-radio/tv-and-radio")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Art and design")
       .searchPrefill("?tag=type/article,culture/culture,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-books/books,-music/music,-film/film,-culture/television,artanddesign/artanddesign,-tv-and-radio/tv-and-radio")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Culture").hide
   )
     .swatch(Culture)
@@ -166,19 +166,19 @@ object AustralianEdition extends RegionalEdition {
     "Lifestyle",
     collection("Lifestyle")
       .searchPrefill("?tag=type/article,lifeandstyle/lifeandstyle,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-food/food,-lifeandstyle/family,-fashion/fashion,-lifeandstyle/health-and-wellbeing,-lifeandstyle/fitness")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Food")
       .searchPrefill("?tag=type/article,lifeandstyle/lifeandstyle,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,food/food,-lifeandstyle/family,-fashion/fashion,-lifeandstyle/health-and-wellbeing,-lifeandstyle/fitness")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Family")
       .searchPrefill("?tag=type/article,lifeandstyle/lifeandstyle,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-food/food,lifeandstyle/family,-fashion/fashion,-lifeandstyle/health-and-wellbeing,-lifeandstyle/fitness")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Fashion")
       .searchPrefill("?tag=type/article,lifeandstyle/lifeandstyle,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-food/food,-lifeandstyle/family,fashion/fashion,-lifeandstyle/health-and-wellbeing,-lifeandstyle/fitness")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Health")
       .searchPrefill("?tag=type/article,lifeandstyle/lifeandstyle,(tone/features|tone/reviews|tone/interview),-tone/news,-tone/minutebyminute,-food/food,-lifeandstyle/family,-fashion/fashion,(lifeandstyle/health-and-wellbeing|lifeandstyle/fitness)")
-      .withArticleItemsCap(10),
+      .withCardItemsCap(10),
     collection("Lifestyle").hide,
     collection("Lifestyle").hide
   )
@@ -191,7 +191,7 @@ object AustralianEdition extends RegionalEdition {
     "Featured",
     collection("Long reads")
       .searchPrefill("?tag=type/article,news/series/the-long-read,-tone/minutebyminute")
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("Featured").hide,
     collection("Featured"),
     collection("Featured").hide
@@ -204,7 +204,7 @@ object AustralianEdition extends RegionalEdition {
     "Sport",
     collection("Sport")
       .searchPrefill("?tag=type/article,sport/sport,(tone/comment|tone/features|tone/analysis),-tone/minutebyminute")
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("Sport").hide,
     collection("Sport").hide
   )
@@ -215,8 +215,8 @@ object AustralianEdition extends RegionalEdition {
   def FrontCrosswordsAu = front(
     "Puzzles",
     collection("Crosswords").searchPrefill("?tag=type/crossword")
-      .withArticleItemsCap(40),
+      .withCardItemsCap(40),
     collection("Quizzes").searchPrefill("?tag=tone/quizzes")
-      .withArticleItemsCap(40)
+      .withCardItemsCap(40)
   )
 }

--- a/app/model/editions/templates/TemplateHelpers.scala
+++ b/app/model/editions/templates/TemplateHelpers.scala
@@ -8,7 +8,7 @@ object TemplateHelpers {
   object Defaults {
     val defaultFrontPresentation = FrontPresentation(model.editions.Swatch.Neutral)
     val defaultCollectionPresentation = CollectionPresentation()
-    val defaultCollectionArticleItemsCap: Int = 200
+    val defaultCollectionCardsCap: Int = 200
   }
 
   def collection(name: String): CollectionTemplate = {

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -111,7 +111,7 @@ class CollectionTemplatingHelper(capi: Capi, ophan: Ophan) extends Logging {
             ).collectFirst{case Some(path) => path},  // Get first non-None match,
             ophanQueryPrefillParams,
             edition,
-            Some(collectionTemplate.articleItemsCap),
+            Some(collectionTemplate.cardCap),
             MetadataForLogging(issueDate, collectionId = None, collectionName = Some(name))
           )
           getPrefillArticles(prefillParams)
@@ -141,7 +141,7 @@ class CollectionTemplatingHelper(capi: Capi, ophan: Ophan) extends Logging {
   private def mapToSkeleton(sortedArticleItems: List[Prefill]): List[EditionsArticleSkeleton] = {
     sortedArticleItems
       .map { case Prefill(pageCode, _, _, metaData, cutoutImage, _, mediaType, pickedKicker, promotionMetric, _) =>
-        val articleMetadata = ArticleMetadata.default.copy(
+        val cardMetadata = CardMetadata.default.copy(
           showByline = if (metaData.showByline) Some(true) else None,
           showQuotedHeadline = if (metaData.showQuotedHeadline) Some(true) else None,
           mediaType = mediaType,
@@ -149,7 +149,7 @@ class CollectionTemplatingHelper(capi: Capi, ophan: Ophan) extends Logging {
           customKicker = pickedKicker,
           promotionMetric = promotionMetric
         )
-        EditionsArticleSkeleton(pageCode.toString, articleMetadata)
+        EditionsArticleSkeleton(pageCode.toString, cardMetadata)
       }
   }
 

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -152,7 +152,8 @@ trait CollectionsQueries {
         fronts.is_special,
 
         cards.collection_id AS cards_collection_id,
-        cards.id     AS cards_id,
+        cards.id            AS cards_id,
+        cards.card_type     AS cards_card_type,
         cards.index         AS cards_index,
         cards.added_on      AS cards_added_on,
         cards.metadata      AS cards_metadata

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -43,7 +43,7 @@ trait CollectionsQueries {
                  collections.path_type,
                  collections.content_prefill_window_start,
                  collections.content_prefill_window_end,
-                 articles.page_code,
+                 cards.id,
                  edition_issues.name,
                  edition_issues.issue_date,
                  edition_issues.timezone_id
@@ -64,7 +64,7 @@ trait CollectionsQueries {
 
         val contentPrefillQueryTimeWindow = CapiQueryTimeWindow(timeWinStart, timeWinEnd)
 
-        (date, edition, zone, CapiPrefillQuery(rs.string("prefill"), pathType), contentPrefillQueryTimeWindow, rs.string("page_code"))
+        (date, edition, zone, CapiPrefillQuery(rs.string("prefill"), pathType), contentPrefillQueryTimeWindow, rs.string("id"))
       }.list().apply()
 
     rows.headOption.map { case (issueDate, edition, zone, prefillQueryUrlSegments, contentPrefillQueryTimeWindow, _) =>
@@ -114,11 +114,11 @@ trait CollectionsQueries {
       sql"""
           INSERT INTO articles (
           collection_id,
-          page_code,
+          id,
           index,
           added_on,
           metadata
-          ) VALUES (${collection.id}, ${article.pageCode}, $index, $addedOn, ${article.metadata.map(m => Json.toJson(m).toString)}::JSONB)
+          ) VALUES (${collection.id}, ${article.id}, $index, $addedOn, ${article.metadata.map(m => Json.toJson(m).toString)}::JSONB)
        """.execute().apply()
     }
 
@@ -152,7 +152,7 @@ trait CollectionsQueries {
         fronts.is_special,
 
         articles.collection_id AS articles_collection_id,
-        articles.page_code     AS articles_page_code,
+        articles.id     AS articles_id,
         articles.index         AS articles_index,
         articles.added_on      AS articles_added_on,
         articles.metadata      AS articles_metadata

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -93,11 +93,11 @@ trait IssueQueries extends Logging {
           sql"""
                     INSERT INTO articles (
                     collection_id,
-                    page_code,
+                    id,
                     index,
                     added_on,
                     metadata
-                    ) VALUES ($collectionId, ${article.pageCode}, $tIndex, $truncatedNow, ${Json.toJson(article.metadata).toString}::JSONB)
+                    ) VALUES ($collectionId, ${article.id}, $tIndex, $truncatedNow, ${Json.toJson(article.metadata).toString}::JSONB)
                  """.execute().apply()
         }
       }
@@ -184,7 +184,7 @@ trait IssueQueries extends Logging {
         collections.content_prefill_window_end         AS collections_content_prefill_window_end,
 
         articles.collection_id AS articles_collection_id,
-        articles.page_code     AS articles_page_code,
+        articles.id     AS articles_id,
         articles.index         AS articles_index,
         articles.added_on      AS articles_added_on,
         articles.metadata      AS articles_metadata

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -184,7 +184,8 @@ trait IssueQueries extends Logging {
         collections.content_prefill_window_end         AS collections_content_prefill_window_end,
 
         cards.collection_id AS cards_collection_id,
-        cards.id     AS cards_id,
+        cards.id            AS cards_id,
+        cards.card_type     AS cards_card_type,
         cards.index         AS cards_index,
         cards.added_on      AS cards_added_on,
         cards.metadata      AS cards_metadata

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -10,7 +10,7 @@ import org.postgresql.util.PSQLException
 import play.api.libs.json.Json
 import scalikejdbc._
 import services.editions.publishing.events.PublishEvent
-import services.editions.{DbEditionsArticle, DbEditionsCollection, DbEditionsFront, GenerateEditionTemplateResult}
+import services.editions.{DbEditionsCard, DbEditionsCollection, DbEditionsFront, GenerateEditionTemplateResult}
 
 import scala.util.{Failure, Success, Try}
 
@@ -89,15 +89,15 @@ trait IssueQueries extends Logging {
           RETURNING id;
           """.map(_.string("id")).single().apply().get
 
-        collection.items.zipWithIndex.foreach { case (article, tIndex) =>
+        collection.items.zipWithIndex.foreach { case (card, tIndex) =>
           sql"""
-                    INSERT INTO articles (
+                    INSERT INTO cards (
                     collection_id,
                     id,
                     index,
                     added_on,
                     metadata
-                    ) VALUES ($collectionId, ${article.id}, $tIndex, $truncatedNow, ${Json.toJson(article.metadata).toString}::JSONB)
+                    ) VALUES ($collectionId, ${card.id}, $tIndex, $truncatedNow, ${Json.toJson(card.metadata).toString}::JSONB)
                  """.execute().apply()
         }
       }
@@ -141,7 +141,7 @@ trait IssueQueries extends Logging {
                             issue: EditionsIssue,
                             front: Option[DbEditionsFront],
                             collection: Option[DbEditionsCollection],
-                            article: Option[DbEditionsArticle]
+                            card: Option[DbEditionsCard]
                           )
 
     val rows: List[GetIssueRow] =
@@ -183,23 +183,23 @@ trait IssueQueries extends Logging {
         collections.content_prefill_window_start       AS collections_content_prefill_window_start,
         collections.content_prefill_window_end         AS collections_content_prefill_window_end,
 
-        articles.collection_id AS articles_collection_id,
-        articles.id     AS articles_id,
-        articles.index         AS articles_index,
-        articles.added_on      AS articles_added_on,
-        articles.metadata      AS articles_metadata
+        cards.collection_id AS cards_collection_id,
+        cards.id     AS cards_id,
+        cards.index         AS cards_index,
+        cards.added_on      AS cards_added_on,
+        cards.metadata      AS cards_metadata
 
       FROM edition_issues
       LEFT JOIN fronts ON (fronts.issue_id = edition_issues.id)
       LEFT JOIN collections ON (collections.front_id = fronts.id)
-      LEFT JOIN articles ON (articles.collection_id = collections.id)
+      LEFT JOIN cards ON (cards.collection_id = collections.id)
       WHERE edition_issues.id = $id
       """.map { rs =>
         GetIssueRow(
           EditionsIssue.fromRow(rs),
           DbEditionsFront.fromRowOpt(rs, "fronts_"),
           DbEditionsCollection.fromRowOpt(rs, "collections_"),
-          DbEditionsArticle.fromRowOpt(rs, "articles_"))
+          DbEditionsCard.fromRowOpt(rs, "cards_"))
       }
         .list()
         .apply()
@@ -216,13 +216,13 @@ trait IssueQueries extends Logging {
           .map(_.collection)
           .foldLeft(List.empty[EditionsCollection]) { (acc, cur) => if (acc.exists(c => c.id == cur.id)) acc else acc :+ cur }
           .map { collection =>
-            val articles = rows
-              .flatMap(row => row.article.filter(_.collectionId == collection.id))
+            val cards = rows
+              .flatMap(row => row.card.filter(_.collectionId == collection.id))
               .sortBy(_.index)
-              .map(_.article)
+              .map(_.card)
 
             collection
-              .copy(items = articles)
+              .copy(items = cards)
           }
 
         front.copy(collections = collectionsForFront)

--- a/app/services/editions/package.scala
+++ b/app/services/editions/package.scala
@@ -1,6 +1,6 @@
 package services.editions
 
-import model.editions.{EditionsArticle, EditionsCollection, EditionsFront}
+import model.editions.{EditionsCard, EditionsCollection, EditionsFront}
 import scalikejdbc.WrappedResultSet
 
 // Little helpers so we don't contaminate our business model with relational data
@@ -22,12 +22,12 @@ object DbEditionsCollection {
   }
 }
 
-case class DbEditionsArticle(article: EditionsArticle, collectionId: String, index: Int)
-object DbEditionsArticle {
-  def fromRowOpt(rs: WrappedResultSet, prefix: String): Option[DbEditionsArticle] = {
-    EditionsArticle.fromRowOpt(rs, prefix).map { article =>
-      DbEditionsArticle(
-        article,
+case class DbEditionsCard(card: EditionsCard, collectionId: String, index: Int)
+object DbEditionsCard {
+  def fromRowOpt(rs: WrappedResultSet, prefix: String): Option[DbEditionsCard] = {
+    EditionsCard.fromRowOpt(rs, prefix).map { card =>
+      DbEditionsCard(
+        card,
         rs.string(prefix + "collection_id"),
         rs.int(prefix + "index"))
     }

--- a/conf/evolutions/default/11.sql
+++ b/conf/evolutions/default/11.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+
+ALTER TABLE articles RENAME TO cards;
+ALTER TABLE cards ADD COLUMN card_type TEXT NOT NULL DEFAULT 'article';
+ALTER TABLE cards RENAME COLUMN page_code TO id;
+
+# --- !Downs
+
+ALTER TABLE cards RENAME COLUMN id TO page_code;
+ALTER TABLE cards DROP COLUMN card_type;
+ALTER TABLE cards RENAME TO articles;

--- a/test/fixtures/TestEdition.scala
+++ b/test/fixtures/TestEdition.scala
@@ -46,7 +46,7 @@ object TestEdition extends RegionalEdition {
 object FrontTopStories {
   val collectionTopStories = collection("Top Stories")
     .printSentPrefill("?tag=theguardian/mainsection/topstories")
-    .withArticleItemsCap(1)
+    .withCardItemsCap(1)
 
   val collectionTopStories2 = collection("Top Stories 2")
     .withTimeWindowConfig(Some(CapiTimeWindowConfigInDays(-3, 2)))
@@ -62,15 +62,15 @@ object FrontTopStories {
 object FrontNewsUkGuardian {
   val collectionNewsFrontPage = collection("Front Page")
     .printSentPrefill("?tag=theguardian/mainsection/topstories")
-    .withArticleItemsCap(1)
+    .withCardItemsCap(1)
 
   val collectionNewsUkNewsGuardian = collection("UK News")
     .printSentPrefill("?tag=theguardian/mainsection/uknews|theguardian/mainsection/education|theguardian/mainsection/society|theguardian/mainsection/media|theguardian/guardian-members/guardian-members")
-    .withArticleItemsCap(1)
+    .withCardItemsCap(1)
 
   val collectionNewsWeather = collection("Weather")
     .printSentPrefill("?tag=theguardian/mainsection/weather2")
-    .withArticleItemsCap(1)
+    .withCardItemsCap(1)
 
   val front = FrontTemplate(
     name = "UK News",
@@ -83,11 +83,11 @@ object FrontNewsUkGuardian {
 object FrontNewsUkGuardianSaturday {
   val collectionNewsFrontPage = collection("Front Page")
     .printSentPrefill("?tag=theguardian/mainsection/topstories")
-    .withArticleItemsCap(1)
+    .withCardItemsCap(1)
 
   val collectionNewsSpecial1 = collection("News Special").hide
 
-  val collectionNewsWeather = collection("Weather").printSentPrefill("?tag=theguardian/mainsection/weather2").withArticleItemsCap(1)
+  val collectionNewsWeather = collection("Weather").printSentPrefill("?tag=theguardian/mainsection/weather2").withCardItemsCap(1)
 
   val front = FrontTemplate(
     name = "UK News",
@@ -99,7 +99,7 @@ object FrontNewsUkGuardianSaturday {
 
 object FrontCulture {
   val collectionCultureArts = collection("Arts")
-    .printSentPrefill("?tag=theguardian/g2/arts").withArticleItemsCap(2)
+    .printSentPrefill("?tag=theguardian/g2/arts").withCardItemsCap(2)
 
   val collectionCultureTVandRadio = collection("TV & Radio")
   .printSentPrefill("?tag=theguardian/g2/tvandradio")
@@ -115,7 +115,7 @@ object FrontCulture {
 object FrontSpecialSpecial2 {
   val collectionSpecialSpecial2 = collection("Special")
     .printSentPrefill("?tag=theguardian/special-supplement/special-supplement|theobserver/special-supplement/special-supplement")
-      .withArticleItemsCap(4)
+      .withCardItemsCap(4)
 
   val front = FrontTemplate(
     name = "Special 2",

--- a/test/logic/EditionsCheckerTest.scala
+++ b/test/logic/EditionsCheckerTest.scala
@@ -3,7 +3,7 @@ package logic
 import java.time.LocalDate
 
 import model.editions.Edition.DailyEdition
-import model.editions.{EditionsArticle, EditionsCollection, EditionsFront, EditionsFrontMetadata, EditionsIssue}
+import model.editions.{EditionsCard, EditionsCollection, EditionsFront, EditionsFrontMetadata, EditionsIssue}
 import org.scalatest.{FreeSpec, Matchers}
 
 class EditionsCheckerTest extends FreeSpec with Matchers {
@@ -60,7 +60,7 @@ class EditionsCheckerTest extends FreeSpec with Matchers {
     }
   }
 
-  private def getCollection(items: EditionsArticle*) = {
+  private def getCollection(items: EditionsCard*) = {
     EditionsCollection(
       "id",
       "displayName",

--- a/test/model/editions/CardMetadataTest.scala
+++ b/test/model/editions/CardMetadataTest.scala
@@ -3,9 +3,9 @@ package model.editions
 import org.scalatest.{FreeSpec, Matchers}
 import play.api.libs.json.Json
 
-class ArticleMetadataTest extends FreeSpec with Matchers {
+class CardMetadataTest extends FreeSpec with Matchers {
 
-  val articleMetadata = ArticleMetadata(
+  val cardMetadata = CardMetadata(
     Some("headline"),
     Some("customKicker"),
     Some("trailText"),
@@ -33,7 +33,7 @@ class ArticleMetadataTest extends FreeSpec with Matchers {
     None
   )
 
-  private val articleMetadataAsString =
+  private val cardMetadataAsString =
     """
       |{"headline":"headline",
       | "customKicker":"customKicker",
@@ -59,14 +59,14 @@ class ArticleMetadataTest extends FreeSpec with Matchers {
       | "overrideArticleMainMedia":true}
     """.stripMargin.split('\n').map(_.trim).mkString //remove leading/trailing whitespace and join into a single string
 
-  "Article Metadata Data to/from Json" - {
+  "Card Metadata Data to/from Json" - {
 
     "should serialise correctly" in {
-      Json.toJson(articleMetadata).toString() shouldBe articleMetadataAsString
+      Json.toJson(cardMetadata).toString() shouldBe cardMetadataAsString
     }
 
     "should deserialise correctly" in {
-      Json.fromJson[ArticleMetadata](Json.parse(articleMetadataAsString)).get shouldBe articleMetadata
+      Json.fromJson[CardMetadata](Json.parse(cardMetadataAsString)).get shouldBe cardMetadata
     }
 
   }

--- a/test/model/editions/PublishedIssueSerialisationTest.scala
+++ b/test/model/editions/PublishedIssueSerialisationTest.scala
@@ -78,7 +78,7 @@ class PublishedIssueSerialisationTest extends FreeSpec with Matchers {
       json shouldBe expectedJson
     }
 
-    "test serialisation of article furniture" - {
+    "test serialisation of card furniture" - {
       "should output all the fields in the format expected by the editions backend" in {
         val expectedJson =
           """{

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -47,7 +47,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     def hide: EditionsFront = thisFront.copy(isHidden = true)
   }
 
-  private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticle*): EditionsCollection =
+  private def collection(name: String, prefill: Option[CapiPrefillQuery], cards: EditionsCard*): EditionsCollection =
     EditionsCollection(
       name,
       name,
@@ -57,39 +57,39 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       None,
       prefill,
       None,
-      articles.toList
+      cards.toList
     )
 
   implicit class RichEditionsCollection(thisCollection: EditionsCollection) {
     def hide: EditionsCollection = thisCollection.copy(isHidden = true)
   }
 
-  private def article(id: String): EditionsArticle =
-    EditionsArticle(
+  private def card(id: String): EditionsCard =
+    EditionsCard(
       id,
       nowMilli,
-      Some(ArticleMetadata.default)
+      Some(CardMetadata.default)
     )
 
-  "PublishedArticles" - {
-    "article fields should be populated correctly" in {
+  "PublishedCards" - {
+    "card fields should be populated correctly" in {
       val now = OffsetDateTime.of(2019, 9, 30, 10, 23, 0, 0, ZoneOffset.ofHours(1))
-      val article = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
-      val publishedArticle = article.toPublishedArticle
-      publishedArticle.internalPageCode shouldBe 1234456
-      publishedArticle.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
+      val card = EditionsCard("1234456", now.toInstant.toEpochMilli, None)
+      val publishedCard = card.toPublishedCard
+      publishedCard.internalPageCode shouldBe 1234456
+      publishedCard.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
     }
 
     "furniture defaults should be populated correctly" in {
-      val furniture = ArticleMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
-      val article = EditionsArticle("123456", 0, Some(furniture))
-      val published = article.toPublishedArticle
+      val furniture = CardMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
+      val card = EditionsCard("123456", 0, Some(furniture))
+      val published = card.toPublishedCard
 
       published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
     }
 
     val cardImage = Some(Image(Some(100), Some(100), "file://origin.jpg", "file://src.jpg", Some("file://thumb.jpg")))
-    val articleFurniture = ArticleMetadata(
+    val cardFurniture = CardMetadata(
       Some("headline"),
       Some("kicker"),
       Some("trail-text"),
@@ -109,8 +109,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     )
 
     "furniture should be populated when specified, cover cards should be ignored if the media type isn't set to cover card" in {
-      val article = EditionsArticle("123456", 0, Some(articleFurniture))
-      val published = article.toPublishedArticle
+      val card = EditionsCard("123456", 0, Some(cardFurniture))
+      val published = card.toPublishedCard
 
       published.furniture shouldBe PublishedFurniture(
         Some("kicker"),
@@ -128,8 +128,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     "furniture should be populated when specified, cover card should be some if media type is covercard " in {
-      val article = EditionsArticle("123456", 0, Some(articleFurniture.copy(mediaType = Some(MediaType.CoverCard))))
-      val published = article.toPublishedArticle
+      val card = EditionsCard("123456", 0, Some(cardFurniture.copy(mediaType = Some(MediaType.CoverCard))))
+      val published = card.toPublishedCard
 
       val publishedImage = PublishedImage(Some(100), Some(100), "file://src.jpg")
 
@@ -149,7 +149,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     "media type should fall back if there's an invalid cover card" in {
-      val coverCardFurniture = articleFurniture
+      val coverCardFurniture = cardFurniture
         .copy(mediaType = Some(MediaType.CoverCard))
         .copy(coverCardImages = Some(CoverCardImages(
           mobile = cardImage,
@@ -162,10 +162,10 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       )))
 
       List(
-        EditionsArticle("123456", 0, Some(coverCardFurniture)),
-        EditionsArticle("123456", 0, Some(swapped))
+        EditionsCard("123456", 0, Some(coverCardFurniture)),
+        EditionsCard("123456", 0, Some(swapped))
       ).foreach { a =>
-        a.toPublishedArticle.furniture.mediaType shouldBe PublishedMediaType.UseArticleTrail
+        a.toPublishedCard.furniture.mediaType shouldBe PublishedMediaType.UseArticleTrail
       }
     }
   }
@@ -174,15 +174,15 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     "fronts should be filtered out" in {
       val testIssue = issue(2019, 9, 30,
         front("uk-news",
-          collection("london", None, article("123")),
-          collection("financial", None, article("123"))
+          collection("london", None, card("123")),
+          collection("financial", None, card("123"))
         ),
         front("culture",
-          collection("art", None, article("123")),
-          collection("theatre", None, article("123"))
+          collection("art", None, card("123")),
+          collection("theatre", None, card("123"))
         ),
         front("special",
-          collection("magic", None, article("123"))
+          collection("magic", None, card("123"))
         ).hide
       )
       testIssue.fronts.size shouldBe 3
@@ -196,15 +196,15 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     "fronts should be filtered out when hidden" in {
       val testIssue = issue(2019, 9, 30,
         front("uk-news",
-          collection("london", None, article("123")),
-          collection("financial", None, article("123"))
+          collection("london", None, card("123")),
+          collection("financial", None, card("123"))
         ),
         front("culture",
-          collection("art", None, article("123")),
-          collection("theatre", None, article("123"))
+          collection("art", None, card("123")),
+          collection("theatre", None, card("123"))
         ),
         front("special",
-          collection("magic", None, article("123"))
+          collection("magic", None, card("123"))
         ).hide
       )
       testIssue.fronts.size shouldBe 3
@@ -217,8 +217,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       val testIssue = issue(2019, 9, 30,
         front("uk-news"),
         front("culture",
-          collection("art", None, article("123")),
-          collection("theatre", None, article("123"))
+          collection("art", None, card("123")),
+          collection("theatre", None, card("123"))
         ),
         front("empty")
       )
@@ -235,8 +235,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
           collection("financial", None)
         ),
         front("culture",
-          collection("art", None, article("123")),
-          collection("theatre", None, article("123"))
+          collection("art", None, card("123")),
+          collection("theatre", None, card("123"))
         ),
         front("empty")
       )
@@ -250,10 +250,10 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
   "PublishedFront" - {
     "collections should be filtered out when hidden" in {
       val testFront = front("uk-news",
-        collection("london", None, article("123")),
-        collection("financial", None, article("123")),
-        collection("special", None, article("123")).hide,
-        collection("weather", None, article("123"))
+        collection("london", None, card("123")),
+        collection("financial", None, card("123")),
+        collection("special", None, card("123")).hide,
+        collection("weather", None, card("123"))
       )
 
       testFront.collections.size shouldBe 4
@@ -266,8 +266,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
 
     "collections should be filtered out when empty" in {
       val testFront = front("uk-news",
-        collection("london", None, article("123")),
-        collection("financial", None, article("123")),
+        collection("london", None, card("123")),
+        collection("financial", None, card("123")),
         collection("weather", None)
       )
 
@@ -289,10 +289,10 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
         None,
         None,
         None,
-        List(article("123"))
+        List(card("123"))
       )
       val testFront = front("uk-news",
-        collection("london", None, article("123")),
+        collection("london", None, card("123")),
         test
       )
 

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -64,9 +64,9 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     def hide: EditionsCollection = thisCollection.copy(isHidden = true)
   }
 
-  private def article(pageCode: String): EditionsArticle =
+  private def article(id: String): EditionsArticle =
     EditionsArticle(
-      pageCode,
+      id,
       nowMilli,
       Some(ArticleMetadata.default)
     )

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -67,6 +67,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
   private def card(id: String): EditionsCard =
     EditionsCard(
       id,
+      CardType.Article,
       nowMilli,
       Some(CardMetadata.default)
     )
@@ -74,7 +75,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
   "PublishedCards" - {
     "card fields should be populated correctly" in {
       val now = OffsetDateTime.of(2019, 9, 30, 10, 23, 0, 0, ZoneOffset.ofHours(1))
-      val card = EditionsCard("1234456", now.toInstant.toEpochMilli, None)
+      val card = EditionsCard("1234456", CardType.Article, now.toInstant.toEpochMilli, None)
       val publishedCard = card.toPublishedCard
       publishedCard.internalPageCode shouldBe 1234456
       publishedCard.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
@@ -82,7 +83,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
 
     "furniture defaults should be populated correctly" in {
       val furniture = CardMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
-      val card = EditionsCard("123456", 0, Some(furniture))
+      val card = EditionsCard("123456", CardType.Article, 0, Some(furniture))
       val published = card.toPublishedCard
 
       published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
@@ -109,7 +110,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     )
 
     "furniture should be populated when specified, cover cards should be ignored if the media type isn't set to cover card" in {
-      val card = EditionsCard("123456", 0, Some(cardFurniture))
+      val card = EditionsCard("123456", CardType.Article, 0, Some(cardFurniture))
       val published = card.toPublishedCard
 
       published.furniture shouldBe PublishedFurniture(
@@ -128,7 +129,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     "furniture should be populated when specified, cover card should be some if media type is covercard " in {
-      val card = EditionsCard("123456", 0, Some(cardFurniture.copy(mediaType = Some(MediaType.CoverCard))))
+      val card = EditionsCard("123456", CardType.Article, 0, Some(cardFurniture.copy(mediaType = Some(MediaType.CoverCard))))
       val published = card.toPublishedCard
 
       val publishedImage = PublishedImage(Some(100), Some(100), "file://src.jpg")
@@ -162,8 +163,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       )))
 
       List(
-        EditionsCard("123456", 0, Some(coverCardFurniture)),
-        EditionsCard("123456", 0, Some(swapped))
+        EditionsCard("123456", CardType.Article, 0, Some(coverCardFurniture)),
+        EditionsCard("123456", CardType.Article, 0, Some(swapped))
       ).foreach { a =>
         a.toPublishedCard.furniture.mediaType shouldBe PublishedMediaType.UseArticleTrail
       }

--- a/test/model/editions/client/ClientCardMetadataTest.scala
+++ b/test/model/editions/client/ClientCardMetadataTest.scala
@@ -1,14 +1,14 @@
 package model.editions.client
 
-import model.editions.{ArticleMetadata, CoverCardImages, Image, MediaType}
+import model.editions.{CardMetadata, CoverCardImages, Image, MediaType}
 import org.scalatest.{FreeSpec, Matchers}
 
-class ClientArticleMetadataTest extends FreeSpec with Matchers {
+class ClientCardMetadataTest extends FreeSpec with Matchers {
 
-  "ClientArticleMetadata from ArticleMetadata" - {
+  "ClientCardMetadata from CardMetadata" - {
 
-    "should recover promotion metric from a simple ArticleMetadata" in {
-      val articleMetadata = ArticleMetadata(
+    "should recover promotion metric from a simple CardMetadata" in {
+      val cardMetadata = CardMetadata(
         Some("Britain has summer!"),
         Some("Breaking News"),
         Some("Goneth the rain, cometh the sun"),
@@ -23,12 +23,12 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(1)
       )
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
-      clientArticleMetadata.promotionMetric should be (Some(1))
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      clientCardMetadata.promotionMetric should be (Some(1))
     }
 
-    "should send promotion metric to a simple ArticleMetadata" in {
-      val clientArticleMetadata = ClientArticleMetadata(
+    "should send promotion metric to a simple CardMetadata" in {
+      val clientCardMetadata = ClientCardMetadata(
         Some("Britain has summer!"),
         None,
         None,
@@ -60,12 +60,12 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None,
         Some(1)
       )
-      val articleMetadata = clientArticleMetadata.toArticleMetadata
-      articleMetadata.promotionMetric should be (Some(1))
+      val cardMetadata = clientCardMetadata.toCardMetadata
+      cardMetadata.promotionMetric should be (Some(1))
     }
 
-    "should serialise from a simple ArticleMetadata" in {
-      val articleMetadata = ArticleMetadata(
+    "should serialise from a simple CardMetadata" in {
+      val cardMetadata = CardMetadata(
         Some("Britain has summer!"),
         Some("Breaking News"),
         Some("Goneth the rain, cometh the sun"),
@@ -81,25 +81,25 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
-      clientArticleMetadata.headline.isDefined shouldBe true
-      clientArticleMetadata.headline.get shouldBe "Britain has summer!"
+      clientCardMetadata.headline.isDefined shouldBe true
+      clientCardMetadata.headline.get shouldBe "Britain has summer!"
 
-      clientArticleMetadata.customKicker.isDefined shouldBe true
-      clientArticleMetadata.customKicker.get shouldBe "Breaking News"
+      clientCardMetadata.customKicker.isDefined shouldBe true
+      clientCardMetadata.customKicker.get shouldBe "Breaking News"
 
-      clientArticleMetadata.trailText.isDefined shouldBe true
-      clientArticleMetadata.trailText.get shouldBe "Goneth the rain, cometh the sun"
+      clientCardMetadata.trailText.isDefined shouldBe true
+      clientCardMetadata.trailText.get shouldBe "Goneth the rain, cometh the sun"
 
-      clientArticleMetadata.imageHide shouldBe None
-      clientArticleMetadata.imageReplace shouldBe None
-      clientArticleMetadata.imageCutoutReplace shouldBe None
-      clientArticleMetadata.overrideArticleMainMedia shouldBe None
+      clientCardMetadata.imageHide shouldBe None
+      clientCardMetadata.imageReplace shouldBe None
+      clientCardMetadata.imageCutoutReplace shouldBe None
+      clientCardMetadata.overrideArticleMainMedia shouldBe None
     }
 
     "should persist cutout image when selected override is hide image" in {
-      val articleMetadata = ArticleMetadata(
+      val cardMetadata = CardMetadata(
         Some("New Pokemon discovered"),
         None,
         None,
@@ -115,25 +115,25 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
-      clientArticleMetadata.headline.isDefined shouldBe true
-      clientArticleMetadata.headline.get shouldBe "New Pokemon discovered"
+      clientCardMetadata.headline.isDefined shouldBe true
+      clientCardMetadata.headline.get shouldBe "New Pokemon discovered"
 
-      clientArticleMetadata.imageHide shouldBe Some(true)
+      clientCardMetadata.imageHide shouldBe Some(true)
 
-      clientArticleMetadata.imageCutoutReplace shouldBe Some(false)
-      clientArticleMetadata.imageCutoutSrcOrigin shouldBe Some("file://origin-new-pokemon.gif")
-      clientArticleMetadata.imageCutoutSrc shouldBe Some("file://new-pokemon.gif")
-      clientArticleMetadata.imageCutoutSrcHeight shouldBe Some("100")
-      clientArticleMetadata.imageCutoutSrcWidth shouldBe Some("100")
+      clientCardMetadata.imageCutoutReplace shouldBe Some(false)
+      clientCardMetadata.imageCutoutSrcOrigin shouldBe Some("file://origin-new-pokemon.gif")
+      clientCardMetadata.imageCutoutSrc shouldBe Some("file://new-pokemon.gif")
+      clientCardMetadata.imageCutoutSrcHeight shouldBe Some("100")
+      clientCardMetadata.imageCutoutSrcWidth shouldBe Some("100")
 
-      clientArticleMetadata.imageReplace shouldBe None
-      clientArticleMetadata.overrideArticleMainMedia shouldBe None
+      clientCardMetadata.imageReplace shouldBe None
+      clientCardMetadata.overrideArticleMainMedia shouldBe None
     }
 
     "should persist slideshow images when selected override is replace image" in {
-      val articleMetadata = ArticleMetadata(
+      val cardMetadata = CardMetadata(
         Some("Elephants declared best animal"),
         None,
         None,
@@ -149,22 +149,22 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
-      clientArticleMetadata.headline.isDefined shouldBe true
-      clientArticleMetadata.headline.get shouldBe "Elephants declared best animal"
+      clientCardMetadata.headline.isDefined shouldBe true
+      clientCardMetadata.headline.get shouldBe "Elephants declared best animal"
 
-      clientArticleMetadata.imageReplace shouldBe Some(true)
-      clientArticleMetadata.imageSrc shouldBe Some("file://elephant.png")
-      clientArticleMetadata.imageSrcOrigin shouldBe Some("file://elephant.jpg")
-      clientArticleMetadata.imageSrcHeight shouldBe Some("100")
-      clientArticleMetadata.imageSrcWidth shouldBe Some("100")
+      clientCardMetadata.imageReplace shouldBe Some(true)
+      clientCardMetadata.imageSrc shouldBe Some("file://elephant.png")
+      clientCardMetadata.imageSrcOrigin shouldBe Some("file://elephant.jpg")
+      clientCardMetadata.imageSrcHeight shouldBe Some("100")
+      clientCardMetadata.imageSrcWidth shouldBe Some("100")
 
-      clientArticleMetadata.imageHide shouldBe None
+      clientCardMetadata.imageHide shouldBe None
     }
 
     "should only set an image override boolean if its fields are also set" in {
-      val articleMetadata = ArticleMetadata(
+      val cardMetadata = CardMetadata(
         Some("Teenage Mutant Ninja Turtles"),
         None,
         None,
@@ -180,13 +180,13 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
-      clientArticleMetadata.imageReplace shouldBe None
+      clientCardMetadata.imageReplace shouldBe None
     }
 
     "should explicitly set cutout to false if media type is set but not to a cutout" in {
-      val articleMetadata = ArticleMetadata(
+      val cardMetadata = CardMetadata(
         Some("Teenage Mutant Ninja Turtles"),
         None,
         None,
@@ -202,20 +202,20 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientArticleMetadata = ClientArticleMetadata.fromArticleMetadata(articleMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
-      clientArticleMetadata.imageCutoutReplace shouldBe Some(false)
+      clientCardMetadata.imageCutoutReplace shouldBe Some(false)
     }
   }
 
-  "ClientArticleMetadata to ArticleMetadata" - {
+  "ClientCardMetadata to CardMetadata" - {
 
-    def getEmptyClientArticleMetadata = ClientArticleMetadata(
+    def getEmptyClientCardMetadata = ClientCardMetadata(
       None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
     )
 
-    "should convert into ArticleMetadata with multiple image overrides" in {
-      val articleMetadata = getEmptyClientArticleMetadata
+    "should convert into CardMetadata with multiple image overrides" in {
+      val cardMetadata = getEmptyClientCardMetadata
         .copy(headline = Some("New Harry Potter book being written"))
         .copy(sportScore = Some("J.K"))
         .copy(imageReplace = Some(true))
@@ -229,14 +229,14 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         .copy(imageCutoutSrcHeight = Some("100"))
         .copy(imageCutoutSrcWidth = Some("100"))
         .copy(imageCutoutSrcOrigin = Some("file://broom.gif"))
-        .toArticleMetadata
+        .toCardMetadata
 
-      articleMetadata.headline.isDefined shouldBe true
-      articleMetadata.headline.get shouldBe "New Harry Potter book being written"
+      cardMetadata.headline.isDefined shouldBe true
+      cardMetadata.headline.get shouldBe "New Harry Potter book being written"
 
-      articleMetadata.mediaType.isDefined shouldBe true
-      articleMetadata.mediaType.get shouldBe MediaType.Image
-      articleMetadata.replaceImage shouldBe Some(Image(
+      cardMetadata.mediaType.isDefined shouldBe true
+      cardMetadata.mediaType.get shouldBe MediaType.Image
+      cardMetadata.replaceImage shouldBe Some(Image(
         Some(100),
         Some(100),
         "file://lightning.gif",
@@ -244,18 +244,18 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some("file://lightning.png")
       ))
 
-      articleMetadata.cutoutImage shouldBe Some(Image(
+      cardMetadata.cutoutImage shouldBe Some(Image(
         Some(100),
         Some(100),
         "file://broom.gif",
         "file://broom.jpg"
       ))
 
-      articleMetadata.overrideArticleMainMedia shouldBe None
+      cardMetadata.overrideArticleMainMedia shouldBe None
     }
 
-    "should convert into ArticleMetadata without all the image information" in {
-      val articleMetadata = getEmptyClientArticleMetadata
+    "should convert into CardMetadata without all the image information" in {
+      val cardMetadata = getEmptyClientCardMetadata
         .copy(imageReplace = Some(true))
         .copy(imageSrc = Some("file://lightning.jpg"))
         .copy(imageSrcHeight = Some("100"))
@@ -266,11 +266,11 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         .copy(imageCutoutSrc = Some("file://broom.jpg"))
         .copy(coverCardMobileImage = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))))
         .copy(coverCardTabletImage = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))))
-        .toArticleMetadata
+        .toCardMetadata
 
-      articleMetadata.mediaType.isDefined shouldBe true
-      articleMetadata.mediaType.get shouldBe MediaType.Image
-      articleMetadata.replaceImage shouldBe Some(Image(
+      cardMetadata.mediaType.isDefined shouldBe true
+      cardMetadata.mediaType.get shouldBe MediaType.Image
+      cardMetadata.replaceImage shouldBe Some(Image(
         Some(100),
         Some(100),
         "file://lightning.gif",
@@ -278,14 +278,14 @@ class ClientArticleMetadataTest extends FreeSpec with Matchers {
         Some("file://lightning.png")
       ))
 
-      articleMetadata.cutoutImage shouldBe Some(Image(
+      cardMetadata.cutoutImage shouldBe Some(Image(
         None,
         None,
         "file://broom.jpg",
         "file://broom.jpg"
       ))
 
-      articleMetadata.coverCardImages shouldBe Some(CoverCardImages(
+      cardMetadata.coverCardImages shouldBe Some(CoverCardImages(
         mobile = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))),
         tablet = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png")))
       ))

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -187,7 +187,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       val frontPageCollection = issue.fronts.find(_.name == "UK News").value.collections.find(_.name == "Front Page").value
       frontPageCollection.items.size shouldBe 1
       frontPageCollection.items.head.id shouldBe "123456"
-      frontPageCollection.items.head.metadata shouldBe ArticleMetadata.default
+      frontPageCollection.items.head.metadata shouldBe CardMetadata.default
     }
   }
 

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -81,7 +81,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       artsCollection.items.size shouldBe 2
 
       val arts1 = artsCollection.items.head
-      arts1.pageCode shouldBe "345678"
+      arts1.id shouldBe "345678"
 
       arts1.metadata.showByline.isDefined shouldBe true
       arts1.metadata.showByline.value shouldBe true
@@ -115,7 +115,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       artsCollection.items.size shouldBe 2
 
       val arts1 = artsCollection.items.head
-      arts1.pageCode shouldBe "574893"
+      arts1.id shouldBe "574893"
 
     }
 
@@ -136,7 +136,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       artsCollection.items.size shouldBe 2
 
       val arts1 = artsCollection.items.head
-      arts1.pageCode shouldBe "345678"
+      arts1.id shouldBe "345678"
 
     }
 
@@ -157,7 +157,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       artsCollection.items.size shouldBe 2
 
       val arts2 = artsCollection.items.tail.head
-      arts2.pageCode shouldBe "574893"
+      arts2.id shouldBe "574893"
 
       arts2.metadata.showByline.isDefined shouldBe true
       arts2.metadata.showByline.value shouldBe true
@@ -186,7 +186,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       issue.fronts.size shouldBe 4
       val frontPageCollection = issue.fronts.find(_.name == "UK News").value.collections.find(_.name == "Front Page").value
       frontPageCollection.items.size shouldBe 1
-      frontPageCollection.items.head.pageCode shouldBe "123456"
+      frontPageCollection.items.head.id shouldBe "123456"
       frontPageCollection.items.head.metadata shouldBe ArticleMetadata.default
     }
   }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -75,7 +75,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
   private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticleSkeleton*): EditionsCollectionSkeleton =
     EditionsCollectionSkeleton(name, articles.toList, prefill, CollectionPresentation(), capiQueryTimeWindow, hidden = false)
 
-  private def article(pageCode: String): EditionsArticleSkeleton = EditionsArticleSkeleton(pageCode, ArticleMetadata.default)
+  private def article(id: String): EditionsArticleSkeleton = EditionsArticleSkeleton(id, ArticleMetadata.default)
 
   "The editions DB" - {
     "should insert an empty issue" taggedAs UsesDatabase in {
@@ -166,7 +166,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       commentFront.collections.length shouldBe 3
 
       val editionsArticle = newsPoliticsCollection.items.head
-      editionsArticle.pageCode shouldBe "12345"
+      editionsArticle.id shouldBe "12345"
 
       val articleMetadata = editionsArticle.metadata.get
       articleMetadata.overrideArticleMainMedia shouldBe None
@@ -393,11 +393,11 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       updatedBrexshit.displayName shouldBe "brexshit"
 
       // check we are storing some metadata
-      updatedBrexshit.items.find(_.pageCode == "654789").value.addedOn shouldBe future.toInstant.toEpochMilli
-      updatedBrexshit.items.find(_.pageCode == "654789").value.metadata.value shouldBe simpleMetadata
+      updatedBrexshit.items.find(_.id == "654789").value.addedOn shouldBe future.toInstant.toEpochMilli
+      updatedBrexshit.items.find(_.id == "654789").value.metadata.value shouldBe simpleMetadata
 
       // check that the added time hasn't modified
-      updatedBrexshit.items.find(_.pageCode == "76543").value.addedOn shouldBe now.toInstant.toEpochMilli
+      updatedBrexshit.items.find(_.id == "76543").value.addedOn shouldBe now.toInstant.toEpochMilli
     }
 
     "should allow a special front's hidden status to be changed" taggedAs UsesDatabase in {
@@ -480,7 +480,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       }) shouldBe Some(collectionId)
 
       (DB localTx { implicit session =>
-        sql"""SELECT page_code from articles WHERE collection_id = $collectionId""".map(_.string("page_code")).list().apply()
+        sql"""SELECT id from articles WHERE collection_id = $collectionId""".map(_.string("id")).list().apply()
       }).length shouldBe 2
 
       editionsDB.deleteIssue(dbIssue.id)
@@ -496,7 +496,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       }) should be
 
       (DB localTx { implicit session =>
-        sql"""SELECT page_code from articles WHERE collection_id = $collectionId""".map(_.string("page_code")).list().apply()
+        sql"""SELECT id from articles WHERE collection_id = $collectionId""".map(_.string("id")).list().apply()
       }).length shouldBe 0
     }
 

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -370,7 +370,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       val future = now.plusMinutes(20)
       val futureMillis = future.toInstant.toEpochMilli
 
-      val items = EditionsCard("654789", futureMillis, Some(simpleMetadata)) :: brexshit.items
+      val items = EditionsCard("654789", CardType.Article, futureMillis, Some(simpleMetadata)) :: brexshit.items
 
       val evenMoreBrexshit = brexshit.copy(
         lastUpdated = Some(futureMillis),

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -22,7 +22,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
   private val moreRecentThenCreationTime = now.toInstant.toEpochMilli + 1
 
-  private val simpleMetadata = ArticleMetadata(
+  private val simpleMetadata = CardMetadata(
     customKicker = Some("Kicker"),
     headline = None,
     trailText = None,
@@ -75,7 +75,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
   private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticleSkeleton*): EditionsCollectionSkeleton =
     EditionsCollectionSkeleton(name, articles.toList, prefill, CollectionPresentation(), capiQueryTimeWindow, hidden = false)
 
-  private def article(id: String): EditionsArticleSkeleton = EditionsArticleSkeleton(id, ArticleMetadata.default)
+  private def article(id: String): EditionsArticleSkeleton = EditionsArticleSkeleton(id, CardMetadata.default)
 
   "The editions DB" - {
     "should insert an empty issue" taggedAs UsesDatabase in {
@@ -112,7 +112,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       singleIssue.head.issueDate.getDayOfMonth shouldBe 29
     }
 
-    "should insert fronts, collections and articles" taggedAs UsesDatabase in {
+    "should insert fronts, collections and cards" taggedAs UsesDatabase in {
       val id = insertSkeletonIssue(2019, 9, 30,
         front("news/uk",
           collection("politics", Some(CapiPrefillQuery("magic-politics-query", PathType.PrintSent)),
@@ -370,7 +370,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       val future = now.plusMinutes(20)
       val futureMillis = future.toInstant.toEpochMilli
 
-      val items = EditionsArticle("654789", futureMillis, Some(simpleMetadata)) :: brexshit.items
+      val items = EditionsCard("654789", futureMillis, Some(simpleMetadata)) :: brexshit.items
 
       val evenMoreBrexshit = brexshit.copy(
         lastUpdated = Some(futureMillis),
@@ -480,7 +480,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       }) shouldBe Some(collectionId)
 
       (DB localTx { implicit session =>
-        sql"""SELECT id from articles WHERE collection_id = $collectionId""".map(_.string("id")).list().apply()
+        sql"""SELECT id from cards WHERE collection_id = $collectionId""".map(_.string("id")).list().apply()
       }).length shouldBe 2
 
       editionsDB.deleteIssue(dbIssue.id)
@@ -496,7 +496,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       }) should be
 
       (DB localTx { implicit session =>
-        sql"""SELECT id from articles WHERE collection_id = $collectionId""".map(_.string("id")).list().apply()
+        sql"""SELECT id from cards WHERE collection_id = $collectionId""".map(_.string("id")).list().apply()
       }).length shouldBe 0
     }
 


### PR DESCRIPTION
~_NB: Depends on #1563 – dear reader, please review that first!~ ✅ 

## What's changed?

Migrates the Editions `article` entity to `card`, and add 'card_type' property to card model. This opens the door to supporting more card types for our recipe work – `recipes`, `chefs`, and `collections`. We represent `card_type` as an enum in the Editions model.

We also rename `pageCode`, which is an article-specific identifier, to `id`, for the same reason.

Reviewing commit-by-commit might be sensible, as the renaming changes touch many files.

## Implementation notes

Things I've altered:
- the database table, and references to it
- every entity upstream of the Editions publication process

Things I've avoided:
- Collection `items`. This is really `cards`, but I'm reluctant to alter anything that might introduce changes to the publication model, yet.
- Article-related entities that are part of the Editions publication model. These really are articles 😀 (and again, I don't want to change the publication model.)

We may find that we can be bolder with the publication models after working on Recipes publication, but in the mean time, this PR is large, so this perhaps is plenty for now. 

## Checklist

### General
- [x] 🤖 Relevant tests ~added~ modified
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE (I've tested creating a new edition, editing, and proofing/publishing)

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
