### PR TITLE
Revert temporary exclusion of quick-cryptic from Editions prefill

### DIFF
--- a/app/model/editions/templates/DailyEdition.scala
+++ b/app/model/editions/templates/DailyEdition.scala
@@ -441,7 +441,7 @@ object DailyEdition extends RegionalEdition {
 
   def FrontCrosswords = front(
     "Crosswords",
-    collection("Crosswords").searchPrefill("?tag=type/crossword,-crosswords/series/quick-cryptic")
+    collection("Crosswords").searchPrefill("?tag=type/crossword")
   )
 
 }


### PR DESCRIPTION
Reverts guardian/facia-tool#1553