### PR TITLE
docs: Use relative link for fronts-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For information on core Fronts concepts, see the [glossary](./docs/Glossary.md).
 
 ## Fronts Client
 
-You can find the client for the Fronts tool in [fronts-client](/fronts-client).
+You can find the client for the Fronts tool in [fronts-client](./fronts-client).
 
 ### Setup (need to be done once)
 


### PR DESCRIPTION
## What's changed?

This docs link didn’t work for me locally: my editor interprets `/fronts-client` as an absolute path and doesn’t take me to the right file. Github does the right thing in the web UI for both styles, so this PR changes it to use a path relative to the current directory.
