### PR TITLE
Show users editions list or message based on permissions

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -227,6 +227,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
 
   object faciatool {
     lazy val breakingNewsFront = "breaking-news"
+    lazy val editEditions = "edit-editions"
     lazy val frontPressToolTopic = getString("faciatool.sns.tool_topic_arn")
     lazy val publishEventsQueue = getMandatoryString("publish_events.queue_url")
     lazy val showTestContainers = getBoolean("faciatool.show_test_containers").getOrElse(false)

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -227,7 +227,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
 
   object faciatool {
     lazy val breakingNewsFront = "breaking-news"
-    lazy val editEditions = "edit-editions"
+    lazy val canEditEditions = "edit-editions"
     lazy val frontPressToolTopic = getString("faciatool.sns.tool_topic_arn")
     lazy val publishEventsQueue = getMandatoryString("publish_events.queue_url")
     lazy val showTestContainers = getBoolean("faciatool.show_test_containers").getOrElse(false)

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -41,9 +41,11 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
   def configuration = AccessAPIAuthAction { implicit request =>
     val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(request.user.email)
     val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(request.user.email)
+    val hasEditionsPermissions = acl.testUser(Permissions.EditEditions, "facia-tool-allow-edit-editorial-fronts-for-all")(request.user.email)
 
     val acls = AclJson(
       fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
+      editions = Map(config.faciatool.editEditions -> hasEditionsPermissions),
       permissions = Map("configure-config" -> hasConfigureFronts)
     )
 

--- a/app/controllers/DefaultsController.scala
+++ b/app/controllers/DefaultsController.scala
@@ -45,7 +45,7 @@ class DefaultsController(val acl: Acl, val isDev: Boolean, val deps: BaseFaciaCo
 
     val acls = AclJson(
       fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
-      editions = Map(config.faciatool.editEditions -> hasEditionsPermissions),
+      editions = Map(config.faciatool.canEditEditions -> hasEditionsPermissions),
       permissions = Map("configure-config" -> hasConfigureFronts)
     )
 

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -34,11 +34,11 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, val deps
 
     val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
     val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
-    val hasEditionsPermissions = acl.testUser(Permissions.EditEditions, "facia-tool-allow-edit-editorial-fronts-for-all")(req.user.email)
+    val hasEditionsPermissions = acl.testUser(Permissions.EditEditions, "facia-tool-allow-edit-editions-for-all")(req.user.email)
 
     val acls = AclJson(
       fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
-      editions = Map(config.faciatool.editEditions -> hasEditionsPermissions),
+      editions = Map(config.faciatool.canEditEditions -> hasEditionsPermissions),
       permissions = Map("configure-config" -> hasConfigureFronts)
     )
 

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -34,9 +34,14 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, val deps
 
     val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
     val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
+    val hasEditionsPermissions = acl.testUser(Permissions.EditEditions, "facia-tool-allow-edit-editorial-fronts-for-all")(req.user.email)
+
+    //println("#hasBreakingNews="+hasBreakingNews+" hasConfigureFronts="+hasConfigureFronts+" hasEditionsPermissions="+hasEditionsPermissions)//Will remove this
+    //#hasBreakingNews=util.AccessDenied$@1b35415d hasConfigureFronts=util.AccessGranted$@6c6b1540 hasEditionsPermissions=util.AccessDenied$@1b35415d
 
     val acls = AclJson(
       fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
+      editions = Map(config.faciatool.editEditions -> hasEditionsPermissions),
       permissions = Map("configure-config" -> hasConfigureFronts)
     )
 

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -36,9 +36,6 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, val deps
     val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
     val hasEditionsPermissions = acl.testUser(Permissions.EditEditions, "facia-tool-allow-edit-editorial-fronts-for-all")(req.user.email)
 
-    //println("#hasBreakingNews="+hasBreakingNews+" hasConfigureFronts="+hasConfigureFronts+" hasEditionsPermissions="+hasEditionsPermissions)//Will remove this
-    //#hasBreakingNews=util.AccessDenied$@1b35415d hasConfigureFronts=util.AccessGranted$@6c6b1540 hasEditionsPermissions=util.AccessDenied$@1b35415d
-
     val acls = AclJson(
       fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
       editions = Map(config.faciatool.editEditions -> hasEditionsPermissions),

--- a/app/util/Acl.scala
+++ b/app/util/Acl.scala
@@ -23,6 +23,7 @@ object AclJson {
 
 case class AclJson (
   fronts: Map[String, Authorization],
+  editions: Map[String, Authorization],
   permissions: Map[String, Authorization]
 )
 

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -5,7 +5,10 @@ import { Link } from 'react-router-dom';
 import { priorities } from 'constants/priorities';
 import { EditionPriority } from 'types/Priority';
 import HomeContainer from './layout/HomeContainer';
-import { selectAvailableEditions } from 'selectors/configSelectors';
+import {
+  selectAvailableEditions,
+  selectEditionsPermission,
+} from 'selectors/configSelectors';
 import type { State } from 'types/State';
 
 const renderPriority = (priority: string) => (
@@ -23,21 +26,26 @@ const renderEditionPriority = (editionPriority: EditionPriority) => (
 
 type IProps = ReturnType<typeof mapStateToProps>;
 
-const Home = ({ availableEditions }: IProps) => (
+const Home = ({ availableEditions, editEditionsIsPermitted }: IProps) => (
   <HomeContainer>
     <h3>Front priorities</h3>
     <ul>{Object.keys(priorities).map(renderPriority)}</ul>
-
     <h3>Manage editions</h3>
     <ul>
-      {availableEditions &&
+      {!editEditionsIsPermitted ? (
+        <p>
+          You do not have permission to edit Editions. Please contact
+          central.production@guardian.co.uk to request access.
+        </p> /*TODO We can try string to be in Config and display dynamically here? "edit Editions" or "edit Feast Editions" or "edit Fronts" */
+      ) : (
+        availableEditions &&
         availableEditions
           .sort((a, b) =>
             a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1
           )
-          .map(renderEditionPriority)}
+          .map(renderEditionPriority)
+      )}
     </ul>
-
     <h3>Manage edition list</h3>
     <ul>
       <li>
@@ -52,6 +60,7 @@ const Home = ({ availableEditions }: IProps) => (
 
 const mapStateToProps = (state: State) => ({
   availableEditions: selectAvailableEditions(state),
+  editEditionsIsPermitted: selectEditionsPermission(state)['edit-editions'],
 });
 
 export default connect(mapStateToProps)(Home);

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -58,7 +58,7 @@ const mapStateToProps = (state: State) => ({
   editEditionsIsPermitted: selectEditionsPermission(state)?.['edit-editions'],
 });
 
-const displayNoPermissionMessage = (onContent: String) => {
+const displayNoPermissionMessage = (onContent: string) => {
   return (
     <p>
       You do not have permission to edit {onContent}. Please contact

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -61,8 +61,9 @@ const mapStateToProps = (state: State) => ({
 const displayNoPermissionMessage = (onContent: string) => {
   return (
     <p>
-      You do not have permission to edit {onContent}. Please contact
-      central.production@guardian.co.uk to request access.
+      You do not have permission to edit {onContent}. Please contact{' '}
+      <a href="mailto:central.production@guardian.co.uk">Central Production</a>{' '}
+      to request access.
     </p>
   );
 };

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -32,19 +32,14 @@ const Home = ({ availableEditions, editEditionsIsPermitted }: IProps) => (
     <ul>{Object.keys(priorities).map(renderPriority)}</ul>
     <h3>Manage editions</h3>
     <ul>
-      {!editEditionsIsPermitted ? (
-        <p>
-          You do not have permission to edit Editions. Please contact
-          central.production@guardian.co.uk to request access.
-        </p> /*TODO We can try string to be in Config and display dynamically here? "edit Editions" or "edit Feast Editions" or "edit Fronts" */
-      ) : (
-        availableEditions &&
-        availableEditions
-          .sort((a, b) =>
-            a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1
-          )
-          .map(renderEditionPriority)
-      )}
+      {!editEditionsIsPermitted
+        ? displayNoPermissionMessage('Editions')
+        : availableEditions &&
+          availableEditions
+            .sort((a, b) =>
+              a.editionType === b.editionType ? (a.title < b.title ? 0 : 1) : 1
+            )
+            .map(renderEditionPriority)}
     </ul>
     <h3>Manage edition list</h3>
     <ul>
@@ -60,7 +55,16 @@ const Home = ({ availableEditions, editEditionsIsPermitted }: IProps) => (
 
 const mapStateToProps = (state: State) => ({
   availableEditions: selectAvailableEditions(state),
-  editEditionsIsPermitted: selectEditionsPermission(state)['edit-editions'],
+  editEditionsIsPermitted: selectEditionsPermission(state)?.['edit-editions'],
 });
+
+const displayNoPermissionMessage = (onContent: String) => {
+  return (
+    <p>
+      You do not have permission to edit {onContent}. Please contact
+      central.production@guardian.co.uk to request access.
+    </p>
+  );
+};
 
 export default connect(mapStateToProps)(Home);

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -232,6 +232,7 @@ const config: Config = {
   },
   acl: {
     fronts: { 'breaking-news': true },
+    editions: { 'edit-editions': true },
     permissions: { 'configure-config': true },
   },
   collectionCap: 20,

--- a/fronts-client/src/selectors/configSelectors.ts
+++ b/fronts-client/src/selectors/configSelectors.ts
@@ -49,6 +49,11 @@ const selectShouldUsePreviewCODE = createSelector(
   (config) => !config || config.env === 'code'
 );
 
+const selectEditionsPermission = createSelector(
+  selectConfig,
+  (config) => config && config.acl.editions
+);
+
 export {
   selectCapiLiveURL,
   selectCapiPreviewURL,
@@ -59,4 +64,5 @@ export {
   selectGridUrl,
   selectAvailableEditions,
   selectShouldUsePreviewCODE,
+  selectEditionsPermission,
 };

--- a/fronts-client/src/types/Config.ts
+++ b/fronts-client/src/types/Config.ts
@@ -8,6 +8,7 @@ interface Permission {
 
 interface Acl {
   fronts: Permission;
+  editions: Permission;
   permissions: Permission;
 }
 


### PR DESCRIPTION
## What's changed?

At present when user tries to access [Fronts](https://fronts.code.dev-gutools.co.uk/v2) they gets list of Editions on Home page, which they are able to select but depends on permissions Editions might not get edited if not allowed.
We want Home page to not to show editions-list at all if user is not permitted instead they should get relevant message displayed on the screen.

ref: https://trello.com/c/QCmlviYl/2867-fronts-tool-does-not-check-permissions-before-permitting-access-to-editions

If this gets approval our next task will be to implement for Fronts-list.


**UI Testing:**
Tested on my email id which don't have permission to access Editions at the moment hence I will see on screen:

<img width="935" alt="image" src="https://github.com/guardian/facia-tool/assets/17780995/4d7e8559-d2b0-43fa-b4ee-ddf12dae7a08">


 
## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
