### PR TITLE
Do not throw errors when collection.type is not present

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -291,9 +291,15 @@ function updateCollection(
         getState(),
         frontStages.draft
       );
-      dispatch(
-        recordVisibleArticles(collection.id, visibleArticles, frontStages.draft)
-      );
+      if (visibleArticles) {
+        dispatch(
+          recordVisibleArticles(
+            collection.id,
+            visibleArticles,
+            frontStages.draft
+          )
+        );
+      }
     } catch (e) {
       dispatch(collectionActions.updateError(e, collection.id));
       throw e;
@@ -405,7 +411,7 @@ function getVisibleArticles(
   collection: Collection,
   state: State,
   stage: Stages
-): Promise<VisibleArticlesResponse> {
+): Promise<VisibleArticlesResponse | undefined> {
   const collectionType = collection.type;
   const groups = getGroupsByStage(collection, stage);
   const selectGroupArticles = createSelectGroupArticles();
@@ -414,12 +420,8 @@ function getVisibleArticles(
   );
   const articleDetails = getVisibilityArticleDetails(groupsWithArticles);
 
-  // Assume all articles are always visible if there is no collection type.
   if (!collectionType) {
-    return Promise.resolve({
-      desktop: Infinity,
-      mobile: Infinity,
-    });
+    return Promise.resolve(undefined);
   }
 
   return fetchVisibleArticles(collectionType, articleDetails);

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -414,6 +414,14 @@ function getVisibleArticles(
   );
   const articleDetails = getVisibilityArticleDetails(groupsWithArticles);
 
+  // Assume all articles are always visible if there is no collection type.
+  if (!collectionType) {
+    return Promise.resolve({
+      desktop: Infinity,
+      mobile: Infinity,
+    });
+  }
+
   return fetchVisibleArticles(collectionType, articleDetails);
 }
 

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -74,6 +74,34 @@ describe('Collection actions', () => {
         collectionActions.updateSuccess('exampleCollection')
       );
     });
+
+    it('should handle collections without types in a a collection update', async () => {
+      const { type, ...collection }: any =
+        stateWithCollection.collections.data.exampleCollection;
+
+      fetchMock.once('/v2Edits', collection, {
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      const store = mockStore({
+        config,
+        ...stateWithCollection,
+      });
+
+      await store.dispatch(updateCollection(collection) as any);
+      const actions = store.getActions();
+      expect(actions[2]).toEqual({
+        type: 'FETCH_VISIBLE_ARTICLES_SUCCESS',
+        payload: {
+          collectionId: 'exampleCollection',
+          visibleArticles: {
+            desktop: Infinity,
+            mobile: Infinity,
+          },
+          stage: 'draft',
+        },
+      });
+    });
   });
 
   describe('Get Collections thunk', () => {

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -90,17 +90,7 @@ describe('Collection actions', () => {
 
       await store.dispatch(updateCollection(collection) as any);
       const actions = store.getActions();
-      expect(actions[2]).toEqual({
-        type: 'FETCH_VISIBLE_ARTICLES_SUCCESS',
-        payload: {
-          collectionId: 'exampleCollection',
-          visibleArticles: {
-            desktop: Infinity,
-            mobile: Infinity,
-          },
-          stage: 'draft',
-        },
-      });
+      expect(actions[2]).toEqual(undefined);
     });
   });
 

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -144,7 +144,7 @@ interface Collection {
   groups?: string[];
   metadata?: Array<{ type: string }>;
   uneditable?: boolean;
-  type: string;
+  type?: string;
   frontsToolSettings?: FrontsToolSettings;
   isHidden?: boolean;
   targetedTerritory?: string;


### PR DESCRIPTION
## What's changed?

As part of work on #1558, I noticed that [we see a lot of errors in Sentry](https://the-guardian.sentry.io/issues/5042764688/?project=35467&query=&referrer=project-issue-stream) related to the `collection.type` property not being visible. This is always true in an Editions context, where the collection model differs slightly from Fronts, and does not include presentation information.

This PR amends the function that fetches this information, `getVisibleArticles`, to avoid fetching this data if the `type` property is not present.

## How to test

- The automated tests should pass
- The desktop/mobile markers should be present in Fronts as per, and not visible in editions:

<img width="718" alt="Screenshot 2024-04-23 at 14 44 24" src="https://github.com/guardian/facia-tool/assets/7767575/39e5b139-2e3a-4c66-96cb-80ba3a45c672">

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
