### PR TITLE
Remove red ink in integration test runs

### DIFF
--- a/fronts-client/integration/server/server.js
+++ b/fronts-client/integration/server/server.js
@@ -195,6 +195,10 @@ module.exports = async () =>
       return res.json([]);
     });
 
+    app.get('*/last-proofed-version*', (req, res) => {
+      return res.json(null);
+    });
+
     // send the assets from dist
     app.get('*/:file', (req, res) =>
       req.params[0].includes('bbc') // prevents error messages from External Snap Link fixture

--- a/fronts-client/integration/server/server.js
+++ b/fronts-client/integration/server/server.js
@@ -161,23 +161,20 @@ module.exports = async () =>
     app.get('/editions-api/collections/:id/prefill', (req, res) => {
       return res.json(prefill);
     });
+
     app.post('/editions-api/collections', (req, res) => {
-      return res.json([
-        {
-          id: req.body[0].id,
+      const collectionStubs = [collection, collectionTwo];
+
+      // Expects a body of `{ id: string }[]`
+      return res.json(
+        req.body.map(({ id }, index) => ({
+          id,
           collection: {
-            ...collection,
-            items: collection.draft
-          }
-        },
-        {
-          id: req.body[1].id,
-          collection: {
-            ...collectionTwo,
-            items: collectionTwo.draft
-          }
-        }
-      ]);
+            ...collectionStubs[index],
+            items: collectionStubs[index].draft,
+          },
+        }))
+      );
     });
 
     // catch requests to discard collection endpoint


### PR DESCRIPTION
## What's changed?

In chatting about #1566 with @fredex42, some error logging when running integration tests was causing confusion. This PR should remove it. See the commits for individual fixes.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
