### PR TITLE
Correct resolution for datetime when updating collection name

### DIFF
--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -73,7 +73,7 @@ trait CollectionsQueries {
   }
 
   def updateCollectionName(collection: EditionsCollection): EditionsCollection = DB localTx { implicit session =>
-    val lastUpdated = LocalDateTime.now()
+    val lastUpdated = EditionsDB.truncateDateTime(OffsetDateTime.now())
     sql"""
       UPDATE collections
       SET "name" = ${collection.displayName.trim()},


### PR DESCRIPTION
_co-authored-by: @fredex42_ 

## What's changed?

This PR fixes a bug: card forms were being closed unexpectedly as users in Editions were working on the product.

This was happening because collections were being incorrectly considered to have updated underneath the user, refreshing the collection unnecessarily and causing the forms to close.

## A bit more detail

The editions collection update mechanism uses timestamps to figure out when collections are stale, using a compare-and-swap mechanism. If the server collection's `updated_on` value is greater than the clients, the server returns the newer collection.

There is a side-effect in the UI that would be nice to fix, but in this case highlighted a bug: when a collection is updated underneath the user while its cards have open forms, those forms close. This is because, at present, cards' UUIDs are synthesised by the client, and so incoming cards are not recognised by the UI as the same as current cards – thus the relationship between the card UUID and the UI state indicating its open state is severed.

Users noticed that the bug occurred after collections were renamed. This happens because the rename mechanism changes the `updated_on` property of the database at microsecond resolution, but the tool expects millisecond resolution.

The resulting rounding error sometimes results in the queried `updated_on` value being greater than its database value, and so the collection is always considered stale. Constantly refreshing collections means constantly closing forms.

## Why did we only see this now?

Because although the two paths, `updateCollection` and `renameCollection`, had different logic, they both happened to return the same result – until #1566! Java 8's `Instant.now()` returns milliseconds, but [Java 9+ returns microseconds](https://stackoverflow.com/questions/39586311/java-8-localdatetime-now-only-giving-precision-of-milliseconds). #1566 bumped us to Java 11, changing the behaviour of the code and revealing the bug.

## Any problems anywhere else?

Every instance of `.now()` we can see in the codebase is now run through `truncateDateTime`, so we shouldn't see this behaviour anywhere else.

## How to test

Running `main` locally or in code, rename a collection. After a few tries, you should notice that the tool always considers that collection to be stale when it polls, returning the 'new' collection. As a result, card forms will close on poll:

![form-open](https://github.com/guardian/facia-tool/assets/7767575/de4f4530-9f13-40df-aa07-e0d0459d99ce)

Switch to this branch. You should note that after renaming a collection, it's impossible to reproduce this bug:

![form-OK](https://github.com/guardian/facia-tool/assets/7767575/d7aa3fa0-4557-4099-928f-f8380e4b2e01)

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
