### PR TITLE
Add hover buttons to recipe cards

### DIFF
--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -106,7 +106,7 @@ interface ArticleBodyProps {
   sectionName?: string;
   displayPlaceholders?: boolean;
   uuid: string;
-  onDelete?: () => void;
+  onDelete: () => void;
   onAddToClipboard?: () => void;
   isUneditable?: boolean;
   byline?: string;
@@ -321,22 +321,35 @@ const articleBodyDefault = React.memo(
         </ImageAndGraphWrapper>
         <HoverActionsAreaOverlay disabled={isUneditable}>
           <HoverActionsButtonWrapper
-            buttons={[
-              { text: 'View', component: HoverViewButton },
-              { text: 'Ophan', component: HoverOphanButton },
-              { text: 'Clipboard', component: HoverAddToClipboardButton },
-              { text: 'Delete', component: HoverDeleteButton },
-            ]}
-            buttonProps={{
-              isLive,
-              urlPath,
-              onDelete,
-              onAddToClipboard,
-            }}
             size={size}
             toolTipPosition={'top'}
-            toolTipAlign={'left'}
-          />
+            toolTipAlign={'right'}
+          >
+            {(props) => (
+              <>
+                <HoverViewButton
+                  hoverText="View"
+                  isLive={true}
+                  urlPath={urlPath}
+                  isSnapLink={true}
+                  {...props}
+                />
+                <HoverOphanButton {...props} hoverText="Ophan" />
+                {onAddToClipboard && (
+                  <HoverAddToClipboardButton
+                    onAddToClipboard={onAddToClipboard}
+                    hoverText="Clipboard"
+                    {...props}
+                  />
+                )}
+                <HoverDeleteButton
+                  onDelete={onDelete}
+                  hoverText="Delete"
+                  {...props}
+                />
+              </>
+            )}
+          </HoverActionsButtonWrapper>
         </HoverActionsAreaOverlay>
       </>
     );

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -339,7 +339,7 @@ const articleBodyDefault = React.memo(
                 {isLive && (
                   <HoverOphanButton
                     {...props}
-                    href={isLive ? paths?.live : paths?.preview}
+                    href={paths?.ophan}
                     hoverText="Ophan"
                   />
                 )}

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -33,6 +33,7 @@ import { ImageMetadataContainer } from 'components/image/ImageMetaDataContainer'
 import EditModeVisibility from 'components/util/EditModeVisibility';
 import PageViewDataWrapper from '../../PageViewDataWrapper';
 import ImageAndGraphWrapper from 'components/image/ImageAndGraphWrapper';
+import { getPaths } from 'util/paths';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -106,7 +107,7 @@ interface ArticleBodyProps {
   sectionName?: string;
   displayPlaceholders?: boolean;
   uuid: string;
-  onDelete: () => void;
+  onDelete?: () => void;
   onAddToClipboard?: () => void;
   isUneditable?: boolean;
   byline?: string;
@@ -178,6 +179,7 @@ const articleBodyDefault = React.memo(
   }: ArticleBodyProps) => {
     const displayByline = size === 'default' && showByline && byline;
     const now = Date.now();
+    const paths = urlPath ? getPaths(urlPath) : undefined;
 
     return (
       <>
@@ -327,14 +329,20 @@ const articleBodyDefault = React.memo(
           >
             {(props) => (
               <>
-                <HoverViewButton
-                  hoverText="View"
-                  isLive={true}
-                  urlPath={urlPath}
-                  isSnapLink={true}
-                  {...props}
-                />
-                <HoverOphanButton {...props} hoverText="Ophan" />
+                {urlPath && (
+                  <HoverViewButton
+                    hoverText="View"
+                    href={isLive ? paths?.live : paths?.preview}
+                    {...props}
+                  />
+                )}
+                {isLive && (
+                  <HoverOphanButton
+                    {...props}
+                    href={isLive ? paths?.live : paths?.preview}
+                    hoverText="Ophan"
+                  />
+                )}
                 {onAddToClipboard && (
                   <HoverAddToClipboardButton
                     onAddToClipboard={onAddToClipboard}
@@ -342,11 +350,13 @@ const articleBodyDefault = React.memo(
                     {...props}
                   />
                 )}
-                <HoverDeleteButton
-                  onDelete={onDelete}
-                  hoverText="Delete"
-                  {...props}
-                />
+                {onDelete && (
+                  <HoverDeleteButton
+                    onDelete={onDelete}
+                    hoverText="Delete"
+                    {...props}
+                  />
+                )}
               </>
             )}
           </HoverActionsButtonWrapper>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -326,8 +326,7 @@ const articleBodyDefault = React.memo(
             size={size}
             toolTipPosition={'top'}
             toolTipAlign={'right'}
-          >
-            {(props) => (
+            renderButtons={(props) => (
               <>
                 {urlPath && (
                   <HoverViewButton
@@ -359,7 +358,7 @@ const articleBodyDefault = React.memo(
                 )}
               </>
             )}
-          </HoverActionsButtonWrapper>
+          />
         </HoverActionsAreaOverlay>
       </>
     );

--- a/fronts-client/src/components/card/recipe/RecipeCard.tsx
+++ b/fronts-client/src/components/card/recipe/RecipeCard.tsx
@@ -16,12 +16,20 @@ import { ThumbnailSmall } from 'components/image/Thumbnail';
 import CardMetaContent from '../CardMetaContent';
 import { upperFirst } from 'lodash';
 import { useSelector } from 'react-redux';
+import { HoverActionsAreaOverlay } from 'components/CollectionHoverItems';
+import { HoverActionsButtonWrapper } from 'components/inputs/HoverActionButtonWrapper';
+import {
+  HoverAddToClipboardButton,
+  HoverDeleteButton,
+  HoverViewButton,
+} from 'components/inputs/HoverActionButtons';
+import { getPaths } from 'util/paths';
 
 interface Props {
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
-  onDelete?: (uuid: string) => void;
-  onAddToClipboard?: (uuid: string) => void;
+  onDelete: () => void;
+  onAddToClipboard: () => void;
   onClick?: () => void;
   id: string;
   collectionId?: string;
@@ -53,6 +61,9 @@ export const RecipeCard = ({
   const recipe = useSelector((state) =>
     recipeSelectors.selectById(state, card.id)
   );
+  const paths = recipe?.canonicalArticle
+    ? getPaths(recipe.canonicalArticle)
+    : undefined;
 
   return (
     <CardContainer {...rest}>
@@ -82,6 +93,32 @@ export const RecipeCard = ({
         <ImageAndGraphWrapper size={size}>
           <ThumbnailSmall url={recipe?.featuredImage.url} />
         </ImageAndGraphWrapper>
+        <HoverActionsAreaOverlay data-testid="hover-overlay">
+          <HoverActionsButtonWrapper
+            toolTipPosition={'top'}
+            toolTipAlign={'right'}
+          >
+            {(props) => (
+              <>
+                <HoverViewButton
+                  hoverText="View"
+                  href={paths?.live}
+                  {...props}
+                />
+                <HoverAddToClipboardButton
+                  onAddToClipboard={onAddToClipboard}
+                  hoverText="Clipboard"
+                  {...props}
+                />
+                <HoverDeleteButton
+                  hoverText="Delete"
+                  onDelete={onDelete}
+                  {...props}
+                />
+              </>
+            )}
+          </HoverActionsButtonWrapper>
+        </HoverActionsAreaOverlay>
       </CardBody>
     </CardContainer>
   );

--- a/fronts-client/src/components/card/recipe/RecipeCard.tsx
+++ b/fronts-client/src/components/card/recipe/RecipeCard.tsx
@@ -97,8 +97,7 @@ export const RecipeCard = ({
           <HoverActionsButtonWrapper
             toolTipPosition={'top'}
             toolTipAlign={'right'}
-          >
-            {(props) => (
+            renderButtons={(props) => (
               <>
                 <HoverViewButton
                   hoverText="View"
@@ -117,7 +116,7 @@ export const RecipeCard = ({
                 />
               </>
             )}
-          </HoverActionsButtonWrapper>
+          />
         </HoverActionsAreaOverlay>
       </CardBody>
     </CardContainer>

--- a/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
+++ b/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
@@ -54,8 +54,8 @@ const SnapLinkURL = styled.p`
 interface ContainerProps {
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
-  onDelete?: (uuid: string) => void;
-  onAddToClipboard?: (uuid: string) => void;
+  onDelete: () => void;
+  onAddToClipboard: () => void;
   onClick?: () => void;
   id: string;
   collectionId?: string;
@@ -192,23 +192,33 @@ const SnapLinkCard = ({
           justify={'space-between'}
         >
           <HoverActionsButtonWrapper
-            buttons={[
-              { text: 'View', component: HoverViewButton },
-              { text: 'Ophan', component: HoverOphanButton },
-              { text: 'Clipboard', component: HoverAddToClipboardButton },
-              { text: 'Delete', component: HoverDeleteButton },
-            ]}
-            buttonProps={{
-              isLive: true, // it should not be possible for a snap link to be anything other than live?
-              urlPath,
-              onAddToClipboard,
-              onDelete,
-              isSnapLink: true,
-            }}
             size={size}
             toolTipPosition={'top'}
             toolTipAlign={'right'}
-          />
+          >
+            {(props) => (
+              <>
+                <HoverViewButton
+                  hoverText="View"
+                  isLive={true}
+                  urlPath={urlPath}
+                  isSnapLink={true}
+                  {...props}
+                />
+                <HoverOphanButton {...props} hoverText="Ophan" />
+                <HoverAddToClipboardButton
+                  onAddToClipboard={onAddToClipboard}
+                  hoverText="Clipboard"
+                  {...props}
+                />
+                <HoverDeleteButton
+                  onDelete={onDelete}
+                  hoverText="Delete"
+                  {...props}
+                />
+              </>
+            )}
+          </HoverActionsButtonWrapper>
         </HoverActionsAreaOverlay>
       </SnapLinkBodyContainer>
       {children}

--- a/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
+++ b/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
@@ -37,6 +37,7 @@ import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import ImageAndGraphWrapper from 'components/image/ImageAndGraphWrapper';
 import { ThumbnailCutout } from 'components/image/Thumbnail';
 import PageViewDataWrapper from 'components/PageViewDataWrapper';
+import { getPathsForSnap } from 'util/paths';
 
 const SnapLinkBodyContainer = styled(CardBody)`
   justify-content: space-between;
@@ -198,14 +199,14 @@ const SnapLinkCard = ({
           >
             {(props) => (
               <>
-                <HoverViewButton
-                  hoverText="View"
-                  isLive={true}
-                  urlPath={urlPath}
-                  isSnapLink={true}
+                {urlPath && (
+                  <HoverViewButton hoverText="View" href={urlPath} {...props} />
+                )}
+                <HoverOphanButton
                   {...props}
+                  hoverText="Ophan"
+                  href={urlPath && getPathsForSnap(urlPath).ophan}
                 />
-                <HoverOphanButton {...props} hoverText="Ophan" />
                 <HoverAddToClipboardButton
                   onAddToClipboard={onAddToClipboard}
                   hoverText="Clipboard"

--- a/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
+++ b/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
@@ -196,8 +196,7 @@ const SnapLinkCard = ({
             size={size}
             toolTipPosition={'top'}
             toolTipAlign={'right'}
-          >
-            {(props) => (
+            renderButtons={(props) => (
               <>
                 {urlPath && (
                   <HoverViewButton hoverText="View" href={urlPath} {...props} />
@@ -219,7 +218,7 @@ const SnapLinkCard = ({
                 />
               </>
             )}
-          </HoverActionsButtonWrapper>
+          />
         </HoverActionsAreaOverlay>
       </SnapLinkBodyContainer>
       {children}

--- a/fronts-client/src/components/feed/ArticleFeedItem.tsx
+++ b/fronts-client/src/components/feed/ArticleFeedItem.tsx
@@ -20,6 +20,7 @@ import { insertCardWithCreate } from '../../actions/Cards';
 import { connect } from 'react-redux';
 import { FeedItem } from './FeedItem';
 import { ContentInfo } from './ContentInfo';
+import { CardTypesMap } from 'constants/cardTypes';
 
 const Tone = styled.span`
   font-weight: normal;
@@ -56,6 +57,7 @@ const ArticleFeedItemComponent = ({
 
   return (
     <FeedItem
+      type={CardTypesMap.ARTICLE}
       id={article.id}
       title={article.webTitle}
       liveUrl={getPaths(article.id).live}

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -10,6 +10,7 @@ import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
 import { State } from '../../types/State';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
+import { CardTypesMap } from 'constants/cardTypes';
 
 interface ComponentProps {
   chef: Chef;
@@ -33,6 +34,7 @@ export const ChefFeedItemComponent = ({
   return (
     <FeedItem
       id={chef.id}
+      type={CardTypesMap.CHEF}
       title={`${chef.firstName} ${chef.lastName}`}
       hasVideo={false}
       isLive={true}

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -206,7 +206,9 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
             {(props) => (
               <>
                 <HoverViewButton hoverText="View" href={href} {...props} />
-                <HoverOphanButton {...props} href={ophan} hoverText="Ophan" />
+                {isLive && (
+                  <HoverOphanButton {...props} href={ophan} hoverText="Ophan" />
+                )}
                 <HoverAddToClipboardButton
                   onAddToClipboard={onAddToClipboard}
                   hoverText="Clipboard"

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -20,6 +20,7 @@ import CircularIconContainer from 'components/icons/CircularIconContainer';
 import RefreshPeriodically from '../util/RefreshPeriodically';
 import { collectionArticlesPollInterval } from 'constants/polling';
 import RenderOffscreen from 'components/util/RenderOffscreen';
+import { getPaths } from 'util/paths';
 
 const Container = styled.div`
   display: flex;
@@ -136,6 +137,9 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
       handleDragStart,
     } = this.props;
 
+    const { preview, live } = getPaths(id);
+    const href = isLive ? live : preview;
+
     return (
       <Container
         data-testid="feed-item"
@@ -201,14 +205,13 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
           >
             {(props) => (
               <>
-                <HoverViewButton
-                  hoverText="View"
-                  isLive={isLive}
-                  urlPath={id}
-                  isSnapLink={true}
+                <HoverViewButton hoverText="View" href={href} {...props} />
+                <HoverOphanButton
                   {...props}
+                  isLive={isLive}
+                  href={href}
+                  hoverText="Ophan"
                 />
-                <HoverOphanButton {...props} hoverText="Ophan" />
                 <HoverAddToClipboardButton
                   onAddToClipboard={onAddToClipboard}
                   hoverText="Clipboard"

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -196,19 +196,27 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
         </FeedItemContainer>
         <HoverActionsAreaOverlay data-testid="hover-overlay">
           <HoverActionsButtonWrapper
-            buttons={[
-              { text: 'View', component: HoverViewButton },
-              { text: 'Ophan', component: HoverOphanButton },
-              { text: 'Clipboard', component: HoverAddToClipboardButton },
-            ]}
-            buttonProps={{
-              isLive,
-              urlPath: id,
-              onAddToClipboard,
-            }}
             toolTipPosition={'top'}
             toolTipAlign={'right'}
-          />
+          >
+            {(props) => (
+              <>
+                <HoverViewButton
+                  hoverText="View"
+                  isLive={isLive}
+                  urlPath={id}
+                  isSnapLink={true}
+                  {...props}
+                />
+                <HoverOphanButton {...props} hoverText="Ophan" />
+                <HoverAddToClipboardButton
+                  onAddToClipboard={onAddToClipboard}
+                  hoverText="Clipboard"
+                  {...props}
+                />
+              </>
+            )}
+          </HoverActionsButtonWrapper>
         </HoverActionsAreaOverlay>
       </Container>
     );

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -137,7 +137,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
       handleDragStart,
     } = this.props;
 
-    const { preview, live } = getPaths(id);
+    const { preview, live, ophan } = getPaths(id);
     const href = isLive ? live : preview;
 
     return (
@@ -206,12 +206,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
             {(props) => (
               <>
                 <HoverViewButton hoverText="View" href={href} {...props} />
-                <HoverOphanButton
-                  {...props}
-                  isLive={isLive}
-                  href={href}
-                  hoverText="Ophan"
-                />
+                <HoverOphanButton {...props} href={ophan} hoverText="Ophan" />
                 <HoverAddToClipboardButton
                   onAddToClipboard={onAddToClipboard}
                   hoverText="Clipboard"

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -206,8 +206,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
           <HoverActionsButtonWrapper
             toolTipPosition={'top'}
             toolTipAlign={'right'}
-          >
-            {(props) => (
+            renderButtons={(props) => (
               <>
                 <HoverViewButton hoverText="View" href={href} {...props} />
                 {displayOphanLink && (
@@ -220,7 +219,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
                 />
               </>
             )}
-          </HoverActionsButtonWrapper>
+          />
         </HoverActionsAreaOverlay>
       </Container>
     );

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -21,6 +21,7 @@ import RefreshPeriodically from '../util/RefreshPeriodically';
 import { collectionArticlesPollInterval } from 'constants/polling';
 import RenderOffscreen from 'components/util/RenderOffscreen';
 import { getPaths } from 'util/paths';
+import { CardTypes, CardTypesMap } from 'constants/cardTypes';
 
 const Container = styled.div`
   display: flex;
@@ -99,6 +100,7 @@ const VideoIconContainer = styled(CircularIconContainer)`
 
 interface FeedItemProps {
   id: string;
+  type: CardTypes;
   title: string;
   liveUrl?: string;
   metaContent?: JSX.Element;
@@ -124,6 +126,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
   public render() {
     const {
       id,
+      type,
       title,
       liveUrl,
       isLive,
@@ -139,6 +142,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 
     const { preview, live, ophan } = getPaths(id);
     const href = isLive ? live : preview;
+    const displayOphanLink = type === CardTypesMap.ARTICLE && isLive;
 
     return (
       <Container
@@ -206,7 +210,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
             {(props) => (
               <>
                 <HoverViewButton hoverText="View" href={href} {...props} />
-                {isLive && (
+                {displayOphanLink && (
                   <HoverOphanButton {...props} href={ophan} hoverText="Ophan" />
                 )}
                 <HoverAddToClipboardButton

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -47,7 +47,7 @@ export const RecipeFeedItem = ({ recipe }: ComponentProps) => {
   return (
     <FeedItem
       type={CardTypesMap.RECIPE}
-      id={recipe.id}
+      id={recipe.canonicalArticle}
       title={recipe.title}
       thumbnail={recipe.featuredImage.url}
       liveUrl={`https://theguardian.com/${recipe.canonicalArticle}`}

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -10,6 +10,7 @@ import noop from 'lodash/noop';
 import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
 import { connect } from 'react-redux';
 import { ContentInfo } from './ContentInfo';
+import { CardTypesMap } from 'constants/cardTypes';
 
 interface ComponentProps {
   recipe: Recipe;
@@ -32,6 +33,7 @@ export const RecipeFeedItemComponent = ({
 
   return (
     <FeedItem
+      type={CardTypesMap.RECIPE}
       id={recipe.id}
       title={recipe.title}
       thumbnail={recipe.featuredImage.url}

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -1,26 +1,39 @@
 import { Recipe } from '../../types/Recipe';
 import { FeedItem } from './FeedItem';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { State } from '../../types/State';
 import {
   dragOffsetX,
   dragOffsetY,
 } from '../FrontsEdit/CollectionComponents/ArticleDrag';
-import noop from 'lodash/noop';
 import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
-import { connect } from 'react-redux';
 import { ContentInfo } from './ContentInfo';
 import { CardTypesMap } from 'constants/cardTypes';
+import { useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
+import { insertCardWithCreate } from 'actions/Cards';
 
 interface ComponentProps {
   recipe: Recipe;
-  shouldObscureFeed: boolean;
 }
 
-export const RecipeFeedItemComponent = ({
-  recipe,
-  shouldObscureFeed,
-}: ComponentProps) => {
+export const RecipeFeedItem = ({ recipe }: ComponentProps) => {
+  const shouldObscureFeed = useSelector<State, boolean>((state) =>
+    selectFeatureValue(state, 'obscure-feed')
+  );
+
+  const dispatch = useDispatch();
+
+  const onAddToClipboard = useCallback(() => {
+    dispatch<any>(
+      insertCardWithCreate(
+        { type: 'clipboard', id: 'clipboard', index: 0 },
+        { type: 'RECIPE', data: recipe },
+        'clipboard'
+      )
+    );
+  }, [recipe]);
+
   const handleDragStart = (
     event: React.DragEvent<HTMLDivElement>,
     dragNode: HTMLDivElement
@@ -41,15 +54,9 @@ export const RecipeFeedItemComponent = ({
       hasVideo={false}
       isLive={true} // We do not yet serve preview recipes
       handleDragStart={handleDragStart}
-      onAddToClipboard={noop}
+      onAddToClipboard={onAddToClipboard}
       shouldObscureFeed={shouldObscureFeed}
       metaContent={<ContentInfo>Recipe</ContentInfo>}
     />
   );
 };
-
-const mapStateToProps = (state: State) => ({
-  shouldObscureFeed: selectFeatureValue(state, 'obscure-feed'),
-});
-
-export const RecipeFeedItem = connect(mapStateToProps)(RecipeFeedItemComponent);

--- a/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
@@ -43,14 +43,14 @@ interface WrapperProps {
   size?: CardSizes; // Article Component size
   toolTipPosition: 'top' | 'left' | 'bottom' | 'right';
   toolTipAlign: 'left' | 'center' | 'right';
-  children: (renderProps: ButtonProps) => JSX.Element;
+  renderButtons: (renderProps: ButtonProps) => JSX.Element;
 }
 
 export const HoverActionsButtonWrapper = ({
   toolTipPosition,
   toolTipAlign,
   size,
-  children,
+  renderButtons,
 }: WrapperProps) => {
   const [toolTipText, setToolTipText] = useState<string | undefined>(undefined);
 
@@ -72,7 +72,7 @@ export const HoverActionsButtonWrapper = ({
           <ToolTip text={toolTipText} />
         </ToolTipWrapper>
       ) : null}
-      {children({
+      {renderButtons({
         showToolTip,
         hideToolTip,
         size: size,

--- a/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled } from 'constants/theme';
 import ToolTip from './HoverActionToolTip';
 import { CardSizes } from 'types/Collection';
@@ -33,84 +33,50 @@ const ToolTipWrapper = styled.div<{
       : null};
 `;
 
-interface HoverButtonInterface {
-  text: string;
-  component: React.ComponentType<ButtonPropsFromWrapper>;
-}
-export interface ButtonPropsFromWrapper {
-  showToolTip: () => void;
+export interface ButtonProps {
+  showToolTip: (text: string) => void;
   hideToolTip: () => void;
-  isSnapLink?: boolean;
+  size?: CardSizes;
 }
-interface WrapperProps<ButtonProps> {
-  buttons: HoverButtonInterface[];
-  buttonProps: ButtonProps;
+
+interface WrapperProps {
   size?: CardSizes; // Article Component size
   toolTipPosition: 'top' | 'left' | 'bottom' | 'right';
   toolTipAlign: 'left' | 'center' | 'right';
+  children: (renderProps: ButtonProps) => JSX.Element;
 }
 
-interface WrapperState {
-  isToolTipVisible: boolean;
-  toolTipText: string;
-}
+export const HoverActionsButtonWrapper = ({
+  toolTipPosition,
+  toolTipAlign,
+  size,
+  children,
+}: WrapperProps) => {
+  const [toolTipText, setToolTipText] = useState<string | undefined>(undefined);
 
-class HoverActionsButtonWrapper<ButtonProps> extends React.Component<
-  WrapperProps<ButtonProps>,
-  WrapperState
-> {
-  constructor(props: WrapperProps<ButtonProps>) {
-    super(props);
-    this.state = {
-      isToolTipVisible: false,
-      toolTipText: '',
-    };
-  }
-
-  public render() {
-    const { buttons, buttonProps, toolTipPosition, toolTipAlign } = this.props;
-    const { isToolTipVisible, toolTipText } = this.state;
-
-    return (
-      <HoverActionsWrapper
-        size={this.props.size}
-        data-testid="hover-actions-wrapper"
-      >
-        {isToolTipVisible ? (
-          <ToolTipWrapper
-            toolTipPosition={toolTipPosition}
-            toolTipAlign={toolTipAlign}
-          >
-            <ToolTip text={toolTipText} />
-          </ToolTipWrapper>
-        ) : null}
-        {buttons.map((ButtonObj) => (
-          <ButtonObj.component
-            key={ButtonObj.text}
-            {...buttonProps}
-            showToolTip={() => {
-              this.showToolTip(ButtonObj.text);
-            }}
-            hideToolTip={() => {
-              this.hideToolTip();
-            }}
-          />
-        ))}
-      </HoverActionsWrapper>
-    );
-  }
-
-  private showToolTip = (text: string) =>
-    this.setState({
-      isToolTipVisible: true,
-      toolTipText: text,
-    });
-
-  private hideToolTip = () => {
-    this.setState({
-      isToolTipVisible: false,
-    });
+  const showToolTip = (text: string) => {
+    setToolTipText(text);
   };
-}
 
-export { HoverActionsButtonWrapper, HoverButtonInterface };
+  const hideToolTip = () => {
+    setToolTipText(undefined);
+  };
+
+  return (
+    <HoverActionsWrapper size={size} data-testid="hover-actions-wrapper">
+      {toolTipText !== undefined ? (
+        <ToolTipWrapper
+          toolTipPosition={toolTipPosition}
+          toolTipAlign={toolTipAlign}
+        >
+          <ToolTip text={toolTipText} />
+        </ToolTipWrapper>
+      ) : null}
+      {children({
+        showToolTip,
+        hideToolTip,
+        size: size,
+      })}
+    </HoverActionsWrapper>
+  );
+};

--- a/fronts-client/src/components/inputs/HoverActionButtons.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtons.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ButtonCircular from './ButtonCircular';
 import Link from '../Link';
-import { getPaths } from '../../util/paths';
 import { ButtonProps } from './HoverActionButtonWrapper';
 import {
   AddToClipboardHoverIcon,
@@ -76,28 +75,18 @@ const HoverAddToClipboardButton = ({
 );
 
 const HoverViewButton = ({
-  isLive,
-  urlPath = '',
   showToolTip,
   hideToolTip,
-  isSnapLink = false,
+  href,
   hoverText,
 }: ButtonPropsWithHoverText & {
-  isLive?: boolean;
-  urlPath?: string;
-  isSnapLink?: boolean;
+  href?: string;
 }) => (
   <Link
     onClick={(e: React.MouseEvent) => {
       e.stopPropagation();
     }}
-    href={
-      isSnapLink
-        ? urlPath
-        : isLive
-        ? getPaths(urlPath).live
-        : getPaths(urlPath).preview
-    }
+    href={href}
   >
     <ActionButton
       tabIndex={-1}
@@ -110,39 +99,29 @@ const HoverViewButton = ({
 );
 
 const HoverOphanButton = ({
-  isLive,
-  urlPath,
+  href,
   showToolTip,
   hideToolTip,
-  isSnapLink = false,
   hoverText,
 }: ButtonPropsWithHoverText & {
-  isLive?: boolean;
-  urlPath?: string;
-  isSnapLink?: boolean;
-}) =>
-  isLive ? (
-    <Link
-      onClick={(e: React.MouseEvent) => {
-        e.stopPropagation();
-      }}
-      href={
-        isSnapLink
-          ? urlPath && getPaths(urlPath).ophan
-          : getPaths(`https://www.theguardian.com/${urlPath}`).ophan
-      }
-      data-testid={'ophan-hover-button'}
+  href?: string;
+}) => (
+  <Link
+    onClick={(e: React.MouseEvent) => {
+      e.stopPropagation();
+    }}
+    href={href}
+    data-testid={'ophan-hover-button'}
+  >
+    <ActionButton
+      tabIndex={-1}
+      onMouseEnter={() => showToolTip(hoverText)}
+      onMouseLeave={hideToolTip}
     >
-      <ActionButton
-        tabIndex={-1}
-        onMouseEnter={() => showToolTip(hoverText)}
-        onMouseLeave={hideToolTip}
-      >
-        <OphanHoverIcon />
-      </ActionButton>
-    </Link>
-  ) : null;
-
+      <OphanHoverIcon />
+    </ActionButton>
+  </Link>
+);
 export {
   HoverDeleteButton,
   HoverViewButton,

--- a/fronts-client/src/components/inputs/HoverActionButtons.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtons.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ButtonCircular from './ButtonCircular';
 import Link from '../Link';
 import { getPaths } from '../../util/paths';
-import { ButtonPropsFromWrapper } from './HoverActionButtonWrapper';
+import { ButtonProps } from './HoverActionButtonWrapper';
 import {
   AddToClipboardHoverIcon,
   OphanHoverIcon,
@@ -32,24 +32,20 @@ ActionButton.defaultProps = {
   danger: false,
 };
 
-interface ButtonPropsFromArticle {
-  isLive?: boolean;
-  urlPath?: string;
-  onDelete?: () => void;
-  onAddToClipboard?: () => void;
-}
-
-type ButtonProps = ButtonPropsFromArticle & ButtonPropsFromWrapper;
+type ButtonPropsWithHoverText = ButtonProps & {
+  hoverText: string;
+};
 
 const HoverDeleteButton = ({
   showToolTip,
   hideToolTip,
   onDelete,
-}: ButtonProps) => (
+  hoverText,
+}: ButtonPropsWithHoverText & { onDelete: () => void }) => (
   <ActionButton
     danger
     data-testid={'delete-hover-button'}
-    onMouseEnter={showToolTip}
+    onMouseEnter={() => showToolTip(hoverText)}
     onMouseLeave={hideToolTip}
     onClick={(e: React.MouseEvent) => {
       e.stopPropagation();
@@ -64,10 +60,11 @@ const HoverAddToClipboardButton = ({
   showToolTip,
   hideToolTip,
   onAddToClipboard,
-}: ButtonProps) => (
+  hoverText,
+}: ButtonPropsWithHoverText & { onAddToClipboard: () => void }) => (
   <ActionButton
     data-testid={'add-to-clipboard-hover-button'}
-    onMouseEnter={showToolTip}
+    onMouseEnter={() => showToolTip(hoverText)}
     onMouseLeave={hideToolTip}
     onClick={(e: React.MouseEvent) => {
       e.stopPropagation();
@@ -84,7 +81,12 @@ const HoverViewButton = ({
   showToolTip,
   hideToolTip,
   isSnapLink = false,
-}: ButtonProps) => (
+  hoverText,
+}: ButtonPropsWithHoverText & {
+  isLive?: boolean;
+  urlPath?: string;
+  isSnapLink?: boolean;
+}) => (
   <Link
     onClick={(e: React.MouseEvent) => {
       e.stopPropagation();
@@ -99,7 +101,7 @@ const HoverViewButton = ({
   >
     <ActionButton
       tabIndex={-1}
-      onMouseEnter={showToolTip}
+      onMouseEnter={() => showToolTip(hoverText)}
       onMouseLeave={hideToolTip}
     >
       <ViewHoverIcon />
@@ -113,7 +115,12 @@ const HoverOphanButton = ({
   showToolTip,
   hideToolTip,
   isSnapLink = false,
-}: ButtonProps) =>
+  hoverText,
+}: ButtonPropsWithHoverText & {
+  isLive?: boolean;
+  urlPath?: string;
+  isSnapLink?: boolean;
+}) =>
   isLive ? (
     <Link
       onClick={(e: React.MouseEvent) => {
@@ -128,7 +135,7 @@ const HoverOphanButton = ({
     >
       <ActionButton
         tabIndex={-1}
-        onMouseEnter={showToolTip}
+        onMouseEnter={() => showToolTip(hoverText)}
         onMouseLeave={hideToolTip}
       >
         <OphanHoverIcon />

--- a/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
+++ b/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
@@ -14,29 +14,27 @@ import {
 } from '../HoverActionButtons';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '../../../constants/theme';
+import { noop } from 'lodash';
 
 afterEach(cleanup);
 
-// Mocks //
-const onDelete = () => {};
-const Buttons = [
-  { text: 'View', component: HoverViewButton },
-  { text: 'Ophan', component: HoverOphanButton },
-  { text: 'Delete', component: HoverDeleteButton },
-];
-
 const HoverWrapper = (
   <ThemeProvider theme={theme}>
-    <HoverActionsButtonWrapper
-      buttons={Buttons}
-      buttonProps={{
-        isLive: true,
-        urlPath: 'test-string',
-        onDelete,
-      }}
-      toolTipPosition={'top'}
-      toolTipAlign={'center'}
-    />
+    <HoverActionsButtonWrapper toolTipPosition={'top'} toolTipAlign={'center'}>
+      {(props) => (
+        <>
+          <HoverViewButton
+            hoverText="View"
+            isLive={true}
+            urlPath={'test-string'}
+            isSnapLink={true}
+            {...props}
+          />
+          <HoverOphanButton {...props} isLive={true} hoverText="Ophan" />
+          <HoverDeleteButton onDelete={noop} hoverText="Delete" {...props} />
+        </>
+      )}
+    </HoverActionsButtonWrapper>
   </ThemeProvider>
 );
 
@@ -56,15 +54,28 @@ describe('Hover Action Button Wrapper', () => {
     const { container } = render(
       <ThemeProvider theme={theme}>
         <HoverActionsButtonWrapper
-          buttons={Buttons}
-          buttonProps={{
-            isLive: false, // testing isLive
-            urlPath: 'test-string',
-            onDelete,
-          }}
           toolTipPosition={'top'}
           toolTipAlign={'center'}
-        />
+        >
+          {(props) => (
+            <>
+              <HoverViewButton
+                hoverText="View"
+                isLive={true}
+                urlPath={'test-string'}
+                isSnapLink={true}
+                {...props}
+              />
+              <HoverOphanButton isLive={false} {...props} hoverText="Ophan" />
+
+              <HoverDeleteButton
+                onDelete={noop}
+                hoverText="Delete"
+                {...props}
+              />
+            </>
+          )}
+        </HoverActionsButtonWrapper>
       </ThemeProvider>
     );
 

--- a/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
+++ b/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
@@ -23,14 +23,8 @@ const HoverWrapper = (
     <HoverActionsButtonWrapper toolTipPosition={'top'} toolTipAlign={'center'}>
       {(props) => (
         <>
-          <HoverViewButton
-            hoverText="View"
-            isLive={true}
-            urlPath={'test-string'}
-            isSnapLink={true}
-            {...props}
-          />
-          <HoverOphanButton {...props} isLive={true} hoverText="Ophan" />
+          <HoverViewButton hoverText="View" href={'test-string'} {...props} />
+          <HoverOphanButton {...props} hoverText="Ophan" />
           <HoverDeleteButton onDelete={noop} hoverText="Delete" {...props} />
         </>
       )}
@@ -61,13 +55,10 @@ describe('Hover Action Button Wrapper', () => {
             <>
               <HoverViewButton
                 hoverText="View"
-                isLive={true}
-                urlPath={'test-string'}
-                isSnapLink={true}
+                href={'test-string'}
                 {...props}
               />
-              <HoverOphanButton isLive={false} {...props} hoverText="Ophan" />
-
+              <HoverOphanButton {...props} hoverText="Ophan" />
               <HoverDeleteButton
                 onDelete={noop}
                 hoverText="Delete"

--- a/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
+++ b/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
@@ -20,19 +20,20 @@ afterEach(cleanup);
 
 const HoverWrapper = (
   <ThemeProvider theme={theme}>
-    <HoverActionsButtonWrapper toolTipPosition={'top'} toolTipAlign={'center'}>
-      {(props) => (
+    <HoverActionsButtonWrapper
+      toolTipPosition={'top'}
+      toolTipAlign={'center'}
+      renderButtons={(props) => (
         <>
           <HoverViewButton hoverText="View" href={'test-string'} {...props} />
           <HoverOphanButton {...props} hoverText="Ophan" />
           <HoverDeleteButton onDelete={noop} hoverText="Delete" {...props} />
         </>
       )}
-    </HoverActionsButtonWrapper>
+    />
   </ThemeProvider>
 );
 
-// Tests //
 describe('Hover Action Button Wrapper', () => {
   it('should render Wrapper with Buttons', () => {
     const { container, getByTitle } = render(HoverWrapper);

--- a/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
+++ b/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
@@ -43,41 +43,6 @@ describe('Hover Action Button Wrapper', () => {
     expect(getByTitle('ophan')).toBeTruthy();
     expect(getByTitle('delete')).toBeTruthy();
   });
-
-  it('should render Wrapper without Ophan Button when Draft', () => {
-    const { container } = render(
-      <ThemeProvider theme={theme}>
-        <HoverActionsButtonWrapper
-          toolTipPosition={'top'}
-          toolTipAlign={'center'}
-        >
-          {(props) => (
-            <>
-              <HoverViewButton
-                hoverText="View"
-                href={'test-string'}
-                {...props}
-              />
-              <HoverOphanButton {...props} hoverText="Ophan" />
-              <HoverDeleteButton
-                onDelete={noop}
-                hoverText="Delete"
-                {...props}
-              />
-            </>
-          )}
-        </HoverActionsButtonWrapper>
-      </ThemeProvider>
-    );
-
-    const wrapper = container.firstChild as HTMLElement;
-    expect(wrapper.childNodes.length).toEqual(2);
-    // TODO explicitly check ophanButton is NOT rendered using queryByAltText - solve TS error in testing library
-    const ophanButton = wrapper.querySelector(
-      '[data-testid="ophan-hover-button"]'
-    );
-    expect(ophanButton).toBeFalsy();
-  });
 });
 
 describe('Hover Action Button ToolTip', () => {

--- a/fronts-client/src/util/__tests__/paths.spec.ts
+++ b/fronts-client/src/util/__tests__/paths.spec.ts
@@ -1,11 +1,10 @@
 import { getPaths } from '../paths';
 
-const testURL = `https://www.theguardian.com/society/2018/oct/16/labour-seeks-to-force-publication-of-universal-credit-impact-analysis`;
 const testURLPath = `society/2018/oct/16/labour-seeks-to-force-publication-of-universal-credit-impact-analysis`;
 
 describe('getPaths', () => {
   it('creates correct ophan URI from URL', () => {
-    expect(getPaths(testURL).ophan).toEqual(
+    expect(getPaths(testURLPath).ophan).toEqual(
       'https://dashboard.ophan.co.uk/info?path=/society/2018/oct/16/labour-seeks-to-force-publication-of-universal-credit-impact-analysis'
     );
   });

--- a/fronts-client/src/util/paths.ts
+++ b/fronts-client/src/util/paths.ts
@@ -4,7 +4,7 @@ const getPathFromUri = (uri: string): string | void => {
 };
 
 const ophanURIFromPath = (path: string) =>
-  `https://dashboard.ophan.co.uk/info?path=${path}`;
+  `https://dashboard.ophan.co.uk/info?path=/${path}`;
 
 const liveURIFromPath = (path: string) => `https://www.theguardian.com/${path}`;
 

--- a/fronts-client/src/util/paths.ts
+++ b/fronts-client/src/util/paths.ts
@@ -11,7 +11,10 @@ const liveURIFromPath = (path: string) => `https://www.theguardian.com/${path}`;
 const previewURIFromPath = (path: string) =>
   `https://preview.gutools.co.uk/${path}`;
 
-const getPaths = (uri: string) => {
+export const getPathsForSnap = (path: string) =>
+  getPaths(`https://www.theguardian.com/${path}`);
+
+export const getPaths = (uri: string) => {
   const path = /https:\/\/www\.theguardian.com(.+)/.test(uri)
     ? getPathFromUri(uri)
     : uri;
@@ -28,5 +31,3 @@ const getPaths = (uri: string) => {
         preview: undefined,
       };
 };
-
-export { getPaths };


### PR DESCRIPTION
## What's changed?

Add working hover buttons to recipe cards. The 'view' button takes you to the source article for the recipe (`canonicalArticle`).

I didn't add Ophan – but perhaps that could also refer to the article?

![hover-actions](https://github.com/guardian/facia-tool/assets/7767575/c7d68f18-7340-4ca8-88e6-427dc199b178)

## Implementation notes

This includes a refactor of the hover states to factor out the code that reasons about URLs into the parts of the app that care about them. The problem was that this code didn't know about recipes, and it didn't feel appropriate for a simple hover button to know so much about parts of the app that we know change at a different cadence. The new API is hopefully a little simpler and more idiomatic – opinions welcome.

Tested locally with Fronts and Editions cards of article and snaplink, as well as our new recipe cards.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
