### PR TITLE
Add hover overlay on chef card

### DIFF
--- a/fronts-client/src/components/card/chef/ChefCard.tsx
+++ b/fronts-client/src/components/card/chef/ChefCard.tsx
@@ -16,12 +16,19 @@ import CardHeadingContainer from '../CardHeadingContainer';
 import CardHeading from '../CardHeading';
 import ImageAndGraphWrapper from '../../image/ImageAndGraphWrapper';
 import { ThumbnailSmall } from '../../image/Thumbnail';
+import { HoverActionsAreaOverlay } from '../../CollectionHoverItems';
+import { HoverActionsButtonWrapper } from '../../inputs/HoverActionButtonWrapper';
+import {
+  HoverAddToClipboardButton,
+  HoverDeleteButton,
+  HoverViewButton,
+} from '../../inputs/HoverActionButtons';
 
 interface Props {
   onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
   onDrop?: (d: React.DragEvent<HTMLElement>) => void;
-  onDelete?: (uuid: string) => void;
-  onAddToClipboard?: (uuid: string) => void;
+  onDelete: () => void;
+  onAddToClipboard: () => void;
   onClick?: () => void;
   id: string;
   collectionId?: string;
@@ -79,6 +86,31 @@ export const ChefCard = ({
         <ImageAndGraphWrapper size={size}>
           <ThumbnailSmall url={chef?.bylineLargeImageUrl} />
         </ImageAndGraphWrapper>
+        <HoverActionsAreaOverlay data-testid="hover-overlay">
+          <HoverActionsButtonWrapper
+            toolTipPosition={'top'}
+            toolTipAlign={'right'}
+            renderButtons={(props) => (
+              <>
+                <HoverViewButton
+                  hoverText="View"
+                  href={chef?.webUrl}
+                  {...props}
+                />
+                <HoverAddToClipboardButton
+                  hoverText="Clipboard"
+                  onAddToClipboard={onAddToClipboard}
+                  {...props}
+                />
+                <HoverDeleteButton
+                  hoverText="Delete"
+                  onDelete={onDelete}
+                  {...props}
+                />
+              </>
+            )}
+          />
+        </HoverActionsAreaOverlay>
       </CardBody>
     </CardContainer>
   );

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -1,5 +1,5 @@
 import { Chef } from '../../types/Chef';
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   dragOffsetX,
   dragOffsetY,
@@ -8,9 +8,9 @@ import { FeedItem } from './FeedItem';
 import { ContentInfo } from './ContentInfo';
 import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
 import { State } from '../../types/State';
-import { connect } from 'react-redux';
-import noop from 'lodash/noop';
 import { CardTypesMap } from 'constants/cardTypes';
+import { connect, useDispatch } from 'react-redux';
+import { insertCardWithCreate } from '../../actions/Cards';
 
 interface ComponentProps {
   chef: Chef;
@@ -21,6 +21,18 @@ export const ChefFeedItemComponent = ({
   chef,
   shouldObscureFeed,
 }: ComponentProps) => {
+  const dispatch = useDispatch();
+
+  const onAddToClipboard = useCallback(() => {
+    dispatch<any>(
+      insertCardWithCreate(
+        { type: 'clipboard', id: 'clipboard', index: 0 },
+        { type: 'CHEF', data: chef },
+        'clipboard'
+      )
+    );
+  }, [chef]);
+
   const handleDragStart = (
     event: React.DragEvent<HTMLDivElement>,
     dragNode: HTMLDivElement
@@ -40,7 +52,7 @@ export const ChefFeedItemComponent = ({
       isLive={true}
       liveUrl={`https://theguardian.com/${chef.apiUrl}`}
       thumbnail={chef.bylineLargeImageUrl}
-      onAddToClipboard={noop}
+      onAddToClipboard={onAddToClipboard}
       handleDragStart={handleDragStart}
       shouldObscureFeed={shouldObscureFeed}
       metaContent={<ContentInfo>Chef</ContentInfo>}


### PR DESCRIPTION
## What's changed?
Reference of this work derived from @jonathonherbert 's work on adding hover-overlay on recipe in PR #1577 

This will add overlay on chef cards too with View/Clipboard/Delete options.

https://github.com/guardian/facia-tool/assets/17780995/1f94788c-196b-4418-967a-2b7c0bb5b3d3




## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
