### PR TITLE
Specify Java 11 for SBT Snyk job and remove Java option from non SBT job

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,7 +13,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       ORG: guardian
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
       EXCLUDE: package-lock.json # exclude V1, since it has its own special job below (because of JSPM)
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -22,7 +22,6 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       ORG: guardian
-      JAVA_VERSION: 8
       EXCLUDE: fronts-client # exclude V2, since it's captured by the main job above
       SKIP_SBT: true # exclude scala, since it's captured by the main job above
       NODE_PACKAGE_JSON_FILES_MISSING_LOCK: v1_jspm_snyk_workaround/package.json v1_jspm_snyk_workaround/result/package.json


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

The first Snyk job (`snyk-v2-and-scala`) [hasn't been running properly](https://github.com/guardian/facia-tool/actions/workflows/snyk.yml) since [this commit](https://github.com/guardian/facia-tool/commit/734f4eddc21383a492682dd82d0b04ef4176733a)

- Specifies Java version 11 rather than 8 in main Snyk job (`snyk-V2-and-scala`) which [seems to fix the broken job](https://github.com/guardian/facia-tool/actions/runs/9094064578/job/24994326457)
- Removes Java option from non SBT Snyk job (`snyk-V1-only`)


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
