### PR TITLE
Add new "highlights" container layout

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -15,7 +15,7 @@ class FixedContainers(val config: ApplicationConfiguration) {
 
   val showcase = slices(ShowcaseSingleStories)
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
-  val highlights = slices(QuarterQuarterQuarterQuarter)
+  val highlights = slices(Highlights)
   val video = slices(TTT).copy(customCssClasses = Set("fc-container--video"))
 
   val all: Map[String, ContainerDefinition] = Map(

--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -15,6 +15,7 @@ class FixedContainers(val config: ApplicationConfiguration) {
 
   val showcase = slices(ShowcaseSingleStories)
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
+  val highlights = slices(QuarterQuarterQuarterQuarter)
   val video = slices(TTT).copy(customCssClasses = Set("fc-container--video"))
 
   val all: Map[String, ContainerDefinition] = Map(
@@ -34,6 +35,7 @@ class FixedContainers(val config: ApplicationConfiguration) {
     ("fixed/video", video),
     ("fixed/video/vertical", video),
     ("fixed/thrasher", thrasher),
+    ("fixed/highlights", highlights),
     ("fixed/showcase", showcase)
   ) ++ (if (config.faciatool.showTestContainers) Map(
     ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))

--- a/app/slices/Slice.scala
+++ b/app/slices/Slice.scala
@@ -906,8 +906,16 @@ case object ShowcaseSingleStories extends Slice {
 
 
 /*
- * The Highlights layout is used to display select features above the title piece for apps and web
+ * The Highlights layout is used to display select features in the header for apps and web
  * 
+ * Desktop:
+ * .____________.____________.____________.
+ * |       #####|       #####|       #####|
+ * |       #####|       #####|       #####|
+ * |       #####|       #####|       #####|
+ * '--------------------------------------'
+ * 
+ * Mobile:
  * .___________.___________.___________.
  * |           |           |           |
  * |           |           |           |
@@ -918,27 +926,27 @@ case object ShowcaseSingleStories extends Slice {
  */
 case object Highlights extends Slice {
   val layout = SliceLayout(
-    // cssClassName = "t-t-t",
+    cssClassName = "t-t-t",
     columns = Seq(
       SingleItem(
         colSpan = 1,
         ItemClasses(
-          mobile = Half,
-          tablet = Third
+          mobile = Standard,
+          tablet = MediaList
         )
       ),
       SingleItem(
         colSpan = 1,
         ItemClasses(
-          mobile = Half,
-          tablet = Third
+          mobile = Standard,
+          tablet = MediaList
         )
       ),
       SingleItem(
         colSpan = 1,
         ItemClasses(
-          mobile = Half,
-          tablet = Third
+          mobile = Standard,
+          tablet = MediaList
         )
       )
     )

--- a/app/slices/Slice.scala
+++ b/app/slices/Slice.scala
@@ -903,3 +903,44 @@ case object ShowcaseSingleStories extends Slice {
     ),
   )
 }
+
+
+/*
+ * The Highlights layout is used to display select features above the title piece for apps and web
+ * 
+ * .___________.___________.___________.
+ * |           |           |           |
+ * |           |           |           |
+ * |_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|
+ * `-----------------------------------'
+ */
+case object Highlights extends Slice {
+  val layout = SliceLayout(
+    // cssClassName = "t-t-t",
+    columns = Seq(
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Half,
+          tablet = Third
+        )
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Half,
+          tablet = Third
+        )
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Half,
+          tablet = Third
+        )
+      )
+    )
+  )
+}

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -56,12 +56,12 @@ export default {
             'big'
           ]
         },
-        { name: 'fixed/highlights' },
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },
         { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
-        { 'name': 'fixed/showcase' }
+        { 'name': 'fixed/showcase' },
+        { name: 'fixed/highlights' }
     ],
 
     emailTypes: [

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -3,52 +3,65 @@ export default {
     editions: ['uk', 'us', 'au'],
 
     environmentUrlBase: {
-        prod: 'https://theguardian.com/',
-        code: 'https://m.code.dev-theguardian.com/'
+        'prod': 'https://theguardian.com/',
+        'code': 'https://m.code.dev-theguardian.com/'
     },
 
     types: [
-        { name: 'fixed/small/slow-IV' },
-        { name: 'fixed/medium/fast-XII' },
-        { name: 'fixed/small/slow-III' },
-        { name: 'fixed/small/slow-V-third' },
-        { name: 'fixed/small/slow-I' },
-        { name: 'fixed/medium/slow-VI' },
-        { name: 'fixed/large/slow-XIV' },
-        { name: 'fixed/medium/fast-XI' },
-        { name: 'fixed/medium/slow-XII-mpu' },
+        { 'name': 'fixed/small/slow-IV' },
+        { 'name': 'fixed/medium/fast-XII' },
+        { 'name': 'fixed/small/slow-III' },
+        { 'name': 'fixed/small/slow-V-third' },
+        { 'name': 'fixed/small/slow-I' },
+        { 'name': 'fixed/medium/slow-VI' },
+        { 'name': 'fixed/large/slow-XIV' },
+        { 'name': 'fixed/medium/fast-XI' },
+        { 'name': 'fixed/medium/slow-XII-mpu' },
+        { 'name': 'fixed/thrasher' },
+        { 'name': 'fixed/video' },
+        { 'name': 'fixed/video/vertical' },
+        { 'name': 'fixed/medium/slow-VII' },
+        { 'name': 'fixed/small/fast-VIII' },
+        { 'name': 'fixed/small/slow-V-mpu' },
+        { 'name': 'fixed/small/slow-V-half' },
+        {
+          'name': 'dynamic/fast',
+          'groups': [
+            'standard',
+            'big',
+            'very big',
+            'huge'
+          ]
+        },
+        {
+          'name': 'dynamic/slow',
+          'groups': [
+            'standard',
+            'big',
+            'very big',
+            'huge'
+          ]
+        },
+        {
+          'name': 'dynamic/package',
+          'groups': [
+            'standard',
+            'snap'
+          ]
+        },
+        {
+          'name': 'dynamic/slow-mpu',
+          'groups': [
+            'standard',
+            'big'
+          ]
+        },
         { name: 'fixed/highlights' },
-        { name: 'fixed/thrasher' },
-        { name: 'fixed/video' },
-        { name: 'fixed/video/vertical' },
-        { name: 'fixed/medium/slow-VII' },
-        { name: 'fixed/small/fast-VIII' },
-        { name: 'fixed/small/slow-V-mpu' },
-        { name: 'fixed/small/slow-V-half' },
-        {
-            name: 'dynamic/fast',
-            groups: ['standard', 'big', 'very big', 'huge']
-        },
-        {
-            name: 'dynamic/slow',
-            groups: ['standard', 'big', 'very big', 'huge']
-        },
-        {
-            name: 'dynamic/package',
-            groups: ['standard', 'snap']
-        },
-        {
-            name: 'dynamic/slow-mpu',
-            groups: ['standard', 'big']
-        },
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },
-        {
-            name: 'breaking-news/not-for-other-fronts',
-            groups: ['minor', 'major']
-        },
-        { name: 'fixed/showcase' }
+        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
+        { 'name': 'fixed/showcase' }
     ],
 
     emailTypes: [
@@ -66,7 +79,6 @@ export default {
         'world',
         'sport',
         'football',
-        'soccer',
         'commentisfree',
         'culture',
         'business',
@@ -90,53 +102,64 @@ export default {
     headlineLength: 200,
     restrictedHeadlineLength: 90,
 
-    restrictHeadlinesOn: ['breaking-news'],
+    restrictHeadlinesOn: [
+        'breaking-news'
+    ],
 
-    restrictedLiveMode: ['breaking-news'],
+    restrictedLiveMode: [
+        'breaking-news'
+    ],
 
-    askForConfirmation: ['breaking-news'],
+    askForConfirmation: [
+        'breaking-news'
+    ],
 
-    disableSnapLinks: ['breaking-news'],
+    disableSnapLinks: [
+        'breaking-news'
+    ],
 
-    restrictedEditor: ['breaking-news'],
+    restrictedEditor: [
+        'breaking-news'
+    ],
 
     priorities: {
-        editorial: {
+        'editorial': {
             maxFronts: 210,
             hasGroups: false,
             isTypeLocked: false,
             isHiddenLocked: false
         },
-        commercial: {
+        'commercial': {
             maxFronts: 350,
             hasGroups: true,
             isTypeLocked: false,
             isHiddenLocked: false
         },
-        training: {
+        'training': {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: true,
             isHiddenLocked: true
         },
-        email: {
+        'email': {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: false,
             isHiddenLocked: false
         },
-        edition: {
+        'edition': {
             maxFronts: 350,
             hasGroups: true,
             isTypeLocked: true,
             isHiddenLocked: true
         },
-        showcase: {
+        'showcase': {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: false,
             isHiddenLocked: false
         }
+
     },
     defaultPriority: 'editorial',
 
@@ -156,97 +179,87 @@ export default {
     ],
 
     filterTypes: {
-        section: {
-            display: 'in section:',
-            param: 'section',
-            path: 'sections',
-            placeholder: 'e.g. news'
-        },
-        tag: {
-            display: 'with tag:',
-            param: 'tag',
-            path: 'tags',
-            placeholder: 'e.g. sport/triathlon'
-        }
+        section: { display: 'in section:', param: 'section', path: 'sections', placeholder: 'e.g. news' },
+        tag:     { display: 'with tag:',   param: 'tag',     path: 'tags',     placeholder: 'e.g. sport/triathlon' }
     },
 
-    searchPageSize: 50,
+    searchPageSize:        50,
 
-    capiBatchSize: 10,
+    capiBatchSize:         10,
 
-    maxSlideshowImages: 5,
+    maxSlideshowImages:    5,
 
-    collectionsPollMs: 10000,
-    latestArticlesPollMs: 30000,
-    configSettingsPollMs: 30000,
-    cacheExpiryMs: 60000,
-    sparksRefreshMs: 300000,
-    pubTimeRefreshMs: 30000,
-    searchDebounceMs: 300,
+    collectionsPollMs:     10000,
+    latestArticlesPollMs:  30000,
+    configSettingsPollMs:  30000,
+    cacheExpiryMs:         60000,
+    sparksRefreshMs:      300000,
+    pubTimeRefreshMs:      30000,
+    searchDebounceMs:        300,
     frontAgeAlertMs: {
-        front: 60000 * 2 * 1,
-        editorial: 60000 * 2 * 5,
+        front:      60000 * 2 * 1,
+        editorial:  60000 * 2 * 5,
         commercial: 60000 * 2 * 60
     },
-    failsBeforeError: 2,
+    failsBeforeError:           2,
 
-    highFrequencyPaths: ['uk', 'us', 'au', 'uk/sport', 'us/sport', 'au/sport'],
+    highFrequencyPaths:    ['uk', 'us', 'au', 'uk/sport', 'us/sport', 'au/sport'],
 
-    mainDomain: 'www.theguardian.com',
-    mainDomainShort: 'theguardian.com',
+    mainDomain:            'www.theguardian.com',
+    mainDomainShort:       'theguardian.com',
 
-    apiBase: '',
-    apiSearchBase: '/api/preview',
-    apiLiveBase: '/api/live',
-    apiUsageBase: '/api/usage',
-    apiSearchParams: [
+    apiBase:               '',
+    apiSearchBase:         '/api/preview',
+    apiLiveBase:           '/api/live',
+    apiUsageBase:          '/api/usage',
+    apiSearchParams:       [
         'show-elements=video,main',
         'show-blocks=main',
         'show-tags=all',
         'show-atoms=media',
-        'show-fields=' +
-            [
-                'internalPageCode',
-                'isLive',
-                'firstPublicationDate',
-                'scheduledPublicationDate',
-                'headline',
-                'trailText',
-                'byline',
-                'thumbnail',
-                'secureThumbnail',
-                'liveBloggingNow',
-                'membershipAccess',
-                'shortUrl'
-            ].join(',')
+        'show-fields=' + [
+            'internalPageCode',
+            'isLive',
+            'firstPublicationDate',
+            'scheduledPublicationDate',
+            'headline',
+            'trailText',
+            'byline',
+            'thumbnail',
+            'secureThumbnail',
+            'liveBloggingNow',
+            'membershipAccess',
+            'shortUrl'
+        ].join(',')
     ].join('&'),
 
     draggableTypes: {
         configCollection: 'config-collection'
     },
 
-    frontendApiBase: '/frontend',
 
-    reauthPath: '/login/status',
-    reauthInterval: 60000 * 10, // 10 minutes
-    reauthTimeout: 60000,
+    frontendApiBase:       '/frontend',
 
-    imageCdnDomain: '.guim.co.uk',
-    imageCdnDomainExpr: /^https:\/\/(.*)\.guim\.co\.uk\//,
-    imgIXDomainExpr: /^https:\/\/i\.guim\.co\.uk\/img\/static\//,
-    staticImageCdnDomain: 'https://static.guim.co.uk/',
-    previewBase: 'https://preview.gutools.co.uk',
-    viewerHost: 'viewer.gutools.co.uk',
+    reauthPath:            '/login/status',
+    reauthInterval:        60000 * 10, // 10 minutes
+    reauthTimeout:         60000,
 
-    latestSnapPrefix: 'Latest from ',
+    imageCdnDomain:        '.guim.co.uk',
+    imageCdnDomainExpr:    /^https:\/\/(.*)\.guim\.co\.uk\//,
+    imgIXDomainExpr:       /^https:\/\/i\.guim\.co\.uk\/img\/static\//,
+    staticImageCdnDomain:  'https://static.guim.co.uk/',
+    previewBase:           'https://preview.gutools.co.uk',
+    viewerHost:            'viewer.gutools.co.uk',
 
-    ophanBase: 'https://dashboard.ophan.co.uk/summary',
-    ophanFrontBase: 'https://dashboard.ophan.co.uk/info-front?path=',
-    ophanTrailBase: 'https://dashboard.ophan.co.uk/info?path=',
+    latestSnapPrefix:      'Latest from ',
 
-    internalPagePrefix: 'internal-code/page/',
+    ophanBase:             'https://dashboard.ophan.co.uk/summary',
+    ophanFrontBase:        'https://dashboard.ophan.co.uk/info-front?path=',
+    ophanTrailBase:        'https://dashboard.ophan.co.uk/info?path=',
 
-    sparksBatchQueue: 15,
+    internalPagePrefix:    'internal-code/page/',
+
+    sparksBatchQueue:      15,
 
     platforms: {
         app: 'App',

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -3,64 +3,52 @@ export default {
     editions: ['uk', 'us', 'au'],
 
     environmentUrlBase: {
-        'prod': 'https://theguardian.com/',
-        'code': 'https://m.code.dev-theguardian.com/'
+        prod: 'https://theguardian.com/',
+        code: 'https://m.code.dev-theguardian.com/'
     },
 
     types: [
-        { 'name': 'fixed/small/slow-IV' },
-        { 'name': 'fixed/medium/fast-XII' },
-        { 'name': 'fixed/small/slow-III' },
-        { 'name': 'fixed/small/slow-V-third' },
-        { 'name': 'fixed/small/slow-I' },
-        { 'name': 'fixed/medium/slow-VI' },
-        { 'name': 'fixed/large/slow-XIV' },
-        { 'name': 'fixed/medium/fast-XI' },
-        { 'name': 'fixed/medium/slow-XII-mpu' },
-        { 'name': 'fixed/thrasher' },
-        { 'name': 'fixed/video' },
-        { 'name': 'fixed/video/vertical' },
-        { 'name': 'fixed/medium/slow-VII' },
-        { 'name': 'fixed/small/fast-VIII' },
-        { 'name': 'fixed/small/slow-V-mpu' },
-        { 'name': 'fixed/small/slow-V-half' },
+        { name: 'fixed/small/slow-IV' },
+        { name: 'fixed/medium/fast-XII' },
+        { name: 'fixed/small/slow-III' },
+        { name: 'fixed/small/slow-V-third' },
+        { name: 'fixed/small/slow-I' },
+        { name: 'fixed/medium/slow-VI' },
+        { name: 'fixed/large/slow-XIV' },
+        { name: 'fixed/medium/fast-XI' },
+        { name: 'fixed/medium/slow-XII-mpu' },
+        { name: 'fixed/highlights' },
+        { name: 'fixed/thrasher' },
+        { name: 'fixed/video' },
+        { name: 'fixed/video/vertical' },
+        { name: 'fixed/medium/slow-VII' },
+        { name: 'fixed/small/fast-VIII' },
+        { name: 'fixed/small/slow-V-mpu' },
+        { name: 'fixed/small/slow-V-half' },
         {
-          'name': 'dynamic/fast',
-          'groups': [
-            'standard',
-            'big',
-            'very big',
-            'huge'
-          ]
+            name: 'dynamic/fast',
+            groups: ['standard', 'big', 'very big', 'huge']
         },
         {
-          'name': 'dynamic/slow',
-          'groups': [
-            'standard',
-            'big',
-            'very big',
-            'huge'
-          ]
+            name: 'dynamic/slow',
+            groups: ['standard', 'big', 'very big', 'huge']
         },
         {
-          'name': 'dynamic/package',
-          'groups': [
-            'standard',
-            'snap'
-          ]
+            name: 'dynamic/package',
+            groups: ['standard', 'snap']
         },
         {
-          'name': 'dynamic/slow-mpu',
-          'groups': [
-            'standard',
-            'big'
-          ]
+            name: 'dynamic/slow-mpu',
+            groups: ['standard', 'big']
         },
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },
-        { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
-        { 'name': 'fixed/showcase' }
+        {
+            name: 'breaking-news/not-for-other-fronts',
+            groups: ['minor', 'major']
+        },
+        { name: 'fixed/showcase' }
     ],
 
     emailTypes: [
@@ -78,6 +66,7 @@ export default {
         'world',
         'sport',
         'football',
+        'soccer',
         'commentisfree',
         'culture',
         'business',
@@ -101,64 +90,53 @@ export default {
     headlineLength: 200,
     restrictedHeadlineLength: 90,
 
-    restrictHeadlinesOn: [
-        'breaking-news'
-    ],
+    restrictHeadlinesOn: ['breaking-news'],
 
-    restrictedLiveMode: [
-        'breaking-news'
-    ],
+    restrictedLiveMode: ['breaking-news'],
 
-    askForConfirmation: [
-        'breaking-news'
-    ],
+    askForConfirmation: ['breaking-news'],
 
-    disableSnapLinks: [
-        'breaking-news'
-    ],
+    disableSnapLinks: ['breaking-news'],
 
-    restrictedEditor: [
-        'breaking-news'
-    ],
+    restrictedEditor: ['breaking-news'],
 
     priorities: {
-        'editorial': {
+        editorial: {
             maxFronts: 210,
             hasGroups: false,
             isTypeLocked: false,
             isHiddenLocked: false
         },
-        'commercial': {
+        commercial: {
             maxFronts: 350,
             hasGroups: true,
             isTypeLocked: false,
             isHiddenLocked: false
         },
-        'training': {
+        training: {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: true,
             isHiddenLocked: true
         },
-        'email': {
+        email: {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: false,
             isHiddenLocked: false
         },
-        'edition': {
+        edition: {
             maxFronts: 350,
             hasGroups: true,
             isTypeLocked: true,
             isHiddenLocked: true
         },
-        'showcase': {
+        showcase: {
             maxFronts: 50,
             hasGroups: false,
             isTypeLocked: false,
             isHiddenLocked: false
         }
-
     },
     defaultPriority: 'editorial',
 
@@ -178,87 +156,97 @@ export default {
     ],
 
     filterTypes: {
-        section: { display: 'in section:', param: 'section', path: 'sections', placeholder: 'e.g. news' },
-        tag:     { display: 'with tag:',   param: 'tag',     path: 'tags',     placeholder: 'e.g. sport/triathlon' }
+        section: {
+            display: 'in section:',
+            param: 'section',
+            path: 'sections',
+            placeholder: 'e.g. news'
+        },
+        tag: {
+            display: 'with tag:',
+            param: 'tag',
+            path: 'tags',
+            placeholder: 'e.g. sport/triathlon'
+        }
     },
 
-    searchPageSize:        50,
+    searchPageSize: 50,
 
-    capiBatchSize:         10,
+    capiBatchSize: 10,
 
-    maxSlideshowImages:    5,
+    maxSlideshowImages: 5,
 
-    collectionsPollMs:     10000,
-    latestArticlesPollMs:  30000,
-    configSettingsPollMs:  30000,
-    cacheExpiryMs:         60000,
-    sparksRefreshMs:      300000,
-    pubTimeRefreshMs:      30000,
-    searchDebounceMs:        300,
+    collectionsPollMs: 10000,
+    latestArticlesPollMs: 30000,
+    configSettingsPollMs: 30000,
+    cacheExpiryMs: 60000,
+    sparksRefreshMs: 300000,
+    pubTimeRefreshMs: 30000,
+    searchDebounceMs: 300,
     frontAgeAlertMs: {
-        front:      60000 * 2 * 1,
-        editorial:  60000 * 2 * 5,
+        front: 60000 * 2 * 1,
+        editorial: 60000 * 2 * 5,
         commercial: 60000 * 2 * 60
     },
-    failsBeforeError:           2,
+    failsBeforeError: 2,
 
-    highFrequencyPaths:    ['uk', 'us', 'au', 'uk/sport', 'us/sport', 'au/sport'],
+    highFrequencyPaths: ['uk', 'us', 'au', 'uk/sport', 'us/sport', 'au/sport'],
 
-    mainDomain:            'www.theguardian.com',
-    mainDomainShort:       'theguardian.com',
+    mainDomain: 'www.theguardian.com',
+    mainDomainShort: 'theguardian.com',
 
-    apiBase:               '',
-    apiSearchBase:         '/api/preview',
-    apiLiveBase:           '/api/live',
-    apiUsageBase:          '/api/usage',
-    apiSearchParams:       [
+    apiBase: '',
+    apiSearchBase: '/api/preview',
+    apiLiveBase: '/api/live',
+    apiUsageBase: '/api/usage',
+    apiSearchParams: [
         'show-elements=video,main',
         'show-blocks=main',
         'show-tags=all',
         'show-atoms=media',
-        'show-fields=' + [
-            'internalPageCode',
-            'isLive',
-            'firstPublicationDate',
-            'scheduledPublicationDate',
-            'headline',
-            'trailText',
-            'byline',
-            'thumbnail',
-            'secureThumbnail',
-            'liveBloggingNow',
-            'membershipAccess',
-            'shortUrl'
-        ].join(',')
+        'show-fields=' +
+            [
+                'internalPageCode',
+                'isLive',
+                'firstPublicationDate',
+                'scheduledPublicationDate',
+                'headline',
+                'trailText',
+                'byline',
+                'thumbnail',
+                'secureThumbnail',
+                'liveBloggingNow',
+                'membershipAccess',
+                'shortUrl'
+            ].join(',')
     ].join('&'),
 
     draggableTypes: {
         configCollection: 'config-collection'
     },
 
+    frontendApiBase: '/frontend',
 
-    frontendApiBase:       '/frontend',
+    reauthPath: '/login/status',
+    reauthInterval: 60000 * 10, // 10 minutes
+    reauthTimeout: 60000,
 
-    reauthPath:            '/login/status',
-    reauthInterval:        60000 * 10, // 10 minutes
-    reauthTimeout:         60000,
+    imageCdnDomain: '.guim.co.uk',
+    imageCdnDomainExpr: /^https:\/\/(.*)\.guim\.co\.uk\//,
+    imgIXDomainExpr: /^https:\/\/i\.guim\.co\.uk\/img\/static\//,
+    staticImageCdnDomain: 'https://static.guim.co.uk/',
+    previewBase: 'https://preview.gutools.co.uk',
+    viewerHost: 'viewer.gutools.co.uk',
 
-    imageCdnDomain:        '.guim.co.uk',
-    imageCdnDomainExpr:    /^https:\/\/(.*)\.guim\.co\.uk\//,
-    imgIXDomainExpr:       /^https:\/\/i\.guim\.co\.uk\/img\/static\//,
-    staticImageCdnDomain:  'https://static.guim.co.uk/',
-    previewBase:           'https://preview.gutools.co.uk',
-    viewerHost:            'viewer.gutools.co.uk',
+    latestSnapPrefix: 'Latest from ',
 
-    latestSnapPrefix:      'Latest from ',
+    ophanBase: 'https://dashboard.ophan.co.uk/summary',
+    ophanFrontBase: 'https://dashboard.ophan.co.uk/info-front?path=',
+    ophanTrailBase: 'https://dashboard.ophan.co.uk/info?path=',
 
-    ophanBase:             'https://dashboard.ophan.co.uk/summary',
-    ophanFrontBase:        'https://dashboard.ophan.co.uk/info-front?path=',
-    ophanTrailBase:        'https://dashboard.ophan.co.uk/info?path=',
+    internalPagePrefix: 'internal-code/page/',
 
-    internalPagePrefix:    'internal-code/page/',
-
-    sparksBatchQueue:      15,
+    sparksBatchQueue: 15,
 
     platforms: {
         app: 'App',


### PR DESCRIPTION
> Co-authored-by: Wai Sing Yiu <wai.sing.yiu@guardian.co.uk>
> Co-authored-by: Frederick O'Brien <frederick.obrien@guardian.co.uk>


## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Adds new container layout for use as the _"highlights"_ container.

This is a new container layout intended to only be used once per front, in the first position only. This is intended to be guided by training and not enforcement in the tool.

If the first container on a front has this highlights layout, it will be positioned above the title piece/nav sections on both web and apps to showcase feature stories across the site.

The display on desktop is to show three content items and a "peek" of the fourth item.
On mobile and apps it will display two content items and a "peek" of the third item.

## How to test

We deployed the changes to `CODE`.  The Config Tool displayed the new layout type `fixed/highlights` in the drop down list for layout type properly:

<img width="800" alt="Screenshot 2024-05-30 at 10 42 03" src="https://github.com/guardian/facia-tool/assets/89925410/bff40f23-b95c-4600-a618-63e94ddd2161">

The new layout type `fixed/highlights` could be selected:

<img width="790" alt="Screenshot 2024-05-30 at 10 42 25" src="https://github.com/guardian/facia-tool/assets/89925410/f07cb654-1135-4c59-82f8-2a315df464b6">

After saving the container, I could see the new layout type in the output file `config.json` in S3:

<img width="364" alt="Screenshot 2024-05-30 at 10 45 29" src="https://github.com/guardian/facia-tool/assets/89925410/058ff660-fb00-42c0-88af-32ade6e08068">

I reopened the config tool and the container was reloaded with the correct `fixed/highlights` type.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

When this PR is merged, the new layout type `fixed/highlights` will be available on the config tool, but it should not be used until we support this type of container on web/app.

We discussed this issue with the team (homepage redesign) and Jonathan Haynes.  Given that the number of people using the tool in production is quite low, Jonathan believed that it should be sufficient just to make front editors aware that this new layout type should not be used for now.

We should inform users (and Jonathan) before we merge this PR. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [X] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [X] 📷 Screenshots / GIFs of relevant UI changes included
