### PR TITLE
Don't poll every second for switchboard changes

### DIFF
--- a/app/switchboard/Switchboard.scala
+++ b/app/switchboard/Switchboard.scala
@@ -21,7 +21,7 @@ class Lifecycle(conf: SwitchboardConfiguration, scheduler: Scheduler) extends Lo
 
   logger.info("Starting switchboard cache")
   scheduler.scheduleWithFixedDelay(0.seconds, 1.minute) { () => refreshSwitches() }
-  scheduler.scheduleWithFixedDelay(0.seconds, 1.seconds) { () => refreshSwitches() }
+  scheduler.scheduleOnce(0.seconds) { () => refreshSwitches() }
 
   def refreshSwitches(): Unit = {
     logger.info("Refreshing switches from switchboard")


### PR DESCRIPTION
## What's changed?

Seems excessive. Suspect inadvertently introduced in https://github.com/guardian/facia-tool/pull/1543. Spotting as local was busily logging.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
