### PR TITLE
Update election notifications title

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -36,7 +36,7 @@ object BreakingNewsUpdate {
 
   def createPayload(trail: ClientHydratedTrail, email: String): BreakingNewsPayload = {
     val title = trail.topic match {
-      case Some("uk-general-election") => Some("General election 2019")
+      case Some("uk-general-election") => Some("UK general election")
       case Some(topic) if (SportBreakingNewsTopics.map(_.name) :+ SportGlobalTopicName).contains(topic) => Some("Sport breaking news")
       case _ => None
     }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Editorial want to reinstate the UK General Election breaking news alert, the hardcoded title was still referring to the last general election in 2019. This PR updates it to be "UK general election"

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
