### PR TITLE
Add ui to switch between recipes and chefs feeds

### DIFF
--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -2,7 +2,7 @@ import ClipboardHeader from 'components/ClipboardHeader';
 import TextInput from 'components/inputs/TextInput';
 import ShortVerticalPinline from 'components/layout/ShortVerticalPinline';
 import { styled } from 'constants/theme';
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { selectors as recipeSelectors } from 'bundles/recipesBundle';
 import { selectors as chefSelectors } from 'bundles/chefsBundle';
@@ -13,6 +13,7 @@ import { SearchResultsHeadingContainer } from './SearchResultsHeadingContainer';
 import { SearchTitle } from './SearchTitle';
 import { RecipeFeedItem } from './RecipeFeedItem';
 import { ChefFeedItem } from './ChefFeedItem';
+import { RadioButton, RadioGroup } from '../inputs/RadioButtons';
 
 const InputContainer = styled.div`
   margin-bottom: 10px;
@@ -38,34 +39,53 @@ const FeastSearchContainerComponent = ({
   rightHandContainer,
   recipes,
   chefs,
-}: Props) => (
-  <React.Fragment>
-    <InputContainer>
-      <TextInputContainer>
-        <TextInput placeholder="Search recipes" displaySearchIcon />
-      </TextInputContainer>
-      <ClipboardHeader />
-    </InputContainer>
-    <FixedContentContainer>
-      <SearchResultsHeadingContainer>
-        <SearchTitle>
-          {'Results'}
-          <ShortVerticalPinline />
-        </SearchTitle>
-      </SearchResultsHeadingContainer>
-      {Object.values(recipes).map((recipe) => (
-        <RecipeFeedItem key={recipe.id} recipe={recipe} />
-      ))}
-      {Object.values(chefs).map((chef) => (
-        <ChefFeedItem
-          key={chef.id}
-          chef={chef}
-        /> /*TODO: as of now, added rendering of chefs just after the recipes. Need
-      to change when "search-chefs" action gets finalised*/
-      ))}
-    </FixedContentContainer>
-  </React.Fragment>
-);
+}: Props) => {
+  const [selectedOption, setSelectedOption] = useState<string>('recipeFeed');
+  const handleOptionChange = (optionName: string) => {
+    setSelectedOption(optionName);
+  };
+  return (
+    <React.Fragment>
+      <InputContainer>
+        <TextInputContainer>
+          <TextInput placeholder="Search recipes" displaySearchIcon />
+        </TextInputContainer>
+        <ClipboardHeader />
+      </InputContainer>
+      <RadioGroup>
+        <RadioButton
+          checked={selectedOption === 'recipeFeed'}
+          onChange={() => handleOptionChange('recipeFeed')}
+          label="Recipes"
+          inline
+          name="recipeFeed"
+        />
+        <RadioButton
+          checked={selectedOption === 'chefFeed'}
+          onChange={() => handleOptionChange('chefFeed')}
+          label="Chefs"
+          inline
+          name="chefFeed"
+        />
+      </RadioGroup>
+      <FixedContentContainer>
+        <SearchResultsHeadingContainer>
+          <SearchTitle>
+            {'Results'}
+            <ShortVerticalPinline />
+          </SearchTitle>
+        </SearchResultsHeadingContainer>
+        {selectedOption === 'recipeFeed'
+          ? Object.values(recipes).map((recipe) => (
+              <RecipeFeedItem key={recipe.id} recipe={recipe} />
+            ))
+          : Object.values(chefs).map((chef) => (
+              <ChefFeedItem key={chef.id} chef={chef} />
+            ))}
+      </FixedContentContainer>
+    </React.Fragment>
+  );
+};
 
 const mapStateToProps = (state: State) => ({
   recipes: recipeSelectors.selectAll(state),

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -35,15 +35,34 @@ interface Props {
   chefs: Record<string, Chef>;
 }
 
+enum FeedType {
+  recipes = 'recipeFeed',
+  chefs = 'chefFeed',
+}
+
 const FeastSearchContainerComponent = ({
   rightHandContainer,
   recipes,
   chefs,
 }: Props) => {
-  const [selectedOption, setSelectedOption] = useState<string>('recipeFeed');
-  const handleOptionChange = (optionName: string) => {
+  const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
+  const handleOptionChange = (optionName: FeedType) => {
     setSelectedOption(optionName);
   };
+
+  const renderTheFeed = () => {
+    switch (selectedOption) {
+      case FeedType.recipes:
+        return Object.values(recipes).map((recipe) => (
+          <RecipeFeedItem key={recipe.id} recipe={recipe} />
+        ));
+      case FeedType.chefs:
+        return Object.values(chefs).map((chef) => (
+          <ChefFeedItem key={chef.id} chef={chef} />
+        ));
+    }
+  };
+
   return (
     <React.Fragment>
       <InputContainer>
@@ -54,15 +73,15 @@ const FeastSearchContainerComponent = ({
       </InputContainer>
       <RadioGroup>
         <RadioButton
-          checked={selectedOption === 'recipeFeed'}
-          onChange={() => handleOptionChange('recipeFeed')}
+          checked={selectedOption === FeedType.recipes}
+          onChange={() => handleOptionChange(FeedType.recipes)}
           label="Recipes"
           inline
           name="recipeFeed"
         />
         <RadioButton
-          checked={selectedOption === 'chefFeed'}
-          onChange={() => handleOptionChange('chefFeed')}
+          checked={selectedOption === FeedType.chefs}
+          onChange={() => handleOptionChange(FeedType.chefs)}
           label="Chefs"
           inline
           name="chefFeed"
@@ -75,13 +94,7 @@ const FeastSearchContainerComponent = ({
             <ShortVerticalPinline />
           </SearchTitle>
         </SearchResultsHeadingContainer>
-        {selectedOption === 'recipeFeed'
-          ? Object.values(recipes).map((recipe) => (
-              <RecipeFeedItem key={recipe.id} recipe={recipe} />
-            ))
-          : Object.values(chefs).map((chef) => (
-              <ChefFeedItem key={chef.id} chef={chef} />
-            ))}
+        {renderTheFeed()}
       </FixedContentContainer>
     </React.Fragment>
   );

--- a/fronts-client/src/components/feed/SearchResultsHeadingContainer.tsx
+++ b/fronts-client/src/components/feed/SearchResultsHeadingContainer.tsx
@@ -4,6 +4,7 @@ export const SearchResultsHeadingContainer = styled.div`
   border-top: 1px solid ${theme.colors.greyVeryLight};
   align-items: baseline;
   display: flex;
+  margin-top: 10px;
   margin-bottom: 10px;
   flex-direction: row;
 `;


### PR DESCRIPTION
## What's changed?

This will add radio buttons to switch between recipes and chefs feeds. 
Based on selection the result will display accordingly.
At present data for both recipes and chefs are based on fixture data and will be replaced by live items soon.

ref: https://trello.com/c/GlwlhweJ/2935-add-ui-for-switching-between-different-searches
Note: Search functionality is not done in this PR, will be covered in next task.


https://github.com/guardian/facia-tool/assets/17780995/a38de0e9-8a25-4a65-9261-a038e7e97b7d

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
