### PR TITLE
Add recipe collection card

### DIFF
--- a/app/model/editions/EditionsCard.scala
+++ b/app/model/editions/EditionsCard.scala
@@ -1,6 +1,6 @@
 package model.editions
 
-import enumeratum.EnumEntry.Uncapitalised
+import enumeratum.EnumEntry.{Uncapitalised, Hyphencase}
 import enumeratum.{EnumEntry, PlayEnum}
 import logging.Logging
 import play.api.libs.json.{JsResult, Json, OFormat}
@@ -61,12 +61,13 @@ object CardMetadata {
   val default = CardMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None, None)
 }
 
-sealed abstract class CardType extends EnumEntry with Uncapitalised
+sealed abstract class CardType extends EnumEntry with Uncapitalised with Hyphencase
 
 object CardType extends PlayEnum[CardType] {
   case object Article extends CardType
   case object Recipe extends CardType
   case object Chef extends CardType
+  case object FeastCollection extends CardType
   override def values = findValues
 }
 

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAdd.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAdd.tsx
@@ -1,0 +1,53 @@
+import React, { useRef } from 'react';
+import { DragIcon } from 'components/icons/Icons';
+import { styled, theme } from 'constants/theme';
+import RenderOffscreen from 'components/util/RenderOffscreen';
+
+const DragToAddSnapContainer = styled.div`
+  border-top: 1px solid ${theme.card.border};
+  background-color: ${theme.colors.whiteMedium};
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 18px;
+  padding: 0 5px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.colors.whiteDark};
+  }
+  > a {
+    text-decoration: none;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+`;
+
+interface Props {
+  onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
+  testId?: string;
+  dragImage: React.ReactNode;
+  dragImageRef: React.Ref<HTMLDivElement>;
+}
+
+export const DragToAdd: React.FC<Props> = ({
+  onDragStart,
+  testId,
+  dragImage,
+  dragImageRef,
+  children,
+}) => {
+  return (
+    <>
+      <RenderOffscreen ref={dragImageRef}>{dragImage}</RenderOffscreen>
+      <DragToAddSnapContainer
+        data-testid={testId}
+        onDragStart={onDragStart}
+        draggable={true}
+      >
+        <DragIcon />
+        {children}
+      </DragToAddSnapContainer>
+    </>
+  );
+};

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAdd.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAdd.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { DragIcon } from 'components/icons/Icons';
 import { styled, theme } from 'constants/theme';
 import RenderOffscreen from 'components/util/RenderOffscreen';

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
@@ -1,0 +1,45 @@
+import React, { useRef } from 'react';
+import v4 from 'uuid/v4';
+
+import {
+  DraggingArticleComponent,
+  dragOffsetX,
+  dragOffsetY,
+} from './ArticleDrag';
+import { DragToAdd } from './DragToAdd';
+import { Card } from 'types/Collection';
+
+const handleDragStart = (
+  event: React.DragEvent<HTMLDivElement>,
+  dragImageElement: HTMLDivElement | null
+) => {
+  const feastCollectionCard: Card = {
+    cardType: 'feast-collection',
+    id: v4(),
+    meta: {},
+    uuid: v4(),
+    frontPublicationDate: Date.now(),
+  };
+  event.dataTransfer.setData(
+    'feast-collection',
+    JSON.stringify(feastCollectionCard)
+  );
+  if (dragImageElement) {
+    event.dataTransfer.setDragImage(dragImageElement, dragOffsetX, dragOffsetY);
+  }
+};
+
+export const DragToAddFeastCollection = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <DragToAdd
+      dragImage={<DraggingArticleComponent headline="Feast collection" />}
+      dragImageRef={ref}
+      onDragStart={(e: React.DragEvent<HTMLDivElement>) =>
+        handleDragStart(e, ref.current)
+      }
+    >
+      Drag to add a feast collection
+    </DragToAdd>
+  );
+};

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
@@ -8,20 +8,21 @@ import {
 } from './ArticleDrag';
 import { DragToAdd } from './DragToAdd';
 import { Card } from 'types/Collection';
+import { CardTypesMap } from 'constants/cardTypes';
 
 const handleDragStart = (
   event: React.DragEvent<HTMLDivElement>,
   dragImageElement: HTMLDivElement | null
 ) => {
   const feastCollectionCard: Card = {
-    cardType: 'feast-collection',
+    cardType: CardTypesMap.FEAST_COLLECTION,
     id: v4(),
     meta: {},
     uuid: v4(),
     frontPublicationDate: Date.now(),
   };
   event.dataTransfer.setData(
-    'feast-collection',
+    CardTypesMap.FEAST_COLLECTION,
     JSON.stringify(feastCollectionCard)
   );
   if (dragImageElement) {

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddSnap.tsx
@@ -1,33 +1,12 @@
 import React, { useRef } from 'react';
 import v4 from 'uuid/v4';
-import { DragIcon } from 'components/icons/Icons';
-import { styled, theme } from 'constants/theme';
-import RenderOffscreen from 'components/util/RenderOffscreen';
+
 import {
   DraggingArticleComponent,
   dragOffsetX,
   dragOffsetY,
 } from './ArticleDrag';
-
-const DragToAddSnapContainer = styled.div`
-  border-top: 1px solid ${theme.card.border};
-  background-color: ${theme.colors.whiteMedium};
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 18px;
-  padding: 0 5px;
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${theme.colors.whiteDark};
-  }
-  > a {
-    text-decoration: none;
-    &:hover {
-      text-decoration: none;
-    }
-  }
-`;
+import { DragToAdd } from './DragToAdd';
 
 const handleDragStart = (
   event: React.DragEvent<HTMLDivElement>,
@@ -55,20 +34,16 @@ const handleDragStart = (
 const DragToAddTextSnap = () => {
   const ref = useRef<HTMLDivElement>(null);
   return (
-    <>
-      <RenderOffscreen ref={ref}>
-        <DraggingArticleComponent headline="Free text snaplink" />
-      </RenderOffscreen>
-      <DragToAddSnapContainer
-        data-testid="drag-to-add-snap"
-        onDragStart={(e: React.DragEvent<HTMLDivElement>) =>
-          handleDragStart(e, ref.current)
-        }
-        draggable={true}
-      >
-        <DragIcon /> Drag to add a text card
-      </DragToAddSnapContainer>
-    </>
+    <DragToAdd
+      dragImage={<DraggingArticleComponent headline="Free text snaplink" />}
+      dragImageRef={ref}
+      testId="drag-to-add-snap"
+      onDragStart={(e: React.DragEvent<HTMLDivElement>) =>
+        handleDragStart(e, ref.current)
+      }
+    >
+      Drag to add a text card
+    </DragToAdd>
   );
 };
 

--- a/fronts-client/src/components/FrontsEdit/FrontContainer.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContainer.tsx
@@ -14,6 +14,7 @@ import {
   editorOpenAllCollectionsForFront,
   editorCloseAllCollectionsForFront,
 } from 'bundles/frontsUI/thunks';
+import { selectors as editionsIssueSelectors } from '../../bundles/editionsIssueBundle';
 import { CardSets, Card as TCard } from 'types/Collection';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 import { setFocusState } from 'bundles/focusBundle';
@@ -28,6 +29,7 @@ import FrontContent from './FrontContent';
 import DragToAddSnap from './CollectionComponents/DragToAddSnap';
 import { selectPriority } from 'selectors/pathSelectors';
 import { Priorities } from 'types/Priority';
+import { DragToAddFeastCollection } from './CollectionComponents/DragToAddFeastCollection';
 
 const FrontWrapper = styled.div`
   height: 100%;
@@ -54,7 +56,7 @@ const OverviewToggleContainer = styled.div<{ active: boolean }>`
   cursor: pointer;
 `;
 
-const DragToAddSnapContainer = styled.div`
+const DragToAddContainer = styled.div`
   margin-right: auto;
   margin-bottom: 10px;
   margin-top: 10px;
@@ -113,6 +115,7 @@ type FrontProps = FrontPropsBeforeState & {
   overviewIsOpen: boolean;
   editorOpenAllCollectionsForFront: typeof editorOpenAllCollectionsForFront;
   editorCloseAllCollectionsForFront: typeof editorCloseAllCollectionsForFront;
+  isFeast: boolean;
 };
 
 interface FrontState {
@@ -133,7 +136,7 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
   };
 
   public render() {
-    const { overviewIsOpen, id, browsingStage, priority } = this.props;
+    const { overviewIsOpen, id, browsingStage, priority, isFeast } = this.props;
     return (
       <React.Fragment>
         <div
@@ -151,9 +154,14 @@ class FrontContainer extends React.Component<FrontProps, FrontState> {
           <FrontContentContainer>
             <SectionContentMetaContainer>
               {priority === 'email' && (
-                <DragToAddSnapContainer>
+                <DragToAddContainer>
                   <DragToAddSnap />
-                </DragToAddSnapContainer>
+                </DragToAddContainer>
+              )}
+              {isFeast && (
+                <DragToAddContainer>
+                  <DragToAddFeastCollection />
+                </DragToAddContainer>
               )}
               <OverviewHeadingButton onClick={this.handleOpenCollections}>
                 <ButtonLabel>Expand all&nbsp;</ButtonLabel>
@@ -246,6 +254,7 @@ const mapStateToProps = (state: State, { id }: FrontPropsBeforeState) => {
   return {
     overviewIsOpen: selectIsFrontOverviewOpen(state, id),
     priority: selectPriority(state),
+    isFeast: editionsIssueSelectors.selectAll(state)?.platform === 'feast',
   };
 };
 

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -53,6 +53,7 @@ import { CardTypes, CardTypesMap } from 'constants/cardTypes';
 import { RecipeCard } from 'components/card/recipe/RecipeCard';
 import { ChefCard } from 'components/card/chef/ChefCard';
 import { ChefMetaForm } from '../form/ChefMetaForm';
+import { FeastCollectionCard } from './feastCollection/FeastCollectionCard';
 import { selectCollectionType } from 'selectors/frontsSelectors';
 import { Criteria } from 'types/Grid';
 import { Card as CardType } from 'types/Collection';
@@ -253,6 +254,29 @@ class Card extends React.Component<CardContainerProps> {
                 textSize={textSize}
                 showMeta={showMeta}
               />
+            </>
+          );
+        case CardTypesMap.FEAST_COLLECTION:
+          return (
+            <>
+              <FeastCollectionCard
+                frontId={frontId}
+                collectionId={collectionId}
+                id={uuid}
+                isUneditable={isUneditable}
+                {...getNodeProps()}
+                onDelete={this.onDelete}
+                onAddToClipboard={this.handleAddToClipboard}
+                onClick={isUneditable ? undefined : () => onSelect(uuid)}
+                size={size}
+                textSize={textSize}
+                showMeta={showMeta}
+              />
+              {getSublinks}
+              {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
+              {numSupportingArticles === 0
+                ? children
+                : this.state.showCardSublinks && children}
             </>
           );
         default:

--- a/fronts-client/src/components/card/feastCollection/FeastCollectionCard.tsx
+++ b/fronts-client/src/components/card/feastCollection/FeastCollectionCard.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Card, CardSizes } from '../../../types/Collection';
+import { useSelector } from 'react-redux';
+import { selectCard } from '../../../selectors/shared';
+import { State } from '../../../types/State';
+import CardContainer from '../CardContainer';
+import CardBody from '../CardBody';
+import CardMetaHeading from '../CardMetaHeading';
+import CardMetaContainer from '../CardMetaContainer';
+import CardContent from '../CardContent';
+import CardSettingsDisplay from '../CardSettingsDisplay';
+import CardHeadingContainer from '../CardHeadingContainer';
+import CardHeading from '../CardHeading';
+import { HoverActionsAreaOverlay } from '../../CollectionHoverItems';
+import { HoverActionsButtonWrapper } from '../../inputs/HoverActionButtonWrapper';
+import {
+  HoverAddToClipboardButton,
+  HoverDeleteButton,
+} from '../../inputs/HoverActionButtons';
+
+interface Props {
+  onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
+  onDrop?: (d: React.DragEvent<HTMLElement>) => void;
+  onDelete: () => void;
+  onAddToClipboard: () => void;
+  onClick?: () => void;
+  id: string;
+  collectionId?: string;
+  frontId: string;
+  draggable?: boolean;
+  size?: CardSizes;
+  textSize?: CardSizes;
+  fade?: boolean;
+  children?: React.ReactNode;
+  isUneditable?: boolean;
+  showMeta?: boolean;
+}
+
+export const FeastCollectionCard = ({
+  id,
+  fade,
+  size = 'default',
+  textSize = 'default',
+  onDelete,
+  onAddToClipboard,
+  children,
+  isUneditable,
+  collectionId,
+  frontId,
+  showMeta = true,
+  ...rest
+}: Props) => {
+  const card = useSelector<State, Card>((state) => selectCard(state, id));
+
+  return (
+    <>
+      <CardContainer {...rest}>
+        <CardBody data-testid="snap" size={size} fade={fade}>
+          {showMeta && (
+            <CardMetaContainer size={size}>
+              <CardMetaHeading>Recipe collection</CardMetaHeading>
+            </CardMetaContainer>
+          )}
+          <CardContent textSize={textSize}>
+            <CardSettingsDisplay
+              isBreaking={card.meta?.isBreaking}
+              showByline={card.meta?.showByline}
+              showQuotedHeadline={card.meta?.showQuotedHeadline}
+              showLargeHeadline={card.meta?.showLargeHeadline}
+              isBoosted={card.meta?.isBoosted}
+            />
+            <CardHeadingContainer size={size}>
+              <CardHeading data-testid="headline" html>
+                Recipe collection
+              </CardHeading>
+            </CardHeadingContainer>
+          </CardContent>
+          <HoverActionsAreaOverlay data-testid="hover-overlay">
+            <HoverActionsButtonWrapper
+              toolTipPosition={'top'}
+              toolTipAlign={'right'}
+              renderButtons={(props) => (
+                <>
+                  <HoverAddToClipboardButton
+                    hoverText="Clipboard"
+                    onAddToClipboard={onAddToClipboard}
+                    {...props}
+                  />
+                  <HoverDeleteButton
+                    hoverText="Delete"
+                    onDelete={onDelete}
+                    {...props}
+                  />
+                </>
+              )}
+            />
+          </HoverActionsAreaOverlay>
+        </CardBody>
+      </CardContainer>
+      {children}
+    </>
+  );
+};

--- a/fronts-client/src/constants/cardTypes.ts
+++ b/fronts-client/src/constants/cardTypes.ts
@@ -3,6 +3,7 @@ export const CardTypesMap = {
   ARTICLE: 'article',
   RECIPE: 'recipe',
   CHEF: 'chef',
+  FEAST_COLLECTION: 'feast-collection',
 } as const;
 
 export type CardTypes = (typeof CardTypesMap)[keyof typeof CardTypesMap];

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -31,7 +31,7 @@ import {
   isValidURL,
 } from 'util/url';
 import { Recipe } from '../types/Recipe';
-import type { CardTypes } from '../constants/cardTypes';
+import { CardTypesMap, type CardTypes } from '../constants/cardTypes';
 import { Chef } from '../types/Chef';
 
 interface CreateCardOptions {
@@ -283,18 +283,18 @@ const getCardEntitiesFromDrop = async (
 };
 
 const getChefEntityFromFeedDrop = (chef: Chef): [Card] => {
-  const card = createCard(chef.id, false, { cardType: 'chef' });
+  const card = createCard(chef.id, false, { cardType: CardTypesMap.CHEF });
   return [card];
 };
 
 const getRecipeEntityFromFeedDrop = (recipe: Recipe): [Card] => {
-  const card = createCard(recipe.id, false, { cardType: 'recipe' });
+  const card = createCard(recipe.id, false, { cardType: CardTypesMap.RECIPE });
 
   return [card];
 };
 
 const getFeastCollectionFromFeedDrop = (): [Card] => {
-  return [createCard(v4(), false, { cardType: 'feast-collection' })];
+  return [createCard(v4(), false, { cardType: CardTypesMap.FEAST_COLLECTION })];
 };
 
 const getArticleEntitiesFromFeedDrop = (

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -175,6 +175,10 @@ const getCardEntitiesFromDrop = async (
     return getChefEntityFromFeedDrop(drop.data);
   }
 
+  if (drop.type === 'FEAST_COLLECTION') {
+    return getFeastCollectionFromFeedDrop();
+  }
+
   const droppedDataURL = drop.data.trim();
   const resourceIdOrUrl = isGoogleRedirectUrl(droppedDataURL)
     ? getRelevantURLFromGoogleRedirectURL(droppedDataURL)
@@ -287,6 +291,10 @@ const getRecipeEntityFromFeedDrop = (recipe: Recipe): [Card] => {
   const card = createCard(recipe.id, false, { cardType: 'recipe' });
 
   return [card];
+};
+
+const getFeastCollectionFromFeedDrop = (): [Card] => {
+  return [createCard(v4(), false, { cardType: 'feast-collection' })];
 };
 
 const getArticleEntitiesFromFeedDrop = (

--- a/fronts-client/src/util/collectionUtils.ts
+++ b/fronts-client/src/util/collectionUtils.ts
@@ -5,6 +5,7 @@ import { insertCardWithCreate } from 'actions/Cards';
 import { CapiArticle } from 'types/Capi';
 import { Recipe } from '../types/Recipe';
 import { Chef } from '../types/Chef';
+import { CardTypesMap } from 'constants/cardTypes';
 
 export interface RefDrop {
   type: 'REF';
@@ -25,7 +26,16 @@ export interface ChefDrop {
   data: Chef;
 }
 
-export type MappableDropType = RefDrop | CAPIDrop | RecipeDrop | ChefDrop;
+export interface FeastCollectionDrop {
+  type: 'FEAST_COLLECTION';
+}
+
+export type MappableDropType =
+  | RefDrop
+  | CAPIDrop
+  | RecipeDrop
+  | ChefDrop
+  | FeastCollectionDrop;
 
 const dropToCard = (e: React.DragEvent): MappableDropType | null => {
   const map = {

--- a/fronts-client/src/util/collectionUtils.ts
+++ b/fronts-client/src/util/collectionUtils.ts
@@ -43,13 +43,16 @@ const dropToCard = (e: React.DragEvent): MappableDropType | null => {
       type: 'CAPI',
       data: JSON.parse(data),
     }),
-    recipe: (data: string): RecipeDrop => ({
+    [CardTypesMap.RECIPE]: (data: string): RecipeDrop => ({
       type: 'RECIPE',
       data: JSON.parse(data),
     }),
-    chef: (data: string): ChefDrop => ({
+    [CardTypesMap.CHEF]: (data: string): ChefDrop => ({
       type: 'CHEF',
       data: JSON.parse(data),
+    }),
+    [CardTypesMap.FEAST_COLLECTION]: (data: string): FeastCollectionDrop => ({
+      type: 'FEAST_COLLECTION',
     }),
     text: (url: string): RefDrop => ({ type: 'REF', data: url }),
   };


### PR DESCRIPTION
## What's changed?

Adds a feast collection card. It's added by a drag handle that's present at the top of any Front.

![feast-collection](https://github.com/guardian/facia-tool/assets/7767575/d7c1e395-45e9-437c-9705-ec474ecacf03)

The card does not yet have card-specific overrides – that'll come in another PR.

## Implementation notes

I've called this entity 'Feast collection' for now, but there's an open thread in the cross team recipes chat to attempt to rename it something that is further away from 'Collection', which has its own semantics in the Fronts tool.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
