### PR TITLE
don't style the ImageContainer as portrait on editions

### DIFF
--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -272,8 +272,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 
     const { src } = valueRecord ?? {};
     const imageSrc = typeof src === 'string' ? src : '';
-
-
     this.state = {
       isDragging: false,
       modalOpen: false,
@@ -316,7 +314,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
         ? input.value.thumb
         : defaultImageUrl;
 
-    const portraitImage = !!(
+    const usePortraitImageStyling = !!(
+      editMode !== 'editions' &&
       !useDefault &&
       imageDims &&
       imageDims.height > imageDims.width
@@ -342,7 +341,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
           onDragIntentStart={() => this.setState({ isDragging: true })}
           onDragIntentEnd={() => this.setState({ isDragging: false })}
         >
-          <ImageContainer small={small} portrait={portraitImage}>
+          <ImageContainer small={small} portrait={usePortraitImageStyling}>
             <ImageComponent
               style={{
                 backgroundImage: `url(${imageUrl}`,


### PR DESCRIPTION
## What's changed?
Fixes an unintended change from https://github.com/guardian/facia-tool/pull/1590/

When selected Covers images in the editions tool, any shape of crop can be used - including "portrait" crops . If a crop was selected on editions that is taller than it is wide, this caused the `portrait` prop to be passed the the `ImageContainer` component (display wrapper that controls the size and shape of the ImageInput UI).  This prop was only intended to be used for non-editions cards for which a "Portrait" (IE 5:4) crop was selected (as per https://github.com/guardian/facia-tool/pull/1590/ this option is not yet supported, but is planned for a new collection type)

This PR adds an extra conditional to avoid using the portrait styling in Editions Cards with replacement images.


## Implementation notes

Believe the behaviour prior  https://github.com/guardian/facia-tool/pull/1590/ would be for thumbnails of  non-landscape crops in the `InputImage` to bet 'cut off' as they are in the "after" (IE after this change to put back how it was)screenshot. 

This doesn't seem  ideal - we could do another change to make these thumbnails more dynamic.


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included


### Screenshots

before (mobile cover on left  is portrait, tablet on right is landscape):
<img width="1406" alt="Screenshot 2024-06-11 at 12 56 37" src="https://github.com/guardian/facia-tool/assets/30567854/6100cbdd-809b-4ea3-b76e-249652aa9871">

after: before (mobile cover on left  is portrait, tablet on right is landscape):
<img width="1406" alt="Screenshot 2024-06-11 at 12 56 07" src="https://github.com/guardian/facia-tool/assets/30567854/b548c256-784f-46ef-b0fb-93c20ed3b6d0">

