### PR TITLE
Add search chef

### DIFF
--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -96,7 +96,7 @@ export const createFetch =
 
              */
         dispatch(
-          actions.fetchSuccess(resultData, {
+          actions.fetchSuccess(resultData.results, {
             pagination: resultData.pagination || undefined,
             order: resultData.results.map((_) => _.id),
           })

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -1,16 +1,11 @@
 import createAsyncResourceBundle from '../lib/createAsyncResourceBundle';
 import { Chef } from '../types/Chef';
-import chefOttolenghi from './fixtures/chef-ottolenghi.json';
-import chefStein from './fixtures/chef-stein.json';
-import chefCloake from './fixtures/chef-cloake.json';
 import { selectCard } from 'selectors/shared';
 import { State } from 'types/State';
 import { createSelector } from 'reselect';
 import { stripHtml } from 'util/sanitizeHTML';
-// import { createSelectIsArticleStale } from 'util/externalArticle';
 import { ThunkResult } from 'types/Store';
 import { previewCapi, liveCapi } from 'services/capiQuery';
-import { createSelectIsArticleStale } from '../util/externalArticle';
 import { Tag } from '../types/Capi';
 
 const sanitizeTag = (tag: Tag) => ({
@@ -21,31 +16,7 @@ const sanitizeTag = (tag: Tag) => ({
 const bundle = createAsyncResourceBundle<Chef>('chefs', {
   indexById: true,
   selectLocalState: (state) => state.chefs,
-  // initialData: {
-  //   // Add stub data in the absence of proper search data.
-  //   [chefOttolenghi.id]: sanitizeChef(chefOttolenghi),
-  //   [chefStein.id]: sanitizeChef(chefStein),
-  //   [chefCloake.id]: sanitizeChef(chefCloake),
-  // },
 });
-
-/*const isNonCommercialArticle = (article: CapiArticle | undefined): boolean => {
-  if (!article) {
-    return true;
-  }
-
-  if (article.isHosted) {
-    return false;
-  }
-
-  if (!article.tags) {
-    return true;
-  }
-
-  return article.tags.every((tag) => tag.type !== 'paid-content');
-};
-
- */
 
 const fetchResourceOrResults = async (
   capiService: typeof liveCapi,
@@ -53,7 +24,6 @@ const fetchResourceOrResults = async (
   isResource: boolean,
   fetchFromPreview: boolean = false
 ) => {
-  // const capiEndpoint = fetchFromPreview ? capiService.tags : capiService.search;
   const capiEndpoint = capiService.chefs;
   const { response } = await capiEndpoint(params);
 
@@ -68,11 +38,7 @@ const fetchResourceOrResults = async (
 };
 
 export const createFetch =
-  (
-    actions: typeof bundle.actions,
-    // selectIsArticleStale: ReturnType<typeof createSelectIsArticleStale>,
-    isPreview: boolean = false
-  ) =>
+  (actions: typeof bundle.actions, isPreview: boolean = false) =>
   (params: object, isResource: boolean): ThunkResult<void> =>
   async (dispatch, getState) => {
     dispatch(actions.fetchStart());
@@ -84,18 +50,6 @@ export const createFetch =
         isPreview
       );
       if (resultData) {
-        /*const nonCommercialResults = resultData.results.filter((article) =>
-              isNonCommercialArticle(article)
-            );
-            const updatedResults = nonCommercialResults.filter((article) =>
-              selectIsArticleStale(
-                getState(),
-                article.id,
-                article.fields.lastModified
-              )
-            );
-
-             */
         dispatch(
           actions.fetchSuccess(resultData.results.map(sanitizeTag), {
             pagination: resultData.pagination || undefined,
@@ -110,10 +64,7 @@ export const createFetch =
     }
   };
 
-export const fetchLive = createFetch(
-  bundle.actions
-  // createSelectIsArticleStale(bundle.selectors.selectById)
-);
+export const fetchLive = createFetch(bundle.actions);
 
 const selectChefDataFromCardId = (
   state: State,

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -7,14 +7,15 @@ import { selectCard } from 'selectors/shared';
 import { State } from 'types/State';
 import { createSelector } from 'reselect';
 import { stripHtml } from 'util/sanitizeHTML';
-//import { createSelectIsArticleStale } from 'util/externalArticle';
+// import { createSelectIsArticleStale } from 'util/externalArticle';
 import { ThunkResult } from 'types/Store';
 import { previewCapi, liveCapi } from 'services/capiQuery';
 import { createSelectIsArticleStale } from '../util/externalArticle';
+import { Tag } from '../types/Capi';
 
-const sanitizeChef = (chef: Chef) => ({
-  ...chef,
-  bio: stripHtml(chef.bio ?? ''),
+const sanitizeTag = (tag: Tag) => ({
+  ...tag,
+  bio: stripHtml(tag.bio ?? ''),
 });
 
 const bundle = createAsyncResourceBundle<Chef>('chefs', {
@@ -52,7 +53,7 @@ const fetchResourceOrResults = async (
   isResource: boolean,
   fetchFromPreview: boolean = false
 ) => {
-  //const capiEndpoint = fetchFromPreview ? capiService.tags : capiService.search;
+  // const capiEndpoint = fetchFromPreview ? capiService.tags : capiService.search;
   const capiEndpoint = capiService.chefs;
   const { response } = await capiEndpoint(params);
 
@@ -69,7 +70,7 @@ const fetchResourceOrResults = async (
 export const createFetch =
   (
     actions: typeof bundle.actions,
-    //selectIsArticleStale: ReturnType<typeof createSelectIsArticleStale>,
+    // selectIsArticleStale: ReturnType<typeof createSelectIsArticleStale>,
     isPreview: boolean = false
   ) =>
   (params: object, isResource: boolean): ThunkResult<void> =>
@@ -96,7 +97,7 @@ export const createFetch =
 
              */
         dispatch(
-          actions.fetchSuccess(resultData.results, {
+          actions.fetchSuccess(resultData.results.map(sanitizeTag), {
             pagination: resultData.pagination || undefined,
             order: resultData.results.map((_) => _.id),
           })
@@ -111,7 +112,7 @@ export const createFetch =
 
 export const fetchLive = createFetch(
   bundle.actions
-  //createSelectIsArticleStale(bundle.selectors.selectById)
+  // createSelectIsArticleStale(bundle.selectors.selectById)
 );
 
 const selectChefDataFromCardId = (

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -7,6 +7,10 @@ import { selectCard } from 'selectors/shared';
 import { State } from 'types/State';
 import { createSelector } from 'reselect';
 import { stripHtml } from 'util/sanitizeHTML';
+//import { createSelectIsArticleStale } from 'util/externalArticle';
+import { ThunkResult } from 'types/Store';
+import { previewCapi, liveCapi } from 'services/capiQuery';
+import { createSelectIsArticleStale } from '../util/externalArticle';
 
 const sanitizeChef = (chef: Chef) => ({
   ...chef,
@@ -15,13 +19,100 @@ const sanitizeChef = (chef: Chef) => ({
 
 const bundle = createAsyncResourceBundle<Chef>('chefs', {
   indexById: true,
-  initialData: {
-    // Add stub data in the absence of proper search data.
-    [chefOttolenghi.id]: sanitizeChef(chefOttolenghi),
-    [chefStein.id]: sanitizeChef(chefStein),
-    [chefCloake.id]: sanitizeChef(chefCloake),
-  },
+  selectLocalState: (state) => state.chefs,
+  // initialData: {
+  //   // Add stub data in the absence of proper search data.
+  //   [chefOttolenghi.id]: sanitizeChef(chefOttolenghi),
+  //   [chefStein.id]: sanitizeChef(chefStein),
+  //   [chefCloake.id]: sanitizeChef(chefCloake),
+  // },
 });
+
+/*const isNonCommercialArticle = (article: CapiArticle | undefined): boolean => {
+  if (!article) {
+    return true;
+  }
+
+  if (article.isHosted) {
+    return false;
+  }
+
+  if (!article.tags) {
+    return true;
+  }
+
+  return article.tags.every((tag) => tag.type !== 'paid-content');
+};
+
+ */
+
+const fetchResourceOrResults = async (
+  capiService: typeof liveCapi,
+  params: object,
+  isResource: boolean,
+  fetchFromPreview: boolean = false
+) => {
+  //const capiEndpoint = fetchFromPreview ? capiService.tags : capiService.search;
+  const capiEndpoint = capiService.chefs;
+  const { response } = await capiEndpoint(params);
+
+  return {
+    results: response.results,
+    pagination: {
+      totalPages: response.pages,
+      currentPage: response.currentPage,
+      pageSize: response.pageSize,
+    },
+  };
+};
+
+export const createFetch =
+  (
+    actions: typeof bundle.actions,
+    //selectIsArticleStale: ReturnType<typeof createSelectIsArticleStale>,
+    isPreview: boolean = false
+  ) =>
+  (params: object, isResource: boolean): ThunkResult<void> =>
+  async (dispatch, getState) => {
+    dispatch(actions.fetchStart());
+    try {
+      const resultData = await fetchResourceOrResults(
+        isPreview ? previewCapi : liveCapi,
+        params,
+        isResource,
+        isPreview
+      );
+      if (resultData) {
+        /*const nonCommercialResults = resultData.results.filter((article) =>
+              isNonCommercialArticle(article)
+            );
+            const updatedResults = nonCommercialResults.filter((article) =>
+              selectIsArticleStale(
+                getState(),
+                article.id,
+                article.fields.lastModified
+              )
+            );
+
+             */
+        dispatch(
+          actions.fetchSuccess(resultData, {
+            pagination: resultData.pagination || undefined,
+            order: resultData.results.map((_) => _.id),
+          })
+        );
+      } else {
+        dispatch(actions.fetchSuccessIgnore([]));
+      }
+    } catch (e) {
+      dispatch(actions.fetchError(e));
+    }
+  };
+
+export const fetchLive = createFetch(
+  bundle.actions
+  //createSelectIsArticleStale(bundle.selectors.selectById)
+);
 
 const selectChefDataFromCardId = (
   state: State,

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -9,18 +9,22 @@ import { ContentInfo } from './ContentInfo';
 import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
 import { State } from '../../types/State';
 import { CardTypesMap } from 'constants/cardTypes';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import { insertCardWithCreate } from '../../actions/Cards';
+import { selectors as chefSelectors } from 'bundles/chefsBundle';
 
 interface ComponentProps {
-  chef: Chef;
+  id: string;
   shouldObscureFeed: boolean;
 }
 
 export const ChefFeedItemComponent = ({
-  chef,
+  id,
   shouldObscureFeed,
 }: ComponentProps) => {
+  const chef: Chef = useSelector((state) =>
+    chefSelectors.selectById(state, id)
+  );
   const dispatch = useDispatch();
 
   const onAddToClipboard = useCallback(() => {

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -51,7 +51,7 @@ export const ChefFeedItemComponent = ({
     <FeedItem
       id={chef.id}
       type={CardTypesMap.CHEF}
-      title={`${chef.firstName} ${chef.lastName}`}
+      title={`${chef.firstName ?? 'Unknown name'} ${chef.lastName ?? ''}`}
       hasVideo={false}
       isLive={true}
       liveUrl={`https://theguardian.com/${chef.apiUrl}`}

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -22,8 +22,8 @@ export const ChefFeedItemComponent = ({
   id,
   shouldObscureFeed,
 }: ComponentProps) => {
-  const chef: Chef = useSelector((state) =>
-    chefSelectors.selectById(state, id)
+  const chef: Chef = useSelector(
+    (state) => chefSelectors.selectById(state, id)!
   );
   const dispatch = useDispatch();
 

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -2,10 +2,10 @@ import ClipboardHeader from 'components/ClipboardHeader';
 import TextInput from 'components/inputs/TextInput';
 import ShortVerticalPinline from 'components/layout/ShortVerticalPinline';
 import { styled } from 'constants/theme';
-import React, { useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { selectors as recipeSelectors } from 'bundles/recipesBundle';
-import { selectors as chefSelectors } from 'bundles/chefsBundle';
+import { fetchLive, selectors as chefSelectors } from 'bundles/chefsBundle';
 import { State } from 'types/State';
 import { Recipe } from 'types/Recipe';
 import { Chef } from 'types/Chef';
@@ -14,6 +14,8 @@ import { SearchTitle } from './SearchTitle';
 import { RecipeFeedItem } from './RecipeFeedItem';
 import { ChefFeedItem } from './ChefFeedItem';
 import { RadioButton, RadioGroup } from '../inputs/RadioButtons';
+import { getIdFromURL } from '../../util/CAPIUtils';
+import { Dispatch } from '../../types/Store';
 
 const InputContainer = styled.div`
   margin-bottom: 10px;
@@ -46,9 +48,58 @@ const FeastSearchContainerComponent = ({
   chefs,
 }: Props) => {
   const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
+  const [intervalId, setIntervalId] = useState(null);
+  const [inputState, setInputState] = useState({ query: '', chefs: [] });
+
   const handleOptionChange = (optionName: FeedType) => {
     setSelectedOption(optionName);
   };
+
+  const getParams = (query: string) => ({
+    q: query,
+    'page-size': '20',
+    'show-elements': 'image',
+    'show-fields': 'all',
+  });
+
+  // Function to stop polling
+  const stopPolling = useCallback(() => {
+    if (intervalId) {
+      clearInterval(intervalId);
+      setIntervalId(null);
+    }
+  }, [intervalId]);
+
+  const runSearch = useCallback(
+    (page = 1) => {
+      const id = getIdFromURL(inputState.query);
+      const searchTerm = id ? id : inputState.query;
+      //const isLive = capiFeedIndex === 0;
+      //const fetch = isLive ? this.props.fetchLive : this.props.fetchPreview;
+      const fetch = selectedOption === FeedType.chefs ? chefs : recipes;
+      fetch(
+        {
+          ...getParams(searchTerm),
+          page,
+        },
+        !!id
+      );
+    },
+    [inputState]
+  );
+
+  const runSearchAndRestartPolling = useCallback(() => {
+    stopPolling();
+    const newIntervalId = setInterval(() => {
+      runSearch();
+    }, 30000);
+    setIntervalId(newIntervalId);
+    runSearch();
+  }, [stopPolling, runSearch]);
+  //
+  // useEffect(() => {
+  //   return () => stopPolling();
+  // }, [stopPolling]);
 
   const renderTheFeed = () => {
     switch (selectedOption) {
@@ -68,6 +119,10 @@ const FeastSearchContainerComponent = ({
       <InputContainer>
         <TextInputContainer>
           <TextInput placeholder="Search recipes" displaySearchIcon />
+          <div>
+            <button onClick={runSearchAndRestartPolling}>Start Search</button>
+            <button onClick={stopPolling}>Stop Search</button>
+          </div>
         </TextInputContainer>
         <ClipboardHeader />
       </InputContainer>
@@ -100,10 +155,13 @@ const FeastSearchContainerComponent = ({
   );
 };
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: State, dispatch: Dispatch) => ({
   recipes: recipeSelectors.selectAll(state),
-  chefs: chefSelectors.selectAll(state),
+  chefs: (params: object, isResource: boolean) =>
+    dispatch(fetchLive(params, isResource)),
 });
+
+//chefs: chefSelectors.selectAll(state),
 
 export const RecipeSearchContainer = connect(mapStateToProps)(
   FeastSearchContainerComponent

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -14,6 +14,7 @@ import { RecipeFeedItem } from './RecipeFeedItem';
 import { ChefFeedItem } from './ChefFeedItem';
 import { RadioButton, RadioGroup } from '../inputs/RadioButtons';
 import { Dispatch } from 'types/Store';
+import debounce from 'lodash/debounce';
 
 const InputContainer = styled.div`
   margin-bottom: 10px;
@@ -55,8 +56,10 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
     chefSelectors.selectLastFetchOrder(state)
   );
 
+  const debouncedRunSearch = debounce(() => runSearch(), 750);
+
   useEffect(() => {
-    runSearch();
+    debouncedRunSearch();
   }, [selectedOption, searchText]);
 
   const getParams = (query: string) => ({

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -15,7 +15,7 @@ import { RecipeFeedItem } from './RecipeFeedItem';
 import { ChefFeedItem } from './ChefFeedItem';
 import { RadioButton, RadioGroup } from '../inputs/RadioButtons';
 import { getIdFromURL } from '../../util/CAPIUtils';
-import { Dispatch } from '../../types/Store';
+import { Dispatch } from 'types/Store';
 
 const InputContainer = styled.div`
   margin-bottom: 10px;
@@ -42,12 +42,11 @@ enum FeedType {
 
 export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
   const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
-  const [intervalId, setIntervalId] = useState(null);
   const [searchText, setSearchText] = useState('');
   const recipes: Record<string, Recipe> = useSelector((state: State) =>
     recipeSelectors.selectAll(state)
   );
-  const dispatch = useDispatch();
+  const dispatch: Dispatch = useDispatch();
   const fetchChefs = useCallback(
     (params: object, isResource: boolean) => {
       dispatch(fetchLive(params, isResource));
@@ -59,7 +58,7 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
   );
 
   useEffect(() => {
-    runSearchAndRestartPolling();
+    runSearch();
   }, [selectedOption, searchText]);
 
   const getParams = (query: string) => ({
@@ -68,14 +67,6 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
     'show-elements': 'image',
     'show-fields': 'all',
   });
-
-  // Function to stop polling
-  const stopPolling = useCallback(() => {
-    if (intervalId) {
-      clearInterval(intervalId);
-      setIntervalId(null);
-    }
-  }, [intervalId]);
 
   const runSearch = useCallback(
     (page = 1) => {
@@ -90,19 +81,6 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
     },
     [selectedOption, searchText]
   );
-
-  const runSearchAndRestartPolling = useCallback(() => {
-    stopPolling();
-    const newIntervalId = setInterval(() => {
-      runSearch();
-    }, 30000);
-    setIntervalId(newIntervalId);
-    runSearch();
-  }, [stopPolling, runSearch]);
-  //
-  useEffect(() => {
-    return () => stopPolling();
-  }, [stopPolling]);
 
   const renderTheFeed = () => {
     switch (selectedOption) {

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -3,18 +3,16 @@ import TextInput from 'components/inputs/TextInput';
 import ShortVerticalPinline from 'components/layout/ShortVerticalPinline';
 import { styled } from 'constants/theme';
 import React, { useEffect, useState, useCallback } from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectors as recipeSelectors } from 'bundles/recipesBundle';
 import { fetchLive, selectors as chefSelectors } from 'bundles/chefsBundle';
 import { State } from 'types/State';
 import { Recipe } from 'types/Recipe';
-import { Chef } from 'types/Chef';
 import { SearchResultsHeadingContainer } from './SearchResultsHeadingContainer';
 import { SearchTitle } from './SearchTitle';
 import { RecipeFeedItem } from './RecipeFeedItem';
 import { ChefFeedItem } from './ChefFeedItem';
 import { RadioButton, RadioGroup } from '../inputs/RadioButtons';
-import { getIdFromURL } from '../../util/CAPIUtils';
 import { Dispatch } from 'types/Store';
 
 const InputContainer = styled.div`

--- a/fronts-client/src/components/form/ChefMetaForm.tsx
+++ b/fronts-client/src/components/form/ChefMetaForm.tsx
@@ -16,7 +16,7 @@ import { Chef } from 'types/Chef';
 import { useSelector } from 'react-redux';
 import InputTextArea from 'components/inputs/InputTextArea';
 
-type FormProps = {
+interface FormProps {
   card: Card;
   initialValues: ChefCardMeta;
   chef: Chef | undefined;
@@ -24,7 +24,7 @@ type FormProps = {
   size: CardSizes;
   onCancel: () => void;
   onSave: (meta: ChefCardFormData) => void;
-};
+}
 
 type ComponentProps = FormProps &
   InjectedFormProps<ChefCardFormData, FormProps, {}>;

--- a/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
@@ -75,7 +75,7 @@ export const HoverActionsButtonWrapper = ({
       {renderButtons({
         showToolTip,
         hideToolTip,
-        size: size,
+        size,
       })}
     </HoverActionsWrapper>
   );

--- a/fronts-client/src/fixtures/initialState.ts
+++ b/fronts-client/src/fixtures/initialState.ts
@@ -707,6 +707,7 @@ const state = {
     updatingIds: [],
   },
   notifications: { banners: [] },
+  chefs: emptyFeedBundle,
 } as State;
 
 export { state };

--- a/fronts-client/src/services/capiQuery.ts
+++ b/fronts-client/src/services/capiQuery.ts
@@ -57,6 +57,9 @@ interface CAPITagQueryReponse {
     results: Tag[];
     status: CAPIStatus;
     message?: string;
+    currentPage: number;
+    pageSize: number;
+    pages: number;
   };
 }
 
@@ -169,6 +172,14 @@ const capiQuery = (baseURL: string) => {
       return fetchCAPIResponse<CAPITagQueryReponse>(
         `${baseURL}/tags${qs({
           type: 'tracking',
+          ...params,
+        })}`
+      );
+    },
+    chefs: async (params: any): Promise<CAPITagQueryReponse> => {
+      return fetchCAPIResponse<CAPITagQueryReponse>(
+        `${baseURL}/tags${qs({
+          type: 'contributor',
           ...params,
         })}`
       );

--- a/fronts-client/src/types/Capi.ts
+++ b/fronts-client/src/types/Capi.ts
@@ -80,6 +80,7 @@ interface Tag {
   bylineLargeImageUrl?: string;
   sectionId?: string;
   sectionName?: string;
+  bio?: string;
 }
 
 type CapiBool = 'true' | 'false' | boolean;

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -98,9 +98,9 @@ type CardMeta = CardRootMeta & {
   supporting?: string[];
 };
 
-type ChefCardMeta = {
+interface ChefCardMeta {
   bio: string;
-};
+}
 
 interface Card extends CardRootFields {
   meta: CardMeta;

--- a/fronts-client/src/types/State.ts
+++ b/fronts-client/src/types/State.ts
@@ -25,6 +25,7 @@ import { reducer as externalArticles } from 'bundles/externalArticlesBundle';
 import { State as focusState } from 'bundles/focusBundle';
 import { State as featureSwitchesState } from 'reducers/featureSwitchesReducer';
 import { reducer as notificationsReducer } from 'bundles/notificationsBundle';
+import { reducer } from '../bundles/chefsBundle';
 
 interface FeedState {
   feedState: feedStateType;
@@ -58,4 +59,5 @@ export interface State {
   externalArticles: ReturnType<typeof externalArticles>;
   pageViewData: ReturnType<typeof pageViewData>;
   notifications: ReturnType<typeof notificationsReducer>;
+  chefs: ReturnType<typeof reducer>;
 }


### PR DESCRIPTION
## What's changed?

Add search for chef. 
For that we first need chef data rendered into the left container that is search, 
which we are trying to get based on tags that are only contributors at the moment.
Later we will change this to fetch tags that are contributor of type chefs only. 

ref: https://trello.com/c/YsDDwuQr/2761-enable-search-for-chefs

Co-authored: @jonathonherbert (Thanks for sorting issues out and to make PR work altogether 💫).

https://github.com/guardian/facia-tool/assets/17780995/bad6d226-1613-495d-b549-abc2108a1340




## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
