### PR TITLE
Fetch chefs as collections are loaded

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -50,7 +50,7 @@ import type { State } from 'types/State';
 import { cardSets, noOfOpenCollectionsOnFirstLoad } from 'constants/fronts';
 import { Stages, Collection, CardSets } from 'types/Collection';
 import difference from 'lodash/difference';
-import { selectArticlesInCollections } from 'selectors/collection';
+import { selectCardsInCollections } from 'selectors/collection';
 import {
   editorOpenCollections,
   editorCloseCollections,
@@ -358,20 +358,33 @@ const getArticlesForCollections =
     itemSetCandidate: CardSets | CardSets[]
   ): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
+    const state = getState();
     const itemSets = Array.isArray(itemSetCandidate)
       ? itemSetCandidate
       : [itemSetCandidate];
+
     const articleIds = itemSets.reduce(
       (acc, itemSet) => [
         ...acc,
-        ...selectArticlesInCollections(getState(), {
+        ...selectCardsInCollections(state, {
           collectionIds,
           itemSet,
         }),
       ],
       [] as string[]
     );
+
     await dispatch(fetchArticles(articleIds));
+
+    // const chefIds = selectChefsInCollections(state, {
+    //   collectionIds,
+    //   itemSet,
+    // });
+
+    // await Promise.all([
+    //   dispatch(fetchChefs(chefIds)),
+    //   dispatch(fetchArticles(articleIds)),
+    // ]);
   };
 
 const getOphanDataForCollections =

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -68,6 +68,7 @@ import { updateCollectionStrategy } from 'strategies/update-collection';
 import { getPageViewDataForCollection } from 'actions/PageViewData';
 import { isMode } from 'selectors/pathSelectors';
 import { groupBy, uniqBy } from 'lodash';
+import { fetchChefsById } from 'bundles/chefsBundle';
 
 const articlesInCollection = createSelectAllArticlesInCollection();
 
@@ -397,7 +398,10 @@ const fetchCardReferencedEntities =
     }
 
     if (cardsByCardType.chef) {
-      // Todo: fetch our chefs!
+      const chefsPromise = dispatch(
+        fetchChefsById(cardsByCardType.chef.map((chef) => chef.id))
+      );
+      promises.push(chefsPromise);
     }
 
     await Promise.all(promises);

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -19,7 +19,7 @@ import {
 } from 'selectors/configSelectors';
 import {
   createSelectGroupArticles,
-  createSelectAllArticlesInCollection,
+  createSelectAllCardsInCollection,
 } from 'selectors/shared';
 import {
   actions as externalArticleActions,
@@ -70,7 +70,7 @@ import { isMode } from 'selectors/pathSelectors';
 import { groupBy, uniqBy } from 'lodash';
 import { fetchChefsById } from 'bundles/chefsBundle';
 
-const articlesInCollection = createSelectAllArticlesInCollection();
+const articlesInCollection = createSelectAllCardsInCollection();
 
 function fetchStaleCollections(
   collectionIds: string[]

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -85,7 +85,7 @@ function fetchStaleCollections(
     );
 
     dispatch(
-      getArticlesForCollections(
+      fetchCardReferencedEntities(
         fetchedCollectionIds,
         // get article for *all* collecitonItemSets as it reduces complexity of
         // this code (finding which cardSets we need), and the overlap
@@ -352,7 +352,11 @@ const fetchArticles =
     }
   };
 
-const getArticlesForCollections =
+/**
+ * Fetch all of the entities referenced by the cards in the given collection ids
+ * – articles, recipes etc.
+ */
+const fetchCardReferencedEntities =
   (
     collectionIds: string[],
     itemSetCandidate: CardSets | CardSets[]
@@ -363,18 +367,18 @@ const getArticlesForCollections =
       ? itemSetCandidate
       : [itemSetCandidate];
 
-    const articleIds = itemSets.reduce(
+    const cards = itemSets.reduce(
       (acc, itemSet) => [
         ...acc,
         ...selectCardsInCollections(state, {
           collectionIds,
           itemSet,
-        }),
+        }).map((card) => card.id),
       ],
       [] as string[]
     );
 
-    await dispatch(fetchArticles(articleIds));
+    await dispatch(fetchArticles(cards));
 
     // const chefIds = selectChefsInCollections(state, {
     //   collectionIds,
@@ -410,7 +414,7 @@ const openCollectionsAndFetchTheirArticles =
   ): ThunkResult<Promise<void>> =>
   async (dispatch) => {
     dispatch(editorOpenCollections(collectionIds));
-    await dispatch(getArticlesForCollections(collectionIds, itemSet));
+    await dispatch(fetchCardReferencedEntities(collectionIds, itemSet));
     await dispatch(getOphanDataForCollections(collectionIds, frontId, itemSet));
   };
 
@@ -461,7 +465,7 @@ function initialiseCollectionsForFront(
     dispatch(editorOpenCollections(collectionsWithArticlesToLoad));
     await dispatch(getCollections(front.collections));
     await dispatch(
-      getArticlesForCollections(collectionsWithArticlesToLoad, browsingStage)
+      fetchCardReferencedEntities(collectionsWithArticlesToLoad, browsingStage)
     );
     await dispatch(
       getOphanDataForCollections(
@@ -560,7 +564,7 @@ function discardDraftChangesToCollection(
 
 export {
   getCollections,
-  getArticlesForCollections,
+  fetchCardReferencedEntities,
   openCollectionsAndFetchTheirArticles,
   closeCollections,
   fetchStaleCollections,

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -70,7 +70,7 @@ import { isMode } from 'selectors/pathSelectors';
 import { groupBy, uniqBy } from 'lodash';
 import { fetchChefsById } from 'bundles/chefsBundle';
 
-const articlesInCollection = createSelectAllCardsInCollection();
+const selectAllCardsInCollection = createSelectAllCardsInCollection();
 
 function fetchStaleCollections(
   collectionIds: string[]
@@ -80,7 +80,7 @@ function fetchStaleCollections(
     const fetchedCollectionIds = await dispatch(
       getCollections(collectionIds, true)
     );
-    const prevArticleIds = articlesInCollection(
+    const prevArticleIds = selectAllCardsInCollection(
       prevState,
       fetchedCollectionIds
     );

--- a/fronts-client/src/actions/PageViewData.ts
+++ b/fronts-client/src/actions/PageViewData.ts
@@ -7,7 +7,7 @@ import type { PageViewDataFromOphan, PageViewStory } from 'types/PageViewData';
 import type { DerivedArticle } from 'types/Article';
 import type { CardSets } from 'types/Collection';
 import {
-  createSelectArticlesInCollection,
+  createSelectCardsInCollection,
   createSelectArticleFromCard,
 } from 'selectors/shared';
 import pandaFetch from 'services/pandaFetch';
@@ -19,7 +19,7 @@ const intervalInMinutes = 10;
 export const PAGE_VIEW_DATA_RECEIVED = 'PAGE_VIEW_DATA_RECEIVED';
 export const PAGE_VIEW_DATA_REQUESTED = 'PAGE_VIEW_DATA_REQUESTED';
 
-const selectArticlesInCollection = createSelectArticlesInCollection();
+const selectArticlesInCollection = createSelectCardsInCollection();
 const selectArticleFromCard = createSelectArticleFromCard();
 
 const getPageViewDataForCollection = (

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'bundles/externalArticlesBundle';
 import {
   getCollections,
-  getArticlesForCollections,
+  fetchCardReferencedEntities,
   updateCollection,
   fetchArticles,
 } from '../Collections';
@@ -433,7 +433,7 @@ describe('Collection actions', () => {
         ...stateWithCollection,
       });
       await store.dispatch(
-        getArticlesForCollections(['exampleCollection'], 'live') as any
+        fetchCardReferencedEntities(['exampleCollection'], 'live') as any
       );
       const actions = store.getActions();
       expect(actions[0]).toEqual(
@@ -457,7 +457,7 @@ describe('Collection actions', () => {
         ...stateWithCollection,
       });
       await store.dispatch(
-        getArticlesForCollections(['exampleCollection'], 'live') as any
+        fetchCardReferencedEntities(['exampleCollection'], 'live') as any
       );
       const actions = store.getActions();
       expect(actions[0]).toEqual(

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -436,19 +436,25 @@ describe('Collection actions', () => {
     const assertFetchedEntities = async ({
       fixture,
       action,
-      endpoint,
+      mockEndpoint,
       fetchStartAction,
       fetchCompleteActionType,
-      fetchResponse = { response: { results: [capiArticle] } },
+      fetchMockResponse = { response: { results: [capiArticle] } },
     }: {
+      // The state fixture
       fixture: Record<string, unknown>;
+      // The fetchCardReferencedEntities action to dispatch
       action: any;
-      endpoint: string;
+      // The endpoint to mock
+      mockEndpoint: string;
+      // The FETCH_START action we expect
       fetchStartAction: unknown;
+      // The action we expect to complete this thunk with – either success, or error
       fetchCompleteActionType: string;
-      fetchResponse?: number | Record<string, unknown>;
+      // The response to reply with when the mock endpoint is hit
+      fetchMockResponse?: number | Record<string, unknown>;
     }) => {
-      fetchMock.once(endpoint, fetchResponse);
+      fetchMock.once(mockEndpoint, fetchMockResponse);
       const store = mockStore({
         config,
         ...fixture,
@@ -463,7 +469,7 @@ describe('Collection actions', () => {
       await assertFetchedEntities({
         fixture: stateWithCollection,
         action: fetchCardReferencedEntities(['exampleCollection'], 'live'),
-        endpoint:
+        mockEndpoint:
           'begin:/api/preview/search?ids=article/live/0,article/draft/1,a/long/path/2',
         fetchStartAction: externalArticleActions.fetchStart([
           'article/live/0',
@@ -477,7 +483,8 @@ describe('Collection actions', () => {
       await assertFetchedEntities({
         fixture: stateWithDuplicateArticleIdsInCollection,
         action: fetchCardReferencedEntities(['exampleCollection'], 'live'),
-        endpoint: 'begin:/api/preview/search?ids=article/live/0,a/long/path/2',
+        mockEndpoint:
+          'begin:/api/preview/search?ids=article/live/0,a/long/path/2',
         fetchStartAction: externalArticleActions.fetchStart([
           'article/live/0',
           'a/long/path/2',
@@ -490,13 +497,14 @@ describe('Collection actions', () => {
       await assertFetchedEntities({
         fixture: stateWithDuplicateArticleIdsInCollection,
         action: fetchCardReferencedEntities(['exampleCollection'], 'live'),
-        endpoint: 'begin:/api/preview/search?ids=article/live/0,a/long/path/2',
+        mockEndpoint:
+          'begin:/api/preview/search?ids=article/live/0,a/long/path/2',
         fetchStartAction: externalArticleActions.fetchStart([
           'article/live/0',
           'a/long/path/2',
         ]),
         fetchCompleteActionType: externalArticleActionNames.fetchError,
-        fetchResponse: 400,
+        fetchMockResponse: 400,
       });
     });
 
@@ -504,7 +512,7 @@ describe('Collection actions', () => {
       await assertFetchedEntities({
         fixture: stateWithCollectionWithChefs,
         action: fetchCardReferencedEntities(['exampleCollection'], 'live'),
-        endpoint:
+        mockEndpoint:
           'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein%2Cprofile%2Ffelicity-cloake',
         fetchStartAction: chefActions.fetchStart([
           'profile/yotamottolenghi',
@@ -519,7 +527,7 @@ describe('Collection actions', () => {
       await assertFetchedEntities({
         fixture: stateWithCollectionWithDuplicateChefs,
         action: fetchCardReferencedEntities(['exampleCollection'], 'live'),
-        endpoint:
+        mockEndpoint:
           'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein',
         fetchStartAction: chefActions.fetchStart([
           'profile/yotamottolenghi',

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -455,7 +455,6 @@ describe('Collection actions', () => {
       });
       await store.dispatch(action);
       const actions = store.getActions();
-      console.log(actions[1]);
       expect(actions[0]).toEqual(fetchStartAction);
       expect(actions[1].type).toEqual(fetchCompleteActionType);
     };

--- a/fronts-client/src/actions/__tests__/Fronts.spec.ts
+++ b/fronts-client/src/actions/__tests__/Fronts.spec.ts
@@ -4,7 +4,7 @@ import { state as initialState } from 'fixtures/initialState';
 import { scJohnsonPartnerZoneCollection } from 'fixtures/collectionsEndpointResponse';
 import { articlesForScJohnsonPartnerZone } from 'actions/__tests__/capiEndpointResponse';
 import { selectIsCollectionOpen } from 'bundles/frontsUI';
-import { selectArticlesInCollections } from 'selectors/collection';
+import { selectCardsInCollections } from 'selectors/collection';
 import { selectCard } from 'selectors/shared';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 
@@ -51,7 +51,7 @@ describe('Fronts actions', () => {
       // TODO this selectArticalsInCollections returns internal code pages which means we cannot use it with cardSelector
       //  This worked previously because selectArticles in Collection was returning an empty array which was erroneous - TODO
       expect(
-        selectArticlesInCollections(state, {
+        selectCardsInCollections(state, {
           collectionIds,
           itemSet: 'draft',
         }).every((_) => !!selectCard(state, _))

--- a/fronts-client/src/actions/__tests__/Fronts.spec.ts
+++ b/fronts-client/src/actions/__tests__/Fronts.spec.ts
@@ -54,7 +54,7 @@ describe('Fronts actions', () => {
         selectCardsInCollections(state, {
           collectionIds,
           itemSet: 'draft',
-        }).every((_) => !!selectCard(state, _))
+        }).every((_) => !!selectCard(state, _.uuid))
       ).toBe(true);
     });
   });

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -5,7 +5,7 @@ import { State } from 'types/State';
 import { createSelector } from 'reselect';
 import { stripHtml } from 'util/sanitizeHTML';
 import { ThunkResult } from 'types/Store';
-import { previewCapi, liveCapi } from 'services/capiQuery';
+import { liveCapi } from 'services/capiQuery';
 import { Tag } from '../types/Capi';
 
 const sanitizeTag = (tag: Tag) => ({
@@ -20,9 +20,7 @@ const bundle = createAsyncResourceBundle<Chef>('chefs', {
 
 const fetchResourceOrResults = async (
   capiService: typeof liveCapi,
-  params: object,
-  isResource: boolean,
-  fetchFromPreview: boolean = false
+  params: Record<string, string[] | string | number>
 ) => {
   const capiEndpoint = capiService.chefs;
   const { response } = await capiEndpoint(params);
@@ -37,18 +35,17 @@ const fetchResourceOrResults = async (
   };
 };
 
-export const createFetch =
-  (actions: typeof bundle.actions, isPreview: boolean = false) =>
-  (params: object, isResource: boolean): ThunkResult<void> =>
-  async (dispatch, getState) => {
-    dispatch(actions.fetchStart());
+export const fetchChefsById =
+  (tagIds: string[], page = 1, pageSize = 20): ThunkResult<void> =>
+  async (dispatch) => {
+    dispatch(actions.fetchStart(tagIds));
     try {
-      const resultData = await fetchResourceOrResults(
-        isPreview ? previewCapi : liveCapi,
-        params,
-        isResource,
-        isPreview
-      );
+      const params = {
+        ids: tagIds,
+        page,
+        'page-size': pageSize,
+      };
+      const resultData = await fetchResourceOrResults(liveCapi, params);
       if (resultData) {
         dispatch(
           actions.fetchSuccess(resultData.results.map(sanitizeTag), {
@@ -63,8 +60,6 @@ export const createFetch =
       dispatch(actions.fetchError(e));
     }
   };
-
-export const fetchLive = createFetch(bundle.actions);
 
 const selectChefDataFromCardId = (
   state: State,
@@ -93,6 +88,7 @@ const selectChefFromCard = createSelector(
   }
 );
 
+export const actionNames = bundle.actionNames;
 export const actions = bundle.actions;
 export const reducer = bundle.reducer;
 export const selectors = {

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -35,16 +35,16 @@ const fetchResourceOrResults = async (
   };
 };
 
-export const fetchChefsById =
-  (tagIds: string[], page = 1, pageSize = 20): ThunkResult<void> =>
+export const fetchChefs =
+  (
+    // The params to include in the request
+    params: Record<string, string[] | string | number>,
+    // The ids of the chefs being fetched, if known
+    ids?: string[]
+  ): ThunkResult<void> =>
   async (dispatch) => {
-    dispatch(actions.fetchStart(tagIds));
+    dispatch(actions.fetchStart(ids));
     try {
-      const params = {
-        ids: tagIds,
-        page,
-        'page-size': pageSize,
-      };
       const resultData = await fetchResourceOrResults(liveCapi, params);
       if (resultData) {
         dispatch(
@@ -60,6 +60,19 @@ export const fetchChefsById =
       dispatch(actions.fetchError(e));
     }
   };
+
+export const fetchChefsById = (
+  tagIds: string[],
+  page = 1,
+  pageSize = 20
+): ThunkResult<void> => {
+  const params = {
+    ids: tagIds,
+    page,
+    'page-size': pageSize,
+  };
+  return fetchChefs(params, tagIds);
+};
 
 const selectChefDataFromCardId = (
   state: State,

--- a/fronts-client/src/bundles/frontsUI/index.ts
+++ b/fronts-client/src/bundles/frontsUI/index.ts
@@ -41,7 +41,7 @@ import { Stages } from 'types/Collection';
 import { selectPriority } from 'selectors/pathSelectors';
 import { CollectionWithArticles } from 'types/PageViewData';
 import {
-  createSelectArticlesInCollection,
+  createSelectCardsInCollection,
   createSelectArticleFromCard,
 } from 'selectors/shared';
 
@@ -512,7 +512,7 @@ const createSelectOpenCardTitlesForCollection = () => {
 const selectFrontBrowsingStage = (state: GlobalState, frontId: string) =>
   state.editor.frontIdsByBrowsingStage[frontId] || 'draft';
 
-const selectAllArticleIdsForCollection = createSelectArticlesInCollection();
+const selectAllArticleIdsForCollection = createSelectCardsInCollection();
 const selectCurrentlyOpenCollectionsByFront =
   createSelectCurrentlyOpenCollectionsByFront();
 

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -50,7 +50,7 @@ interface ContainerProps {
 
 type Props = ContainerProps & {
   collection: Collection | undefined;
-  articleIds?: string[];
+  cardIds?: string[];
   headlineContent: React.ReactNode;
   metaContent: React.ReactNode;
   children: React.ReactNode;
@@ -245,7 +245,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       id,
       collection,
       frontId,
-      articleIds,
+      cardIds,
       headlineContent,
       metaContent,
       isUneditable,
@@ -256,7 +256,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       handleBlur,
       isEditions,
     }: Props = this.props;
-    const itemCount = articleIds ? articleIds.length : 0;
+    const itemCount = cardIds ? cardIds.length : 0;
     const targetedTerritory = collection ? collection.targetedTerritory : null;
     const { displayName } = this.state;
 
@@ -423,11 +423,11 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 }
 
 const createMapStateToProps = () => {
-  const selectArticlesInCollection = createSelectCardsInCollection();
+  const selectCardsInCollection = createSelectCardsInCollection();
   return (state: State, props: ContainerProps) => {
     return {
       collection: collectionSelectors.selectById(state, props.id),
-      articleIds: selectArticlesInCollection(state, {
+      cardIds: selectCardsInCollection(state, {
         collectionId: props.id,
         collectionSet: props.browsingStage,
         includeSupportingArticles: false,

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -18,7 +18,7 @@ import ButtonCircularCaret, {
 } from './inputs/ButtonCircularCaret';
 import type { State } from 'types/State';
 
-import { createSelectArticlesInCollection } from '../selectors/shared';
+import { createSelectCardsInCollection } from '../selectors/shared';
 import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 import FadeIn from './animation/FadeIn';
 import ContentContainer, {
@@ -423,7 +423,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 }
 
 const createMapStateToProps = () => {
-  const selectArticlesInCollection = createSelectArticlesInCollection();
+  const selectArticlesInCollection = createSelectCardsInCollection();
   return (state: State, props: ContainerProps) => {
     return {
       collection: collectionSelectors.selectById(state, props.id),

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -32,7 +32,7 @@ import {
   selectHasMultipleFrontsOpen,
   createSelectDoesCollectionHaveOpenForms,
 } from 'bundles/frontsUI';
-import { getArticlesForCollections } from 'actions/Collections';
+import { fetchCardReferencedEntities } from 'actions/Collections';
 import { cardSets } from 'constants/fronts';
 import CollectionMetaContainer from 'components/collection/CollectionMetaContainer';
 import ButtonCircularCaret from 'components/inputs/ButtonCircularCaret';
@@ -379,7 +379,7 @@ const mapDispatchToProps = (
     }
   },
   fetchPreviousCollectionArticles: (id: string) => {
-    dispatch(getArticlesForCollections([id], cardSets.previously));
+    dispatch(fetchCardReferencedEntities([id], cardSets.previously));
   },
 });
 

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -27,7 +27,7 @@ interface FrontCollectionOverviewContainerProps {
 
 type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
   collection: Collection | undefined;
-  articleCount: number;
+  cardCount: number;
   openCollection: (id: string) => void;
   hasUnpublishedChanges: boolean;
   hasOpenForms: boolean;
@@ -102,7 +102,7 @@ const StatusWarning = styled(ButtonDefault)`
 
 const CollectionOverview = ({
   collection,
-  articleCount,
+  cardCount,
   openCollection,
   frontId,
   hasUnpublishedChanges,
@@ -130,7 +130,7 @@ const CollectionOverview = ({
     >
       <TextContainerLeft>
         <Name>{collection.displayName}</Name>
-        <ItemCount>({articleCount})</ItemCount>
+        <ItemCount>({cardCount})</ItemCount>
       </TextContainerLeft>
       <TextContainerRight>
         {!!hasOpenForms && (
@@ -161,7 +161,7 @@ const CollectionOverview = ({
 
 const mapStateToProps = () => {
   const selectCollection = createSelectCollection();
-  const selectArticlesInCollection = createSelectCardsInCollection();
+  const selectCardsInCollection = createSelectCardsInCollection();
   const selectCollectionIdsWithOpenForms =
     createSelectCollectionIdsWithOpenForms();
   return (
@@ -175,7 +175,7 @@ const mapStateToProps = () => {
     collection: selectCollection(state, {
       collectionId,
     }),
-    articleCount: selectArticlesInCollection(state, {
+    cardCount: selectCardsInCollection(state, {
       collectionSet,
       collectionId,
       includeSupportingArticles: false,

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -13,7 +13,7 @@ import { createCollectionId } from 'components/CollectionDisplay';
 import ButtonDefault from 'components/inputs/ButtonCircular';
 import {
   createSelectCollection,
-  createSelectArticlesInCollection,
+  createSelectCardsInCollection,
 } from 'selectors/shared';
 import EditModeVisibility from 'components/util/EditModeVisibility';
 import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUI';
@@ -161,7 +161,7 @@ const CollectionOverview = ({
 
 const mapStateToProps = () => {
   const selectCollection = createSelectCollection();
-  const selectArticlesInCollection = createSelectArticlesInCollection();
+  const selectArticlesInCollection = createSelectCardsInCollection();
   const selectCollectionIdsWithOpenForms =
     createSelectCollectionIdsWithOpenForms();
   return (

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -5,7 +5,7 @@ import { styled } from 'constants/theme';
 import React, { useEffect, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectors as recipeSelectors } from 'bundles/recipesBundle';
-import { fetchLive, selectors as chefSelectors } from 'bundles/chefsBundle';
+import { fetchChefs, selectors as chefSelectors } from 'bundles/chefsBundle';
 import { State } from 'types/State';
 import { Recipe } from 'types/Recipe';
 import { SearchResultsHeadingContainer } from './SearchResultsHeadingContainer';
@@ -46,9 +46,9 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
     recipeSelectors.selectAll(state)
   );
   const dispatch: Dispatch = useDispatch();
-  const fetchChefs = useCallback(
-    (params: object, isResource: boolean) => {
-      dispatch(fetchLive(params, isResource));
+  const searchForChefs = useCallback(
+    (params: Record<string, string[] | string | number>) => {
+      dispatch(fetchChefs(params));
     },
     [dispatch]
   );
@@ -71,14 +71,12 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
   const runSearch = useCallback(
     (page = 1) => {
-      const fetch = selectedOption === FeedType.chefs ? fetchChefs : () => {};
-      fetch(
-        {
-          ...getParams(searchText),
-          page,
-        },
-        false
-      );
+      const fetch =
+        selectedOption === FeedType.chefs ? searchForChefs : () => {};
+      fetch({
+        ...getParams(searchText),
+        page,
+      });
     },
     [selectedOption, searchText]
   );

--- a/fronts-client/src/fixtures/shared.ts
+++ b/fronts-client/src/fixtures/shared.ts
@@ -834,6 +834,99 @@ const stateWithSnaplinksAndArticles: any = {
   },
 };
 
+export const stateWithDuplicateArticleIdsInCollection: any = {
+  path: '/v2/editorial',
+  fronts: {
+    frontsConfig: {
+      data: {
+        fronts: {},
+        collections: {
+          exampleCollection: {
+            displayName: 'Example Collection',
+            type: 'type',
+          },
+        },
+      },
+      lastError: null,
+      error: null,
+      lastSuccessfulFetchTimestamp: 1547474511048,
+      loading: false,
+      loadingIds: [],
+      updatingIds: [],
+    },
+    lastPressed: {},
+    collectionVisibility: { draft: {}, live: {} },
+  },
+  collections: {
+    data: {
+      exampleCollection: {
+        id: 'exampleCollection',
+        displayName: 'Example Collection',
+        live: ['abc', 'def'],
+        draft: [],
+        previously: undefined,
+        type: 'type',
+      },
+    },
+    lastError: null,
+    error: null,
+    lastSuccessfulFetchTimestamp: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: [],
+  },
+  groups: {
+    abc: {
+      id: '1',
+      uuid: 'abc',
+      cards: ['95e2bfc0-8999-4e6e-a359-19960967c1e0'],
+      name: 'group1',
+    },
+    def: {
+      id: null,
+      uuid: 'def',
+      name: 'group2',
+      cards: [
+        '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
+        '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d',
+      ],
+    },
+  },
+  cards: {
+    '95e2bfc0-8999-4e6e-a359-19960967c1e0': {
+      id: 'article/live/0',
+      frontPublicationDate: 1,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '95e2bfc0-8999-4e6e-a359-19960967c1e0',
+    },
+    '4bc11359-bb3e-45e7-a0a9-86c0ee52653d': {
+      id: 'article/live/0',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
+    },
+    '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d': {
+      id: 'a/long/path/2',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d',
+    },
+  },
+  externalArticles: {
+    data: {},
+    lastError: null,
+    error: null,
+    lastSuccessfulFetchTimestamp: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: [],
+  },
+  feed: {},
+};
+
 const initialState = {
   collections: {
     data: {},

--- a/fronts-client/src/fixtures/shared.ts
+++ b/fronts-client/src/fixtures/shared.ts
@@ -952,6 +952,198 @@ const initialState = {
   pageViewData: {},
 };
 
+export const stateWithCollectionWithChefs: any = {
+  path: '/v2/editorial',
+  fronts: {
+    frontsConfig: {
+      data: {
+        fronts: {},
+        collections: {
+          exampleCollection: {
+            displayName: 'Example Collection',
+            type: 'type',
+          },
+        },
+      },
+      lastError: null,
+      error: null,
+      lastSuccessfulFetchTimestamp: 1547474511048,
+      loading: false,
+      loadingIds: [],
+      updatingIds: [],
+    },
+    lastPressed: {},
+    collectionVisibility: { draft: {}, live: {} },
+  },
+  collections: {
+    data: {
+      exampleCollection: {
+        id: 'exampleCollection',
+        displayName: 'Example Collection',
+        live: ['abc', 'def'],
+        draft: [],
+        previously: undefined,
+        type: 'type',
+      },
+    },
+    lastError: null,
+    error: null,
+    lastSuccessfulFetchTimestamp: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: [],
+  },
+  groups: {
+    abc: {
+      id: '1',
+      uuid: 'abc',
+      cards: ['95e2bfc0-8999-4e6e-a359-19960967c1e0'],
+      name: 'group1',
+    },
+    def: {
+      id: null,
+      uuid: 'def',
+      name: 'group2',
+      cards: [
+        '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
+        '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d',
+      ],
+    },
+  },
+  cards: {
+    '95e2bfc0-8999-4e6e-a359-19960967c1e0': {
+      id: 'profile/yotamottolenghi',
+      cardType: 'chef',
+      frontPublicationDate: 1,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '95e2bfc0-8999-4e6e-a359-19960967c1e0',
+    },
+    '4bc11359-bb3e-45e7-a0a9-86c0ee52653d': {
+      id: 'profile/rick-stein',
+      cardType: 'chef',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
+    },
+    '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d': {
+      id: 'profile/felicity-cloake',
+      cardType: 'chef',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d',
+    },
+  },
+  externalArticles: {
+    data: {},
+    lastError: null,
+    error: null,
+    lastSuccessfulFetchTimestamp: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: [],
+  },
+  feed: {},
+};
+
+export const stateWithCollectionWithDuplicateChefs: any = {
+  path: '/v2/editorial',
+  fronts: {
+    frontsConfig: {
+      data: {
+        fronts: {},
+        collections: {
+          exampleCollection: {
+            displayName: 'Example Collection',
+            type: 'type',
+          },
+        },
+      },
+      lastError: null,
+      error: null,
+      lastSuccessfulFetchTimestamp: 1547474511048,
+      loading: false,
+      loadingIds: [],
+      updatingIds: [],
+    },
+    lastPressed: {},
+    collectionVisibility: { draft: {}, live: {} },
+  },
+  collections: {
+    data: {
+      exampleCollection: {
+        id: 'exampleCollection',
+        displayName: 'Example Collection',
+        live: ['abc', 'def'],
+        draft: [],
+        previously: undefined,
+        type: 'type',
+      },
+    },
+    lastError: null,
+    error: null,
+    lastSuccessfulFetchTimestamp: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: [],
+  },
+  groups: {
+    abc: {
+      id: '1',
+      uuid: 'abc',
+      cards: ['95e2bfc0-8999-4e6e-a359-19960967c1e0'],
+      name: 'group1',
+    },
+    def: {
+      id: null,
+      uuid: 'def',
+      name: 'group2',
+      cards: [
+        '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
+        '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d',
+      ],
+    },
+  },
+  cards: {
+    '95e2bfc0-8999-4e6e-a359-19960967c1e0': {
+      id: 'profile/yotamottolenghi',
+      cardType: 'chef',
+      frontPublicationDate: 1,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '95e2bfc0-8999-4e6e-a359-19960967c1e0',
+    },
+    '4bc11359-bb3e-45e7-a0a9-86c0ee52653d': {
+      id: 'profile/rick-stein',
+      cardType: 'chef',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '4bc11359-bb3e-45e7-a0a9-86c0ee52653d',
+    },
+    '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d': {
+      id: 'profile/rick-stein',
+      cardType: 'chef',
+      frontPublicationDate: 2,
+      publishedBy: 'Computers',
+      meta: {},
+      uuid: '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d',
+    },
+  },
+  externalArticles: {
+    data: {},
+    lastError: null,
+    error: null,
+    lastSuccessfulFetchTimestamp: null,
+    loading: false,
+    loadingIds: [],
+    updatingIds: [],
+  },
+  feed: {},
+};
+
 export {
   capiArticle,
   capiArticleWithVideo,

--- a/fronts-client/src/selectors/__tests__/collection.spec.ts
+++ b/fronts-client/src/selectors/__tests__/collection.spec.ts
@@ -1,5 +1,5 @@
 import {
-  selectArticlesInCollections,
+  selectCardsInCollections,
   createSelectIsArticleInCollection,
 } from '../collection';
 import { stateWithCollection } from '../../fixtures/shared';
@@ -8,19 +8,19 @@ describe('Collection selectors', () => {
   describe('selectArticlesInCollections', () => {
     it("should select all of the articles in a given collection's itemSet", () => {
       expect(
-        selectArticlesInCollections(stateWithCollection, {
+        selectCardsInCollections(stateWithCollection, {
           collectionIds: ['exampleCollection'],
           itemSet: 'live',
         })
       ).toEqual(['article/live/0', 'article/draft/1', 'a/long/path/2']);
       expect(
-        selectArticlesInCollections(stateWithCollection, {
+        selectCardsInCollections(stateWithCollection, {
           collectionIds: ['exampleCollectionTwo'],
           itemSet: 'live',
         })
       ).toEqual(['article/live/0']);
       expect(
-        selectArticlesInCollections(stateWithCollection, {
+        selectCardsInCollections(stateWithCollection, {
           collectionIds: ['exampleCollectionTwo'],
           itemSet: 'draft',
         })
@@ -28,7 +28,7 @@ describe('Collection selectors', () => {
     });
     it('should return an empty array if no collections are found', () => {
       expect(
-        selectArticlesInCollections(stateWithCollection, {
+        selectCardsInCollections(stateWithCollection, {
           collectionIds: ['invalidCollectionId'],
           itemSet: 'draft',
         })

--- a/fronts-client/src/selectors/__tests__/collection.spec.ts
+++ b/fronts-client/src/selectors/__tests__/collection.spec.ts
@@ -5,25 +5,25 @@ import {
 import { stateWithCollection } from '../../fixtures/shared';
 
 describe('Collection selectors', () => {
-  describe('selectArticlesInCollections', () => {
-    it("should select all of the articles in a given collection's itemSet", () => {
+  describe('selectCardsInCollections', () => {
+    it("should select all of the cards in a given collection's itemSet", () => {
       expect(
         selectCardsInCollections(stateWithCollection, {
           collectionIds: ['exampleCollection'],
           itemSet: 'live',
-        })
+        }).map((card) => card.id)
       ).toEqual(['article/live/0', 'article/draft/1', 'a/long/path/2']);
       expect(
         selectCardsInCollections(stateWithCollection, {
           collectionIds: ['exampleCollectionTwo'],
           itemSet: 'live',
-        })
+        }).map((card) => card.id)
       ).toEqual(['article/live/0']);
       expect(
         selectCardsInCollections(stateWithCollection, {
           collectionIds: ['exampleCollectionTwo'],
           itemSet: 'draft',
-        })
+        }).map((card) => card.id)
       ).toEqual(['article/draft/1', 'a/long/path/2']);
     });
     it('should return an empty array if no collections are found', () => {

--- a/fronts-client/src/selectors/__tests__/shared.spec.ts
+++ b/fronts-client/src/selectors/__tests__/shared.spec.ts
@@ -1,8 +1,8 @@
 import {
   selectExternalArticleFromCard,
   createSelectArticleFromCard,
-  createSelectArticlesInCollectionGroup,
-  createSelectArticlesInCollection,
+  createSelectCardsInCollectionGroup,
+  createSelectCardsInCollection,
   createSelectCollection,
   selectGroupSiblings,
 } from '../shared';
@@ -350,7 +350,7 @@ describe('Shared selectors', () => {
 
   describe('createArticlesInCollectionSelector', () => {
     it('should return a list of all the articles in a given collection', () => {
-      const selector = createSelectArticlesInCollection();
+      const selector = createSelectCardsInCollection();
       expect(
         selector(state, {
           collectionId: 'c1',
@@ -359,7 +359,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af2', 'af1']);
     });
     it('should return articles in supporting positions', () => {
-      const selector = createSelectArticlesInCollection();
+      const selector = createSelectCardsInCollection();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -368,7 +368,7 @@ describe('Shared selectors', () => {
       ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
     it('should not return articles in supporting positions if includeSupportingArticles is false', () => {
-      const selector = createSelectArticlesInCollection();
+      const selector = createSelectCardsInCollection();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -381,7 +381,7 @@ describe('Shared selectors', () => {
 
   describe('createArticlesInCollectionGroupSelector', () => {
     it('should return a list of articles held by the given collection for the given display index', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c1',
@@ -405,7 +405,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af3', 'af4']);
     });
     it('should put articles which are in groups that don`t exis in the config in the first group', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       const currentGroups = state.groups;
       const newGroups = {
         ...currentGroups,
@@ -422,7 +422,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af6', 'af2', 'af1']);
     });
     it('should put articles which are in groups that don`t exis in the config in the first group even when none of the groups have names', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       const newGroups = {
         ...{ g1: { uuid: 'g1', cards: ['af4'] } },
         ...{ g2: { uuid: 'g2', id: 'group6', cards: ['af5'] } },
@@ -439,7 +439,7 @@ describe('Shared selectors', () => {
       ).toEqual(['af5', 'af6', 'af4']);
     });
     it('should return articles in supporting positions', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -449,7 +449,7 @@ describe('Shared selectors', () => {
       ).toEqual(['afWithSupporting', 'afWithSectionKicker']);
     });
     it('should not return articles in supporting positions if includeSupportingArticles is false', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c5',
@@ -460,7 +460,7 @@ describe('Shared selectors', () => {
       ).toEqual(['afWithSupporting']);
     });
     it('should return an empty array if the collection is not found', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'invalid',
@@ -470,7 +470,7 @@ describe('Shared selectors', () => {
       ).toEqual([]);
     });
     it('should return an empty array if the collectionSet is not found', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c1',
@@ -480,7 +480,7 @@ describe('Shared selectors', () => {
       ).toEqual([]);
     });
     it("should handle articles that don't contain a meta key", () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c4',
@@ -490,7 +490,7 @@ describe('Shared selectors', () => {
       ).toEqual([]);
     });
     it('should assume that articles without a meta key are in the first available group', () => {
-      const selector = createSelectArticlesInCollectionGroup();
+      const selector = createSelectCardsInCollectionGroup();
       expect(
         selector(state, {
           collectionId: 'c3',

--- a/fronts-client/src/selectors/collection.ts
+++ b/fronts-client/src/selectors/collection.ts
@@ -1,21 +1,21 @@
 import type { State } from 'types/State';
 import { CardSets } from 'types/Collection';
-import { createSelectArticlesInCollection } from './shared';
+import { createSelectCardsInCollection } from './shared';
 import uniq from 'lodash/uniq';
 import flatten from 'lodash/flatten';
 import { createSelector } from 'reselect';
 import { selectCard } from '../selectors/shared';
 
-const selectArticleIdsInCollection = createSelectArticlesInCollection();
+const selectCardsInCollection = createSelectCardsInCollection();
 
 // Does not return UUIDs. Returns interal page codes for fetching cards
-export const selectArticlesInCollections = createSelector(
+export const selectCardsInCollections = createSelector(
   (
     state: State,
     { collectionIds, itemSet }: { collectionIds: string[]; itemSet: CardSets }
   ) =>
     collectionIds.map((_) =>
-      selectArticleIdsInCollection(state, {
+      selectCardsInCollection(state, {
         collectionId: _,
         collectionSet: itemSet,
       })
@@ -25,8 +25,13 @@ export const selectArticlesInCollections = createSelector(
   (articleIds) => uniq(flatten(articleIds))
 );
 
+export const selectChefsInCollections = (
+  state: State,
+  { collectionIds, itemSet }: { collectionIds: string[]; itemSet: CardSets }
+) => {};
+
 export const createSelectIsArticleInCollection = () => {
-  const selectArticlesInCollection = createSelectArticlesInCollection();
+  const selectArticlesInCollection = createSelectCardsInCollection();
   return createSelector(
     selectArticlesInCollection,
     (_: State, { cardId: articleId }: { cardId: string }) => articleId,

--- a/fronts-client/src/selectors/collection.ts
+++ b/fronts-client/src/selectors/collection.ts
@@ -1,29 +1,23 @@
 import type { State } from 'types/State';
-import { CardSets } from 'types/Collection';
+import { Card, CardSets } from 'types/Collection';
 import { createSelectCardsInCollection } from './shared';
-import uniq from 'lodash/uniq';
-import flatten from 'lodash/flatten';
 import { createSelector } from 'reselect';
 import { selectCard } from '../selectors/shared';
 
 const selectCardsInCollection = createSelectCardsInCollection();
 
-// Does not return UUIDs. Returns interal page codes for fetching cards
-export const selectCardsInCollections = createSelector(
-  (
-    state: State,
-    { collectionIds, itemSet }: { collectionIds: string[]; itemSet: CardSets }
-  ) =>
-    collectionIds.map((_) =>
-      selectCardsInCollection(state, {
-        collectionId: _,
-        collectionSet: itemSet,
-      })
-        .map((articleId) => selectCard(state, articleId))
-        .map((article) => article.id)
-    ),
-  (articleIds) => uniq(flatten(articleIds))
-);
+// Unmemoized – intended to be used for fetch calls.
+// Will need to be memoized if used in UI.
+export const selectCardsInCollections = (
+  state: State,
+  { collectionIds, itemSet }: { collectionIds: string[]; itemSet: CardSets }
+): Card[] =>
+  collectionIds.flatMap((_) =>
+    selectCardsInCollection(state, {
+      collectionId: _,
+      collectionSet: itemSet,
+    }).map((cardId) => selectCard(state, cardId))
+  );
 
 export const selectChefsInCollections = (
   state: State,

--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -12,7 +12,7 @@ import { selectors as frontsConfigSelectors } from 'bundles/frontsConfigBundle';
 
 import { CardSets, Stages } from 'types/Collection';
 import {
-  createSelectArticlesInCollection,
+  createSelectCardsInCollection,
   createSelectCollection,
 } from 'selectors/shared';
 import { createShallowEqualResultSelector } from 'util/selectorUtils';
@@ -328,7 +328,7 @@ const defaultVisibleFrontArticles = {
 };
 
 const createSelectArticleVisibilityDetails = () => {
-  const selectArticlesInCollection = createSelectArticlesInCollection();
+  const selectArticlesInCollection = createSelectCardsInCollection();
 
   // Have to adapt this to work on root state
   const selectRootArticlesInCollection = (

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -321,7 +321,7 @@ const createSelectCardsInCollectionGroup = () => {
 };
 
 const createSelectCardsInCollection = () => {
-  const selectArticlesInCollectionGroups = createSelectCardsInCollectionGroup();
+  const selectCardsInCollectionGroups = createSelectCardsInCollectionGroup();
   return (
     state: State,
     {
@@ -334,15 +334,15 @@ const createSelectCardsInCollection = () => {
       includeSupportingArticles?: boolean;
     }
   ) =>
-    selectArticlesInCollectionGroups(state, {
+    selectCardsInCollectionGroups(state, {
       collectionId,
       collectionSet,
       includeSupportingArticles,
     });
 };
 
-const createSelectAllArticlesInCollection = () => {
-  const articlesInCollection = createSelectCardsInCollection();
+const createSelectAllCardsInCollection = () => {
+  const selectCardsInCollection = createSelectCardsInCollection();
 
   return (state: State, collectionIds: string[]) =>
     collectionIds.reduce(
@@ -351,7 +351,7 @@ const createSelectAllArticlesInCollection = () => {
         ...Object.values(cardSets).reduce(
           (acc1, collectionSet) => [
             ...acc1,
-            ...articlesInCollection(state, {
+            ...selectCardsInCollection(state, {
               collectionId: id,
               collectionSet,
             }),
@@ -505,7 +505,7 @@ export {
   selectCardsFromRootState,
   createSelectCardsInCollectionGroup,
   createSelectCardsInCollection,
-  createSelectAllArticlesInCollection,
+  createSelectAllCardsInCollection,
   createSelectGroupArticles,
   createSelectSupportingArticles,
   createSelectCollection,

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -282,14 +282,14 @@ const selectIncludeSupportingArticles = (
   }
 ) => includeSupportingArticles;
 
-const createSelectArticlesInCollectionGroup = () => {
+const createSelectCardsInCollectionGroup = () => {
   const selectCollectionStageGroups = createSelectCollectionStageGroups();
   return createShallowEqualResultSelector(
     selectCards,
     selectCollectionStageGroups,
     selectGroupName,
     selectIncludeSupportingArticles,
-    (cards, collectionGroups, groupName, includeSupportingArticles = true) => {
+    (cards, collectionGroups, groupName, includeSupportingCards = true) => {
       const groups = groupName
         ? [
             collectionGroups.find(({ id }) => id === groupName) || {
@@ -301,7 +301,7 @@ const createSelectArticlesInCollectionGroup = () => {
         (acc, group) => acc.concat(group.cards || []),
         [] as string[]
       );
-      if (!includeSupportingArticles) {
+      if (!includeSupportingCards) {
         return groupCardIds;
       }
       return groupCardIds.reduce((acc, id) => {
@@ -320,9 +320,8 @@ const createSelectArticlesInCollectionGroup = () => {
   );
 };
 
-const createSelectArticlesInCollection = () => {
-  const selectArticlesInCollectionGroups =
-    createSelectArticlesInCollectionGroup();
+const createSelectCardsInCollection = () => {
+  const selectArticlesInCollectionGroups = createSelectCardsInCollectionGroup();
   return (
     state: State,
     {
@@ -343,7 +342,7 @@ const createSelectArticlesInCollection = () => {
 };
 
 const createSelectAllArticlesInCollection = () => {
-  const articlesInCollection = createSelectArticlesInCollection();
+  const articlesInCollection = createSelectCardsInCollection();
 
   return (state: State, collectionIds: string[]) =>
     collectionIds.reduce(
@@ -504,8 +503,8 @@ export {
   selectExternalArticleFromCard,
   createSelectArticleFromCard,
   selectCardsFromRootState,
-  createSelectArticlesInCollectionGroup,
-  createSelectArticlesInCollection,
+  createSelectCardsInCollectionGroup,
+  createSelectCardsInCollection,
   createSelectAllArticlesInCollection,
   createSelectGroupArticles,
   createSelectSupportingArticles,


### PR DESCRIPTION
_co-authored-by: @Divs-B @JustinPinner_ 

## What's changed?

Fetch chefs as collections are loaded.

It should be easy to extend the logic to recipes once we've a recipes search.

|Before|After|
|-|-|
|![fronts-chefs-fetch-bad](https://github.com/guardian/facia-tool/assets/7767575/b47275ec-c4b3-44d8-bcda-65e750565362)|![fronts-chefs-fetch-good](https://github.com/guardian/facia-tool/assets/7767575/7f5b03ea-eefa-44a2-b48c-fe64732b4d79)|

## Implementation notes

We've slimmed down the fixtures with a utility assertion function. It's still a bit verbose, but hopefully a bit less repetitious than before.

The size of the PR is increased by a refactor to ensure that selectors that referenced 'articles' are now referencing 'cards', which is more correct. Inspecting individual commits should give a clearer picture of the relevant changes.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
