### PR TITLE
Remove MaxPermSize JDK option

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -36,7 +36,7 @@ main() {
 
     printf "\n\rStarting Play App... \n\r\n\r"
 
-    export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xmx4G -Xss4m"
+    export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -Xmx4G -Xss4m"
 
     if [[ "$NO_DEBUG" = true ]] ; then
       sbt "run"


### PR DESCRIPTION
OpenJDK 11 is telling me this option is gone now, and is ignored. Might as well remove it, I figure!

(This stack overflow answer suggests there is no sensible replacement option because the functioning of the garbage collector has changed: https://stackoverflow.com/a/12114284)