### PR TITLE
improve portrait crop visuals

### DIFF
--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -35,9 +35,10 @@ import { updateCollection as updateCollectionAction } from '../actions/Collectio
 import { isMode } from '../selectors/pathSelectors';
 import {
   COLLECTIONS_USING_PORTRAIT_TRAILS,
+  portraitCardImageCriteria,
   SUPPORT_PORTRAIT_CROPS,
 } from 'constants/image';
-import { CropIcon } from './icons/Icons';
+import { AspectRatioBadge } from './icons/AspectRatioBadge';
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
   `front-${frontId}-collection-${id}`;
@@ -275,9 +276,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
       >
         <CollectionHeadingSticky tabIndex={-1}>
           <CollectionHeadingInner>
-            {usePortrait && (
-              <CropIcon title={'uses portrait (5:4) image crops'} />
-            )}
+            {usePortrait && <AspectRatioBadge {...portraitCardImageCriteria} />}
             <CollectionHeadlineWithConfigContainer>
               {this.state.editingContainerName ? (
                 <CollectionHeaderInput

--- a/fronts-client/src/components/icons/AspectRatioBadge.tsx
+++ b/fronts-client/src/components/icons/AspectRatioBadge.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import CircularIconContainer from './CircularIconContainer';
+import { styled, theme } from 'constants/theme';
+
+interface Props {
+  widthAspectRatio: number;
+  heightAspectRatio: number;
+}
+
+const AspectText = styled.span`
+  font-family: TS3TextSans;
+  font-size: 11px;
+  line-height: 1;
+  display: inline-block;
+  min-width: 20px;
+  text-align: center;
+  color: ${theme.colors.white};
+`;
+
+const Container = styled(CircularIconContainer)`
+  margin-right: 10px;
+  background-color: ${theme.colors.blackLight};
+`;
+
+const getAspectDescription = (
+  widthAspectRatio: number,
+  heightAspectRatio: number
+): string =>
+  widthAspectRatio > heightAspectRatio
+    ? 'landscape'
+    : widthAspectRatio < heightAspectRatio
+    ? 'portrait'
+    : 'square';
+
+export const AspectRatioBadge: React.FunctionComponent<Props> = ({
+  widthAspectRatio,
+  heightAspectRatio,
+}) => {
+  return (
+    <Container
+      title={`uses ${widthAspectRatio}:${heightAspectRatio} (${getAspectDescription(
+        widthAspectRatio,
+        heightAspectRatio
+      )}) image crops`}
+    >
+      <AspectText>
+        {widthAspectRatio}:{heightAspectRatio}
+      </AspectText>
+    </Container>
+  );
+};

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -318,28 +318,6 @@ const WarningIcon = ({ fill = theme.colors.white, size = 'm' }: IconProps) => (
   </svg>
 );
 
-const CropIcon = ({
-  fill = theme.colors.greyDark,
-  size = 'xl',
-  title = null,
-}: IconProps) => (
-  <svg
-    width={mapSize(size)}
-    height={mapSize(size)}
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <title>{title}</title>
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M17 15h2V7c0-1.1-.9-2-2-2H9v2h8zM7 17V1H5v4H1v2h4v10c0 1.1.9 2 2 2h10v4h2v-4h4v-2z"
-      fill={fill}
-    />
-  </svg>
-);
-
 export {
   DownCaretIcon,
   RubbishBinIcon,
@@ -356,5 +334,4 @@ export {
   VideoIcon,
   DragHandleIcon as DragIcon,
   WarningIcon,
-  CropIcon,
 };

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -9,7 +9,6 @@ const smallPortaitStyle = `
   width: ${SMALL_PORTRAIT_WIDTH}px;
   height: ${Math.floor(SMALL_PORTRAIT_WIDTH * PORTRAIT_RATIO)}px;
   padding: 40% 0;
-  min-width: 50px;
   margin: 0 auto;
 `;
 
@@ -60,5 +59,6 @@ export const ImageInputImageContainer = styled.div<{
   flex-direction: column;
   position: relative;
   transition: background-color 0.15s;
+  max-width: 100%;
   ${getVariableImageContainerStyle}
 `;

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -7,7 +7,7 @@ const TEXTINPUT_HEIGHT = 30;
 
 const smallPortaitStyle = `
   width: ${SMALL_PORTRAIT_WIDTH}px;
-  height: ${Math.floor(SMALL_PORTRAIT_WIDTH * PORTRAIT_RATIO)}px;
+  height: 100%;
   padding: 40% 0;
   margin: 0 auto;
 `;

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -54,15 +54,19 @@ const AddImageButton = styled(ButtonDefault)<{ small?: boolean }>`
 `;
 
 const ImageComponent = styled.div<{ small: boolean }>`
+  background-size: cover;
   ${({ small }) =>
     small
       ? `position: absolute;
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;`
+    height: 100%;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    `
       : 'position: relative;'}
-  background-size: cover;
   flex-grow: 1;
   cursor: grab;
 `;

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -53,20 +53,24 @@ const AddImageButton = styled(ButtonDefault)<{ small?: boolean }>`
   text-shadow: 0 0 2px black;
 `;
 
-const ImageComponent = styled.div<{ small: boolean }>`
-  background-size: cover;
+const ImageComponent = styled.div<{ small: boolean; portrait: boolean }>`
   ${({ small }) =>
     small
       ? `position: absolute;
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100%;`
+      : 'position: relative;'}
+  background-size: cover;
+  ${({ small, portrait }) =>
+    small && portrait
+      ? `
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
     `
-      : 'position: relative;'}
+      : ``}
   flex-grow: 1;
   cursor: grab;
 `;
@@ -329,6 +333,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
               onDragStart={this.handleDragStart}
               onDrop={this.handleDrop}
               small={small}
+              portrait={portraitImage}
             >
               {hasImage ? (
                 <>


### PR DESCRIPTION
## What's changed?

fixes some visual issues noted for https://github.com/guardian/facia-tool/pull/1591 (feature behind switch)

 - replaces the placeholder "crop" icon next to the collection name for 'portrait crop' collections with a round badge displaying the aspect ratio (as before, only show if not using the default image criteria)
 - Changes the styling for the small portrait imageInputs (IE for slideshow image pickers in 'portrait crop' collections) to avoid overlapping - the image containers no longer use absolute width and height to display the image at the right aspect, but use `background-image:cover` instead

## Implementation notes
Should still be no noticeable changes on PROD as the feature is still behind a switch. 

See testing notes on https://github.com/guardian/facia-tool/pull/1591 for how to view the changes locally.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included


### images:
|before|after|
|---|---|
|.<img width="532" alt="Screenshot 2024-06-17 at 17 07 08" src="https://github.com/guardian/facia-tool/assets/30567854/3b66a25a-7b91-41ca-b91d-09dec04e848d">  |.<img width="563" alt="Screenshot 2024-06-17 at 16 25 26" src="https://github.com/guardian/facia-tool/assets/30567854/21bdf88a-1af0-4580-9e4f-87723f4093b4">  |
| <img width="329" alt="Screenshot 2024-06-17 at 17 07 58" src="https://github.com/guardian/facia-tool/assets/30567854/a4827c46-097c-4381-97ec-2bac6941739f">|<img width="332" alt="Screenshot 2024-06-17 at 16 25 59" src="https://github.com/guardian/facia-tool/assets/30567854/a2b2009c-0e6f-4c3f-bd30-0d1c1211ba49"> |






