### PR TITLE
Fix duplicate chef ids exception on search

### DIFF
--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -50,7 +50,9 @@ export const fetchChefs =
         dispatch(
           actions.fetchSuccess(resultData.results.map(sanitizeTag), {
             pagination: resultData.pagination || undefined,
-            order: resultData.results.map((_) => _.id),
+            order: resultData.results.map(
+              (_) => _.id + '#' + _.r2ContributorId //to fix duplicate chef id where Fronts throws exception (example "profile/alex-clapham" was twice in the data), hence suffix with unique r2ContributorId.
+            ),
           })
         );
       } else {

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -50,9 +50,7 @@ export const fetchChefs =
         dispatch(
           actions.fetchSuccess(resultData.results.map(sanitizeTag), {
             pagination: resultData.pagination || undefined,
-            order: resultData.results.map(
-              (_) => _.id + '#' + _.r2ContributorId //to fix duplicate chef id where Fronts throws exception (example "profile/alex-clapham" was twice in the data), hence suffix with unique r2ContributorId.
-            ),
+            order: resultData.results.map((_) => _.id),
           })
         );
       } else {
@@ -84,6 +82,15 @@ const selectChefDataFromCardId = (
   return selectors.selectById(state, card.id);
 };
 
+const selectLastFetchOrderChefs = (state: State): Chef[] => {
+  return bundle.selectors
+    .selectLastFetchOrder(state)
+    .map((id) => {
+      return bundle.selectors.selectById(state, id) as Chef;
+    })
+    .filter((_) => !!_);
+};
+
 /**
  * Select a Chef from a card, overriding the original values with the card meta
  * if it's present.
@@ -109,4 +116,5 @@ export const reducer = bundle.reducer;
 export const selectors = {
   ...bundle.selectors,
   selectChefFromCard,
+  selectLastFetchOrderChefs,
 };

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -108,10 +108,11 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
         return Object.values(recipes).map((recipe) => (
           <RecipeFeedItem key={recipe.id} recipe={recipe} />
         ));
-      case FeedType.chefs:
+      case FeedType.chefs: {
         return chefSearchIds.map((chefId) => (
-          <ChefFeedItem key={chefId} id={chefId} />
+          <ChefFeedItem key={chefId} id={chefId.split('#')[0]} /> //read id only by removing suffixed r2ContributorId (see chefsBundle.ts for reference)
         ));
+      }
     }
   };
 

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -65,8 +65,8 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
     },
     [dispatch]
   );
-  const chefSearchIds = useSelector((state: State) =>
-    chefSelectors.selectLastFetchOrder(state)
+  const chefs = useSelector((state: State) =>
+    chefSelectors.selectLastFetchOrderChefs(state)
   );
 
   const [page, setPage] = useState(1);
@@ -109,8 +109,8 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
           <RecipeFeedItem key={recipe.id} recipe={recipe} />
         ));
       case FeedType.chefs: {
-        return chefSearchIds.map((chefId) => (
-          <ChefFeedItem key={chefId} id={chefId.split('#')[0]} /> //read id only by removing suffixed r2ContributorId (see chefsBundle.ts for reference)
+        return chefs.map((chef) => (
+          <ChefFeedItem key={chef.id + chef.r2ContributorId} id={chef.id} />
         ));
       }
     }

--- a/fronts-client/src/lib/createAsyncResourceBundle/index.ts
+++ b/fronts-client/src/lib/createAsyncResourceBundle/index.ts
@@ -2,6 +2,7 @@ import without from 'lodash/without';
 import isEqual from 'lodash/isEqual';
 import type { Action } from 'types/Action';
 import { attemptFriendlyErrorMessage } from 'util/error';
+import { Chef } from '../../types/Chef';
 
 interface BaseResource {
   id: string;

--- a/fronts-client/src/types/Capi.ts
+++ b/fronts-client/src/types/Capi.ts
@@ -81,6 +81,7 @@ interface Tag {
   sectionId?: string;
   sectionName?: string;
   bio?: string;
+  r2ContributorId?: string;
 }
 
 type CapiBool = 'true' | 'false' | boolean;

--- a/fronts-client/src/types/Chef.ts
+++ b/fronts-client/src/types/Chef.ts
@@ -12,4 +12,5 @@ export interface Chef {
   firstName: string;
   lastName: string;
   twitterHandle?: string;
+  r2ContributorId?: string;
 }


### PR DESCRIPTION
## What's changed?

This is follow up PR to fix an issue, a scenario where duplicate chef id's present in the chef-feeds when doing search.
Fronts throws exception that key should be unique to render on the feed.
Details: https://github.com/guardian/facia-tool/pull/1597#issuecomment-2180419689

We are using `lastFetchOrder` to get search list page by page, which are collection of `id`'s  but prone to duplicates.
This can be fix by making `lastFetchOrder` to be unique for chefs ,means combining `id` and unique id's that are available as `r2ContributorId` under contributor data structure.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
