### PR TITLE
Switch to 5:4 aspect ratio for Fronts images

### DIFF
--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -31,6 +31,8 @@ import {
   landScapeCardImageCriteria,
   portraitCardImageCriteria,
   defaultCardTrailImageCriteria,
+  landscape5To4CardImageCriteria,
+  COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS,
 } from 'constants/image';
 import Sublinks from '../FrontsEdit/CollectionComponents/Sublinks';
 import {
@@ -186,6 +188,7 @@ class Card extends React.Component<CardContainerProps> {
               onImageDrop={this.handleImageDrop}
               canDragImage={canDragImage}
               canShowPageViewData={canShowPageViewData}
+              imageCriteria={this.determineCardCriteria()}
             >
               <EditModeVisibility visibleMode="fronts">
                 {getSublinks}
@@ -422,7 +425,15 @@ class Card extends React.Component<CardContainerProps> {
       return defaultCardTrailImageCriteria;
     }
 
-    if (!SUPPORT_PORTRAIT_CROPS || !collectionType) {
+    if (!collectionType) {
+      return landScapeCardImageCriteria;
+    }
+
+    if (COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
+      return landscape5To4CardImageCriteria;
+    }
+
+    if (!SUPPORT_PORTRAIT_CROPS) {
       return landScapeCardImageCriteria;
     }
 

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -35,6 +35,8 @@ import PageViewDataWrapper from '../../PageViewDataWrapper';
 import ImageAndGraphWrapper from 'components/image/ImageAndGraphWrapper';
 import { getPaths } from 'util/paths';
 import { getMaybeDimensionsFromWidthAndHeight } from 'util/validateImageSrc';
+import { Criteria } from 'types/Grid';
+import { landscape5To4CardImageCriteria } from 'constants/image';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
   flex-shrink: 0;
@@ -134,6 +136,7 @@ interface ArticleBodyProps {
   collectionId?: string;
   imageSrcWidth?: string;
   imageSrcHeight?: string;
+  imageCriteria?: Criteria;
 }
 
 const articleBodyDefault = React.memo(
@@ -181,6 +184,7 @@ const articleBodyDefault = React.memo(
     promotionMetric,
     imageSrcWidth,
     imageSrcHeight,
+    imageCriteria,
   }: ArticleBodyProps) => {
     const displayByline = size === 'default' && showByline && byline;
     const now = Date.now();
@@ -194,6 +198,12 @@ const articleBodyDefault = React.memo(
       !!imageReplace &&
       thumbnailDims &&
       thumbnailDims.height > thumbnailDims.width;
+    const showThumbnailInLandscape54 =
+      imageCriteria &&
+      imageCriteria.widthAspectRatio ===
+        landscape5To4CardImageCriteria.widthAspectRatio &&
+      imageCriteria.heightAspectRatio ===
+        landscape5To4CardImageCriteria.heightAspectRatio;
 
     return (
       <>
@@ -309,6 +319,7 @@ const articleBodyDefault = React.memo(
                   url={thumbnail}
                   isDraggingImageOver={isDraggingImageOver}
                   isPortrait={thumbnailIsPortrait}
+                  showLandscape54={showThumbnailInLandscape54}
                 >
                   {cutoutThumbnail ? (
                     <ThumbnailCutout src={cutoutThumbnail} />

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -20,6 +20,7 @@ import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import { theme } from 'constants/theme';
 import { getPillarColor } from 'util/getPillarColor';
 import { dragEventHasImageData } from 'util/validateImageSrc';
+import { Criteria } from 'types/Grid';
 
 const ArticleBodyContainer = styled(CardBody)<{
   pillarId: string | undefined;
@@ -57,6 +58,7 @@ interface ArticleComponentProps {
   featureFlagPageViewData?: boolean;
   frontId: string;
   collectionId?: string;
+  imageCriteria?: Criteria;
 }
 
 interface ComponentProps extends ArticleComponentProps {
@@ -104,6 +106,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
       canShowPageViewData = false,
       frontId,
       collectionId,
+      imageCriteria,
     } = this.props;
 
     const getArticleData = () =>
@@ -160,6 +163,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
                 isDraggingImageOver={this.state.isDraggingImageOver}
                 featureFlagPageViewData={featureFlagPageViewData}
                 canShowPageViewData={canShowPageViewData}
+                imageCriteria={imageCriteria}
               />
             </ArticleBodyContainer>
           </DragIntentContainer>

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -48,6 +48,8 @@ import {
   portraitCardImageCriteria,
   COLLECTIONS_USING_PORTRAIT_TRAILS,
   SUPPORT_PORTRAIT_CROPS,
+  COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS,
+  landscape5To4CardImageCriteria,
 } from 'constants/image';
 import { selectors as collectionSelectors } from 'bundles/collectionsBundle';
 import { getContributorImage } from 'util/CAPIUtils';
@@ -918,7 +920,13 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
   private determineCardCriteria = (): Criteria => {
     const { collectionType } = this.props;
-    if (!SUPPORT_PORTRAIT_CROPS || !collectionType) {
+    if (!collectionType) {
+      return landScapeCardImageCriteria;
+    }
+    if (COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
+      return landscape5To4CardImageCriteria;
+    }
+    if (!SUPPORT_PORTRAIT_CROPS) {
       return landScapeCardImageCriteria;
     }
     return COLLECTIONS_USING_PORTRAIT_TRAILS.includes(collectionType)

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -37,7 +37,6 @@ const normalLandscapeStyle = `
 const smallLandscape54Style = `
   width: 100%;
   maxWidth: 180px;
-  aspect-ratio: 5/4;
   padding: 40%;
   minWidth: 50px;
 `;
@@ -45,23 +44,22 @@ const smallLandscape54Style = `
 const normalLandscape54Style = `
   width: 100%;
   maxWidth: 180px;
-  aspect-ratio: 5/4;
 `;
 
 const getVariableImageContainerStyle = ({
   portrait = false,
   small = false,
+  shouldShowLandscape54: shouldShowLandscape54 = false,
 }: {
   small?: boolean;
   portrait?: boolean;
-}) =>
-  portrait
-    ? small
-      ? smallPortaitStyle
-      : normalPortraitStyle
-    : small
-    ? smallLandscapeStyle
-    : normalLandscapeStyle;
+  shouldShowLandscape54?: boolean;
+}) => {
+  if (portrait) return small ? smallPortaitStyle : normalPortraitStyle;
+  else if (shouldShowLandscape54)
+    return small ? smallLandscape54Style : normalLandscape54Style;
+  else return small ? smallLandscapeStyle : normalLandscapeStyle;
+};
 
 // assuming any portrait image (ie height>width)
 // is in the 4:5 ratio for purposes of styling
@@ -69,6 +67,7 @@ const getVariableImageContainerStyle = ({
 export const ImageInputImageContainer = styled.div<{
   small?: boolean;
   portrait?: boolean;
+  shouldShowLandscape54?: boolean;
 }>`
   display: flex;
   flex-direction: column;

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -31,7 +31,7 @@ const smallLandscapeStyle = `
 const normalLandscapeStyle = `
   width: 100%;
   maxWidth: 180px;
-  height: 115px;
+  aspect-ratio: 5/4;
 `;
 
 const getVariableImageContainerStyle = ({

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -31,6 +31,20 @@ const smallLandscapeStyle = `
 const normalLandscapeStyle = `
   width: 100%;
   maxWidth: 180px;
+  height: 115px;
+`;
+
+const smallLandscape54Style = `
+  width: 100%;
+  maxWidth: 180px;
+  aspect-ratio: 5/4;
+  padding: 40%;
+  minWidth: 50px;
+`;
+
+const normalLandscape54Style = `
+  width: 100%;
+  maxWidth: 180px;
   aspect-ratio: 5/4;
 `;
 

--- a/fronts-client/src/components/image/Thumbnail.tsx
+++ b/fronts-client/src/components/image/Thumbnail.tsx
@@ -63,7 +63,7 @@ const ThumbnailEditForm = styled(ThumbnailBase)<{
   url: string | undefined | void;
 }>`
   width: 100%;
-  aspect-ratio: 8/3;
+  height: 115px;
   margin-bottom: 10px;
   opacity: ${({ imageHide }) => (imageHide ? 0.5 : 1)};
   background-image: ${({ url }) => `url('${url}')`};

--- a/fronts-client/src/components/image/Thumbnail.tsx
+++ b/fronts-client/src/components/image/Thumbnail.tsx
@@ -14,12 +14,14 @@ const ThumbnailSmall = styled(ThumbnailBase)<{
   position: relative;
   width: ${theme.thumbnailImage.width};
   min-width: ${theme.thumbnailImage.width};
-  height: ${theme.thumbnailImage.height};
+  aspect-ratio: 5/4;
   color: white;
   font-size: 10px;
   font-weight: bold;
   opacity: ${({ imageHide }) => (imageHide && imageHide ? '0.5' : '1')};
   background-image: ${({ url }) => `url('${url}')`};
+  background-position: center center;
+  background-repeat: no-repeat;
 
   ${({ isPortrait }) =>
     isPortrait &&
@@ -55,7 +57,7 @@ const ThumbnailEditForm = styled(ThumbnailBase)<{
   url: string | undefined | void;
 }>`
   width: 100%;
-  height: 115px;
+  aspect-ratio: 8/3;
   margin-bottom: 10px;
   opacity: ${({ imageHide }) => (imageHide ? 0.5 : 1)};
   background-image: ${({ url }) => `url('${url}')`};

--- a/fronts-client/src/components/image/Thumbnail.tsx
+++ b/fronts-client/src/components/image/Thumbnail.tsx
@@ -10,18 +10,16 @@ const ThumbnailSmall = styled(ThumbnailBase)<{
   isDraggingImageOver?: boolean;
   imageHide?: boolean;
   isPortrait?: boolean;
+  showLandscape54?: boolean;
 }>`
   position: relative;
   width: ${theme.thumbnailImage.width};
   min-width: ${theme.thumbnailImage.width};
-  aspect-ratio: 5/4;
   color: white;
   font-size: 10px;
   font-weight: bold;
   opacity: ${({ imageHide }) => (imageHide && imageHide ? '0.5' : '1')};
   background-image: ${({ url }) => `url('${url}')`};
-  background-position: center center;
-  background-repeat: no-repeat;
 
   ${({ isPortrait }) =>
     isPortrait &&
@@ -30,6 +28,14 @@ const ThumbnailSmall = styled(ThumbnailBase)<{
     background-repeat: no-repeat;
     background-position-x: center;
   `}
+  ${({ showLandscape54 }) =>
+    showLandscape54
+      ? `
+    aspect-ratio: 5/4;
+    background-position: center center;
+    background-repeat: no-repeat;
+  `
+      : `height: ${theme.thumbnailImage.height};`}
 
   ${({ isDraggingImageOver }) =>
     isDraggingImageOver &&

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -54,7 +54,11 @@ const AddImageButton = styled(ButtonDefault)<{ small?: boolean }>`
   text-shadow: 0 0 2px black;
 `;
 
-const ImageComponent = styled.div<{ small: boolean; portrait: boolean }>`
+const ImageComponent = styled.div<{
+  small: boolean;
+  portrait: boolean;
+  shouldShowLandscape54: boolean;
+}>`
   ${({ small }) =>
     small
       ? `position: absolute;
@@ -72,6 +76,12 @@ const ImageComponent = styled.div<{ small: boolean; portrait: boolean }>`
     background-position: center;
     `
       : ``}
+  ${({ shouldShowLandscape54 }) =>
+    shouldShowLandscape54 &&
+    `aspect-ratio: 5/4;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;`}
   flex-grow: 1;
   cursor: grab;
 `;
@@ -279,6 +289,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       disabled,
       isSelected,
       isInvalid,
+      criteria,
     } = this.props;
 
     const imageDims = this.getCurrentImageDimensions();
@@ -304,7 +315,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
       imageDims &&
       imageDims.height > imageDims.width
     );
-
+    const shouldShowLandscape54 =
+      criteria != null &&
+      this.compareAspectRatio(landscape5To4CardImageCriteria, criteria);
     return (
       <InputImageContainer
         small={small}
@@ -325,7 +338,11 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
           onDragIntentStart={() => this.setState({ isDragging: true })}
           onDragIntentEnd={() => this.setState({ isDragging: false })}
         >
-          <ImageContainer small={small} portrait={portraitImage}>
+          <ImageContainer
+            small={small}
+            portrait={portraitImage}
+            shouldShowLandscape54={shouldShowLandscape54}
+          >
             <ImageComponent
               style={{
                 backgroundImage: `url(${imageUrl}`,
@@ -335,6 +352,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
               onDrop={this.handleDrop}
               small={small}
               portrait={portraitImage}
+              shouldShowLandscape54={shouldShowLandscape54}
             >
               {hasImage ? (
                 <>

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -28,6 +28,7 @@ import {
 import imageDragIcon from 'images/icons/image-drag-icon.svg';
 import {
   DRAG_DATA_GRID_IMAGE_URL,
+  landscape5To4CardImageCriteria,
   portraitCardImageCriteria,
 } from 'constants/image';
 import ImageDragIntentIndicator from 'components/image/ImageDragIntentIndicator';
@@ -540,6 +541,13 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     window.addEventListener('message', this.onMessage, false);
   };
 
+  private compareAspectRatio = (criteria1: Criteria, criteria2: Criteria) => {
+    return (
+      criteria1.widthAspectRatio == criteria2.widthAspectRatio &&
+      criteria1.heightAspectRatio == criteria2.heightAspectRatio
+    );
+  };
+
   private criteriaToGridUrl = (): string => {
     const { criteria, gridUrl } = this.props;
 
@@ -548,14 +556,12 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     }
 
     // assumes the only criteria that will be passed as props the defined
-    // constants for portrait(4:5) and landscape (5:3)
-    const usingPortrait =
-      portraitCardImageCriteria.widthAspectRatio == criteria.widthAspectRatio &&
-      portraitCardImageCriteria.heightAspectRatio == criteria.heightAspectRatio;
-
-    return usingPortrait
-      ? `${gridUrl}?cropType=portrait`
-      : `${gridUrl}?customRatio=new,5,4`;
+    // constants for portrait(4:5), landscape (5:3) and landscape (5:4)
+    if (this.compareAspectRatio(portraitCardImageCriteria, criteria))
+      return `${gridUrl}?cropType=portrait`;
+    else if (this.compareAspectRatio(landscape5To4CardImageCriteria, criteria))
+      return `${gridUrl}?cropType=landscape-5-4&customRatio=landscape-5-4,5,4`;
+    else return `${gridUrl}?cropType=landscape`;
   };
 
   private getCurrentImageDimensions = () => {

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -555,7 +555,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 
     return usingPortrait
       ? `${gridUrl}?cropType=portrait`
-      : `${gridUrl}?cropType=landscape`;
+      : `${gridUrl}?customRatio=new,5,4`;
   };
 
   private getCurrentImageDimensions = () => {

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -578,7 +578,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
     if (this.compareAspectRatio(portraitCardImageCriteria, criteria))
       return `${gridUrl}?cropType=portrait`;
     else if (this.compareAspectRatio(landscape5To4CardImageCriteria, criteria))
-      return `${gridUrl}?cropType=landscape-5-4&customRatio=landscape-5-4,5,4`;
+      return `${gridUrl}?cropType=Landscape&customRatio=Landscape,5,4`;
     else return `${gridUrl}?cropType=landscape`;
   };
 

--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -8,7 +8,7 @@ export const SUPPORT_PORTRAIT_CROPS =
 export const landScapeCardImageCriteria = {
   minWidth: 400,
   widthAspectRatio: 5,
-  heightAspectRatio: 3,
+  heightAspectRatio: 4,
 };
 
 export const portraitCardImageCriteria = {

--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -8,7 +8,7 @@ export const SUPPORT_PORTRAIT_CROPS =
 export const landScapeCardImageCriteria = {
   minWidth: 400,
   widthAspectRatio: 5,
-  heightAspectRatio: 4,
+  heightAspectRatio: 3,
 };
 
 export const portraitCardImageCriteria = {
@@ -17,8 +17,18 @@ export const portraitCardImageCriteria = {
   heightAspectRatio: 5,
 };
 
+export const landscape5To4CardImageCriteria = {
+  minWidth: 400,
+  widthAspectRatio: 5,
+  heightAspectRatio: 4,
+};
+
 // @todo - add the right collection type when it exists
 export const COLLECTIONS_USING_PORTRAIT_TRAILS: string[] = [];
+
+export const COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS: string[] = [
+  'fixed/highlights',
+];
 
 export const defaultCardTrailImageCriteria = landScapeCardImageCriteria;
 

--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -26,9 +26,7 @@ export const landscape5To4CardImageCriteria = {
 // @todo - add the right collection type when it exists
 export const COLLECTIONS_USING_PORTRAIT_TRAILS: string[] = [];
 
-export const COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS: string[] = [
-  'fixed/highlights',
-];
+export const COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS: string[] = [];
 
 export const defaultCardTrailImageCriteria = landScapeCardImageCriteria;
 

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -151,7 +151,6 @@ const card = {
 
 const thumbnailImage = {
   width: '83px',
-  height: '50px',
 };
 
 export const theme = {

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -151,6 +151,7 @@ const card = {
 
 const thumbnailImage = {
   width: '83px',
+  height: '50px',
 };
 
 export const theme = {


### PR DESCRIPTION
## What's changed?

As part of the redesigned homepage project, we want to switch images displayed on fronts to the aspect ratio 5:4 for landscape.  At this phase, we want to enforce 5:4 image crop on replacement images / slideshows to new container types only.

The previous PRs #1590 and #1598 by @dblatcher laid the groundwork for supporting different image crops based on the collection's layout type.  This pull request extends the mechanism to enable 5:4 landscape crop on selected collection type.

This pull request defines the list of collection type (`COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS`) selected for 5:4 image crop.  In future, we can add the new dynamic layout types (and other new container types) to the list.

It makes the following changes for the selected collection type:

1. change `InputImage` component to open Grid with 5:4 landscape crop when users replace the trail image or set slideshow images for the selected collection type.
2. change `ThumbnailSmall` component to use 5:4 image crop for trail image preview even if the card uses the default 5:3 trail image set in the composer.  It is to mimic the auto-crop behaviour on `dotcom-rendering`.
3. change the trail image preview to 5:4 image in the `ArticleMetaForm` when the card is opened for editing.  It requires changes to the `ImageInputImageContainer` and `ImageComponent` components.
4. update the `Card`, `ArticleCard` and `ArticleBody` to pass on the image criteria (whether the collection requires landscape 5:3 or landscape 5:4) to lower level components.


## Implementation notes
As we do not set any layout types for the 5:4 landscape image crop, we do not expect any changes to the existing UI and functions in fronts tool after this PR is merged.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [X] 🔍 Checked on CODE

### Client
- [X] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [X] 📷 Screenshots / GIFs of relevant UI changes included

For the testing purpose, I applied the 5:4 image aspect ratio on `fixed/highlights` container in the tests below.

When we replace the trail image of a card, the fronts tool enforce 5:4 image crop in the Grid:

<img width="500px" src="https://github.com/user-attachments/assets/758c7cdb-6d06-4bbb-95cf-bdec4fb59a4f" />

The trail image preview in the collection is also set to 5:4 crop even if the trail image (which is 5:3) is not replaced.  The trail image in clipboard remains 5:3 ratio.

<img width="360px" src="https://github.com/user-attachments/assets/76d6934f-01fb-4e55-b754-80b38817a1e3" />

Slideshows have also been changed to enforce 5:4 image crop and their preview images show 5:4 aspect ratio:

<img width="360px" src="https://github.com/user-attachments/assets/c86a1d87-c07e-476c-9af7-e7f648b899b9" />