### PR TITLE
Temporarily increase the maximum number of images in a slideshow

### DIFF
--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -4,7 +4,7 @@ import compact from 'lodash/compact';
 import clamp from 'lodash/clamp';
 import pickBy from 'lodash/pickBy';
 import { isDirty } from 'redux-form';
-import pageConfig from 'util/extractConfigFromPage';
+// import pageConfig from 'util/extractConfigFromPage';
 import { CardMeta, ImageData } from 'types/Collection';
 import { DerivedArticle } from 'types/Article';
 import { CapiArticle } from 'types/Capi';
@@ -74,11 +74,14 @@ export const getCapiValuesForArticleFields = (
   };
 };
 
-const tenImagesFeatureSwitch = pageConfig?.userData?.featureSwitches.find(
-  (feature) => feature.key === 'ten-image-slideshows'
-);
+// const tenImagesFeatureSwitch = pageConfig?.userData?.featureSwitches.find(
+//   (feature) => feature.key === 'ten-image-slideshows'
+// );
 
-export const maxSlideshowImages = tenImagesFeatureSwitch?.enabled ? 10 : 5;
+// export const maxSlideshowImages = tenImagesFeatureSwitch?.enabled ? 10 : 5;
+
+//bypasses the feature switch to temporarily ensure anyone can add 10 images to a slideshow
+export const maxSlideshowImages = 10;
 
 export const getInitialValuesForCardForm = (
   article: DerivedArticle | void


### PR DESCRIPTION
## What's changed?

We are upping the allowed number of images in slideshows from 5 to 10 for the election. 

I've preferred to override the value in the form itself rather than amend the object in the model [here](https://github.com/guardian/facia-tool/blob/96de71f0f70d4e4b3db49a647d172bdd7c9a639a/app/model/FeatureSwitches.scala#L36). The reason for this is that, AFAICT, feature switch data gets saved in the user preferences which are stored in a dynamo table, so updating the object wouldn't change pre-existing user preferences (from my testing at least, happy for people to check using build 8168).

I can imagine some of the staff who might need to use will already have a user preference (and probably set to false, so they'd be forced to toggle the switch again), so this felt like the simplest solution to avoid people having to mess with a feature switch.

## How to test

Check out the branch, how many images can you add to a slideshow? 