### PR TITLE
Sealed trait for Editions Card

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -21,7 +21,7 @@ import services._
 import services.editions.EditionsTemplating
 import services.editions.db.EditionsDB
 import services.editions.publishing.events.PublishEventsListener
-import services.editions.publishing.{EditionsBucket, FeastPublicationTarget, Publishing}
+import services.editions.publishing.{EditionsAppPublicationTarget, FeastPublicationTarget, Publishing}
 import slices.{Containers, FixedContainers}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import thumbnails.ContainerThumbnails
@@ -62,8 +62,8 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
   // Editions services
   val editionsDb = new EditionsDB(config.postgres.url, config.postgres.user, config.postgres.password)
   val templating = new EditionsTemplating(EditionsAppTemplates.templates ++ FeastAppTemplates.templates, capi, ophan)
-  val publishingBucket = new EditionsBucket(s3Client, config.aws.publishedEditionsIssuesBucket)
-  val previewBucket = new EditionsBucket(s3Client, config.aws.previewEditionsIssuesBucket)
+  val publishingBucket = new EditionsAppPublicationTarget(s3Client, config.aws.publishedEditionsIssuesBucket)
+  val previewBucket = new EditionsAppPublicationTarget(s3Client, config.aws.previewEditionsIssuesBucket)
   val feastPublicationTarget = new FeastPublicationTarget(snsClient, config, TimestampGenerator())
   val editionsPublishing = new Publishing(publishingBucket, previewBucket, feastPublicationTarget, editionsDb)
   PublishEventsListener.apply(config, editionsDb).start

--- a/app/model/FeastAppModel.scala
+++ b/app/model/FeastAppModel.scala
@@ -10,9 +10,9 @@ object FeastAppModel {
 
   case class RecipeIdentifier(id:String)
   case class Recipe(recipe:RecipeIdentifier) extends ContainerItem
-  case class Chef(backgroundHex:Option[String], id:String, image:Option[String], bio: String, foregroundHex:Option[String]) extends ContainerItem
+  case class Chef(id:String, image:Option[String], bio: Option[String], backgroundHex:Option[String], foregroundHex:Option[String]) extends ContainerItem
   case class Palette(backgroundHex:String, foregroundHex:String)
-  case class SubCollection(byline:Option[String], darkPalette:Option[Palette], image:Option[String], body:Option[String], title:String, lightPalette:Option[Palette], recipes:Seq[String]) extends ContainerItem
+  case class FeastCollection(byline:Option[String], darkPalette:Option[Palette], image:Option[String], body:Option[String], title:String, lightPalette:Option[Palette], recipes:Seq[String]) extends ContainerItem
 
   case class FeastAppContainer(id:String, title:String, body:Option[String], items:Seq[ContainerItem])
   //type FeastAppCuration = Map[String, IndexedSeq[FeastAppContainer]]
@@ -29,7 +29,7 @@ object FeastAppModel {
   implicit val recipeFormat:Format[Recipe] = Json.format[Recipe]
   implicit val chefFormat:Format[Chef] = Json.format[Chef]
   implicit val paletteFormat:Format[Palette] = Json.format[Palette]
-  implicit val subCollectionFormat:Format[SubCollection] = Json.format[SubCollection]
+  implicit val subCollectionFormat:Format[FeastCollection] = Json.format[FeastCollection]
 
   implicit val containerItemFormat:Format[ContainerItem] = Format.apply(
     jsValue=> {
@@ -38,7 +38,7 @@ object FeastAppModel {
     {
       case o:Recipe=>recipeFormat.writes(o)
       case o:Chef=>chefFormat.writes(o)
-      case o:SubCollection=>subCollectionFormat.writes(o)
+      case o:FeastCollection=>subCollectionFormat.writes(o)
     }
   )
   implicit val feastAppContainerFormat:Format[FeastAppContainer] = Json.format[FeastAppContainer]

--- a/app/model/editions/EditionsAppTemplates.scala
+++ b/app/model/editions/EditionsAppTemplates.scala
@@ -312,5 +312,5 @@ case class EditionsCollectionSkeleton(
 
 case class EditionsArticleSkeleton(
                                     id: String,
-                                    metadata: CardMetadata
+                                    metadata: EditionsArticleMetadata
 )

--- a/app/model/editions/EditionsCard.scala
+++ b/app/model/editions/EditionsCard.scala
@@ -4,12 +4,8 @@ import enumeratum.EnumEntry.{Hyphencase, Uncapitalised}
 import enumeratum.{EnumEntry, PlayEnum}
 import logging.Logging
 import model.editions.EditionsArticle.logger
-import play.api.libs.json.{JsResult, Json, OFormat}
+import play.api.libs.json.{Json, OFormat}
 import scalikejdbc.WrappedResultSet
-import play.api.libs.json.JsValue
-import play.api.libs.json.JsPath
-import play.api.libs.json.JsonValidationError
-import play.api.libs.json.JsError
 import play.api.libs.json.Reads
 
 case class Image (

--- a/app/model/editions/EditionsCard.scala
+++ b/app/model/editions/EditionsCard.scala
@@ -73,7 +73,6 @@ object CardType extends PlayEnum[CardType] {
   override def values = findValues
 }
 
-
 /**
   * A Card for Editions-based platforms. Analogous to the `Trail` type in
   * facia-scala-client.
@@ -82,6 +81,10 @@ object CardType extends PlayEnum[CardType] {
   * not available in facia-scala-client.
   */
 sealed trait EditionsCard
+
+object EditionsCard {
+  implicit val format: OFormat[EditionsCard] = Json.format[EditionsCard]
+}
 
 case class EditionsArticle(id: String, addedOn: Long, metadata: Option[EditionsArticleMetadata]) extends EditionsCard with Logging {
   def toPublished: PublishedArticle = {
@@ -132,7 +135,7 @@ case class EditionsArticle(id: String, addedOn: Long, metadata: Option[EditionsA
 }
 
 object EditionsArticle extends Logging {
-  implicit val writes: OFormat[EditionsArticle] = Json.format[EditionsArticle]
+  implicit val format: OFormat[EditionsArticle] = Json.format[EditionsArticle]
 
   def fromRowOpt(rs: WrappedResultSet, prefix: String = ""): Option[EditionsCard] = {
     for {
@@ -158,12 +161,28 @@ object EditionsArticle extends Logging {
 
 case class EditionsRecipe(id: String, addedOn: Long) extends EditionsCard
 
+object EditionsRecipe {
+  implicit val format: OFormat[EditionsRecipe] = Json.format[EditionsRecipe]
+}
+
 case class EditionsChefMetadata(
   bio: Option[String] = None,
   palette: Option[Palette] = None, 
   chefImageOverride: Option[Image] = None, 
 )
 
+object EditionsChefMetadata {
+  implicit val format: OFormat[EditionsChefMetadata] = Json.format[EditionsChefMetadata]
+}
+
 case class EditionsChef(id: String, addedOn: Long, metadata: Option[EditionsChefMetadata]) extends EditionsCard
 
+object EditionsChef {
+  implicit val format: OFormat[EditionsChef] = Json.format[EditionsChef]
+}
+
 case class EditionsFeastCollection(id: String, addedOn: Long) extends EditionsCard
+
+object EditionsFeastCollection {
+  implicit val format: OFormat[EditionsFeastCollection] = Json.format[EditionsFeastCollection]
+}

--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -1,12 +1,13 @@
 package model.editions
 
-import model.editions.client.ClientArticleMetadata
+import model.editions.client.ClientCardMetadata
 import play.api.libs.json.{Json, OFormat}
 import services.editions.prefills.CapiQueryTimeWindow
+import model.editions.client.ClientCardMetadata
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
 
-case class EditionsClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long, meta: Option[ClientArticleMetadata] = None)
+case class EditionsClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long, meta: Option[ClientCardMetadata] = None)
 
 object EditionsClientCard {
   implicit val format: OFormat[EditionsClientCard] = Json.format[EditionsClientCard]
@@ -14,49 +15,56 @@ object EditionsClientCard {
   def fromCard(card: EditionsCard): EditionsClientCard = card match {
     case EditionsArticle(id, addedOn, metadata) => 
       EditionsClientCard(
-        id,
-        Some(card.cardType),
-        card.addedOn,
-        card.metadata.map(ClientArticleMetadata.fromCardMetadata)
+        id = "internal-code/page/" + id,
+        Some(CardType.Article),
+        addedOn,
+        metadata.map(ClientCardMetadata.fromCardMetadata)
       )
     case EditionsRecipe(id, addedOn) => 
       EditionsClientCard(
         id,
         Some(CardType.Recipe),
-        card.addedOn
+        addedOn
       )
     case EditionsChef(id, addedOn, metadata) => 
       EditionsClientCard(
         id,
-        Some(CardType.Recipe),
-        card.addedOn
+        Some(CardType.Chef),
+        addedOn,
+        metadata.map(ClientCardMetadata.fromCardMetadata)
       )
     case EditionsFeastCollection(id, addedOn) => 
+      EditionsClientCard(
+        id,
+        Some(CardType.FeastCollection),
+        addedOn
+      )
   }
-    val id = card.cardType match {
-      case CardType.Article => "internal-code/page/" + card.id
-      case _ => card.id
-    }
 
-    EditionsClientCard(
-      id,
-      Some(card.cardType),
-      card.addedOn,
-      card.metadata.map(ClientArticleMetadata.fromCardMetadata)
-    )
-  }
-  def toCard(card: EditionsClientCard): EditionsCard = {
-    val id = card.cardType match {
-      case Some(CardType.Article) | None => card.id.split("/").last
-      case _ => card.id
-    }
-
-    EditionsCard(
-      id,
-      card.cardType.getOrElse(CardType.Article),
-      card.frontPublicationDate,
-      card.meta.map(_.toCardMetadata)
-    )
+  def toCard(card: EditionsClientCard): EditionsCard = card.cardType match {
+    case Some(CardType.Article) | None => 
+      val id = card.id.split("/").last
+      EditionsArticle(
+        id,
+        card.frontPublicationDate,
+        card.meta.map(_.toArticleMetadata)
+      )
+    case Some(CardType.Recipe) =>
+      EditionsRecipe(
+        card.id,
+        card.frontPublicationDate,
+      )
+    case Some(CardType.Chef) =>
+      EditionsChef(
+        card.id,
+        card.frontPublicationDate,
+        card.meta.map(_.toChefMetadata)
+      )
+    case Some(CardType.FeastCollection) =>
+      EditionsFeastCollection(
+        card.id,
+        card.frontPublicationDate,
+      )
   }
 }
 

--- a/app/model/editions/EditionsClientCollection.scala
+++ b/app/model/editions/EditionsClientCollection.scala
@@ -1,17 +1,38 @@
 package model.editions
 
-import model.editions.client.ClientCardMetadata
+import model.editions.client.ClientArticleMetadata
 import play.api.libs.json.{Json, OFormat}
 import services.editions.prefills.CapiQueryTimeWindow
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
 
-case class EditionsClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long, meta: Option[ClientCardMetadata])
+case class EditionsClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long, meta: Option[ClientArticleMetadata] = None)
 
 object EditionsClientCard {
   implicit val format: OFormat[EditionsClientCard] = Json.format[EditionsClientCard]
 
-  def fromCard(card: EditionsCard): EditionsClientCard = {
+  def fromCard(card: EditionsCard): EditionsClientCard = card match {
+    case EditionsArticle(id, addedOn, metadata) => 
+      EditionsClientCard(
+        id,
+        Some(card.cardType),
+        card.addedOn,
+        card.metadata.map(ClientArticleMetadata.fromCardMetadata)
+      )
+    case EditionsRecipe(id, addedOn) => 
+      EditionsClientCard(
+        id,
+        Some(CardType.Recipe),
+        card.addedOn
+      )
+    case EditionsChef(id, addedOn, metadata) => 
+      EditionsClientCard(
+        id,
+        Some(CardType.Recipe),
+        card.addedOn
+      )
+    case EditionsFeastCollection(id, addedOn) => 
+  }
     val id = card.cardType match {
       case CardType.Article => "internal-code/page/" + card.id
       case _ => card.id
@@ -21,7 +42,7 @@ object EditionsClientCard {
       id,
       Some(card.cardType),
       card.addedOn,
-      card.metadata.map(ClientCardMetadata.fromCardMetadata)
+      card.metadata.map(ClientArticleMetadata.fromCardMetadata)
     )
   }
   def toCard(card: EditionsClientCard): EditionsCard = {

--- a/app/model/editions/EditionsCollection.scala
+++ b/app/model/editions/EditionsCollection.scala
@@ -19,7 +19,9 @@ case class EditionsCollection(
   def toPublishedCollection: PublishedCollection = PublishedCollection(
     id,
     displayName,
-    items.map(_.toPublishedCard)
+    items.collect {
+      case article: EditionsArticle => EditionsArticle.toPublishedArticle(article)
+    }
   )
 }
 

--- a/app/model/editions/EditionsFront.scala
+++ b/app/model/editions/EditionsFront.scala
@@ -30,7 +30,7 @@ case class EditionsFront(
     collections: List[EditionsCollection]
 ) {
   def toPublishedFront: PublishedFront = {
-    val name = metadata.collect { case EditionsFrontMetadata(Some(overrideName), _) => overrideName }.getOrElse(displayName)
+    val name = getName
     val swatch = metadata.collect { case EditionsFrontMetadata(_, Some(swatch)) => swatch }.getOrElse(Swatch.Neutral)
     PublishedFront(
       id,
@@ -42,6 +42,9 @@ case class EditionsFront(
       swatch
     )
   }
+
+  def getName = metadata.collect { case EditionsFrontMetadata(Some(overrideName), _) => overrideName }.getOrElse(displayName)
+
 }
 
 object EditionsFront {

--- a/app/model/editions/client/ClientCardMetadata.scala
+++ b/app/model/editions/client/ClientCardMetadata.scala
@@ -4,45 +4,54 @@ import ai.x.play.json.Jsonx
 import model.editions.{CardMetadata, CoverCardImages, Image, MediaType}
 import play.api.libs.json.OFormat
 import model.editions.Palette
+import model.editions.EditionsArticleMetadata
+import model.editions.EditionsChefMetadata
 
 // This is a subset of the shared model here - https://github.com/guardian/facia-scala-client/blob/master/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala#L18
 // Why not reuse that model? We only want to surface the fields necessary for editions
 case class ClientCardMetadata(
-  headline: Option[String],
-  customKicker: Option[String],
-  showKickerCustom: Option[Boolean],
-  trailText: Option[String],
-  showQuotedHeadline: Option[Boolean],
-  showByline: Option[Boolean],
-  byline: Option[String],
-  sportScore: Option[String],
+  headline: Option[String] = None,
+  customKicker: Option[String] = None,
+  showKickerCustom: Option[Boolean] = None,
+  trailText: Option[String] = None,
+  showQuotedHeadline: Option[Boolean] = None,
+  showByline: Option[Boolean] = None,
+  byline: Option[String] = None,
+  sportScore: Option[String] = None,
 
-  imageHide: Option[Boolean],
+  imageHide: Option[Boolean] = None,
 
-  imageReplace: Option[Boolean],
-  imageSrc: Option[String],
-  imageSrcHeight: Option[String],
-  imageSrcWidth: Option[String],
-  imageSrcOrigin: Option[String],
-  imageSrcThumb: Option[String],
+  imageReplace: Option[Boolean] = None,
+  imageSrc: Option[String] = None,
+  imageSrcHeight: Option[String] = None,
+  imageSrcWidth: Option[String] = None,
+  imageSrcOrigin: Option[String] = None,
+  imageSrcThumb: Option[String] = None,
 
-  imageCutoutReplace: Option[Boolean],
-  imageCutoutSrc: Option[String],
-  imageCutoutSrcHeight: Option[String],
-  imageCutoutSrcWidth: Option[String],
-  imageCutoutSrcOrigin: Option[String],
+  imageCutoutReplace: Option[Boolean] = None,
+  imageCutoutSrc: Option[String] = None,
+  imageCutoutSrcHeight: Option[String] = None,
+  imageCutoutSrcWidth: Option[String] = None,
+  imageCutoutSrcOrigin: Option[String] = None,
 
-  overrideArticleMainMedia: Option[Boolean],
+  overrideArticleMainMedia: Option[Boolean] = None,
 
-  coverCardImageReplace: Option[Boolean],
-  coverCardMobileImage: Option[Image],
-  coverCardTabletImage: Option[Image],
-  promotionMetric: Option[Double],
-  bio: Option[String], // Chef
-  palette: Option[Palette], // Chef
-  chefImageOverride: Option[Image] // Chef
+  coverCardImageReplace: Option[Boolean] = None,
+  coverCardMobileImage: Option[Image] = None,
+  coverCardTabletImage: Option[Image] = None,
+  promotionMetric: Option[Double] = None,
+  bio: Option[String] = None, // Chef
+  palette: Option[Palette] = None, // Chef
+  chefImageOverride: Option[Image] = None// Chef
 ) {
-  def toCardMetadata: CardMetadata = {
+  def toChefMetadata: EditionsChefMetadata = 
+    EditionsChefMetadata(
+      bio,
+      palette,
+      chefImageOverride
+    )
+
+  def toArticleMetadata: EditionsArticleMetadata = {
     val cutoutImage: Option[Image] = (imageCutoutSrcHeight, imageCutoutSrcWidth, imageCutoutSrc, imageCutoutSrcOrigin) match {
       case (height, width, Some(src), Some(origin)) => Some(Image(height.map(_.toInt), width.map(_.toInt), origin, src))
       // If we don't have an origin, duplicate the src into the origin
@@ -68,7 +77,7 @@ case class ClientCardMetadata(
       case _ => Some(CoverCardImages(coverCardMobileImage, coverCardTabletImage))
     }
 
-    CardMetadata(
+    EditionsArticleMetadata(
       headline,
       customKicker,
       trailText,
@@ -81,10 +90,7 @@ case class ClientCardMetadata(
       replaceImage,
       overrideArticleMainMedia,
       coverCardImages,
-      promotionMetric,
-      bio,
-      palette,
-      chefImageOverride
+      promotionMetric
     )
   }
 }
@@ -92,7 +98,15 @@ case class ClientCardMetadata(
 object ClientCardMetadata {
   implicit val format: OFormat[ClientCardMetadata] = Jsonx.formatCaseClassUseDefaults[ClientCardMetadata]
 
-  def fromCardMetadata(cardMetadata: CardMetadata): ClientCardMetadata = {
+  def fromCardMetadata(cardMetadata: EditionsChefMetadata): ClientCardMetadata = {
+    ClientCardMetadata(
+      bio = cardMetadata.bio,
+      palette = cardMetadata.palette,
+      chefImageOverride = cardMetadata.chefImageOverride
+    )
+  }
+
+  def fromCardMetadata(cardMetadata: EditionsArticleMetadata): ClientCardMetadata = {
     val mediaType: MediaType = cardMetadata.mediaType.getOrElse(MediaType.UseArticleTrail)
 
     ClientCardMetadata(
@@ -125,10 +139,7 @@ object ClientCardMetadata {
       cardMetadata.mediaType.map { _ => mediaType == MediaType.CoverCard},
       cardMetadata.coverCardImages.flatMap(_.mobile),
       cardMetadata.coverCardImages.flatMap(_.tablet),
-      cardMetadata.promotionMetric,
-      cardMetadata.bio,
-      cardMetadata.palette,
-      cardMetadata.chefImageOverride
+      cardMetadata.promotionMetric
     )
   }
 }

--- a/app/model/editions/client/ClientCardMetadata.scala
+++ b/app/model/editions/client/ClientCardMetadata.scala
@@ -1,7 +1,8 @@
 package model.editions.client
 
 import ai.x.play.json.Jsonx
-import model.editions.{CardMetadata, CoverCardImages, Image, MediaType}
+import play.api.libs.json.JsSuccess
+import model.editions.{CoverCardImages, Image, MediaType}
 import play.api.libs.json.OFormat
 import model.editions.Palette
 import model.editions.EditionsArticleMetadata
@@ -18,24 +19,19 @@ case class ClientCardMetadata(
   showByline: Option[Boolean] = None,
   byline: Option[String] = None,
   sportScore: Option[String] = None,
-
   imageHide: Option[Boolean] = None,
-
   imageReplace: Option[Boolean] = None,
   imageSrc: Option[String] = None,
   imageSrcHeight: Option[String] = None,
   imageSrcWidth: Option[String] = None,
   imageSrcOrigin: Option[String] = None,
   imageSrcThumb: Option[String] = None,
-
   imageCutoutReplace: Option[Boolean] = None,
   imageCutoutSrc: Option[String] = None,
   imageCutoutSrcHeight: Option[String] = None,
   imageCutoutSrcWidth: Option[String] = None,
   imageCutoutSrcOrigin: Option[String] = None,
-
   overrideArticleMainMedia: Option[Boolean] = None,
-
   coverCardImageReplace: Option[Boolean] = None,
   coverCardMobileImage: Option[Image] = None,
   coverCardTabletImage: Option[Image] = None,
@@ -44,7 +40,7 @@ case class ClientCardMetadata(
   palette: Option[Palette] = None, // Chef
   chefImageOverride: Option[Image] = None// Chef
 ) {
-  def toChefMetadata: EditionsChefMetadata = 
+  def toChefMetadata: EditionsChefMetadata =
     EditionsChefMetadata(
       bio,
       palette,

--- a/app/services/editions/EditionsTemplating.scala
+++ b/app/services/editions/EditionsTemplating.scala
@@ -141,7 +141,7 @@ class CollectionTemplatingHelper(capi: Capi, ophan: Ophan) extends Logging {
   private def mapToSkeleton(sortedArticleItems: List[Prefill]): List[EditionsArticleSkeleton] = {
     sortedArticleItems
       .map { case Prefill(pageCode, _, _, metaData, cutoutImage, _, mediaType, pickedKicker, promotionMetric, _) =>
-        val cardMetadata = CardMetadata.default.copy(
+        val cardMetadata = EditionsArticleMetadata.default.copy(
           showByline = if (metaData.showByline) Some(true) else None,
           showQuotedHeadline = if (metaData.showQuotedHeadline) Some(true) else None,
           mediaType = mediaType,

--- a/app/services/editions/publishing/EditionsAppPublicationTarget.scala
+++ b/app/services/editions/publishing/EditionsAppPublicationTarget.scala
@@ -1,9 +1,9 @@
 package services.editions.publishing
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
 import com.amazonaws.util.StringInputStream
-import model.editions.{EditionsIssue, PublishAction, PublishableIssue}
+import model.editions.EditionsIssue
 import play.api.libs.json.{Json, Writes}
 import PublishedIssueFormatters._
 import com.typesafe.scalalogging.LazyLogging

--- a/app/services/editions/publishing/EditionsAppPublicationTarget.scala
+++ b/app/services/editions/publishing/EditionsAppPublicationTarget.scala
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.builder.{ReflectionToStringBuilder, ToStringStyl
 
 import java.nio.charset.StandardCharsets
 
-object EditionsBucket extends LazyLogging {
+object EditionsAppPublicationTarget extends LazyLogging {
 
   val baseMetadata: ObjectMetadata = {
     val metadata = new ObjectMetadata()
@@ -33,7 +33,7 @@ object EditionsBucket extends LazyLogging {
   }
 }
 
-class EditionsBucket(s3Client: AmazonS3, bucketName: String) extends PublicationTarget with LazyLogging {
+class EditionsAppPublicationTarget(s3Client: AmazonS3, bucketName: String) extends PublicationTarget with LazyLogging {
   override def putIssue(issue: EditionsIssue, version: String, action: PublishAction): Unit = {
     val outputKey = createKey(issue, version)
     val publishableIssue = issue.toPublishableIssue(version, action)
@@ -41,13 +41,13 @@ class EditionsBucket(s3Client: AmazonS3, bucketName: String) extends Publication
   }
 
   override def putIssueJson[T: Writes](content: T, key:String): Unit = {
-    val request = EditionsBucket.createPutObjectRequest(bucketName, key, content)
+    val request = EditionsAppPublicationTarget.createPutObjectRequest(bucketName, key, content)
     logger.info(ReflectionToStringBuilder.toString(request, ToStringStyle.MULTI_LINE_STYLE))
     s3Client.putObject(request)
   }
 
   def putEditionsList(rawJson: String): Unit = {
-    val metadata = EditionsBucket.baseMetadata
+    val metadata = EditionsAppPublicationTarget.baseMetadata
     metadata.setContentLength(rawJson.getBytes(StandardCharsets.UTF_8).length)
     val request = new PutObjectRequest(bucketName, "editionsList", new StringInputStream(rawJson), metadata)
     s3Client.putObject(request)

--- a/app/services/editions/publishing/EditionsBucket.scala
+++ b/app/services/editions/publishing/EditionsBucket.scala
@@ -3,21 +3,16 @@ package services.editions.publishing
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.amazonaws.util.StringInputStream
-import model.editions.PublishableIssue
+import model.editions.{EditionsIssue, PublishAction, PublishableIssue}
 import play.api.libs.json.{Json, Writes}
 import PublishedIssueFormatters._
 import com.typesafe.scalalogging.LazyLogging
+import model.editions.PublishAction.PublishAction
 import org.apache.commons.lang3.builder.{ReflectionToStringBuilder, ToStringStyle}
 
 import java.nio.charset.StandardCharsets
 
 object EditionsBucket extends LazyLogging {
-
-  def createIssuePrefix(issue: PublishableIssue): String = s"${issue.name.entryName}/${issue.issueDate.toString}"
-
-  def createIssueFilename(issue: PublishableIssue): String = s"${issue.version}.json"
-
-  def createKey(issue: PublishableIssue): String = s"${createIssuePrefix(issue)}/${createIssueFilename(issue)}"
 
   val baseMetadata: ObjectMetadata = {
     val metadata = new ObjectMetadata()
@@ -39,9 +34,10 @@ object EditionsBucket extends LazyLogging {
 }
 
 class EditionsBucket(s3Client: AmazonS3, bucketName: String) extends PublicationTarget with LazyLogging {
-  override def putIssue(issue: PublishableIssue, key: Option[String]=None): Unit = {
-    val outputKey = key.getOrElse(EditionsBucket.createKey(issue))
-    putIssueJson(issue, outputKey)
+  override def putIssue(issue: EditionsIssue, version: String, action: PublishAction): Unit = {
+    val outputKey = createKey(issue, version)
+    val publishableIssue = issue.toPublishableIssue(version, action)
+    putIssueJson(publishableIssue, outputKey)
   }
 
   override def putIssueJson[T: Writes](content: T, key:String): Unit = {

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -3,9 +3,9 @@ package services.editions.publishing
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest}
 import conf.ApplicationConfiguration
-import model.FeastAppModel.{Chef, ContainerItem, FeastAppContainer, FeastAppCuration, FeastCollection, Palette, Recipe, RecipeIdentifier}
+import model.FeastAppModel.{Chef, ContainerItem, FeastAppContainer, FeastAppCuration, FeastCollection, Recipe, RecipeIdentifier}
 import model.editions.PublishAction.PublishAction
-import model.editions.{EditionsArticle, EditionsCard, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsIssue, EditionsRecipe, PublishableIssue, PublishedArticle, PublishedCollection}
+import model.editions.{EditionsArticle, EditionsCard, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsIssue, EditionsRecipe}
 import play.api.libs.json.{Json, Writes}
 import util.TimestampGenerator
 

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -1,71 +1,84 @@
 package services.editions.publishing
+
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest}
 import conf.ApplicationConfiguration
-import model.FeastAppModel.{ContainerItem, FeastAppContainer, FeastAppCuration, Recipe, RecipeIdentifier}
-import model.editions.{PublishableIssue, PublishedArticle, PublishedCollection}
+import model.FeastAppModel.{Chef, ContainerItem, FeastAppContainer, FeastAppCuration, FeastCollection, Palette, Recipe, RecipeIdentifier}
+import model.editions.PublishAction.PublishAction
+import model.editions.{EditionsArticle, EditionsCard, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsIssue, EditionsRecipe, PublishableIssue, PublishedArticle, PublishedCollection}
 import play.api.libs.json.{Json, Writes}
 import util.TimestampGenerator
+
 import scala.jdk.CollectionConverters._
 
 object FeastPublicationTarget {
   object MessageType extends Enumeration {
     val Issue, EditionsList = Value
   }
+
   type MessageType = MessageType.Value
 }
 
-class FeastPublicationTarget(snsClient:AmazonSNS, config: ApplicationConfiguration, timestamp:TimestampGenerator) extends PublicationTarget {
-  private def transformArticles(source:PublishedArticle):ContainerItem = {
-    //FIXME: This is a hack, since we can't actually generate any of the content types that Feast wants yet!
-    Recipe(recipe = RecipeIdentifier(source.internalPageCode.toString))
+class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfiguration, timestamp: TimestampGenerator) extends PublicationTarget {
+  private def transformArticles(source: EditionsCard): ContainerItem = {
+    source match {
+      case _: EditionsArticle => throw new Error("Article not permitted in a Feast Front")
+      case EditionsRecipe(id, _) => Recipe(RecipeIdentifier(id))
+      case EditionsChef(id, addedOn, metadata) => Chef(id = id,
+        image = metadata.flatMap(_.chefImageOverride.map(_.src)),
+        bio = metadata.flatMap(_.bio),
+        backgroundHex = metadata.flatMap(_.palette.map(_.backgroundHex)),
+        foregroundHex = metadata.flatMap(_.palette.map(_.foregroundHex)))
+      case _:EditionsFeastCollection => FeastCollection(byline=None, darkPalette=None, image=None, body=None, title="", lightPalette=None, recipes=List.empty)
+    }
   }
 
   private val findSpace = "\\s+".r
 
   /**
    * Feast app expects a name like `all-recipes` wheras we have `All Recipes`
+   *
    * @param originalName name to transform
    * @return name in kebab-case
    */
-  private def transformName(originalName:String):String = findSpace.replaceAllIn(originalName.toLowerCase, "-")
+  private def transformName(originalName: String): String = findSpace.replaceAllIn(originalName.toLowerCase, "-")
 
-  private def transformCollections(collection:PublishedCollection):FeastAppContainer =
+  private def transformCollections(collection: EditionsCollection): FeastAppContainer =
     FeastAppContainer(
-      id=collection.id,
-      title=collection.name,
-      body=Some(""),  //TBD, this is just how it appears in the data at the moment
+      id = collection.id,
+      title = collection.displayName,
+      body = Some(""), //TBD, this is just how it appears in the data at the moment
       items = collection.items.map(transformArticles)
     )
 
-  def transformContent(source: PublishableIssue): FeastAppCuration = {
+  def transformContent(source: EditionsIssue, version: String): FeastAppCuration = {
     FeastAppCuration(
-      id=source.id,
-      issueDate=source.issueDate,
-      edition=source.edition,
-      version=source.version,
-      fronts=source.fronts.map(f=>{
-        (transformName(f.name), f.collections.map(transformCollections).toIndexedSeq)
+      id = source.id,
+      issueDate = source.issueDate,
+      edition = source.edition,
+      version = version,
+      fronts = source.fronts.map(f => {
+        (transformName(f.getName), f.collections.map(transformCollections).toIndexedSeq)
       }).toMap
     )
   }
 
-  override def putIssue(issue: PublishableIssue, key: Option[String]=None): Unit = {
-    val outputKey = key.getOrElse(EditionsBucket.createKey(issue))
-    putIssueJson(transformContent(issue), outputKey)
+  override def putIssue(issue: EditionsIssue, version: String, action: PublishAction): Unit = {
+    val outputKey = createKey(issue, version)
+    putIssueJson(transformContent(issue, version), outputKey)
   }
 
-  private def createPublishRequest(content:String, messageType:FeastPublicationTarget.MessageType):PublishRequest = {
+  private def createPublishRequest(content: String, messageType: FeastPublicationTarget.MessageType): PublishRequest = {
     new PublishRequest()
       .withMessage(content)
       .withTopicArn(config.aws.feastAppPublicationTopic)
       .withMessageAttributes(Map(
-        "timestamp"->new MessageAttributeValue().withDataType("Number").withStringValue(timestamp.getTimestamp.toString),
-        "type"->new MessageAttributeValue().withDataType("String").withStringValue(messageType.toString),
+        "timestamp" -> new MessageAttributeValue().withDataType("Number").withStringValue(timestamp.getTimestamp.toString),
+        "type" -> new MessageAttributeValue().withDataType("String").withStringValue(messageType.toString),
       ).asJava)
   }
 
-  override def putIssueJson[T:Writes](issue: T, key:String): Unit = {
+  override def putIssueJson[T: Writes](issue: T, key: String): Unit = {
     val content = Json.stringify(Json.toJson(issue))
     snsClient.publish(createPublishRequest(content, FeastPublicationTarget.MessageType.Issue))
   }

--- a/app/services/editions/publishing/PublicationTarget.scala
+++ b/app/services/editions/publishing/PublicationTarget.scala
@@ -1,6 +1,6 @@
 package services.editions.publishing
 
-import model.editions.{EditionsIssue, PublishableIssue}
+import model.editions.EditionsIssue
 import model.editions.PublishAction.PublishAction
 import play.api.libs.json.Writes
 

--- a/app/services/editions/publishing/PublicationTarget.scala
+++ b/app/services/editions/publishing/PublicationTarget.scala
@@ -4,7 +4,7 @@ import model.editions.{EditionsIssue, PublishableIssue}
 import model.editions.PublishAction.PublishAction
 import play.api.libs.json.Writes
 
-trait PublicationTarget {
+trait PublicationTarget extends PublicationTargetHelpers {
   def putIssue(issue: EditionsIssue, version:String, action: PublishAction): Unit
 
   protected def putIssueJson[C: Writes](content: C, key:String): Unit
@@ -13,12 +13,14 @@ trait PublicationTarget {
   //but with an arbitrary string, making it unchecked.  This can probably be pulled into `putIssueJson` but I think that
   // is out of scope for this PR
   def putEditionsList(rawJson: String): Unit
+}
 
+object PublicationTarget extends PublicationTargetHelpers
+
+trait PublicationTargetHelpers {
   private def createIssuePrefix(issue: EditionsIssue): String = s"${issue.edition.entryName}/${issue.issueDate.toString}"
 
   private def createIssueFilename(version:String): String = s"$version.json"
 
   def createKey(issue: EditionsIssue, version:String): String = s"${createIssuePrefix(issue)}/${createIssueFilename(version)}"
-
 }
-

--- a/app/services/editions/publishing/PublicationTarget.scala
+++ b/app/services/editions/publishing/PublicationTarget.scala
@@ -1,11 +1,11 @@
 package services.editions.publishing
 
-import model.editions.PublishableIssue
+import model.editions.{EditionsIssue, PublishableIssue}
+import model.editions.PublishAction.PublishAction
 import play.api.libs.json.Writes
-import PublishedIssueFormatters._
 
 trait PublicationTarget {
-  def putIssue(issue: PublishableIssue, key:Option[String] = None): Unit
+  def putIssue(issue: EditionsIssue, version:String, action: PublishAction): Unit
 
   protected def putIssueJson[C: Writes](content: C, key:String): Unit
 
@@ -13,5 +13,12 @@ trait PublicationTarget {
   //but with an arbitrary string, making it unchecked.  This can probably be pulled into `putIssueJson` but I think that
   // is out of scope for this PR
   def putEditionsList(rawJson: String): Unit
+
+  private def createIssuePrefix(issue: EditionsIssue): String = s"${issue.edition.entryName}/${issue.issueDate.toString}"
+
+  private def createIssueFilename(version:String): String = s"$version.json"
+
+  def createKey(issue: EditionsIssue, version:String): String = s"${createIssuePrefix(issue)}/${createIssueFilename(version)}"
+
 }
 

--- a/app/services/editions/publishing/Publishing.scala
+++ b/app/services/editions/publishing/Publishing.scala
@@ -18,7 +18,7 @@ class Publishing(editionsAppPublicationBucket: EditionsBucket,
                 ) extends Logging {
 
   def updatePreview(issue: EditionsIssue) = {
-    val previewIssue = issue.toPreviewIssue
+
     // Archive a copy
     issue.edition match {
       case FeastNorthernHemisphere | FeastSouthernHemisphere =>
@@ -26,7 +26,7 @@ class Publishing(editionsAppPublicationBucket: EditionsBucket,
         //Preview will be implemented, when it exists.
         ()
       case _ =>
-        editionsAppPreviewBucket.putIssue(previewIssue)
+        editionsAppPreviewBucket.putIssue(issue, "preview", PublishAction.preview)
     }
   }
 
@@ -47,14 +47,15 @@ class Publishing(editionsAppPublicationBucket: EditionsBucket,
 
     logger.info(s"Uploading $action request for issue ${issue.id} to S3")(markers)
 
-    val publishedIssue = issue.toPublishableIssue(versionId, action)
+    getPublicationTarget(issue).putIssue(issue, versionId, PublishAction.proof)
+  }
 
-    // Archive a copy
+  def getPublicationTarget(issue:EditionsIssue): PublicationTarget ={
     issue.edition match {
       case FeastNorthernHemisphere | FeastSouthernHemisphere =>
-        feastAppPublicationTarget.putIssue(publishedIssue)
+        feastAppPublicationTarget
       case _ =>
-        editionsAppPublicationBucket.putIssue(publishedIssue)
+        editionsAppPublicationBucket
     }
   }
 
@@ -78,19 +79,14 @@ class Publishing(editionsAppPublicationBucket: EditionsBucket,
 
     logger.info(s"Uploading $action request for issue ${issue.id} to S3")(markers)
 
-    val publishedIssue = if(!issue.supportsProofing) {
+    val (finalVersion, finalAction) = if(!issue.supportsProofing) {
       val newVersion = db.createIssueVersion(issue.id, user, OffsetDateTime.now())
-      issue.toPublishableIssue(newVersion, PublishAction.proof) //Not very self-explanatory; the use of `PublishAction.proof` here means "build the issue afresh".
+      (newVersion, PublishAction.proof) //Not very self-explanatory; the use of `PublishAction.proof` here means "build the issue afresh".
     } else {
-      issue.toPublishableIssue(version, PublishAction.publish)  //PublishAction.publish here means "only use the previously proofed issue"
+      (version, PublishAction.publish)  //PublishAction.publish here means "only use the previously proofed issue"
     }
 
-    // Archive a copy
-    issue.edition match {
-      case FeastNorthernHemisphere | FeastSouthernHemisphere =>
-        feastAppPublicationTarget.putIssue(publishedIssue)
-      case _ =>
-        editionsAppPublicationBucket.putIssue(publishedIssue)
-    }
+    getPublicationTarget(issue).putIssue(issue, finalVersion, finalAction)
   }
+
 }

--- a/app/services/editions/publishing/Publishing.scala
+++ b/app/services/editions/publishing/Publishing.scala
@@ -11,8 +11,8 @@ import play.api.libs.json.Writes
 
 import scala.jdk.CollectionConverters._
 
-class Publishing(editionsAppPublicationBucket: EditionsBucket,
-                 editionsAppPreviewBucket: EditionsBucket,
+class Publishing(editionsAppPublicationBucket: EditionsAppPublicationTarget,
+                 editionsAppPreviewBucket: EditionsAppPublicationTarget,
                  feastAppPublicationTarget: FeastPublicationTarget,
                  db: EditionsDB
                 ) extends Logging {

--- a/test/model/editions/CardMetadataTest.scala
+++ b/test/model/editions/CardMetadataTest.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.Json
 
 class CardMetadataTest extends FreeSpec with Matchers {
 
-  val cardMetadata = CardMetadata(
+  val cardMetadata = EditionsArticleMetadata(
     Some("headline"),
     Some("customKicker"),
     Some("trailText"),
@@ -66,7 +66,7 @@ class CardMetadataTest extends FreeSpec with Matchers {
     }
 
     "should deserialise correctly" in {
-      Json.fromJson[CardMetadata](Json.parse(cardMetadataAsString)).get shouldBe cardMetadata
+      Json.fromJson[EditionsArticleMetadata](Json.parse(cardMetadataAsString)).get shouldBe cardMetadata
     }
 
   }

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -71,7 +71,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       id,
       CardType.Article,
       nowMilli,
-      Some(CardMetadata.default)
+      Some(EditionsArticleMetadata.default)
     )
 
   "PublishedCards" - {
@@ -84,7 +84,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     "furniture defaults should be populated correctly" in {
-      val furniture = CardMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
+      val furniture = EditionsArticleMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
       val card = EditionsCard("123456", CardType.Article, 0, Some(furniture))
       val published = card.toPublishedCard
 
@@ -92,7 +92,7 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     val cardImage = Some(Image(Some(100), Some(100), "file://origin.jpg", "file://src.jpg", Some("file://thumb.jpg")))
-    val cardFurniture = CardMetadata(
+    val cardFurniture = EditionsArticleMetadata(
       Some("headline"),
       Some("kicker"),
       Some("trail-text"),

--- a/test/model/editions/PublishedIssueTest.scala
+++ b/test/model/editions/PublishedIssueTest.scala
@@ -67,9 +67,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
   }
 
   private def card(id: String): EditionsCard =
-    EditionsCard(
+    EditionsArticle(
       id,
-      CardType.Article,
       nowMilli,
       Some(EditionsArticleMetadata.default)
     )
@@ -77,16 +76,16 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
   "PublishedCards" - {
     "card fields should be populated correctly" in {
       val now = OffsetDateTime.of(2019, 9, 30, 10, 23, 0, 0, ZoneOffset.ofHours(1))
-      val card = EditionsCard("1234456", CardType.Article, now.toInstant.toEpochMilli, None)
-      val publishedCard = card.toPublishedCard
+      val card = EditionsArticle("1234456", now.toInstant.toEpochMilli, None)
+      val publishedCard = EditionsArticle.toPublishedArticle(card)
       publishedCard.internalPageCode shouldBe 1234456
       publishedCard.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
     }
 
     "furniture defaults should be populated correctly" in {
       val furniture = EditionsArticleMetadata(None, None, None, None, None, None, None, None, None, None, None, None, None)
-      val card = EditionsCard("123456", CardType.Article, 0, Some(furniture))
-      val published = card.toPublishedCard
+      val card = EditionsArticle("123456", 0, Some(furniture))
+      val published = EditionsArticle.toPublishedArticle(card)
 
       published.furniture shouldBe PublishedFurniture(None, None, None, None, false, false, PublishedMediaType.UseArticleTrail, None, None, false, None)
     }
@@ -112,8 +111,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     )
 
     "furniture should be populated when specified, cover cards should be ignored if the media type isn't set to cover card" in {
-      val card = EditionsCard("123456", CardType.Article, 0, Some(cardFurniture))
-      val published = card.toPublishedCard
+      val card = EditionsArticle("123456", 0, Some(cardFurniture))
+      val published = EditionsArticle.toPublishedArticle(card)
 
       published.furniture shouldBe PublishedFurniture(
         Some("kicker"),
@@ -131,8 +130,8 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
     }
 
     "furniture should be populated when specified, cover card should be some if media type is covercard " in {
-      val card = EditionsCard("123456", CardType.Article, 0, Some(cardFurniture.copy(mediaType = Some(MediaType.CoverCard))))
-      val published = card.toPublishedCard
+      val card = EditionsArticle("123456", 0, Some(cardFurniture.copy(mediaType = Some(MediaType.CoverCard))))
+      val published = EditionsArticle.toPublishedArticle(card)
 
       val publishedImage = PublishedImage(Some(100), Some(100), "file://src.jpg")
 
@@ -165,10 +164,10 @@ class PublishedIssueTest extends FreeSpec with Matchers with OptionValues {
       )))
 
       List(
-        EditionsCard("123456", CardType.Article, 0, Some(coverCardFurniture)),
-        EditionsCard("123456", CardType.Article, 0, Some(swapped))
+        EditionsArticle("123456", 0, Some(coverCardFurniture)),
+        EditionsArticle("123456", 0, Some(swapped))
       ).foreach { a =>
-        a.toPublishedCard.furniture.mediaType shouldBe PublishedMediaType.UseArticleTrail
+        EditionsArticle.toPublishedArticle(a).furniture.mediaType shouldBe PublishedMediaType.UseArticleTrail
       }
     }
   }

--- a/test/model/editions/client/ClientCardMetadataTest.scala
+++ b/test/model/editions/client/ClientCardMetadataTest.scala
@@ -23,12 +23,12 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None,
         Some(1)
       )
-      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
       clientCardMetadata.promotionMetric should be (Some(1))
     }
 
     "should send promotion metric to a simple CardMetadata" in {
-      val clientCardMetadata = ClientArticleMetadata(
+      val clientCardMetadata = ClientCardMetadata(
         Some("Britain has summer!"),
         None,
         None,
@@ -63,7 +63,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None,
         None
       )
-      val cardMetadata = clientCardMetadata.toCardMetadata
+      val cardMetadata = clientCardMetadata.toArticleMetadata
       cardMetadata.promotionMetric should be (Some(1))
     }
 
@@ -84,7 +84,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.headline.isDefined shouldBe true
       clientCardMetadata.headline.get shouldBe "Britain has summer!"
@@ -118,7 +118,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.headline.isDefined shouldBe true
       clientCardMetadata.headline.get shouldBe "New Pokemon discovered"
@@ -152,7 +152,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.headline.isDefined shouldBe true
       clientCardMetadata.headline.get shouldBe "Elephants declared best animal"
@@ -183,7 +183,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.imageReplace shouldBe None
     }
@@ -205,7 +205,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.imageCutoutReplace shouldBe Some(false)
     }
@@ -213,7 +213,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
 
   "ClientCardMetadata to CardMetadata" - {
 
-    def getEmptyClientCardMetadata = ClientArticleMetadata(
+    def getEmptyClientCardMetadata = ClientCardMetadata(
       None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
     )
 
@@ -232,7 +232,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         .copy(imageCutoutSrcHeight = Some("100"))
         .copy(imageCutoutSrcWidth = Some("100"))
         .copy(imageCutoutSrcOrigin = Some("file://broom.gif"))
-        .toCardMetadata
+        .toArticleMetadata
 
       cardMetadata.headline.isDefined shouldBe true
       cardMetadata.headline.get shouldBe "New Harry Potter book being written"
@@ -269,7 +269,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         .copy(imageCutoutSrc = Some("file://broom.jpg"))
         .copy(coverCardMobileImage = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))))
         .copy(coverCardTabletImage = Some(Image(Some(100), Some(100), "file://origin.png", "file://src.png", Some("file://thumb.png"))))
-        .toCardMetadata
+        .toArticleMetadata
 
       cardMetadata.mediaType.isDefined shouldBe true
       cardMetadata.mediaType.get shouldBe MediaType.Image

--- a/test/model/editions/client/ClientCardMetadataTest.scala
+++ b/test/model/editions/client/ClientCardMetadataTest.scala
@@ -1,6 +1,6 @@
 package model.editions.client
 
-import model.editions.{CardMetadata, CoverCardImages, Image, MediaType}
+import model.editions.{EditionsArticleMetadata, CoverCardImages, Image, MediaType}
 import org.scalatest.{FreeSpec, Matchers}
 
 class ClientCardMetadataTest extends FreeSpec with Matchers {
@@ -8,7 +8,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
   "ClientCardMetadata from CardMetadata" - {
 
     "should recover promotion metric from a simple CardMetadata" in {
-      val cardMetadata = CardMetadata(
+      val cardMetadata = EditionsArticleMetadata(
         Some("Britain has summer!"),
         Some("Breaking News"),
         Some("Goneth the rain, cometh the sun"),
@@ -23,12 +23,12 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None,
         Some(1)
       )
-      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
       clientCardMetadata.promotionMetric should be (Some(1))
     }
 
     "should send promotion metric to a simple CardMetadata" in {
-      val clientCardMetadata = ClientCardMetadata(
+      val clientCardMetadata = ClientArticleMetadata(
         Some("Britain has summer!"),
         None,
         None,
@@ -68,7 +68,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
     }
 
     "should serialise from a simple CardMetadata" in {
-      val cardMetadata = CardMetadata(
+      val cardMetadata = EditionsArticleMetadata(
         Some("Britain has summer!"),
         Some("Breaking News"),
         Some("Goneth the rain, cometh the sun"),
@@ -84,7 +84,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.headline.isDefined shouldBe true
       clientCardMetadata.headline.get shouldBe "Britain has summer!"
@@ -102,7 +102,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
     }
 
     "should persist cutout image when selected override is hide image" in {
-      val cardMetadata = CardMetadata(
+      val cardMetadata = EditionsArticleMetadata(
         Some("New Pokemon discovered"),
         None,
         None,
@@ -118,7 +118,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.headline.isDefined shouldBe true
       clientCardMetadata.headline.get shouldBe "New Pokemon discovered"
@@ -136,7 +136,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
     }
 
     "should persist slideshow images when selected override is replace image" in {
-      val cardMetadata = CardMetadata(
+      val cardMetadata = EditionsArticleMetadata(
         Some("Elephants declared best animal"),
         None,
         None,
@@ -152,7 +152,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.headline.isDefined shouldBe true
       clientCardMetadata.headline.get shouldBe "Elephants declared best animal"
@@ -167,7 +167,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
     }
 
     "should only set an image override boolean if its fields are also set" in {
-      val cardMetadata = CardMetadata(
+      val cardMetadata = EditionsArticleMetadata(
         Some("Teenage Mutant Ninja Turtles"),
         None,
         None,
@@ -183,13 +183,13 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.imageReplace shouldBe None
     }
 
     "should explicitly set cutout to false if media type is set but not to a cutout" in {
-      val cardMetadata = CardMetadata(
+      val cardMetadata = EditionsArticleMetadata(
         Some("Teenage Mutant Ninja Turtles"),
         None,
         None,
@@ -205,7 +205,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
         None
       )
 
-      val clientCardMetadata = ClientCardMetadata.fromCardMetadata(cardMetadata)
+      val clientCardMetadata = ClientArticleMetadata.fromCardMetadata(cardMetadata)
 
       clientCardMetadata.imageCutoutReplace shouldBe Some(false)
     }
@@ -213,7 +213,7 @@ class ClientCardMetadataTest extends FreeSpec with Matchers {
 
   "ClientCardMetadata to CardMetadata" - {
 
-    def getEmptyClientCardMetadata = ClientCardMetadata(
+    def getEmptyClientCardMetadata = ClientArticleMetadata(
       None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
     )
 

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -187,7 +187,7 @@ class EditionsTemplatingTest extends FreeSpec with Matchers with OptionValues wi
       val frontPageCollection = issue.fronts.find(_.name == "UK News").value.collections.find(_.name == "Front Page").value
       frontPageCollection.items.size shouldBe 1
       frontPageCollection.items.head.id shouldBe "123456"
-      frontPageCollection.items.head.metadata shouldBe CardMetadata.default
+      frontPageCollection.items.head.metadata shouldBe EditionsArticleMetadata.default
     }
   }
 

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -22,7 +22,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
   private val moreRecentThenCreationTime = now.toInstant.toEpochMilli + 1
 
-  private val simpleMetadata = CardMetadata(
+  private val simpleMetadata = EditionsArticleMetadata(
     customKicker = Some("Kicker"),
     headline = None,
     trailText = None,
@@ -75,7 +75,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
   private def collection(name: String, prefill: Option[CapiPrefillQuery], articles: EditionsArticleSkeleton*): EditionsCollectionSkeleton =
     EditionsCollectionSkeleton(name, articles.toList, prefill, CollectionPresentation(), capiQueryTimeWindow, hidden = false)
 
-  private def article(id: String): EditionsArticleSkeleton = EditionsArticleSkeleton(id, CardMetadata.default)
+  private def article(id: String): EditionsArticleSkeleton = EditionsArticleSkeleton(id, EditionsArticleMetadata.default)
 
   "should insert an empty issue" taggedAs UsesDatabase in {
     val id = insertSkeletonIssue(2019, 9, 30)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -166,8 +166,11 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     val editionsArticle = newsPoliticsCollection.items.head
     editionsArticle.id shouldBe "12345"
 
-    val articleMetadata = editionsArticle.metadata.get
-    articleMetadata.overrideArticleMainMedia shouldBe None
+    val articleMetadata = editionsArticle match {
+      case e: EditionsArticle => e.metadata
+      case _ => None
+    }
+    articleMetadata.get.overrideArticleMainMedia shouldBe None
 
     commentFront.metadata.get.nameOverride shouldBe None
     commentFront.metadata.get.swatch shouldBe Some(Swatch.Culture)
@@ -368,7 +371,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     val future = now.plusMinutes(20)
     val futureMillis = future.toInstant.toEpochMilli
 
-    val items = EditionsCard("654789", CardType.Article, futureMillis, Some(simpleMetadata)) :: brexshit.items
+    val items = EditionsArticle("654789", futureMillis, Some(simpleMetadata)) :: brexshit.items
 
     val evenMoreBrexshit = brexshit.copy(
       lastUpdated = Some(futureMillis),
@@ -392,7 +395,12 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
     // check we are storing some metadata
     updatedBrexshit.items.find(_.id == "654789").value.addedOn shouldBe future.toInstant.toEpochMilli
-    updatedBrexshit.items.find(_.id == "654789").value.metadata.value shouldBe simpleMetadata
+    val metadata = updatedBrexshit.items.find(_.id == "654789").value match {
+      case e: EditionsArticle => e.metadata
+      case _ => None
+    }
+
+    metadata.get shouldBe simpleMetadata
 
     // check that the added time hasn't modified
     updatedBrexshit.items.find(_.id == "76543").value.addedOn shouldBe now.toInstant.toEpochMilli
@@ -410,7 +418,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     val retrievedIssue = editionsDB.getIssue(id).value
     val retrievedCollection = retrievedIssue.fronts.head.collections.head
 
-    val recipeCard = EditionsCard("654789", CardType.Recipe, now.toInstant.toEpochMilli, Some(simpleMetadata))
+    val recipeCard = EditionsRecipe("654789", now.toInstant.toEpochMilli)
     val items = retrievedCollection.copy(items = retrievedCollection.items :+ recipeCard)
     editionsDB.updateCollection(items)
 

--- a/test/services/editions/publishing/EditionsAppPublicationTargetTest.scala
+++ b/test/services/editions/publishing/EditionsAppPublicationTargetTest.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.Json
 import services.editions.publishing.PublishedIssueFormatters._
 import scala.io.Source
 
-class EditionsBucketTest extends FreeSpec with Matchers with OptionValues with EitherValues {
+class EditionsAppPublicationTargetTest extends FreeSpec with Matchers with OptionValues with EitherValues {
   "Saving a publication to a bucket" - {
     val issueDate = LocalDate.of(2019, 9, 30)
     val issue: EditionsIssue = EditionsIssue(
@@ -31,7 +31,7 @@ class EditionsBucketTest extends FreeSpec with Matchers with OptionValues with E
 
     "publication is preview" - {
       val key = PublicationTarget.createKey(issue, "preview")
-      val putObjectRequest = EditionsBucket.createPutObjectRequest("test-bucket", key, previewIssue)
+      val putObjectRequest = EditionsAppPublicationTarget.createPutObjectRequest("test-bucket", key, previewIssue)
 
       "key is correct" in {
         putObjectRequest.getKey shouldBe "daily-edition/2019-09-30/preview.json"
@@ -51,7 +51,7 @@ class EditionsBucketTest extends FreeSpec with Matchers with OptionValues with E
     "publication is version called banana" - {
       val publishedIssue = issue.toPublishableIssue("banana", PublishAction.proof)
       val key = PublicationTarget.createKey(issue, "banana")
-      val putObjectRequest = EditionsBucket.createPutObjectRequest("test-bucket", key, publishedIssue)
+      val putObjectRequest = EditionsAppPublicationTarget.createPutObjectRequest("test-bucket", key, publishedIssue)
 
       "key is correct" in {
         putObjectRequest.getKey shouldBe "daily-edition/2019-09-30/banana.json"

--- a/test/services/editions/publishing/EditionsAppPublicationTargetTest.scala
+++ b/test/services/editions/publishing/EditionsAppPublicationTargetTest.scala
@@ -5,7 +5,6 @@ import model.editions.{CuratedPlatform, Edition, EditionsIssue, PublishAction}
 import services.editions.publishing.PublishedIssueFormatters._
 import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
 import play.api.libs.json.Json
-import services.editions.publishing.PublishedIssueFormatters._
 import scala.io.Source
 
 class EditionsAppPublicationTargetTest extends FreeSpec with Matchers with OptionValues with EitherValues {

--- a/test/services/editions/publishing/EditionsBucketTest.scala
+++ b/test/services/editions/publishing/EditionsBucketTest.scala
@@ -27,9 +27,10 @@ class EditionsBucketTest extends FreeSpec with Matchers with OptionValues with E
       platform = CuratedPlatform.Editions
     )
 
+    val previewIssue = issue.toPreviewIssue
+
     "publication is preview" - {
-      val previewIssue = issue.toPreviewIssue
-      val key = EditionsBucket.createKey(previewIssue)
+      val key = PublicationTarget.createKey(issue, "preview")
       val putObjectRequest = EditionsBucket.createPutObjectRequest("test-bucket", key, previewIssue)
 
       "key is correct" in {
@@ -49,7 +50,7 @@ class EditionsBucketTest extends FreeSpec with Matchers with OptionValues with E
 
     "publication is version called banana" - {
       val publishedIssue = issue.toPublishableIssue("banana", PublishAction.proof)
-      val key = EditionsBucket.createKey(publishedIssue)
+      val key = PublicationTarget.createKey(issue, "banana")
       val putObjectRequest = EditionsBucket.createPutObjectRequest("test-bucket", key, publishedIssue)
 
       "key is correct" in {

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -4,14 +4,14 @@ import com.amazonaws.services.sns.AmazonSNSClient
 import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest, PublishResult}
 import conf.ApplicationConfiguration
 import model.FeastAppModel
-import model.editions.{CuratedPlatform, Edition, EditionsCollection, EditionsFront, EditionsIssue, EditionsRecipe, PublishAction, PublishableIssue, PublishedArticle, PublishedCollection, PublishedFront}
+import model.editions.{CuratedPlatform, Edition, EditionsCollection, EditionsFront, EditionsIssue, EditionsRecipe, PublishAction}
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import org.scalatest.{FreeSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 import play.api.libs.json.Json
-import model.FeastAppModel.{Chef, FeastAppContainer, FeastAppCuration, Recipe, RecipeIdentifier}
+import model.FeastAppModel.{Chef, FeastAppContainer, Recipe, RecipeIdentifier}
 import util.TimestampGenerator
 
 import java.time.LocalDate

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.sns.AmazonSNSClient
 import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest, PublishResult}
 import conf.ApplicationConfiguration
 import model.FeastAppModel
-import model.editions.{Edition, PublishAction, PublishableIssue, PublishedArticle, PublishedCollection, PublishedFront}
+import model.editions.{CuratedPlatform, Edition, EditionsCollection, EditionsFront, EditionsIssue, EditionsRecipe, PublishAction, PublishableIssue, PublishedArticle, PublishedCollection, PublishedFront}
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import org.scalatest.{FreeSpec, Matchers}
@@ -27,12 +27,58 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
     false
   )
 
+  val testIssue = EditionsIssue(
+    id = "123456ABCD",
+    edition = Edition.FeastNorthernHemisphere,  //?? ma
+    platform = CuratedPlatform.Feast,
+    timezoneId = "Europe/London",
+    issueDate = LocalDate.of(2024,5,3),
+    createdOn = 0L,
+    createdBy = "test",
+    createdEmail = "test@test.com",
+    launchedOn = None,
+    launchedBy = None,
+    launchedEmail = None,
+    supportsProofing = false,
+    fronts = List(
+      EditionsFront(
+        "b09354b1-f971-4d08-961b-dc83004c6b1f",
+        "All Recipes",
+        index = 0,
+        isSpecial = false, // :(
+        isHidden = false,
+        updatedOn = None,
+        updatedBy = None,
+        updatedEmail = None,
+        metadata = None,
+        collections = List(
+          EditionsCollection(
+            id="98e89761-fdf0-4903-b49d-2af7d66fc930",
+            displayName="Dish of the day",
+            isHidden =  false,
+            lastUpdated = None,
+            updatedBy = None,
+            updatedEmail = None,
+            prefill = None,
+            contentPrefillTimeWindow = None,
+            items=List(
+              EditionsRecipe(
+                "id",
+                0L
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
   val mockTSG = mock[TimestampGenerator]
   when(mockTSG.getTimestamp).thenReturn(12345678L)
 
   "putIssueJson" - {
     val issue = Map(
-      "chefs" -> FeastAppContainer("chefs", "Chefs", None, Seq(Chef(None, "bob-the-pirate", None, "Bob is a pirate", None))),
+      "chefs" -> FeastAppContainer("chefs", "Chefs", None, Seq(Chef("bob-the-pirate", None, Some("Bob is a pirate"), None, None))),
       "recipes" -> FeastAppContainer("recipes", "Recipes", None, Seq(Recipe(RecipeIdentifier("abcdefg"))))
     )
 
@@ -90,40 +136,12 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
 
   "transformContent" - {
     "should transform the Editions content" - {
-      val incoming = PublishableIssue(
-        PublishAction.publish,
-        "123456ABCD",
-        Edition.FeastNorthernHemisphere,  //?? maybe a modelling mistake here
-        Edition.FeastNorthernHemisphere,
-        LocalDate.of(2024,5,3),
-        "v1",
-        fronts=List(
-          PublishedFront("b09354b1-f971-4d08-961b-dc83004c6b1f","All Recipes",
-            swatch=null,
-            collections=List(
-              PublishedCollection(
-                id="98e89761-fdf0-4903-b49d-2af7d66fc930",
-                name="Dish of the day",
-                items=List(
-                  PublishedArticle(
-                    internalPageCode = 123456,
-                    null
-                  )
-                )
-              )
-            )
-          )
-        ),
-        notificationUTCOffset=0,
-        topic=None
-      )
-
       val mockSNS = mock[AmazonSNSClient]
       when(mockSNS.publish(any[PublishRequest])).thenReturn(new PublishResult())
 
       val toTest = new FeastPublicationTarget(mockSNS, conf, mockTSG)
 
-      val result = toTest.transformContent(incoming)
+      val result = toTest.transformContent(testIssue, "v1")
       result.fronts.contains("all-recipes") shouldBe true
       val allRecipesFront = result.fronts("all-recipes")
       allRecipesFront.length shouldBe 1
@@ -131,54 +149,26 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
       allRecipesFront.head.body shouldBe Some("") //this is just how the `body` field is currently rendered
       allRecipesFront.head.id shouldBe "98e89761-fdf0-4903-b49d-2af7d66fc930"
       allRecipesFront.head.items.length shouldBe 1
-      allRecipesFront.head.items.head.asInstanceOf[FeastAppModel.Recipe].recipe.id shouldBe "123456"
+      allRecipesFront.head.items.head.asInstanceOf[FeastAppModel.Recipe].recipe.id shouldBe "id"
     }
   }
 
   "putIssue" - {
     "should output the transformed version of the content" - {
-      val incoming = PublishableIssue(
-        PublishAction.publish,
-        "123456ABCD",
-        Edition.FeastNorthernHemisphere,  //?? maybe a modelling mistake here
-        Edition.FeastNorthernHemisphere,
-        LocalDate.of(2024,5,3),
-        "v1",
-        fronts=List(
-          PublishedFront("b09354b1-f971-4d08-961b-dc83004c6b1f","All Recipes",
-            swatch=null,
-            collections=List(
-              PublishedCollection(
-                id="98e89761-fdf0-4903-b49d-2af7d66fc930",
-                name="Dish of the day",
-                items=List(
-                  PublishedArticle(
-                    internalPageCode = 123456,
-                    null
-                  )
-                )
-              )
-            )
-          )
-        ),
-        notificationUTCOffset=0,
-        topic=None
-      )
-
-      val serializedVersion = """{"id":"123456ABCD","edition":"feast-northern-hemisphere","issueDate":"2024-05-03","version":"v1","fronts":{"all-recipes":[{"id":"98e89761-fdf0-4903-b49d-2af7d66fc930","title":"Dish of the day","body":"","items":[{"recipe":{"id":"123456"}}]}]}}"""
+      val serializedVersion = """{"id":"123456ABCD","edition":"feast-northern-hemisphere","issueDate":"2024-05-03","version":"v1","fronts":{"all-recipes":[{"id":"98e89761-fdf0-4903-b49d-2af7d66fc930","title":"Dish of the day","body":"","items":[{"recipe":{"id":"id"}}]}]}}"""
 
       val mockSNS = mock[AmazonSNSClient]
       when(mockSNS.publish(any[PublishRequest])).thenReturn(new PublishResult())
 
       val toTest = new FeastPublicationTarget(mockSNS, conf, mockTSG)
 
-      toTest.putIssue(incoming, Some("test-key"))
+      toTest.putIssue(testIssue, "v1", PublishAction.publish)
       val expectedRequest = new PublishRequest()
         .withTopicArn("fake-publication-topic")
         .withMessage(serializedVersion)
         .withMessageAttributes(Map(
-          "type"->new MessageAttributeValue().withDataType("String").withStringValue("Issue"),
-          "timestamp"->new MessageAttributeValue().withDataType("Number").withStringValue("12345678")
+          "timestamp"->new MessageAttributeValue().withDataType("Number").withStringValue("12345678"),
+          "type"->new MessageAttributeValue().withDataType("String").withStringValue("Issue")
         ).asJava)
       verify(mockSNS).publish(expectedRequest)
     }

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -173,5 +173,4 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
       verify(mockSNS).publish(expectedRequest)
     }
   }
-
 }

--- a/test/services/editions/publishing/PublishingTest.scala
+++ b/test/services/editions/publishing/PublishingTest.scala
@@ -9,7 +9,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import services.editions.db.EditionsDB
 
 import java.time.LocalDate
-import scala.util.{Failure, Try}
+import scala.util.Try
 import model.editions.CuratedPlatform
 import model.editions.PublishAction.PublishAction
 

--- a/test/services/editions/publishing/PublishingTest.scala
+++ b/test/services/editions/publishing/PublishingTest.scala
@@ -16,8 +16,8 @@ import model.editions.PublishAction.PublishAction
 class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
   "publishing.publish" - {
     "should send Feast editions to Feast publication backend" - {
-      val editionsAppPublicationBucket = mock[EditionsBucket]
-      val editionsAppPreviewBucket = mock[EditionsBucket]
+      val editionsAppPublicationBucket = mock[EditionsAppPublicationTarget]
+      val editionsAppPreviewBucket = mock[EditionsAppPublicationTarget]
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
@@ -49,8 +49,8 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
     }
 
     "should send Editorial editions to Editions publication backend" - {
-      val editionsAppPublicationBucket = mock[EditionsBucket]
-      val editionsAppPreviewBucket = mock[EditionsBucket]
+      val editionsAppPublicationBucket = mock[EditionsAppPublicationTarget]
+      val editionsAppPreviewBucket = mock[EditionsAppPublicationTarget]
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
@@ -84,8 +84,8 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
 
   "publishing.updatePreview" - {
     "should send Editorial editions to Editions preview backend" - {
-      val editionsAppPublicationBucket = mock[EditionsBucket]
-      val editionsAppPreviewBucket = mock[EditionsBucket]
+      val editionsAppPublicationBucket = mock[EditionsAppPublicationTarget]
+      val editionsAppPreviewBucket = mock[EditionsAppPublicationTarget]
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
@@ -117,8 +117,8 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
     }
 
     "should do nothing if you pass a Feast edition" - {
-      val editionsAppPublicationBucket = mock[EditionsBucket]
-      val editionsAppPreviewBucket = mock[EditionsBucket]
+      val editionsAppPublicationBucket = mock[EditionsAppPublicationTarget]
+      val editionsAppPreviewBucket = mock[EditionsAppPublicationTarget]
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 


### PR DESCRIPTION
_co-authored-by: @Divs-B_

## What's changed?

Makes the Editions Card a sealed trait, which will improve our modelling as we introduce different metadata for different card types, and make it easier to guard against incorrect behaviour – for example, articles in Feast issues, and recipes in Editions issues.

This is a no-op – nothing in the app behaviour should change. We have good tests as guardrails here, but a end-to-end check of Editions preview and publication 

## Implementation notes

There are two important changes:
- a sealed trait for the `EditionsCard` type, which is now inherited by Article, Recipe, Chef and FeastCollection cards. ([ddc7dec](https://github.com/guardian/facia-tool/pull/1605/commits/ddc7decdf95e932bf88d875624ebf7337af47234), [e7b2851](https://github.com/guardian/facia-tool/pull/1605/commits/e7b28519463505ffb750a99b56f22d071baa9bbf))
- moving the Editions App- and Feast-specific modelling and logic for publication into their respective `PublicationTarget` implementations, so `FeastPublicationTarget` does not depend on a `PublishedIssue` (which contains Editions-specific logic.) [f043cd4](https://github.com/guardian/facia-tool/pull/1605/commits/f043cd41d9d51ceaa777fea621474743a114d5f2)

As an incidental change, we've renamed `EditionsBucket` to `EditionsAppPublicationTarget`, to better reflect its relationship with the Editions App product and the trait it implements. ([6a3c606](https://github.com/guardian/facia-tool/pull/1605/commits/6a3c6060d4d79a1b5231555cd9aa8ed46919bef7))

We _haven't_ touched the `EditionsClientCard` model (which could also be a sealed trait.) The reasoning for this is that this model is simply there to adapt a few article-specific properties (`id` formatting,  `frontPublicationDate` -> `addedOn`), and replicating the hierarchy in another place felt like overkill. Sadly, this means we still keep the expansive `ClientCardMetadata` case class, which contains all possible meta properties. We could follow this up with an alternative approach if there was appetite.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included

### Additional checks
- [x] Preview editions behaves as expected
- [x] Proof editions behaves as expected
- [x] Proof feast behaves as expected
