### PR TITLE
Store recipes nested in feast collections, and ensure other card types are not permitted within them

### DIFF
--- a/app/model/editions/EditionsCard.scala
+++ b/app/model/editions/EditionsCard.scala
@@ -189,7 +189,14 @@ object EditionsArticle extends Logging {
   }
 }
 
-case class EditionsRecipe(id: String, addedOn: Long) extends EditionsCard {
+// Only certain cards are permitted within a FeastCollection.
+sealed trait EditionsFeastCollectionItem extends EditionsCard
+
+object EditionsFeastCollectionItem {
+  implicit val format: OFormat[EditionsFeastCollectionItem] = Json.format[EditionsFeastCollectionItem]
+}
+
+case class EditionsRecipe(id: String, addedOn: Long) extends EditionsCard with EditionsFeastCollectionItem {
   val cardType: CardType = CardType.Recipe
 }
 
@@ -217,7 +224,8 @@ object EditionsChef {
 
 case class EditionsFeastCollectionMetadata(
   title: Option[String] = None,
-  theme: Option[FeastCollectionTheme] = None
+  theme: Option[FeastCollectionTheme] = None,
+  collectionItems: List[EditionsFeastCollectionItem] = List.empty
 )
 
 object EditionsFeastCollectionMetadata {

--- a/app/model/editions/client/ClientCardMetadata.scala
+++ b/app/model/editions/client/ClientCardMetadata.scala
@@ -42,6 +42,7 @@ case class ClientCardMetadata(
   chefImageOverride: Option[Image] = None, // Chef
   title: Option[String] = None, // FeastCollection
   feastCollectionTheme: Option[FeastCollectionTheme] = None, // FeastCollection
+  supporting: List[EditionsSupportingClientCard] = List.empty
 ) {
   def toChefMetadata: EditionsChefMetadata =
     EditionsChefMetadata(
@@ -54,6 +55,7 @@ case class ClientCardMetadata(
     EditionsFeastCollectionMetadata(
       title,
       feastCollectionTheme,
+      collectionItems = supporting.map(EditionsSupportingClientCard.toFeastCollectionItem)
     )
 
   def toArticleMetadata: EditionsArticleMetadata = {
@@ -106,7 +108,8 @@ object ClientCardMetadata {
   def fromCardMetadata(cardMetadata: EditionsFeastCollectionMetadata): ClientCardMetadata = {
     ClientCardMetadata(
       title = cardMetadata.title,
-      feastCollectionTheme = cardMetadata.theme
+      feastCollectionTheme = cardMetadata.theme,
+      supporting = cardMetadata.collectionItems.map(card => EditionsSupportingClientCard.fromFeastCollectionItem(card))
     )
   }
 

--- a/app/model/editions/client/EditionsClientCollection.scala
+++ b/app/model/editions/client/EditionsClientCollection.scala
@@ -5,9 +5,9 @@ import services.editions.prefills.CapiQueryTimeWindow
 import model.editions.EditionsCard
 import model.editions.EditionsArticle
 import model.editions.{CapiPrefillQuery, EditionsCollection, EditionsRecipe, EditionsChef, EditionsFeastCollection, CardType}
+import model.editions.EditionsFeastCollectionItem
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
-
 case class EditionsClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long, meta: Option[ClientCardMetadata] = None)
 
 object EditionsClientCard {
@@ -69,6 +69,19 @@ object EditionsClientCard {
         card.meta.map(_.toFeastCollectionMetadata)
       )
   }
+}
+
+case class EditionsSupportingClientCard(id: String, cardType: Option[CardType], frontPublicationDate: Long)
+
+object EditionsSupportingClientCard {
+  implicit def format: OFormat[EditionsSupportingClientCard] = Json.format[EditionsSupportingClientCard]
+
+  def fromFeastCollectionItem(item: EditionsFeastCollectionItem) = item match {
+    case EditionsRecipe(id, addedOn) => EditionsSupportingClientCard(id, Some(CardType.Recipe), addedOn)
+  }
+
+  def toFeastCollectionItem(supportingCard: EditionsSupportingClientCard) = 
+    EditionsRecipe(supportingCard.id, supportingCard.frontPublicationDate)
 }
 
 case class EditionsClientCollection(

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import type { State } from 'types/State';
 import { createSelectArticleVisibilityDetails } from 'selectors/frontsSelectors';
 import FocusWrapper from 'components/FocusWrapper';
+import { CardTypes } from 'constants/cardTypes';
 
 const getArticleNotifications = (
   id: string,
@@ -184,6 +185,10 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
                           cardId={card.uuid}
                           onMove={handleMove}
                           onDrop={handleInsert}
+                          cardTypeAllowList={this.getPermittedCardTypes(
+                            card.cardType
+                          )}
+                          dropMessage={this.getDropMessage(card.cardType)}
                         >
                           {(supporting, getSupportingProps) => (
                             <Card
@@ -223,6 +228,14 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
       </CollectionWrapper>
     );
   }
+
+  private getPermittedCardTypes = (
+    cardType?: CardTypes
+  ): CardTypes[] | undefined =>
+    cardType === 'feast-collection' ? ['recipe'] : undefined;
+
+  private getDropMessage = (cardType?: CardTypes) =>
+    cardType === 'feast-collection' ? 'Place recipe here' : 'Sublink';
 }
 
 const createMapStateToProps = () => {

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
@@ -31,7 +31,7 @@ export const DragToAddFeastCollection = () => {
       dragImage={<DraggingArticleComponent headline="Feast collection" />}
       dragImageRef={ref}
       onDragStart={(e: React.DragEvent<HTMLDivElement>) =>
-        handleDragStart(e, ref.current!)
+        ref.current && handleDragStart(e, ref.current)
       }
     >
       Drag to add a feast collection

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
@@ -9,6 +9,7 @@ import {
 import { DragToAdd } from './DragToAdd';
 import { Card } from 'types/Collection';
 import { CardTypesMap } from 'constants/cardTypes';
+import { CARD_TYPE } from 'lib/dnd/constants';
 
 const handleDragStart = (
   event: React.DragEvent<HTMLDivElement>,
@@ -25,6 +26,7 @@ const handleDragStart = (
     CardTypesMap.FEAST_COLLECTION,
     JSON.stringify(feastCollectionCard)
   );
+  event.dataTransfer.setData(CARD_TYPE, CardTypesMap.FEAST_COLLECTION);
   if (dragImageElement) {
     event.dataTransfer.setDragImage(dragImageElement, dragOffsetX, dragOffsetY);
   }

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/DragToAddFeastCollection.tsx
@@ -1,19 +1,14 @@
 import React, { useRef } from 'react';
 import v4 from 'uuid/v4';
-
-import {
-  DraggingArticleComponent,
-  dragOffsetX,
-  dragOffsetY,
-} from './ArticleDrag';
+import { DraggingArticleComponent } from './ArticleDrag';
 import { DragToAdd } from './DragToAdd';
 import { Card } from 'types/Collection';
 import { CardTypesMap } from 'constants/cardTypes';
-import { CARD_TYPE } from 'lib/dnd/constants';
+import { handleDragStartForCard } from 'util/dragAndDrop';
 
 const handleDragStart = (
   event: React.DragEvent<HTMLDivElement>,
-  dragImageElement: HTMLDivElement | null
+  dragImageElement: HTMLDivElement
 ) => {
   const feastCollectionCard: Card = {
     cardType: CardTypesMap.FEAST_COLLECTION,
@@ -22,14 +17,11 @@ const handleDragStart = (
     uuid: v4(),
     frontPublicationDate: Date.now(),
   };
-  event.dataTransfer.setData(
+
+  return handleDragStartForCard(
     CardTypesMap.FEAST_COLLECTION,
-    JSON.stringify(feastCollectionCard)
-  );
-  event.dataTransfer.setData(CARD_TYPE, CardTypesMap.FEAST_COLLECTION);
-  if (dragImageElement) {
-    event.dataTransfer.setDragImage(dragImageElement, dragOffsetX, dragOffsetY);
-  }
+    feastCollectionCard
+  )(event, dragImageElement);
 };
 
 export const DragToAddFeastCollection = () => {
@@ -39,7 +31,7 @@ export const DragToAddFeastCollection = () => {
       dragImage={<DraggingArticleComponent headline="Feast collection" />}
       dragImageRef={ref}
       onDragStart={(e: React.DragEvent<HTMLDivElement>) =>
-        handleDragStart(e, ref.current)
+        handleDragStart(e, ref.current!)
       }
     >
       Drag to add a feast collection

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -71,7 +71,7 @@ class Sublinks extends React.Component<SublinkProps> {
               this.setState({ dragHoverActive: false });
             }}
             delay={100}
-            filterRegisterEvent={this.dragEventNotDenylisted}
+            filterRegisterEvent={e => !denyDragEvent()(e)}
             onIntentConfirm={() => {
               toggleShowArticleSublinks();
             }}
@@ -99,8 +99,6 @@ class Sublinks extends React.Component<SublinkProps> {
       </>
     );
   }
-
-  private dragEventNotDenylisted = (e: React.DragEvent) => !denyDragEvent()(e);
 }
 
 export default Sublinks;

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -40,7 +40,7 @@ interface SublinkProps {
   toggleShowArticleSublinks: (e?: React.MouseEvent) => void;
   showArticleSublinks: boolean;
   parentId: string;
-  // The label to show the user, e.g. '2 sublinks'. Should be singular.
+  // The singular label to show the user, e.g. 'sublink'.
   sublinkLabel?: string;
 }
 
@@ -100,8 +100,7 @@ class Sublinks extends React.Component<SublinkProps> {
     );
   }
 
-  private dragEventNotDenylisted = (e: React.DragEvent) =>
-    !denyDragEvent()(e);
+  private dragEventNotDenylisted = (e: React.DragEvent) => !denyDragEvent()(e);
 }
 
 export default Sublinks;

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -41,6 +41,8 @@ interface SublinkProps {
   toggleShowArticleSublinks: (e?: React.MouseEvent) => void;
   showArticleSublinks: boolean;
   parentId: string;
+  // The label to show the user, e.g. '2 sublinks'. Should be singular.
+  sublinkLabel?: string;
 }
 
 class Sublinks extends React.Component<SublinkProps> {
@@ -54,6 +56,7 @@ class Sublinks extends React.Component<SublinkProps> {
       toggleShowArticleSublinks,
       showArticleSublinks,
       parentId,
+      sublinkLabel = 'sublink',
     } = this.props;
 
     const isClipboard = parentId === 'clipboard';
@@ -82,7 +85,7 @@ class Sublinks extends React.Component<SublinkProps> {
                 {!isClipboard && <CardMetaContainer />}
                 <SublinkCardContent displaySize="small" showMeta={isClipboard}>
                   <span>
-                    {numSupportingArticles} sublink
+                    {numSupportingArticles} {sublinkLabel}
                     {numSupportingArticles > 1 && 's'}
                     <ButtonCircularCaret
                       openDir={showArticleSublinks ? 'up' : 'down'}

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Sublinks.tsx
@@ -7,8 +7,7 @@ import CardContainer from 'components/card/CardContainer';
 import CardContent from 'components/card/CardContent';
 import CardMetaContainer from 'components/card/CardMetaContainer';
 import DragIntentContainer from 'components/DragIntentContainer';
-import { dragEventIsDenylisted } from 'lib/dnd/Level';
-import { collectionDropTypeDenylist } from 'constants/fronts';
+import { denyDragEvent } from 'lib/dnd/CardTypeLevel';
 
 const SublinkCardBody = styled(CardBody)<{
   dragHoverActive: boolean;
@@ -102,7 +101,7 @@ class Sublinks extends React.Component<SublinkProps> {
   }
 
   private dragEventNotDenylisted = (e: React.DragEvent) =>
-    !dragEventIsDenylisted(e, collectionDropTypeDenylist);
+    !denyDragEvent()(e);
 }
 
 export default Sublinks;

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -276,7 +276,13 @@ class Card extends React.Component<CardContainerProps> {
                 textSize={textSize}
                 showMeta={showMeta}
               />
-              {getSublinks}
+              <Sublinks
+                numSupportingArticles={numSupportingArticles}
+                toggleShowArticleSublinks={this.toggleShowArticleSublinks}
+                showArticleSublinks={this.state.showCardSublinks}
+                parentId={parentId}
+                sublinkLabel="recipe"
+              />
               {/* If there are no supporting articles, the children still need to be rendered, because the dropzone is a child  */}
               {numSupportingArticles === 0
                 ? children

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -3,10 +3,6 @@ import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { connect } from 'react-redux';
 import { Card } from 'types/Collection';
-import ArticleDrag, {
-  dragOffsetX,
-  dragOffsetY,
-} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone, {
   DefaultDropContainer,
   DefaultDropIndicator,
@@ -58,15 +54,10 @@ const CardLevel = ({
     arr={supporting || []}
     parentType="card"
     parentId={cardId}
-    type="card"
-    getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}
     canDrop={!isUneditable}
     cardTypeAllowList={cardTypeAllowList}
-    renderDrag={(af) => <ArticleDrag id={af.uuid} />}
-    dragImageOffsetX={dragOffsetX}
-    dragImageOffsetY={dragOffsetY}
     renderDrop={
       isUneditable
         ? undefined

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Level, LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
+import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { connect } from 'react-redux';
 import { Card } from 'types/Collection';
@@ -12,8 +12,9 @@ import DropZone, {
   DefaultDropIndicator,
 } from 'components/DropZone';
 import { createSelectSupportingArticles } from 'selectors/shared';
-import { collectionDropTypeDenylist } from 'constants/fronts';
 import { theme, styled } from 'constants/theme';
+import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
+import { CardTypes } from 'constants/cardTypes';
 
 interface OuterProps {
   cardId: string;
@@ -21,6 +22,8 @@ interface OuterProps {
   onMove: MoveHandler<Card>;
   onDrop: DropHandler;
   isUneditable?: boolean;
+  dropMessage?: string;
+  cardTypeAllowList?: CardTypes[];
 }
 
 interface InnerProps {
@@ -48,10 +51,11 @@ const CardLevel = ({
   onMove,
   onDrop,
   isUneditable,
+  dropMessage,
+  cardTypeAllowList,
 }: Props) => (
-  <Level
+  <CardTypeLevel
     arr={supporting || []}
-    denylistedDataTransferTypes={collectionDropTypeDenylist}
     parentType="card"
     parentId={cardId}
     type="card"
@@ -59,6 +63,7 @@ const CardLevel = ({
     onMove={onMove}
     onDrop={onDrop}
     canDrop={!isUneditable}
+    cardTypeAllowList={cardTypeAllowList}
     renderDrag={(af) => <ArticleDrag id={af.uuid} />}
     dragImageOffsetX={dragOffsetX}
     dragImageOffsetY={dragOffsetY}
@@ -69,7 +74,7 @@ const CardLevel = ({
             <DropZone
               {...props}
               dropColor={theme.base.colors.dropZoneActiveSublink}
-              dropMessage={'Sublink'}
+              dropMessage={dropMessage ?? 'Sublink'}
               dropContainer={CardDropContainer}
               dropIndicator={CardDropIndicator}
             />
@@ -77,7 +82,7 @@ const CardLevel = ({
     }
   >
     {children}
-  </Level>
+  </CardTypeLevel>
 );
 
 const createMapStateToProps = () => {

--- a/fronts-client/src/components/clipboard/ClipboardLevel.tsx
+++ b/fronts-client/src/components/clipboard/ClipboardLevel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Level, LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
+import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { selectClipboardArticles } from 'selectors/clipboardSelectors';
 import { connect } from 'react-redux';
@@ -9,8 +9,8 @@ import ArticleDrag, {
   dragOffsetY,
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone, { DefaultDropContainer } from 'components/DropZone';
-import { collectionDropTypeDenylist } from 'constants/fronts';
 import { styled, theme } from 'constants/theme';
+import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
 
 interface OuterProps {
   children: LevelChild<Card>;
@@ -42,9 +42,8 @@ const ClipboardDropContainer = styled(DefaultDropContainer)<{
 `;
 
 const ClipboardLevel = ({ children, cards, onMove, onDrop }: Props) => (
-  <Level
+  <CardTypeLevel
     containerElement={ClipboardItemContainer}
-    denylistedDataTransferTypes={collectionDropTypeDenylist}
     arr={cards}
     parentType="clipboard"
     parentId="clipboard"
@@ -64,7 +63,7 @@ const ClipboardLevel = ({ children, cards, onMove, onDrop }: Props) => (
     )}
   >
     {children}
-  </Level>
+  </CardTypeLevel>
 );
 
 const mapStateToProps = (state: State) => ({

--- a/fronts-client/src/components/clipboard/ClipboardLevel.tsx
+++ b/fronts-client/src/components/clipboard/ClipboardLevel.tsx
@@ -4,10 +4,6 @@ import type { State } from 'types/State';
 import { selectClipboardArticles } from 'selectors/clipboardSelectors';
 import { connect } from 'react-redux';
 import { Card } from 'types/Collection';
-import ArticleDrag, {
-  dragOffsetX,
-  dragOffsetY,
-} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone, { DefaultDropContainer } from 'components/DropZone';
 import { styled, theme } from 'constants/theme';
 import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
@@ -47,13 +43,8 @@ const ClipboardLevel = ({ children, cards, onMove, onDrop }: Props) => (
     arr={cards}
     parentType="clipboard"
     parentId="clipboard"
-    type="card"
-    dragImageOffsetX={dragOffsetX}
-    dragImageOffsetY={dragOffsetY}
-    getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}
-    renderDrag={(af) => <ArticleDrag id={af.uuid} />}
     renderDrop={(props) => (
       <DropZone
         {...props}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -3,10 +3,6 @@ import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { connect } from 'react-redux';
 import { Card } from 'types/Collection';
-import ArticleDrag, {
-  dragOffsetX,
-  dragOffsetY,
-} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone, { DefaultDropContainer } from 'components/DropZone';
 import { createSelectArticlesFromIds } from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
@@ -69,14 +65,9 @@ const GroupLevel = ({
     arr={cards}
     parentType="group"
     parentId={groupId}
-    type="card"
-    dragImageOffsetX={dragOffsetX}
-    dragImageOffsetY={dragOffsetY}
-    getId={({ uuid }) => uuid}
     onMove={onMove}
     onDrop={onDrop}
     canDrop={!isUneditable}
-    renderDrag={(af) => <ArticleDrag id={af.uuid} />}
     renderDrop={
       isUneditable
         ? () => <Spacer />

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Level, LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
+import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { connect } from 'react-redux';
 import { Card } from 'types/Collection';
@@ -8,9 +8,9 @@ import ArticleDrag, {
   dragOffsetY,
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 import DropZone, { DefaultDropContainer } from 'components/DropZone';
-import { collectionDropTypeDenylist } from 'constants/fronts';
 import { createSelectArticlesFromIds } from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
+import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
 
 interface OuterProps {
   groupId: string;
@@ -65,9 +65,8 @@ const GroupLevel = ({
   onDrop,
   isUneditable,
 }: Props) => (
-  <Level
+  <CardTypeLevel
     arr={cards}
-    denylistedDataTransferTypes={collectionDropTypeDenylist}
     parentType="group"
     parentId={groupId}
     type="card"
@@ -92,7 +91,7 @@ const GroupLevel = ({
     }
   >
     {children}
-  </Level>
+  </CardTypeLevel>
 );
 
 const createMapStateToProps = () => {

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -1,9 +1,5 @@
 import { Chef } from '../../types/Chef';
 import React, { useCallback } from 'react';
-import {
-  dragOffsetX,
-  dragOffsetY,
-} from '../FrontsEdit/CollectionComponents/ArticleDrag';
 import { FeedItem } from './FeedItem';
 import { ContentInfo } from './ContentInfo';
 import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
@@ -12,6 +8,7 @@ import { CardTypesMap } from 'constants/cardTypes';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { insertCardWithCreate } from '../../actions/Cards';
 import { selectors as chefSelectors } from 'bundles/chefsBundle';
+import { handleDragStartForCard } from 'util/dragAndDrop';
 
 interface ComponentProps {
   id: string;
@@ -37,16 +34,6 @@ export const ChefFeedItemComponent = ({
     );
   }, [chef]);
 
-  const handleDragStart = (
-    event: React.DragEvent<HTMLDivElement>,
-    dragNode: HTMLDivElement
-  ) => {
-    event.dataTransfer.setData('chef', JSON.stringify(chef));
-    if (dragNode) {
-      event.dataTransfer.setDragImage(dragNode, dragOffsetX, dragOffsetY);
-    }
-  };
-
   return (
     <FeedItem
       id={chef.id}
@@ -57,7 +44,7 @@ export const ChefFeedItemComponent = ({
       liveUrl={`https://theguardian.com/${chef.apiUrl}`}
       thumbnail={chef.bylineLargeImageUrl}
       onAddToClipboard={onAddToClipboard}
-      handleDragStart={handleDragStart}
+      handleDragStart={handleDragStartForCard(CardTypesMap.CHEF, chef)}
       shouldObscureFeed={shouldObscureFeed}
       metaContent={<ContentInfo>Chef</ContentInfo>}
     />

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -2,16 +2,13 @@ import { Recipe } from '../../types/Recipe';
 import { FeedItem } from './FeedItem';
 import React, { useCallback } from 'react';
 import { State } from '../../types/State';
-import {
-  dragOffsetX,
-  dragOffsetY,
-} from '../FrontsEdit/CollectionComponents/ArticleDrag';
 import { selectFeatureValue } from '../../selectors/featureSwitchesSelectors';
 import { ContentInfo } from './ContentInfo';
 import { CardTypesMap } from 'constants/cardTypes';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { insertCardWithCreate } from 'actions/Cards';
+import { handleDragStartForCard } from 'util/dragAndDrop';
 
 interface ComponentProps {
   recipe: Recipe;
@@ -34,16 +31,6 @@ export const RecipeFeedItem = ({ recipe }: ComponentProps) => {
     );
   }, [recipe]);
 
-  const handleDragStart = (
-    event: React.DragEvent<HTMLDivElement>,
-    dragNode: HTMLDivElement
-  ) => {
-    event.dataTransfer.setData('recipe', JSON.stringify(recipe));
-    if (dragNode) {
-      event.dataTransfer.setDragImage(dragNode, dragOffsetX, dragOffsetY);
-    }
-  };
-
   return (
     <FeedItem
       type={CardTypesMap.RECIPE}
@@ -53,7 +40,7 @@ export const RecipeFeedItem = ({ recipe }: ComponentProps) => {
       liveUrl={`https://theguardian.com/${recipe.canonicalArticle}`}
       hasVideo={false}
       isLive={true} // We do not yet serve preview recipes
-      handleDragStart={handleDragStart}
+      handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
       onAddToClipboard={onAddToClipboard}
       shouldObscureFeed={shouldObscureFeed}
       metaContent={<ContentInfo>Recipe</ContentInfo>}

--- a/fronts-client/src/lib/dnd/CardTypeLevel.tsx
+++ b/fronts-client/src/lib/dnd/CardTypeLevel.tsx
@@ -4,8 +4,21 @@ import Level, { LevelProps } from './Level';
 import { CardTypes, CardTypesMap } from 'constants/cardTypes';
 import { collectionDropTypeDenylist } from 'constants/fronts';
 import { CARD_TYPE } from './constants';
+import ArticleDrag, {
+  dragOffsetX,
+  dragOffsetY,
+} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
 
-type Props = Omit<LevelProps<Card>, 'denyDragEvent' | 'getDropType'> & {
+type Props = Omit<
+  LevelProps<Card>,
+  | 'denyDragEvent'
+  | 'getDropType'
+  | 'dragImageOffsetX'
+  | 'dragImageOffsetY'
+  | 'renderDrag'
+  | 'type'
+  | 'getId'
+> & {
   cardTypeAllowList?: CardTypes[];
 };
 
@@ -32,5 +45,10 @@ export const CardTypeLevel: React.FC<Props> = (props: Props) => (
     {...props}
     denyDragEvent={denyDragEvent(props.cardTypeAllowList)}
     getDropType={(card) => card.cardType || CardTypesMap.ARTICLE}
+    dragImageOffsetX={dragOffsetX}
+    dragImageOffsetY={dragOffsetY}
+    renderDrag={(af) => <ArticleDrag id={af.uuid} />}
+    type="card"
+    getId={({ uuid }) => uuid}
   />
 );

--- a/fronts-client/src/lib/dnd/CardTypeLevel.tsx
+++ b/fronts-client/src/lib/dnd/CardTypeLevel.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Card } from 'types/Collection';
+import Level, { LevelProps } from './Level';
+import { CardTypes, CardTypesMap } from 'constants/cardTypes';
+import { collectionDropTypeDenylist } from 'constants/fronts';
+import { CARD_TYPE } from './constants';
+
+type Props = Omit<LevelProps<Card>, 'denyDragEvent' | 'getDropType'> & {
+  cardTypeAllowList?: CardTypes[];
+};
+
+export const denyDragEvent =
+  (cardTypeAllowList?: string[] | undefined) => (e: React.DragEvent) => {
+    const dropEventIsNotPermitted = e.dataTransfer.types.some((type) =>
+      collectionDropTypeDenylist.includes(type)
+    );
+
+    const cardTypeBeingDroppedIsNotPermitted =
+      !!cardTypeAllowList &&
+      !!e.dataTransfer.getData(CARD_TYPE) &&
+      !cardTypeAllowList.includes(e.dataTransfer.getData(CARD_TYPE));
+
+    return dropEventIsNotPermitted || cardTypeBeingDroppedIsNotPermitted;
+  };
+
+/**
+ * A Level that only accepts a Card type. Useful for providing common drag and
+ * behaviour for Card components.
+ */
+export const CardTypeLevel: React.FC<Props> = (props: Props) => (
+  <Level
+    {...props}
+    denyDragEvent={denyDragEvent(props.cardTypeAllowList)}
+    getDropType={(card) => card.cardType || CardTypesMap.ARTICLE}
+  />
+);

--- a/fronts-client/src/lib/dnd/Node.tsx
+++ b/fronts-client/src/lib/dnd/Node.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PathConsumer, Parent } from './AddParentInfo';
-import { TRANSFER_TYPE } from './constants';
+import { CARD_TYPE, TRANSFER_TYPE } from './constants';
 
 interface ChildrenProps {
   draggable: true;
@@ -11,6 +11,7 @@ interface OuterProps<T> {
   children: (
     getProps: (forceClone: boolean) => ChildrenProps
   ) => React.ReactNode;
+  dropType?: string;
   renderDrag?: (data: T) => React.ReactNode;
   dragImageOffsetX?: number;
   dragImageOffsetY?: number;
@@ -66,11 +67,15 @@ class Node<T> extends React.Component<Props<T>> {
         dragImageOffsetY
       );
     }
-    const { parents, type, id, index, data } = this.props;
+    const { parents, type, id, index, data, dropType } = this.props;
     e.dataTransfer.setData(
       TRANSFER_TYPE,
       JSON.stringify({ parents, type, id, index, data, forceClone })
     );
+
+    if (dropType) {
+      e.dataTransfer.setData(CARD_TYPE, dropType);
+    }
   };
 }
 

--- a/fronts-client/src/lib/dnd/constants.ts
+++ b/fronts-client/src/lib/dnd/constants.ts
@@ -1,3 +1,4 @@
 export const TRANSFER_TYPE = '@@TRANSFER@@';
+export const CARD_TYPE = '@@CARD_TYPE@@';
 export const NO_STORE_ERROR =
   'Store is not set, make sure there is `Root` component above this';

--- a/fronts-client/src/util/collectionUtils.ts
+++ b/fronts-client/src/util/collectionUtils.ts
@@ -37,27 +37,29 @@ export type MappableDropType =
   | ChefDrop
   | FeastCollectionDrop;
 
-const dropToCard = (e: React.DragEvent): MappableDropType | null => {
-  const map = {
-    capi: (data: string): CAPIDrop => ({
-      type: 'CAPI',
-      data: JSON.parse(data),
-    }),
-    [CardTypesMap.RECIPE]: (data: string): RecipeDrop => ({
-      type: 'RECIPE',
-      data: JSON.parse(data),
-    }),
-    [CardTypesMap.CHEF]: (data: string): ChefDrop => ({
-      type: 'CHEF',
-      data: JSON.parse(data),
-    }),
-    [CardTypesMap.FEAST_COLLECTION]: (data: string): FeastCollectionDrop => ({
-      type: 'FEAST_COLLECTION',
-    }),
-    text: (url: string): RefDrop => ({ type: 'REF', data: url }),
-  };
+const dropToCardMap = {
+  capi: (data: string): CAPIDrop => ({
+    type: 'CAPI',
+    data: JSON.parse(data),
+  }),
+  [CardTypesMap.RECIPE]: (data: string): RecipeDrop => ({
+    type: 'RECIPE',
+    data: JSON.parse(data),
+  }),
+  [CardTypesMap.CHEF]: (data: string): ChefDrop => ({
+    type: 'CHEF',
+    data: JSON.parse(data),
+  }),
+  [CardTypesMap.FEAST_COLLECTION]: (): FeastCollectionDrop => ({
+    type: 'FEAST_COLLECTION',
+  }),
+  text: (url: string): RefDrop => ({ type: 'REF', data: url }),
+};
 
-  for (const [type, fn] of Object.entries(map)) {
+export type InsertDropType = keyof typeof dropToCardMap;
+
+const dropToCard = (e: React.DragEvent): MappableDropType | null => {
+  for (const [type, fn] of Object.entries(dropToCardMap)) {
     const data = e.dataTransfer.getData(type);
     if (data) {
       return fn(data);

--- a/fronts-client/src/util/dragAndDrop.ts
+++ b/fronts-client/src/util/dragAndDrop.ts
@@ -1,0 +1,17 @@
+import {
+  dragOffsetX,
+  dragOffsetY,
+} from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
+import { CardTypesMap } from 'constants/cardTypes';
+import { CARD_TYPE } from 'lib/dnd/constants';
+import { InsertDropType } from './collectionUtils';
+
+export const handleDragStartForCard =
+  (cardType: InsertDropType, data: unknown) =>
+  (event: React.DragEvent<HTMLDivElement>, dragNode: HTMLDivElement) => {
+    event.dataTransfer.setData(cardType, JSON.stringify(data));
+    event.dataTransfer.setData(CARD_TYPE, CardTypesMap.CHEF);
+    if (dragNode) {
+      event.dataTransfer.setDragImage(dragNode, dragOffsetX, dragOffsetY);
+    }
+  };


### PR DESCRIPTION
## What's changed?

Stores recipes nested in feast collections, and ensures that other card types are not permitted within them.

Note the refresh, indicating that the data is stored correctly. Prior to this PR, refreshing the page would remove the nested items.

![collections](https://github.com/user-attachments/assets/d726dfef-5678-4aa0-a2ad-c27aa4e7158e)

## Implementation notes

Although it's no longer possible to put chefs and feast collections _within_ feast collections, the drop icons do still appear when the user hovers over them. I timeboxed fixing this but it turned out to be a bit more complicated that expected! Perhaps we can circle back if user feedback suggests it's a priority.

It wasn't far off the beaten track for this PR, so I've added some messaging changes, too – the drop placeholders say 'Place recipe here' (they used to say 'sublink'), and the sublink expander at the bottom of the Feast Collection card says 'recipes' rather than 'sublinks'.

## How to test

- Attempt to add various cards to a Feast Collection. Do recipes go in? Do all others stay out?
- Refresh the page. The recipes should remain in the collection.
- The behaviour of article drag and drop in usual fronts should not have changed – the 'sublinks' messaging should remain: 
<img width="677" alt="Screenshot 2024-07-29 at 16 24 04" src="https://github.com/user-attachments/assets/2875855e-e457-46a7-af67-72cf77f74e67">

All tested locally.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
