### PR TITLE
Update Feast model to draw data from new card meta

### DIFF
--- a/app/model/FeastAppModel.scala
+++ b/app/model/FeastAppModel.scala
@@ -4,15 +4,31 @@ import model.editions.Edition
 import play.api.libs.json._
 
 import java.time.LocalDate
+import model.editions.Palette
 
 object FeastAppModel {
   sealed trait ContainerItem
 
-  case class RecipeIdentifier(id:String)
-  case class Recipe(recipe:RecipeIdentifier) extends ContainerItem
-  case class Chef(id:String, image:Option[String], bio: Option[String], backgroundHex:Option[String], foregroundHex:Option[String]) extends ContainerItem
-  case class Palette(backgroundHex:String, foregroundHex:String)
-  case class FeastCollection(byline:Option[String], darkPalette:Option[Palette], image:Option[String], body:Option[String], title:String, lightPalette:Option[Palette], recipes:Seq[String]) extends ContainerItem
+  case class RecipeIdentifier(id: String)
+
+  case class Recipe(recipe: RecipeIdentifier) extends ContainerItem
+
+  case class Chef(id: String,
+    image: Option[String] = None,
+    bio:  Option[String] = None,
+    backgroundHex: Option[String] = None,
+    foregroundHex: Option[String] = None
+  ) extends ContainerItem
+
+  case class FeastCollection(
+    byline: Option[String] = None,
+    darkPalette: Option[Palette] = None,
+    image: Option[String] = None,
+    body: Option[String] = None,
+    title: String,
+    lightPalette: Option[Palette] = None,
+    recipes: Seq[String]
+  ) extends ContainerItem
 
   case class FeastAppContainer(id:String, title:String, body:Option[String], items:Seq[ContainerItem])
   //type FeastAppCuration = Map[String, IndexedSeq[FeastAppContainer]]

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -10,6 +10,7 @@ import play.api.libs.json.{Json, Writes}
 import util.TimestampGenerator
 
 import scala.jdk.CollectionConverters._
+import logging.Logging
 
 object FeastPublicationTarget {
   object MessageType extends Enumeration {
@@ -19,8 +20,8 @@ object FeastPublicationTarget {
   type MessageType = MessageType.Value
 }
 
-class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfiguration, timestamp: TimestampGenerator) extends PublicationTarget {
-  private def transformArticles(source: EditionsCard): ContainerItem = {
+class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfiguration, timestamp: TimestampGenerator) extends PublicationTarget with Logging {
+  private def transformCards(source: EditionsCard): ContainerItem = {
     source match {
       case _: EditionsArticle => throw new Error("Article not permitted in a Feast Front")
       case EditionsRecipe(id, _) => Recipe(RecipeIdentifier(id))
@@ -29,7 +30,20 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
         bio = metadata.flatMap(_.bio),
         backgroundHex = metadata.flatMap(_.theme.map(_.palette.backgroundHex)),
         foregroundHex = metadata.flatMap(_.theme.map(_.palette.foregroundHex)))
-      case _:EditionsFeastCollection => FeastCollection(byline=None, darkPalette=None, image=None, body=None, title="", lightPalette=None, recipes=List.empty)
+      case EditionsFeastCollection(id, addedOn, metadata) => 
+        val recipes = metadata.map(_.collectionItems.map {
+          case EditionsRecipe(id, addedOn) => id
+        }).getOrElse(List.empty)
+
+        FeastCollection(
+          byline = None,
+          darkPalette = metadata.flatMap(_.theme.map(_.darkPalette)),
+          lightPalette = metadata.flatMap(_.theme.map(_.lightPalette)),
+          image = metadata.flatMap(_.theme.flatMap(_.imageURL)),
+          body = None,
+          title = metadata.flatMap(_.title).getOrElse("No title"),
+          recipes = recipes
+        )
     }
   }
 
@@ -48,7 +62,7 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
       id = collection.id,
       title = collection.displayName,
       body = Some(""), //TBD, this is just how it appears in the data at the moment
-      items = collection.items.map(transformArticles)
+      items = collection.items.map(transformCards)
     )
 
   def transformContent(source: EditionsIssue, version: String): FeastAppCuration = {
@@ -80,6 +94,9 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
 
   override def putIssueJson[T: Writes](issue: T, key: String): Unit = {
     val content = Json.stringify(Json.toJson(issue))
+
+    logger.info(s"Publishing content for issue $key: $content")
+
     snsClient.publish(createPublishRequest(content, FeastPublicationTarget.MessageType.Issue))
   }
 

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -25,14 +25,14 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
     source match {
       case _: EditionsArticle => throw new Error("Article not permitted in a Feast Front")
       case EditionsRecipe(id, _) => Recipe(RecipeIdentifier(id))
-      case EditionsChef(id, addedOn, metadata) => Chef(id = id,
+      case EditionsChef(id, _, metadata) => Chef(id = id,
         image = metadata.flatMap(_.chefImageOverride.map(_.src)),
         bio = metadata.flatMap(_.bio),
         backgroundHex = metadata.flatMap(_.theme.map(_.palette.backgroundHex)),
         foregroundHex = metadata.flatMap(_.theme.map(_.palette.foregroundHex)))
-      case EditionsFeastCollection(id, addedOn, metadata) => 
+      case EditionsFeastCollection(_, _, metadata) =>
         val recipes = metadata.map(_.collectionItems.map {
-          case EditionsRecipe(id, addedOn) => id
+          case EditionsRecipe(id, _) => id
         }).getOrElse(List.empty)
 
         FeastCollection(


### PR DESCRIPTION
## What's changed?

Updates our Feast model to draw data from the new card meta introduced in #1589, #1607, and #1609.

## How to test

- The automated tests should pass ✅ 
- In Fronts CODE, create an issue with lots of different card types, and hit publish.
- Ensure there are no error logs ([example logs.](https://logs.gutools.co.uk/s/content-platforms/goto/49c1f9c0-50d5-11ef-9b23-1daebb1c9ea0))
- Check what was published by visiting the relevant content endpoint, e.g `recipes.code.dev-guardianapis.com/feast-northern-hemisphere/all-recipes/2024-08-01/curation.json`

For example, for the input: 

<img width="784" alt="Screenshot 2024-08-02 at 14 54 15" src="https://github.com/user-attachments/assets/631951ee-69c1-4b75-b4ae-48aea1a8c32f">

We get the output: 

<details>
<summary>Expand to see JSON</summary>

```json
[
    {
        "id": "7018406a-e9a0-442b-80d8-f22cba53ceee",
        "title": "Dish of the day",
        "body": "",
        "items": [
            {
                "backgroundHex": "#BB3B80",
                "id": "profile/yotamottolenghi",
                "bio": "Yotam Ottolenghi is  chef-patron of the Ottolenghi delis and the Nopi and Rovi restaurants. He has  published 10 bestselling cookbooks",
                "foregroundHex": "#F9F9F5"
            },
            {
                "darkPalette": {
                    "backgroundHex": "#363632",
                    "foregroundHex": "#FCF1F0"
                },
                "image": "https://uploads.guim.co.uk/2024/03/21/Baking.png",
                "title": "Sweet treats",
                "lightPalette": {
                    "backgroundHex": "#F9F9F5",
                    "foregroundHex": "#DB2712"
                },
                "recipes": [
                    "c2c9118b7e7b4a4aae48f31d4704dbd1",
                    "ae779e4975904ba6a601449e513d88f7"
                ]
            },
            {
                "recipe": {
                    "id": "c2c9118b7e7b4a4aae48f31d4704dbd1"
                }
            },
            {
                "recipe": {
                    "id": "ae779e4975904ba6a601449e513d88f7"
                }
            }
        ]
    },
    {
        "id": "a9949d60-2b76-4f71-88ba-4e7ff9636c71",
        "title": "Collection 2",
        "body": "",
        "items": []
    },
    {
        "id": "914bad50-1493-41c8-b3da-6a1bde94ab42",
        "title": "Collection 3",
        "body": "",
        "items": []
    },
    {
        "id": "ec085650-b225-478a-914f-4cb3efb22ce4",
        "title": "Collection 4",
        "body": "",
        "items": []
    },
    {
        "id": "bdd83158-62c7-4a1a-a4d6-75786d4a397d",
        "title": "Collection 5",
        "body": "",
        "items": []
    },
    {
        "id": "8ba7b176-3677-4559-9479-79be518276bf",
        "title": "Collection 6",
        "body": "",
        "items": []
    },
    {
        "id": "c9ae61e9-29fd-44ea-ae85-637d9be987d6",
        "title": "Collection 7",
        "body": "",
        "items": []
    },
    {
        "id": "368b0a3f-e7d6-4f0e-963b-c216e78f8370",
        "title": "Collection 8",
        "body": "",
        "items": []
    },
    {
        "id": "008aef4d-73a3-4ed4-9ac0-563df9388398",
        "title": "Collection 9",
        "body": "",
        "items": []
    }
]
```

</details>

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
