### PR TITLE
Ignore fetch order if the resources we are fetching are already known

### DIFF
--- a/fronts-client/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
+++ b/fronts-client/src/lib/createAsyncResourceBundle/__tests__/createAsyncResourceBundle.spec.ts
@@ -45,6 +45,7 @@ describe('createAsyncResourceBundle', () => {
         type: 'FETCH_SUCCESS',
         payload: {
           data: { data: 'exampleData' },
+          ignoreOrder: false,
           pagination: undefined,
           time: 1337,
         },


### PR DESCRIPTION
## What's changed?
When adding any Front in the Feast Edition, the chef search displays incorrect data, 
it displays those cards that are present in that Front and not the whole chef feed.


https://github.com/user-attachments/assets/2e515017-3f0b-4266-94ab-3c154c1c67a2



## Implementation notes
In general, feed that goes into search (here chef search) holds `payload` but also along with `pagination` and `lastFetchOrder` that we need them for fetching next batches, these we don't want to alter when we are adding Front, when we are adding Front we are fetching cards from the same call `fetchChefs`  where`lastFetchOrder` gets changed to `ids` records only that impacts the whole search feed.
We have decided to ignore `pagination` and `lastFetchOrder` when we are fetching card details for Front.  

## Testing

This fixes the bug

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
