### PR TITLE
Update documentation on permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can find the client for the Fronts tool in [fronts-client](./fronts-client).
 1. Install [NVM](https://github.com/creationix/nvm).
 2. Ensure [Docker](https://www.docker.com/products/docker-desktop) is installed
 3. Get credentials from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=cmsFronts-dev,capi-api-gateway,frontend-dev) (`cmsFronts`, `capi` & `frontend`).
-4. Grant [code](https://permissions.code.dev-gutools.co.uk/) permissions (used for local builds as well).  You need:
+4. Grant [code](https://permissions.code.dev-gutools.co.uk/) permissions (used for local builds as well).  Any engineer on ed tools should be able to give you access. You need:
     1. fronts_access
     1. launch_commercial_fronts
     1. edit_editorial_fronts


### PR DESCRIPTION
## What's changed?

Makes it clear that CODE access can be granted by engineers on the team, and does not require CP or an EM.

I've chosen to call the team ed tools because I believe this term is still well understood and will outlive the current team name