### PR TITLE
Hide new containers behind env

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -18,12 +18,6 @@ object ObscureFeed extends FeatureSwitch(
   enabled = false
 )
 
-object UseNewContainers extends FeatureSwitch(
-  key = "use-new-containers",
-  title = "Use the fancy fairgound new containers",
-  enabled = false
-)
-
 object PageViewDataVisualisation extends FeatureSwitch(
   key = "page-view-data-visualisation",
   title = "Show page view data visualisation (aka spark lines)",
@@ -49,7 +43,7 @@ object UsePortraitCropsForSomeCollectionTypes extends FeatureSwitch(
 )
 
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes, UseNewContainers)
+  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     val newSwitches = userDataSwitches match {

--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -18,6 +18,12 @@ object ObscureFeed extends FeatureSwitch(
   enabled = false
 )
 
+object UseNewContainers extends FeatureSwitch(
+  key = "use-new-containers",
+  title = "Use the fancy fairgound new containers",
+  enabled = false
+)
+
 object PageViewDataVisualisation extends FeatureSwitch(
   key = "page-view-data-visualisation",
   title = "Show page view data visualisation (aka spark lines)",
@@ -43,7 +49,7 @@ object UsePortraitCropsForSomeCollectionTypes extends FeatureSwitch(
 )
 
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes)
+  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes, UseNewContainers)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     val newSwitches = userDataSwitches match {

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -56,21 +56,6 @@ export default {
             'big'
           ]
         },
-        // {
-        //   'name': 'dynamic/fast-v2',
-        //   'groups': [
-        //     'standard',
-        //     'splash'
-        //   ]
-        // },
-        // {
-        //   'name': 'dynamic/package-v2',
-        //   'groups': [
-        //     'standard',
-        //     'snap'
-        //   ],
-        //   'displayName': 'Flexible multiple'
-        // },
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -56,20 +56,21 @@ export default {
             'big'
           ]
         },
-        {
-          'name': 'dynamic/fast-v2',
-          'groups': [
-            'standard',
-            'splash'
-          ]
-        },
-        {
-          'name': 'dynamic/package-v2',
-          'groups': [
-            'standard',
-            'snap'
-          ]
-        },
+        // {
+        //   'name': 'dynamic/fast-v2',
+        //   'groups': [
+        //     'standard',
+        //     'splash'
+        //   ]
+        // },
+        // {
+        //   'name': 'dynamic/package-v2',
+        //   'groups': [
+        //     'standard',
+        //     'snap'
+        //   ],
+        //   'displayName': 'Flexible multiple'
+        // },
         { name: 'nav/list' },
         { name: 'nav/media-list' },
         { name: 'news/most-popular' },

--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -11,6 +11,23 @@ export function init (res) {
     if (res.defaults.switches['']) {
         CONST.types.push({ 'name': 'all-items/not-for-production' });
     }
+    // if (res.defaults.userdata.featureSwitches['use-new-containers']) {
+    //     CONST.types.push([
+    //          {
+    //           'name': 'dynamic/fast-v2',
+    //           'groups': [
+    //             'standard',
+    //             'splash'
+    //           ]
+    //         },
+    //         {
+    //           'name': 'dynamic/package-v2',
+    //           'groups': [
+    //             'standard',
+    //             'snap'
+    //           ]
+    //         }]);
+    // }
 }
 
 export function getPriority (priority) {

--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -13,7 +13,7 @@ export function init (res) {
     }
     // These containers are under development and are not yet ready for production.
     // They will need to be added to the types list in default.js when ready.
-    if (res.defaults.env.toLowerCase() === 'code') {
+    if (res.defaults.env.toLowerCase() !== 'prod') {
         CONST.types.push(
              {
               'name': 'dynamic/fast-v2',

--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -11,23 +11,25 @@ export function init (res) {
     if (res.defaults.switches['']) {
         CONST.types.push({ 'name': 'all-items/not-for-production' });
     }
-    // if (res.defaults.userdata.featureSwitches['use-new-containers']) {
-    //     CONST.types.push([
-    //          {
-    //           'name': 'dynamic/fast-v2',
-    //           'groups': [
-    //             'standard',
-    //             'splash'
-    //           ]
-    //         },
-    //         {
-    //           'name': 'dynamic/package-v2',
-    //           'groups': [
-    //             'standard',
-    //             'snap'
-    //           ]
-    //         }]);
-    // }
+    // These containers are under development and are not yet ready for production.
+    // They will need to be added to the types list in default.js when ready.
+    if (res.defaults.env.toLowerCase() === 'code') {
+        CONST.types.push(
+             {
+              'name': 'dynamic/fast-v2',
+              'groups': [
+                'standard',
+                'splash'
+              ]
+            },
+            {
+              'name': 'dynamic/package-v2',
+              'groups': [
+                'standard',
+                'snap'
+              ]
+            });
+    }
 }
 
 export function getPriority (priority) {


### PR DESCRIPTION
## What's changed?

Hides the new containers (implemented by the fairground team) in the config tool behind the environment variable. On code: 


<img width="748" alt="image" src="https://github.com/user-attachments/assets/1addd1d1-7dea-4acf-85ca-f5c1e4ee6309">
