### PR TITLE
Update dynamic v2 container names to flexible

### DIFF
--- a/app/services/ContainerService.scala
+++ b/app/services/ContainerService.scala
@@ -38,7 +38,7 @@ class ContainerService(val containers: Containers) {
           Some(numberVisible)
         )
       }
-      case DynamicV2(container) => {
+      case Flexible(container) => {
         val numberVisible = container.storiesVisible(stories)
         StoriesVisibleResponse(
           Some(numberVisible),

--- a/app/slices/Container.scala
+++ b/app/slices/Container.scala
@@ -10,8 +10,8 @@ class Containers(val fixedContainers: FixedContainers) extends Logging {
     ("dynamic/slow", Dynamic(DynamicSlow)),
     ("dynamic/package", Dynamic(DynamicPackage)),
     ("dynamic/slow-mpu", Dynamic(DynamicSlowMPU)),
-    ("dynamic/fast-v2", DynamicV2(DynamicFastV2)),
-    ("dynamic/package-v2", DynamicV2(DynamicPackageV2)),
+    ("flexible/general", Flexible(FlexibleGeneral)),
+    ("flexible/special", Flexible(FlexibleSpecial)),
     ("nav/list", NavList),
     ("nav/media-list", NavMediaList),
     ("news/most-popular", MostPopular)
@@ -32,7 +32,7 @@ class Containers(val fixedContainers: FixedContainers) extends Logging {
 sealed trait Container
 
 case class Dynamic(get: DynamicContainer) extends Container
-case class DynamicV2(get: DynamicV2Container) extends Container
+case class Flexible(get: FlexibleContainer) extends Container
 case class Fixed(get: ContainerDefinition) extends Container
 case object NavList extends Container
 case object NavMediaList extends Container

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -1,10 +1,10 @@
 package slices
 
-trait DynamicV2Container {
+trait FlexibleContainer {
   def storiesVisible(stories: Seq[Story]): Int
 }
 
-object DynamicFastV2 extends DynamicV2Container {
+object FlexibleGeneral extends FlexibleContainer {
   def storiesVisible(stories: Seq[Story]): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val splash = byGroup.getOrElse(3, Seq.empty) ++
@@ -16,7 +16,7 @@ object DynamicFastV2 extends DynamicV2Container {
   }
 }
 
-object DynamicPackageV2 extends DynamicV2Container {
+object FlexibleSpecial extends FlexibleContainer {
   def storiesVisible(stories: Seq[Story]): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val snap = byGroup.getOrElse(3, Seq.empty) ++

--- a/app/thumbnails/ContainerThumbnails.scala
+++ b/app/thumbnails/ContainerThumbnails.scala
@@ -161,10 +161,10 @@ class ContainerThumbnails(val fixedContainers: FixedContainers) {
       case "fixed/small/slow-V-half" =>
         Some(Seq(HalfHl4))
 
-      case "dynamic/fast-v2" =>
+      case "flexible/general" =>
         Some(Seq(FullMedia75, HalfHl3))
 
-      case "dynamic/package-v2" =>
+      case "flexible/special" =>
         Some(Seq(FullMedia75, QuarterQuarterQuarterQuarter))
 
       case _ =>

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -48,7 +48,7 @@ import {
   InsertActionCreator,
   InsertThunkActionCreator,
 } from 'types/Cards';
-import { DYNAMIC_FAST_V2_NAME } from 'constants/dynamicContainers';
+import { FLEXIBLE_GENERAL_NAME } from 'constants/flexibleContainers';
 
 // Creates a thunk action creator from a plain action creator that also allows
 // passing a persistence location
@@ -213,7 +213,7 @@ const mayModifyCardForDestinationGroup = (
     const groupId = to.id;
     const { collection } = selectGroupCollection(state, groupId);
     const group = selectGroups(state)[groupId];
-    if (collection?.type === DYNAMIC_FAST_V2_NAME) {
+    if (collection?.type === FLEXIBLE_GENERAL_NAME) {
       if (
         group &&
         (!group.id || parseInt(group.id) === 0) &&

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -203,7 +203,12 @@ const updateCardMetaWithPersist = addPersistMetaToAction(updateCardMeta, {
   persistTo: 'collection',
 });
 
-const mayModifyCardForDestinationGroup = (
+/** Cards in the standard group of a flexible general container should not be gigaboosted.
+ * When moving a card from the splash group to the standard group, this function checks if the card should be modified.
+ * If so, it will automatically adjust the boost level from gigaboost to megaboost.
+ */
+
+const mayLowerCardBoostLevelForDestinationGroup = (
   state: State,
   to: PosSpec,
   card: Card,
@@ -260,7 +265,7 @@ const insertCardWithCreate =
           return;
         }
 
-        const modifyCardAction = mayModifyCardForDestinationGroup(
+        const modifyCardAction = mayLowerCardBoostLevelForDestinationGroup(
           state,
           to,
           card,
@@ -268,7 +273,6 @@ const insertCardWithCreate =
         );
         if (modifyCardAction) dispatch(modifyCardAction);
 
-        // TODO modify card data
         dispatch(
           insertActionCreator(
             toWithRespectToState.id,
@@ -369,7 +373,7 @@ const moveCard = (
           dispatch(cardsReceived([parent, ...supporting]));
         }
 
-        const modifyCardAction = mayModifyCardForDestinationGroup(
+        const modifyCardAction = mayLowerCardBoostLevelForDestinationGroup(
           state,
           to,
           parent,

--- a/fronts-client/src/components/card/CardSettingsDisplay.tsx
+++ b/fronts-client/src/components/card/CardSettingsDisplay.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { styled, theme } from 'constants/theme';
-import { DYNAMIC_CONTAINER_V2_SET } from 'constants/dynamicContainers';
+import { FLEXIBLE_CONTAINER_SET } from 'constants/flexibleContainers';
 
 const ArticleMetadataProperties = styled.div`
   padding: 0 4px 3px 0;
@@ -19,12 +19,12 @@ const ArticleMetadataProperty = styled.div`
 
 const shouldShowLegacyBoost = (collectionType?: string, isBoosted?: boolean) =>
   /* don't show old Boost option in dynamic v2 */
-  isBoosted && !DYNAMIC_CONTAINER_V2_SET.includes(collectionType);
+  isBoosted && !FLEXIBLE_CONTAINER_SET.includes(collectionType);
 
 const shouldShowBoostLevel = (collectionType?: string, boostLevel?: string) =>
   boostLevel !== 'default' &&
   /* show new Boost level in new dynamic container or clipboard */
-  (DYNAMIC_CONTAINER_V2_SET.includes(collectionType) || !collectionType);
+  (FLEXIBLE_CONTAINER_SET.includes(collectionType) || !collectionType);
 
 const displayBoostLevel = (boostLevel?: string) => {
   if (boostLevel === 'gigaboost') return 'Giga boost';

--- a/fronts-client/src/components/card/CardSettingsDisplay.tsx
+++ b/fronts-client/src/components/card/CardSettingsDisplay.tsx
@@ -18,19 +18,25 @@ const ArticleMetadataProperty = styled.div`
 `;
 
 const shouldShowLegacyBoost = (collectionType?: string, isBoosted?: boolean) =>
-  /* don't show old Boost option in dynamic v2 */
+  /* don't show old Boost option in flexible containers */
   isBoosted && !FLEXIBLE_CONTAINER_SET.includes(collectionType);
 
 const shouldShowBoostLevel = (collectionType?: string, boostLevel?: string) =>
   boostLevel !== 'default' &&
-  /* show new Boost level in new dynamic container or clipboard */
+  /* show new Boost level in flexible containers or clipboard */
   (FLEXIBLE_CONTAINER_SET.includes(collectionType) || !collectionType);
 
-const displayBoostLevel = (boostLevel?: string) => {
-  if (boostLevel === 'gigaboost') return 'Giga boost';
-  else if (boostLevel === 'megaboost') return 'Mega boost';
-  else if (boostLevel === 'boost') return 'Boost';
-  else return '';
+const getBoostLevelLabel = (boostLevel?: string): string | undefined => {
+  switch (boostLevel) {
+    case 'gigaboost':
+      return 'Giga boost';
+    case 'megaboost':
+      return 'Mega boost';
+    case 'boost':
+      return 'Boost';
+    default:
+      return undefined;
+  }
 };
 
 export default ({
@@ -74,7 +80,7 @@ export default ({
       )}
       {shouldShowBoostLevel(collectionType, boostLevel) && (
         <ArticleMetadataProperty>
-          {displayBoostLevel(boostLevel)}
+          {getBoostLevelLabel(boostLevel)}
         </ArticleMetadataProperty>
       )}
       {shouldShowLegacyBoost(collectionType, isBoosted) && (

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -75,9 +75,9 @@ import { ImageRowContainer } from './ImageRowContainer';
 import { ImageCol } from './ImageCol';
 import InputRadio from 'components/inputs/InputRadio';
 import {
-  DYNAMIC_FAST_V2_NAME,
-  DYNAMIC_PACKAGE_V2_NAME,
-} from 'constants/dynamicContainers';
+  FLEXIBLE_GENERAL_NAME,
+  FLEXIBLE_SPECIAL_NAME,
+} from 'constants/flexibleContainers';
 
 interface ComponentProps extends ContainerProps {
   articleExists: boolean;
@@ -531,9 +531,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
     const allowGigaBoost = () =>
       !collectionType /* clipboard */ ||
       (collectionType &&
-        (collectionType === DYNAMIC_PACKAGE_V2_NAME /* dynamic package */ ||
+        (collectionType === FLEXIBLE_SPECIAL_NAME /* flexible special */ ||
           (collectionType ===
-            DYNAMIC_FAST_V2_NAME /* splash group in dynamic fast */ &&
+            FLEXIBLE_GENERAL_NAME /* splash group in flexible general */ &&
             groupSizeId &&
             groupSizeId > 0)));
 

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -58,8 +58,7 @@ const RadioButtonLabel = styled.label`
 `;
 
 const RadioButton = styled.input`
-  position: absolute;
-  opacity: 0;
+  display: none;
   :checked + ${RadioButtonLabel} {
     border-radius: 50%;
     border: solid 1px ${theme.base.colors.radioButtonSelected};
@@ -69,12 +68,6 @@ const RadioButton = styled.input`
   }
   &:hover:not(:checked):not([disabled]) + ${RadioButtonLabel}:after {
     display: block;
-  }
-  :focus + ${RadioButtonLabel} {
-    outline-offset: 1px;
-    outline-width: 1px;
-    outline-color: ${theme.base.colors.highlightColor};
-    outline-style: solid;
   }
 
   &:disabled + ${RadioButtonLabel} {

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -58,7 +58,8 @@ const RadioButtonLabel = styled.label`
 `;
 
 const RadioButton = styled.input`
-  display: none;
+  position: absolute;
+  opacity: 0;
   :checked + ${RadioButtonLabel} {
     border-radius: 50%;
     border: solid 1px ${theme.base.colors.radioButtonSelected};
@@ -68,6 +69,12 @@ const RadioButton = styled.input`
   }
   &:hover:not(:checked):not([disabled]) + ${RadioButtonLabel}:after {
     display: block;
+  }
+  :focus + ${RadioButtonLabel} {
+    outline-offset: 1px;
+    outline-width: 1px;
+    outline-color: ${theme.base.colors.highlightColor};
+    outline-style: solid;
   }
 
   &:disabled + ${RadioButtonLabel} {

--- a/fronts-client/src/constants/dynamicContainers.ts
+++ b/fronts-client/src/constants/dynamicContainers.ts
@@ -1,12 +1,3 @@
-export const DYNAMIC_FAST_V2_NAME = 'dynamic/fast-v2';
-
-export const DYNAMIC_PACKAGE_V2_NAME = 'dynamic/package-v2';
-
-export const DYNAMIC_CONTAINER_V2_SET: (string | undefined)[] = [
-  DYNAMIC_FAST_V2_NAME,
-  DYNAMIC_PACKAGE_V2_NAME,
-];
-
 export const DYNAMIC_CONTAINER_V1_SET: (string | undefined)[] = [
   'dynamic/fast',
   'dynamic/slow',

--- a/fronts-client/src/constants/dynamicContainers.ts
+++ b/fronts-client/src/constants/dynamicContainers.ts
@@ -1,4 +1,4 @@
-export const DYNAMIC_CONTAINER_V1_SET: (string | undefined)[] = [
+export const DYNAMIC_CONTAINER_SET: (string | undefined)[] = [
   'dynamic/fast',
   'dynamic/slow',
   'dynamic/package',

--- a/fronts-client/src/constants/flexibleContainers.ts
+++ b/fronts-client/src/constants/flexibleContainers.ts
@@ -1,0 +1,8 @@
+export const FLEXIBLE_GENERAL_NAME = 'flexible/general';
+
+export const FLEXIBLE_SPECIAL_NAME = 'flexible/special';
+
+export const FLEXIBLE_CONTAINER_SET: (string | undefined)[] = [
+  FLEXIBLE_GENERAL_NAME,
+  FLEXIBLE_SPECIAL_NAME,
+];

--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -1,8 +1,8 @@
 import pageConfig from 'util/extractConfigFromPage';
 import {
-  DYNAMIC_FAST_V2_NAME,
-  DYNAMIC_PACKAGE_V2_NAME,
-} from './dynamicContainers';
+  FLEXIBLE_GENERAL_NAME,
+  FLEXIBLE_SPECIAL_NAME,
+} from './flexibleContainers';
 
 export const SUPPORT_PORTRAIT_CROPS =
   pageConfig?.userData?.featureSwitches.find(
@@ -31,8 +31,8 @@ export const landscape5To4CardImageCriteria = {
 export const COLLECTIONS_USING_PORTRAIT_TRAILS: string[] = [];
 
 export const COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS: string[] = [
-  DYNAMIC_FAST_V2_NAME,
-  DYNAMIC_PACKAGE_V2_NAME,
+  FLEXIBLE_GENERAL_NAME,
+  FLEXIBLE_SPECIAL_NAME,
 ];
 
 export const defaultCardTrailImageCriteria = landScapeCardImageCriteria;

--- a/fronts-client/src/selectors/__tests__/formSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/formSelectors.spec.ts
@@ -39,10 +39,10 @@ describe('Form utils', () => {
         )
       ).toEqual([...defaultFields, 'isBoosted']);
     });
-    it('should add boostLevel and remove large headline for dynamic collection v2 configs', () => {
+    it('should add boostLevel and remove large headline for flexible collection configs', () => {
       const localState = cloneDeep(state);
       localState.fronts.frontsConfig.data.collections.exampleCollection.type =
-        'dynamic/fast-v2';
+        'flexible/general';
       const selectFormFields = createSelectFormFieldsForCard();
       expect(
         selectFormFields(

--- a/fronts-client/src/selectors/formSelectors.ts
+++ b/fronts-client/src/selectors/formSelectors.ts
@@ -3,7 +3,7 @@ import { createSelectArticleFromCard } from 'selectors/shared';
 import { selectCollectionConfig } from 'selectors/frontsSelectors';
 import { hasMainVideo } from 'util/externalArticle';
 import {
-  isCollectionConfigDynamicV1,
+  isCollectionConfigDynamic,
   isCollectionConfigFlexible,
 } from '../util/frontsUtils';
 import { createSelector } from 'reselect';
@@ -101,12 +101,7 @@ export const createSelectFormFieldsForCard = () => {
       if (isCollectionConfigFlexible(parentCollectionConfig)) {
         fields = without(fields, 'showLargeHeadline');
       }
-      if (
-        isCollectionConfigDynamicV1(parentCollectionConfig) ||
-        /* don't show old Boost checkbox in new dynamic container */
-        (derivedArticle.isBoosted &&
-          !isCollectionConfigFlexible(parentCollectionConfig))
-      ) {
+      if (isCollectionConfigDynamic(parentCollectionConfig)) {
         fields.push('isBoosted');
       }
       if (derivedArticle.liveBloggingNow === 'true') {

--- a/fronts-client/src/selectors/formSelectors.ts
+++ b/fronts-client/src/selectors/formSelectors.ts
@@ -4,7 +4,7 @@ import { selectCollectionConfig } from 'selectors/frontsSelectors';
 import { hasMainVideo } from 'util/externalArticle';
 import {
   isCollectionConfigDynamicV1,
-  isCollectionConfigDynamicV2,
+  isCollectionConfigFlexible,
 } from '../util/frontsUtils';
 import { createSelector } from 'reselect';
 import type { State } from 'types/State';
@@ -91,21 +91,21 @@ export const createSelectFormFieldsForCard = () => {
       let fields = defaultFields.slice();
 
       if (
-        isCollectionConfigDynamicV2(parentCollectionConfig) ||
+        isCollectionConfigFlexible(parentCollectionConfig) ||
         (derivedArticle.boostLevel &&
           derivedArticle.boostLevel !== 'default' &&
           !parentCollectionConfig) /* show in clipboard if it is boosted */
       ) {
         fields.push('boostLevel');
       }
-      if (isCollectionConfigDynamicV2(parentCollectionConfig)) {
+      if (isCollectionConfigFlexible(parentCollectionConfig)) {
         fields = without(fields, 'showLargeHeadline');
       }
       if (
         isCollectionConfigDynamicV1(parentCollectionConfig) ||
         /* don't show old Boost checkbox in new dynamic container */
         (derivedArticle.isBoosted &&
-          !isCollectionConfigDynamicV2(parentCollectionConfig))
+          !isCollectionConfigFlexible(parentCollectionConfig))
       ) {
         fields.push('isBoosted');
       }

--- a/fronts-client/src/selectors/formSelectors.ts
+++ b/fronts-client/src/selectors/formSelectors.ts
@@ -90,6 +90,8 @@ export const createSelectFormFieldsForCard = () => {
       }
       let fields = defaultFields.slice();
 
+      // Flexible collections have various boost levels options.
+      // The previously existing dynamic collections only have one boost level (isBoosted)."
       if (
         isCollectionConfigFlexible(parentCollectionConfig) ||
         (derivedArticle.boostLevel &&

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -21,13 +21,13 @@ interface Group {
   cards: string[];
 }
 
-// CardSets represent all of the lists of cards available in a collection.
+/** CardSets represent all of the lists of cards available in a collection. */
 type CardSets = 'draft' | 'live' | 'previously';
-// Stages represent only those lists which are curated by the user.
+/** Stages represent only those lists which are curated by the user.*/
 type Stages = 'draft' | 'live';
 type CardSizes = 'wide' | 'default' | 'medium' | 'small';
-// BoostLevels defines the string literals which represents each of the four levels
-// introduced by the new dynamic containers
+/** BoostLevels defines the string literals which represents each of the four levels
+ * introduced by the new flexible containers. */
 type BoostLevels = 'default' | 'boost' | 'megaboost' | 'gigaboost';
 
 interface NestedCardRootFields {
@@ -63,7 +63,9 @@ type CardRootMeta = ChefCardMeta &
     imageCutoutSrcHeight?: string;
     imageCutoutSrcOrigin?: string;
     isBreaking?: boolean;
+    /** For dynamic collections only */
     isBoosted?: boolean;
+    /** For flexible collections only */
     boostLevel?: BoostLevels;
     showLivePlayable?: boolean;
     showMainVideo?: boolean;

--- a/fronts-client/src/util/frontsUtils.ts
+++ b/fronts-client/src/util/frontsUtils.ts
@@ -6,8 +6,10 @@ import { Stages, Collection } from 'types/Collection';
 import { frontStages } from 'constants/fronts';
 import {
   DYNAMIC_CONTAINER_V1_SET,
-  DYNAMIC_CONTAINER_V2_SET,
 } from 'constants/dynamicContainers';
+import {
+  FLEXIBLE_CONTAINER_SET
+} from 'constants/flexibleContainers';
 
 const getFrontCollections = (
   frontId: string | void,
@@ -86,9 +88,9 @@ const isCollectionConfigDynamicV1 = (
   config: CollectionConfig | undefined
 ): boolean => DYNAMIC_CONTAINER_V1_SET.includes(config?.type);
 
-const isCollectionConfigDynamicV2 = (
+const isCollectionConfigFlexible = (
   config: CollectionConfig | undefined
-): boolean => DYNAMIC_CONTAINER_V2_SET.includes(config?.type);
+): boolean => FLEXIBLE_CONTAINER_SET.includes(config?.type);
 
 export {
   getFrontCollections,
@@ -99,5 +101,5 @@ export {
   getGroupsByStage,
   isCollectionConfigDynamic,
   isCollectionConfigDynamicV1,
-  isCollectionConfigDynamicV2,
+  isCollectionConfigFlexible,
 };

--- a/fronts-client/src/util/frontsUtils.ts
+++ b/fronts-client/src/util/frontsUtils.ts
@@ -4,12 +4,8 @@ import { detectPressFailureMs } from 'constants/fronts';
 import { ArticleDetails } from 'types/FaciaApi';
 import { Stages, Collection } from 'types/Collection';
 import { frontStages } from 'constants/fronts';
-import {
-  DYNAMIC_CONTAINER_V1_SET,
-} from 'constants/dynamicContainers';
-import {
-  FLEXIBLE_CONTAINER_SET
-} from 'constants/flexibleContainers';
+import { DYNAMIC_CONTAINER_SET } from 'constants/dynamicContainers';
+import { FLEXIBLE_CONTAINER_SET } from 'constants/flexibleContainers';
 
 const getFrontCollections = (
   frontId: string | void,
@@ -80,13 +76,7 @@ const getGroupsByStage = (collection: Collection, stage: Stages) => {
 
 const isCollectionConfigDynamic = (
   config: CollectionConfig | undefined
-): boolean => {
-  return !!(config?.type?.indexOf('dynamic/') === 0);
-};
-
-const isCollectionConfigDynamicV1 = (
-  config: CollectionConfig | undefined
-): boolean => DYNAMIC_CONTAINER_V1_SET.includes(config?.type);
+): boolean => DYNAMIC_CONTAINER_SET.includes(config?.type);
 
 const isCollectionConfigFlexible = (
   config: CollectionConfig | undefined
@@ -100,6 +90,5 @@ export {
   getVisibilityArticleDetails,
   getGroupsByStage,
   isCollectionConfigDynamic,
-  isCollectionConfigDynamicV1,
   isCollectionConfigFlexible,
 };

--- a/public/src/js/constants/article-meta-fields.js
+++ b/public/src/js/constants/article-meta-fields.js
@@ -150,7 +150,7 @@ export default Object.freeze([
         key: 'boostLevel',
         editable: true,
         omitForSupporting: true,
-        ifState: 'inDynamicCollectionV2',
+        ifState: 'inFlexibleCollection',
         label: 'boost level',
         type: 'string'
     },

--- a/public/src/js/constants/article-meta-fields.js
+++ b/public/src/js/constants/article-meta-fields.js
@@ -142,7 +142,7 @@ export default Object.freeze([
         key: 'isBoosted',
         editable: true,
         omitForSupporting: true,
-        ifState: 'inDynamicCollectionV1',
+        ifState: 'inDynamicCollection',
         label: 'boost',
         type: 'boolean'
     },

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -86,7 +86,6 @@ export default class Article extends DropTarget {
             'isEmpty',
             'visited',
             'inDynamicCollection',
-            'inDynamicCollectionV1',
             'inFlexibleCollection',
             'tone',
             'primaryTag',
@@ -103,7 +102,6 @@ export default class Article extends DropTarget {
 
         this.state.enableContentOverrides(this.meta.snapType() !== 'latest');
         this.state.inDynamicCollection(deepGet(opts, '.group.parent.isDynamic'));
-        this.state.inDynamicCollectionV1(deepGet(opts, '.group.parent.isDynamicV1'));
         this.state.inFlexibleCollection(deepGet(opts, '.group.parent.isFlexible'));
         this.state.visited(opts.visited);
         this.frontPublicationDate = opts.frontPublicationDate;

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -87,7 +87,7 @@ export default class Article extends DropTarget {
             'visited',
             'inDynamicCollection',
             'inDynamicCollectionV1',
-            'inDynamicCollectionV2',
+            'inFlexibleCollection',
             'tone',
             'primaryTag',
             'sectionName',
@@ -104,7 +104,7 @@ export default class Article extends DropTarget {
         this.state.enableContentOverrides(this.meta.snapType() !== 'latest');
         this.state.inDynamicCollection(deepGet(opts, '.group.parent.isDynamic'));
         this.state.inDynamicCollectionV1(deepGet(opts, '.group.parent.isDynamicV1'));
-        this.state.inDynamicCollectionV2(deepGet(opts, '.group.parent.isDynamicV2'));
+        this.state.inFlexibleCollection(deepGet(opts, '.group.parent.isFlexible'));
         this.state.visited(opts.visited);
         this.frontPublicationDate = opts.frontPublicationDate;
         this.publishedBy = opts.publishedBy;

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -38,7 +38,6 @@ export default class Collection extends BaseClass {
 
         this.isDynamic = opts.type.indexOf('dynamic/') === 0;
         this.isFlexible = opts.type === ('flexible/general') || opts.type === ('flexible/special');
-        this.isDynamicV1 = this.isDynamic && !this.isFlexible;
 
         this.dom = undefined;
         var onDomLoadResolve;

--- a/public/src/js/models/collections/collection.js
+++ b/public/src/js/models/collections/collection.js
@@ -37,8 +37,8 @@ export default class Collection extends BaseClass {
             && this.alsoOn.some(front => front.priority === 'commercial');
 
         this.isDynamic = opts.type.indexOf('dynamic/') === 0;
-        this.isDynamicV2 = opts.type === ('dynamic/fast-v2') || opts.type === ('dynamic/package-v2');
-        this.isDynamicV1 = this.isDynamic && !this.isDynamicV2;
+        this.isFlexible = opts.type === ('flexible/general') || opts.type === ('flexible/special');
+        this.isDynamicV1 = this.isDynamic && !this.isFlexible;
 
         this.dom = undefined;
         var onDomLoadResolve;

--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -16,14 +16,14 @@ export function init (res) {
     if (res.defaults.env.toLowerCase() !== 'prod') {
         CONST.types.push(
              {
-              'name': 'dynamic/fast-v2',
+              'name': 'flexible/general',
               'groups': [
                 'standard',
                 'splash'
               ]
             },
             {
-              'name': 'dynamic/package-v2',
+              'name': 'flexible/special',
               'groups': [
                 'standard',
                 'snap'


### PR DESCRIPTION
Follows up on the [PR introducing these containers](https://github.com/guardian/facia-tool/pull/1611), mainly to:

- update the name of the containers from dynamic/fast-v2 and dynamic/package-v2 to their new and proper names of flexible/general and flexible/special respectively. 
- Address some of the comments from the previous PR. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
