### PR TITLE
Tweak highlights layout slice

### DIFF
--- a/app/slices/Slice.scala
+++ b/app/slices/Slice.scala
@@ -937,51 +937,73 @@ case object ShowcaseSingleStories extends Slice {
   )
 }
 
-
 /*
- * The Highlights layout is used to display select features in the header for apps and web
+ * The Highlights layout is used to display select features in the header for apps and web, notably via a carousel.
+ * The implementation on platforms effectively limits the display to 6 cards altogether, and only 2-4 cards at a time.
+ * In the tool, we're satisfied with using a 6 card layout to hint at the number of visible stories.
  *
  * Desktop:
- * .____________.____________.____________.
- * |       #####|       #####|       #####|
- * |       #####|       #####|       #####|
- * |       #####|       #####|       #####|
- * '--------------------------------------'
+ * .____________.____________.____________.____________.____________.____________.
+ * |       #####|       #####|       #####|       #####|       #####|       #####|
+ * |       #####|       #####|       #####|       #####|       #####|       #####|
+ * |       #####|       #####|       #####|       #####|       #####|       #####|
+ * '-----------------------------------------------------------------------------'
  *
  * Mobile:
- * .___________.___________.___________.
- * |           |           |           |
- * |           |           |           |
- * |_#########_|_#########_|_#########_|
- * |_#########_|_#########_|_#########_|
- * |_#########_|_#########_|_#########_|
- * `-----------------------------------'
+ * .___________.___________.___________.___________.___________.___________.
+ * |           |           |           |           |           |           |
+ * |           |           |           |           |           |           |
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * `-----------------------------------------------------------------------'
  */
 case object Highlights extends Slice {
   val layout = SliceLayout(
-    cssClassName = "t-t-t",
+    cssClassName = "t-t-t-t-t-t",
     columns = Seq(
       SingleItem(
         colSpan = 1,
         ItemClasses(
           mobile = Standard,
-          tablet = MediaList
-        )
+          tablet = MediaList,
+        ),
       ),
       SingleItem(
         colSpan = 1,
         ItemClasses(
           mobile = Standard,
-          tablet = MediaList
-        )
+          tablet = MediaList,
+        ),
       ),
       SingleItem(
         colSpan = 1,
         ItemClasses(
           mobile = Standard,
-          tablet = MediaList
-        )
-      )
-    )
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+    ),
   )
 }


### PR DESCRIPTION
## What's changed?

Tweaks the slice layout for highlights containers. This mainly affects the number of stories before/after the desktop/mobile split in a front. As per the comment, on platforms the total number of stories that get rendered is 6, hence this 6 card layout. 

See this PR for the corresponding implementation in [frontend](https://github.com/guardian/frontend/pull/27375).

## Images

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4b594fae-40f8-4219-abbd-7cbd52b3ba9b

[after]: https://github.com/user-attachments/assets/80d186e7-51d0-42cd-8354-48d3c36a8110


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
