### PR TITLE
API endpoint to add collection to Front (editions/feast only)

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -268,6 +268,19 @@ class EditionsController(db: EditionsDB,
     }
   }
 
+  def removeCollectionFromFront(frontId: String, collectionId: String) = EditEditionsAuthAction { req =>
+    db.removeCollectionFromFront(
+      frontId = frontId,
+      collectionId,
+      user = req.user,
+      now = OffsetDateTime.now()
+    ) match {
+      case Right(front) => Ok(Json.toJson(front))
+      case Left(EditionsDB.NotFoundError(message)) => NotFound
+      case Left(error) => InternalServerError(error.getMessage())
+    }
+  }
+
   private def getAvailableCuratedPlatformEditions: Map[String, List[CuratedPlatformDefinition]] = {
     val feastAppEditions = FeastAppTemplates.getAvailableTemplates
 

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -255,6 +255,12 @@ class EditionsController(db: EditionsDB,
     } getOrElse NotFound(s"Front $id not found")
   }
 
+  def addCollectionToFront(id: String) = EditEditionsAuthAction { req =>
+    db.addCollectionToFront(frontId = id, user = req.user, now = OffsetDateTime.now()).map {
+      state => Ok(Json.toJson(state))
+    } getOrElse NotFound(s"Front $id not found")
+  }
+
   private def getAvailableCuratedPlatformEditions: Map[String, List[CuratedPlatformDefinition]] = {
     val feastAppEditions = FeastAppTemplates.getAvailableTemplates
 

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -256,9 +256,16 @@ class EditionsController(db: EditionsDB,
   }
 
   def addCollectionToFront(id: String) = EditEditionsAuthAction { req =>
-    db.addCollectionToFront(frontId = id, user = req.user, now = OffsetDateTime.now()).map {
-      state => Ok(Json.toJson(state))
-    } getOrElse NotFound(s"Front $id not found")
+    db.addCollectionToFront(
+      frontId = id,
+      user = req.user,
+      now = OffsetDateTime.now(),
+      name = req.queryString.get("name").flatMap(_.headOption)
+    ) match {
+      case Right(front) => Ok(Json.toJson(front))
+      case Left(EditionsDB.NotFoundError(message)) => NotFound
+      case Left(error) => InternalServerError(error.getMessage())
+    }
   }
 
   private def getAvailableCuratedPlatformEditions: Map[String, List[CuratedPlatformDefinition]] = {

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -193,8 +193,13 @@ trait CollectionsQueries {
 
   private case class GetCollectionsRow(collection: EditionsCollection, card: Option[DbEditionsCard])
 
-  protected def insertCollection(frontId: String, collectionIndex: Int, name: String, now: OffsetDateTime, user: User)(implicit session: DBSession) = 
-    Try { 
+  /**
+    * Insert a collection owned by the specified front.
+    *
+    * @return the Collection id
+    */
+  protected def insertCollection(frontId: String, collectionIndex: Int, name: String, now: OffsetDateTime, user: User)(implicit session: DBSession) =
+    Try {
       sql"""
         INSERT INTO collections (
           front_id,

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -23,7 +23,7 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
     val truncatedNow = EditionsDB.truncateDateTime(now)
 
     for {
-      currentFront <- getFront(frontId).toRight(EditionsDB.NotFoundError("Front not found"))
+      currentFront <- getFront(frontId).toRight(EditionsDB.NotFoundError(s"Front ${frontId} not found"))
       collectionId <- insertCollection(
         frontId = currentFront.id,
         collectionIndex = collectionIndex.getOrElse(currentFront.collections.size),
@@ -31,8 +31,8 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
         user = user,
         now = truncatedNow
       )
-      updatedFront <- getFront(frontId).toRight(EditionsDB.InvariantError("Updated front not found in issue"))
-      newCollection <- updatedFront.collections.find(_.id == collectionId).toRight(EditionsDB.InvariantError("New collection not found in updated front"))
+      updatedFront <- getFront(frontId).toRight(EditionsDB.InvariantError(s"Updated front ${frontId} not found in issue"))
+      newCollection <- updatedFront.collections.find(_.id == collectionId).toRight(EditionsDB.InvariantError(s"New collection ${collectionId} not found in updated front ${frontId}"))
     } yield updatedFront
   }
 }

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -32,7 +32,7 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
         now = truncatedNow
       )
       updatedFront <- getFront(frontId).toRight(EditionsDB.InvariantError(s"Updated front ${frontId} not found in issue"))
-      newCollection <- updatedFront.collections.find(_.id == collectionId).toRight(EditionsDB.InvariantError(s"New collection ${collectionId} not found in updated front ${frontId}"))
+      _ <- updatedFront.collections.find(_.id == collectionId).toRight(EditionsDB.InvariantError(s"New collection ${collectionId} not found in updated front ${frontId}"))
     } yield updatedFront
   }
 

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -4,13 +4,64 @@ import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.time.temporal.ChronoUnit
 
 import scalikejdbc._
+import com.gu.pandomainauth.model.User
+import services.editions.DbEditionsFront
+import model.editions.EditionsFront
+import scala.util.Try
 
 class EditionsDB(url: String, user: String, password: String) extends IssueQueries with FrontsQueries with CollectionsQueries {
   Class.forName("org.postgresql.Driver")
   ConnectionPool.singleton(url, user, password)
+
+
+  /**
+    * Add a Collection to a Front at the specified index.
+    *
+    * @return the ID of the collection.
+    */
+  def addCollectionToFront(frontId: String, collectionIndex: Option[Int] = None, user: User, now: OffsetDateTime): Either[Error, EditionsFront] = DB localTx { implicit session => 
+    val truncatedNow = EditionsDB.truncateDateTime(now)
+    val defaultName = "New collection"
+
+    for {
+      currentDBFront <- getFront(frontId).toRight(EditionsDB.NotFoundError("Front not found"))
+      currentIssue <- getIssue(currentDBFront.issueId, session).toRight(EditionsDB.InvariantError("Issue not found for given front"))
+      currentFront <- currentIssue.fronts.find(_.id == frontId).toRight(EditionsDB.InvariantError("Front not found in issue"))
+      collectionId <- insertCollection(
+        frontId = currentFront.id,
+        collectionIndex = collectionIndex.getOrElse(currentFront.collections.size),
+        name = defaultName,
+        user = user,
+        now = truncatedNow
+      )
+      updatedIssue <- getIssue(currentDBFront.issueId, session).toRight(EditionsDB.InvariantError("Issue not found for updated front"))
+      updatedFront <- updatedIssue.fronts.find(_.id == frontId).toRight(EditionsDB.InvariantError("Updated front not found in issue"))
+      newCollection <- updatedFront.collections.find(_.id == collectionId).toRight(EditionsDB.InvariantError("New collection not found in updated front"))
+    } yield updatedFront
+  }
+
+  private def getFront(id: String)(implicit session: DBSession): Option[DbEditionsFront] = {
+    sql"""
+        SELECT *
+        FROM fronts
+        WHERE id = $id
+    """.map(rs => {
+      DbEditionsFront.fromRowOpt(rs, "")
+    }).single.apply().flatMap(identity)
+  }
 }
 
 object EditionsDB {
   def dateTimeFromMillis(millis: Long): OffsetDateTime = Instant.ofEpochMilli(millis).atOffset(ZoneOffset.UTC)
   def truncateDateTime(odt: OffsetDateTime): OffsetDateTime = odt.truncatedTo(ChronoUnit.MILLIS)
+  def getUserName(user: User) = user.firstName + " " + user.lastName
+
+  // An entity the user expected to be there was not found
+  case class NotFoundError(message: String) extends Error(message)
+
+  // There was a problem writing data to the DB
+  case class WriteError(message: String) extends Error(message)
+
+  // There was an issue with the data stored in the DB
+  case class InvariantError(message: String) extends Error(message)
 }

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -15,20 +15,19 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
 
 
   /**
-    * Add a Collection to a Front at the specified index.
+    * Add a EditionsCollection to an EditionsFront at the specified index.
     *
     * @return the ID of the collection.
     */
-  def addCollectionToFront(frontId: String, collectionIndex: Option[Int] = None, user: User, now: OffsetDateTime): Either[Error, EditionsFront] = DB localTx { implicit session =>
+  def addCollectionToFront(frontId: String, name: Option[String] = None, collectionIndex: Option[Int] = None, user: User, now: OffsetDateTime): Either[Error, EditionsFront] = DB localTx { implicit session =>
     val truncatedNow = EditionsDB.truncateDateTime(now)
-    val defaultName = "New collection"
 
     for {
       currentFront <- getFront(frontId).toRight(EditionsDB.NotFoundError("Front not found"))
       collectionId <- insertCollection(
         frontId = currentFront.id,
         collectionIndex = collectionIndex.getOrElse(currentFront.collections.size),
-        name = defaultName,
+        name = name.getOrElse("New collection"),
         user = user,
         now = truncatedNow
       )

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -2,8 +2,13 @@ package services.editions.db
 
 import logging.Logging
 import model.editions.{EditionsFront, EditionsFrontMetadata}
+import services.editions.DbEditionsFront
 import scalikejdbc._
 import play.api.libs.json._
+import com.gu.pandomainauth.model.User
+import java.time.OffsetDateTime
+import scala.util.Try
+import scala.util.Failure
 
 trait FrontsQueries extends Logging {
   def updateFrontMetadata(id: String, metadata: EditionsFrontMetadata): Option[EditionsFrontMetadata] = DB localTx { implicit session =>

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -78,38 +78,7 @@ trait FrontsQueries extends Logging {
     val rows: List[FrontAndNestedEntitiesRow] =
       sql"""
         SELECT
-          fronts.id            AS fronts_id,
-          fronts.issue_id      AS fronts_issue_id,
-          fronts.index         AS fronts_index,
-          fronts.name          AS fronts_name,
-          fronts.is_special    AS fronts_is_special,
-          fronts.is_hidden     AS fronts_is_hidden,
-          fronts.metadata      AS fronts_metadata,
-          fronts.updated_on    AS fronts_updated_on,
-          fronts.updated_by    AS fronts_updated_by,
-          fronts.updated_email AS fronts_updated_email,
-
-          collections.id            AS collections_id,
-          collections.front_id      AS collections_front_id,
-          collections.index         AS collections_index,
-          collections.name          AS collections_name,
-          collections.is_hidden     AS collections_is_hidden,
-          collections.metadata      AS collections_metadata,
-          collections.updated_on    AS collections_updated_on,
-          collections.updated_by    AS collections_updated_by,
-          collections.updated_email AS collections_updated_email,
-          collections.prefill       AS collections_prefill,
-          collections.path_type     AS collections_path_type,
-          collections.content_prefill_window_start       AS collections_content_prefill_window_start,
-          collections.content_prefill_window_end         AS collections_content_prefill_window_end,
-
-          cards.collection_id AS cards_collection_id,
-          cards.id            AS cards_id,
-          cards.card_type     AS cards_card_type,
-          cards.index         AS cards_index,
-          cards.added_on      AS cards_added_on,
-          cards.metadata      AS cards_metadata
-
+        ${FrontsQueries.frontAndNestedEntitiesColumns}
         FROM fronts
         LEFT JOIN collections ON (collections.front_id = fronts.id)
         LEFT JOIN cards ON (cards.collection_id = collections.id)
@@ -155,4 +124,38 @@ object FrontsQueries {
         front.copy(collections = collectionsForFront)
       }
   }
+
+  val frontAndNestedEntitiesColumns = sqls"""
+      fronts.id            AS fronts_id,
+      fronts.issue_id      AS fronts_issue_id,
+      fronts.index         AS fronts_index,
+      fronts.name          AS fronts_name,
+      fronts.is_special    AS fronts_is_special,
+      fronts.is_hidden     AS fronts_is_hidden,
+      fronts.metadata      AS fronts_metadata,
+      fronts.updated_on    AS fronts_updated_on,
+      fronts.updated_by    AS fronts_updated_by,
+      fronts.updated_email AS fronts_updated_email,
+
+      collections.id            AS collections_id,
+      collections.front_id      AS collections_front_id,
+      collections.index         AS collections_index,
+      collections.name          AS collections_name,
+      collections.is_hidden     AS collections_is_hidden,
+      collections.metadata      AS collections_metadata,
+      collections.updated_on    AS collections_updated_on,
+      collections.updated_by    AS collections_updated_by,
+      collections.updated_email AS collections_updated_email,
+      collections.prefill       AS collections_prefill,
+      collections.path_type     AS collections_path_type,
+      collections.content_prefill_window_start       AS collections_content_prefill_window_start,
+      collections.content_prefill_window_end         AS collections_content_prefill_window_end,
+
+      cards.collection_id AS cards_collection_id,
+      cards.id            AS cards_id,
+      cards.card_type     AS cards_card_type,
+      cards.index         AS cards_index,
+      cards.added_on      AS cards_added_on,
+      cards.metadata      AS cards_metadata
+  """
 }

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -9,6 +9,15 @@ import com.gu.pandomainauth.model.User
 import java.time.OffsetDateTime
 import scala.util.Try
 import scala.util.Failure
+import services.editions.DbEditionsCollection
+import services.editions.DbEditionsCard
+import model.editions.EditionsCollection
+
+case class FrontAndNestedEntitiesRow(
+  front: Option[DbEditionsFront],
+  collection: Option[DbEditionsCollection],
+  card: Option[DbEditionsCard]
+)
 
 trait FrontsQueries extends Logging {
   def updateFrontMetadata(id: String, metadata: EditionsFrontMetadata): Option[EditionsFrontMetadata] = DB localTx { implicit session =>
@@ -63,5 +72,87 @@ trait FrontsQueries extends Logging {
       if (!isSpecial) logger.warn(s"Tried to update hidden state on front $id which is not a special front")
       isHidden
     }
+  }
+
+  protected def getFront(frontId: String)(implicit session: DBSession): Option[EditionsFront] = {
+    val rows: List[FrontAndNestedEntitiesRow] =
+      sql"""
+        SELECT
+          fronts.id            AS fronts_id,
+          fronts.issue_id      AS fronts_issue_id,
+          fronts.index         AS fronts_index,
+          fronts.name          AS fronts_name,
+          fronts.is_special    AS fronts_is_special,
+          fronts.is_hidden     AS fronts_is_hidden,
+          fronts.metadata      AS fronts_metadata,
+          fronts.updated_on    AS fronts_updated_on,
+          fronts.updated_by    AS fronts_updated_by,
+          fronts.updated_email AS fronts_updated_email,
+
+          collections.id            AS collections_id,
+          collections.front_id      AS collections_front_id,
+          collections.index         AS collections_index,
+          collections.name          AS collections_name,
+          collections.is_hidden     AS collections_is_hidden,
+          collections.metadata      AS collections_metadata,
+          collections.updated_on    AS collections_updated_on,
+          collections.updated_by    AS collections_updated_by,
+          collections.updated_email AS collections_updated_email,
+          collections.prefill       AS collections_prefill,
+          collections.path_type     AS collections_path_type,
+          collections.content_prefill_window_start       AS collections_content_prefill_window_start,
+          collections.content_prefill_window_end         AS collections_content_prefill_window_end,
+
+          cards.collection_id AS cards_collection_id,
+          cards.id            AS cards_id,
+          cards.card_type     AS cards_card_type,
+          cards.index         AS cards_index,
+          cards.added_on      AS cards_added_on,
+          cards.metadata      AS cards_metadata
+
+        FROM fronts
+        LEFT JOIN collections ON (collections.front_id = fronts.id)
+        LEFT JOIN cards ON (cards.collection_id = collections.id)
+        WHERE fronts.id = $frontId
+      """.map { rs =>
+        FrontAndNestedEntitiesRow(
+          DbEditionsFront.fromRowOpt(rs, "fronts_"),
+          DbEditionsCollection.fromRowOpt(rs, "collections_"),
+          DbEditionsCard.fromRowOpt(rs, "cards_")
+        )
+      }
+        .list
+        .apply()
+
+    FrontsQueries.toEditionsFront(rows).headOption
+  }
+}
+
+
+object FrontsQueries {
+  def toEditionsFront(rows: List[FrontAndNestedEntitiesRow]): List[EditionsFront] = {
+    rows
+      .flatMap(_.front)
+      .sortBy(_.index)
+      .map(_.front)
+      .distinctBy(_.id)
+      .map { front =>
+        val collectionsForFront = rows
+          .flatMap { _.collection.filter(_.frontId == front.id) }
+          .sortBy(_.index)
+          .map(_.collection)
+          .foldLeft(List.empty[EditionsCollection]) { (acc, cur) => if (acc.exists(c => c.id == cur.id)) acc else acc :+ cur }
+          .map { collection =>
+            val cards = rows
+              .flatMap(_.card.filter(_.collectionId == collection.id))
+              .sortBy(_.index)
+              .map(_.card)
+
+            collection
+              .copy(items = cards)
+          }
+
+        front.copy(collections = collectionsForFront)
+      }
   }
 }

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -155,38 +155,7 @@ trait IssueQueries extends Logging {
         edition_issues.launched_on,
         edition_issues.launched_by,
         edition_issues.launched_email,
-
-        fronts.id            AS fronts_id,
-        fronts.issue_id      AS fronts_issue_id,
-        fronts.index         AS fronts_index,
-        fronts.name          AS fronts_name,
-        fronts.is_special    AS fronts_is_special,
-        fronts.is_hidden     AS fronts_is_hidden,
-        fronts.metadata      AS fronts_metadata,
-        fronts.updated_on    AS fronts_updated_on,
-        fronts.updated_by    AS fronts_updated_by,
-        fronts.updated_email AS fronts_updated_email,
-
-        collections.id            AS collections_id,
-        collections.front_id      AS collections_front_id,
-        collections.index         AS collections_index,
-        collections.name          AS collections_name,
-        collections.is_hidden     AS collections_is_hidden,
-        collections.metadata      AS collections_metadata,
-        collections.updated_on    AS collections_updated_on,
-        collections.updated_by    AS collections_updated_by,
-        collections.updated_email AS collections_updated_email,
-        collections.prefill       AS collections_prefill,
-        collections.path_type     AS collections_path_type,
-        collections.content_prefill_window_start       AS collections_content_prefill_window_start,
-        collections.content_prefill_window_end         AS collections_content_prefill_window_end,
-
-        cards.collection_id AS cards_collection_id,
-        cards.id            AS cards_id,
-        cards.card_type     AS cards_card_type,
-        cards.index         AS cards_index,
-        cards.added_on      AS cards_added_on,
-        cards.metadata      AS cards_metadata
+        ${FrontsQueries.frontAndNestedEntitiesColumns}
 
       FROM edition_issues
       LEFT JOIN fronts ON (fronts.issue_id = edition_issues.id)

--- a/app/services/editions/db/IssueQueries.scala
+++ b/app/services/editions/db/IssueQueries.scala
@@ -22,8 +22,8 @@ trait IssueQueries extends Logging {
                    user: User,
                    now: OffsetDateTime
                  ): String = DB localTx { implicit session =>
-    val userName = user.firstName + " " + user.lastName
     val truncatedNow = EditionsDB.truncateDateTime(now)
+    val userName = EditionsDB.getUserName(user)
 
     import genEditionTemplateResult.{issueSkeleton, contentPrefillTimeWindow}
 
@@ -141,7 +141,11 @@ trait IssueQueries extends Logging {
     }.toOption.apply()
   }
 
-  def getIssue(id: String): Option[EditionsIssue] = DB readOnly { implicit session =>
+  def getIssue(id: String): Option[EditionsIssue] = DB readOnly { implicit session => getIssue(id, session) }
+
+  def getIssue(id: String, session: DBSession): Option[EditionsIssue] = {
+    implicit val _session = session
+
     case class GetIssueRow(
                             issue: EditionsIssue,
                             front: Option[DbEditionsFront],

--- a/conf/routes
+++ b/conf/routes
@@ -118,6 +118,7 @@ GET         /editions-api/issues/:id/preflight-checks            controllers.Edi
 
 PUT         /editions-api/fronts/:frontId/metadata               controllers.EditionsController.putFrontMetadata(frontId)
 PUT         /editions-api/fronts/:frontId/is-hidden/:state       controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
+PUT         /editions-api/fronts/:frontId/add-collection         controllers.EditionsController.addCollectionToFront(frontId)
 
 POST        /editions-api/collections                            controllers.EditionsController.getCollections()
 GET         /editions-api/collections/:collectionId              controllers.EditionsController.getCollection(collectionId)

--- a/conf/routes
+++ b/conf/routes
@@ -102,26 +102,27 @@ GET         /v2/*path                                controllers.V2App.index(pat
 POST        /api/usage                               controllers.GridProxy.addUsage()
 
 # Editions
-GET         /editions-api/editions                               controllers.EditionsController.getAvailableEditions
-GET         /editions-api/editions/:edition/issues               controllers.EditionsController.listIssues(edition: Edition)
-POST        /editions-api/editions/:name/issues                  controllers.EditionsController.createIssue(name)
-GET         /editions-api/republish-editions                     controllers.EditionsController.republishEditionsAppEditionsList
-GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
-DELETE      /editions-api/issues/:id                             controllers.EditionsController.deleteIssue(id)
-GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)
-GET         /editions-api/issues/:id/versions                    controllers.EditionsController.getVersions(id)
-GET         /editions-api/issues/:id/last-proofed-version        controllers.EditionsController.getLastProofedVersion(id)
-POST        /editions-api/issues/:id/proof                       controllers.EditionsController.proofIssue(id)
-POST        /editions-api/issues/:id/publish/:version            controllers.EditionsController.publishIssue(id, version)
-GET         /editions-api/issues/:id/preview                     controllers.EditionsController.getPreviewEdition(id)
-GET         /editions-api/issues/:id/preflight-checks            controllers.EditionsController.checkIssue(id: String)
+GET         /editions-api/editions                                          controllers.EditionsController.getAvailableEditions
+GET         /editions-api/editions/:edition/issues                          controllers.EditionsController.listIssues(edition: Edition)
+POST        /editions-api/editions/:name/issues                             controllers.EditionsController.createIssue(name)
+GET         /editions-api/republish-editions                                controllers.EditionsController.republishEditionsAppEditionsList
+GET         /editions-api/issues/:id                                        controllers.EditionsController.getIssue(id)
+DELETE      /editions-api/issues/:id                                        controllers.EditionsController.deleteIssue(id)
+GET         /editions-api/issues/:id/summary                                controllers.EditionsController.getIssueSummary(id)
+GET         /editions-api/issues/:id/versions                               controllers.EditionsController.getVersions(id)
+GET         /editions-api/issues/:id/last-proofed-version                   controllers.EditionsController.getLastProofedVersion(id)
+POST        /editions-api/issues/:id/proof                                  controllers.EditionsController.proofIssue(id)
+POST        /editions-api/issues/:id/publish/:version                       controllers.EditionsController.publishIssue(id, version)
+GET         /editions-api/issues/:id/preview                                controllers.EditionsController.getPreviewEdition(id)
+GET         /editions-api/issues/:id/preflight-checks                       controllers.EditionsController.checkIssue(id: String)
 
-PUT         /editions-api/fronts/:frontId/metadata               controllers.EditionsController.putFrontMetadata(frontId)
-PUT         /editions-api/fronts/:frontId/is-hidden/:state       controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
-PUT         /editions-api/fronts/:frontId/add-collection         controllers.EditionsController.addCollectionToFront(frontId)
+PUT         /editions-api/fronts/:frontId/metadata                          controllers.EditionsController.putFrontMetadata(frontId)
+PUT         /editions-api/fronts/:frontId/is-hidden/:state                  controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
+PUT         /editions-api/fronts/:frontId/collection                        controllers.EditionsController.addCollectionToFront(frontId)
+DELETE      /editions-api/fronts/:frontId/collection/:collectionId          controllers.EditionsController.removeCollectionFromFront(frontId, collectionId)
 
-POST        /editions-api/collections                            controllers.EditionsController.getCollections()
-GET         /editions-api/collections/:collectionId              controllers.EditionsController.getCollection(collectionId)
-PUT         /editions-api/collections/:collectionId              controllers.EditionsController.updateCollection(collectionId)
-PATCH       /editions-api/collections/:collectionId/name         controllers.EditionsController.renameCollection(collectionId)
-GET         /editions-api/collections/:collectionId/prefill      controllers.EditionsController.getPrefillForCollection(collectionId)
+POST        /editions-api/collections                                       controllers.EditionsController.getCollections()
+GET         /editions-api/collections/:collectionId                         controllers.EditionsController.getCollection(collectionId)
+PUT         /editions-api/collections/:collectionId                         controllers.EditionsController.updateCollection(collectionId)
+PATCH       /editions-api/collections/:collectionId/name                    controllers.EditionsController.renameCollection(collectionId)
+GET         /editions-api/collections/:collectionId/prefill                 controllers.EditionsController.getPrefillForCollection(collectionId)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -610,15 +610,29 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
         val issue: EditionsIssue = editionsDB.getIssue(issueId).value
         val frontFromIssue = issue.fronts.head
 
-        editionsDB.addCollectionToFront(frontFromIssue.id, user = user, now = now) match {
+        editionsDB.addCollectionToFront(frontFromIssue.id, name = Some("Test Collection"), user = user, now = now) match {
           case Right(front) =>
             front.collections.size shouldBe 2
-            front.collections.last.displayName shouldBe "New collection"
+            front.collections.last.displayName shouldBe "Test Collection"
           case Left(error) =>
             Assertions.fail(s"Error adding collection to front: ${error.getMessage()}")
         }
       }
 
+      "should add a default name if one is not provided" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None))
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+
+        editionsDB.addCollectionToFront(frontFromIssue.id, user = user, now = now) match {
+          case Right(front) =>
+            front.collections.last.displayName shouldBe "New collection"
+          case Left(error) =>
+            Assertions.fail(s"Error adding collection to front: ${error.getMessage()}")
+        }
+      }
 
       "should fail with a NotFoundError when the specified front does not exist" taggedAs UsesDatabase in {
         editionsDB.addCollectionToFront("does-not-exist", user = user, now = now) match {

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -12,6 +12,7 @@ import scalikejdbc._
 import services.editions.GenerateEditionTemplateResult
 import services.editions.prefills.CapiQueryTimeWindow
 import org.scalatest.Assertions
+import services.editions.db.EditionsDB.NotFoundError
 
 class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with EditionsDBEvolutions with OptionValues {
 
@@ -656,6 +657,63 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
             Assertions.fail()
           case Left(error) =>
             error shouldBe an[EditionsDB.WriteError]
+        }
+      }
+    }
+
+    "Remove collection" - {
+      "should remove a given collection" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None), collection("sport", None), collection("culture", None)),
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+        frontFromIssue.collections.size shouldBe 3
+
+        editionsDB.removeCollectionFromFront(frontFromIssue.id, frontFromIssue.collections(2).id, user = user, now = now) match {
+          case Right(front) =>
+            front.collections.map(_.displayName) shouldBe List("politics", "sport")
+          case Left(error) =>
+            Assertions.fail(s"Error removing collection to front: ${error.getMessage()}")
+        }
+
+        editionsDB.removeCollectionFromFront(frontFromIssue.id, frontFromIssue.collections(0).id, user = user, now = now) match {
+          case Right(front) =>
+            front.collections.map(_.displayName) shouldBe List("sport")
+          case Left(error) =>
+            Assertions.fail(s"Error removing collection to front: ${error.getMessage()}")
+        }
+      }
+
+      "should fail when the front does not exist" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None), collection("sport", None), collection("culture", None)),
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+        frontFromIssue.collections.size shouldBe 3
+
+        editionsDB.removeCollectionFromFront("does-not-exist", frontFromIssue.collections(2).id, user = user, now = now) match {
+          case Right(front) =>
+            Assertions.fail(s"Removing a collection from a front that does not exist should not succeed")
+          case Left(error) =>
+            error shouldBe an[NotFoundError]
+        }
+      }
+
+      "should fail when the collection does not exist" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None), collection("sport", None), collection("culture", None)),
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+        frontFromIssue.collections.size shouldBe 3
+
+        editionsDB.removeCollectionFromFront(frontFromIssue.id, "does-not-exist", user = user, now = now) match {
+          case Right(front) =>
+            Assertions.fail(s"Removing a collection that does not exist should not succeed")
+          case Left(error) =>
+            error shouldBe an[NotFoundError]
         }
       }
     }


### PR DESCRIPTION
## What's changed?

Adds an API endpoint to add a new collection to a Front, at

`PUT editions-api/front/:frontId/collection?name=optional-name`

## Implementation notes

- I've factored out the nested row aggregation logic common to issue and fronts queries in dd57774336a9b7bba5066d153e1e3fd98514d354. Hopefully it's clear what the intermediate case class is used for.
- There are a few ways that DB queries can go wrong, and I was loathe to continue the tradition of modelling all of these failure modes in `Option[Result]`, so I've added three error states for missing things, logic invariants, and write errors. This enables the API to respond with the correct status code. Hopefully that looks useful and isn't overkill – feedback welcome!

## How to test

- The automated tests should pass. They should cover happy and unhappy paths. A few unhappy paths are difficult to test because of the transactional nature of the operation (they should never fail!)
- Try pinging the endpoint locally or in CODE (you'll need to borrow a cookie from a valid browser-based request – I'd recommend importing a valid API call with 'copy to cURL' and Postman). The endpoint should work as expected.

Tested locally with cURL, and verified in client.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
