### PR TITLE
API endpoint to remove collection from front (editions/feast only)

### DIFF
--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -268,6 +268,19 @@ class EditionsController(db: EditionsDB,
     }
   }
 
+  def removeCollectionFromFront(frontId: String, collectionId: String) = EditEditionsAuthAction { req =>
+    db.removeCollectionFromFront(
+      frontId = frontId,
+      collectionId,
+      user = req.user,
+      now = OffsetDateTime.now()
+    ) match {
+      case Right(front) => Ok(Json.toJson(front))
+      case Left(EditionsDB.NotFoundError(message)) => NotFound
+      case Left(error) => InternalServerError(error.getMessage())
+    }
+  }
+
   private def getAvailableCuratedPlatformEditions: Map[String, List[CuratedPlatformDefinition]] = {
     val feastAppEditions = FeastAppTemplates.getAvailableTemplates
 

--- a/app/controllers/EditionsController.scala
+++ b/app/controllers/EditionsController.scala
@@ -14,7 +14,7 @@ import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.Result
 import services.Capi
 import services.editions.EditionsTemplating
-import services.editions.db.EditionsDB
+import services.editions.db.{EditionsCollectionUpdate, EditionsDB}
 import services.editions.prefills.{CapiPrefillTimeParams, MetadataForLogging, PrefillParamsAdapter}
 import services.editions.publishing.Publishing
 import services.editions.publishing.PublishedIssueFormatters._
@@ -144,10 +144,9 @@ class EditionsController(db: EditionsDB,
     }
   }
 
-  def updateCollection(collectionId: String) = EditEditionsAuthAction(parse.json[EditionsFrontendCollectionWrapper]) { req =>
+  def updateCollection() = EditEditionsAuthAction(parse.json[EditionsCollectionUpdate]) { req =>
     val form = req.body
-    val collectionToUpdate = EditionsFrontendCollectionWrapper.toCollection(form)
-    val updatedCollection = db.updateCollection(collectionToUpdate)
+    val updatedCollection = db.updateCollection(form)
     for {
       issueId <- db.getIssueIdFromCollectionId(updatedCollection.id)
       issue <- db.getIssue(issueId)

--- a/app/model/editions/client/EditionsClientCollection.scala
+++ b/app/model/editions/client/EditionsClientCollection.scala
@@ -4,7 +4,7 @@ import play.api.libs.json.{Json, OFormat}
 import services.editions.prefills.CapiQueryTimeWindow
 import model.editions.EditionsCard
 import model.editions.EditionsArticle
-import model.editions.{CapiPrefillQuery, EditionsCollection, EditionsRecipe, EditionsChef, EditionsFeastCollection, CardType}
+import model.editions.{CapiPrefillQuery, CardType, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsRecipe}
 import model.editions.EditionsFeastCollectionItem
 
 // Ideally the frontend can be changed so we don't have this weird modelling!
@@ -80,7 +80,7 @@ object EditionsSupportingClientCard {
     case EditionsRecipe(id, addedOn) => EditionsSupportingClientCard(id, Some(CardType.Recipe), addedOn)
   }
 
-  def toFeastCollectionItem(supportingCard: EditionsSupportingClientCard) = 
+  def toFeastCollectionItem(supportingCard: EditionsSupportingClientCard) =
     EditionsRecipe(supportingCard.id, supportingCard.frontPublicationDate)
 }
 

--- a/conf/routes
+++ b/conf/routes
@@ -102,26 +102,27 @@ GET         /v2/*path                                controllers.V2App.index(pat
 POST        /api/usage                               controllers.GridProxy.addUsage()
 
 # Editions
-GET         /editions-api/editions                               controllers.EditionsController.getAvailableEditions
-GET         /editions-api/editions/:edition/issues               controllers.EditionsController.listIssues(edition: Edition)
-POST        /editions-api/editions/:name/issues                  controllers.EditionsController.createIssue(name)
-GET         /editions-api/republish-editions                     controllers.EditionsController.republishEditionsAppEditionsList
-GET         /editions-api/issues/:id                             controllers.EditionsController.getIssue(id)
-DELETE      /editions-api/issues/:id                             controllers.EditionsController.deleteIssue(id)
-GET         /editions-api/issues/:id/summary                     controllers.EditionsController.getIssueSummary(id)
-GET         /editions-api/issues/:id/versions                    controllers.EditionsController.getVersions(id)
-GET         /editions-api/issues/:id/last-proofed-version        controllers.EditionsController.getLastProofedVersion(id)
-POST        /editions-api/issues/:id/proof                       controllers.EditionsController.proofIssue(id)
-POST        /editions-api/issues/:id/publish/:version            controllers.EditionsController.publishIssue(id, version)
-GET         /editions-api/issues/:id/preview                     controllers.EditionsController.getPreviewEdition(id)
-GET         /editions-api/issues/:id/preflight-checks            controllers.EditionsController.checkIssue(id: String)
+GET         /editions-api/editions                                          controllers.EditionsController.getAvailableEditions
+GET         /editions-api/editions/:edition/issues                          controllers.EditionsController.listIssues(edition: Edition)
+POST        /editions-api/editions/:name/issues                             controllers.EditionsController.createIssue(name)
+GET         /editions-api/republish-editions                                controllers.EditionsController.republishEditionsAppEditionsList
+GET         /editions-api/issues/:id                                        controllers.EditionsController.getIssue(id)
+DELETE      /editions-api/issues/:id                                        controllers.EditionsController.deleteIssue(id)
+GET         /editions-api/issues/:id/summary                                controllers.EditionsController.getIssueSummary(id)
+GET         /editions-api/issues/:id/versions                               controllers.EditionsController.getVersions(id)
+GET         /editions-api/issues/:id/last-proofed-version                   controllers.EditionsController.getLastProofedVersion(id)
+POST        /editions-api/issues/:id/proof                                  controllers.EditionsController.proofIssue(id)
+POST        /editions-api/issues/:id/publish/:version                       controllers.EditionsController.publishIssue(id, version)
+GET         /editions-api/issues/:id/preview                                controllers.EditionsController.getPreviewEdition(id)
+GET         /editions-api/issues/:id/preflight-checks                       controllers.EditionsController.checkIssue(id: String)
 
-PUT         /editions-api/fronts/:frontId/metadata               controllers.EditionsController.putFrontMetadata(frontId)
-PUT         /editions-api/fronts/:frontId/is-hidden/:state       controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
-PUT         /editions-api/fronts/:frontId/add-collection         controllers.EditionsController.addCollectionToFront(frontId)
+PUT         /editions-api/fronts/:frontId/metadata                          controllers.EditionsController.putFrontMetadata(frontId)
+PUT         /editions-api/fronts/:frontId/is-hidden/:state                  controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
+PUT         /editions-api/fronts/:frontId/collection                        controllers.EditionsController.addCollectionToFront(frontId)
+DELETE      /editions-api/fronts/:frontId/collection/:collectionId          controllers.EditionsController.removeCollectionFromFront(frontId, collectionId)
 
-POST        /editions-api/collections                            controllers.EditionsController.getCollections()
-GET         /editions-api/collections/:collectionId              controllers.EditionsController.getCollection(collectionId)
-PUT         /editions-api/collections/:collectionId              controllers.EditionsController.updateCollection(collectionId)
-PATCH       /editions-api/collections/:collectionId/name         controllers.EditionsController.renameCollection(collectionId)
-GET         /editions-api/collections/:collectionId/prefill      controllers.EditionsController.getPrefillForCollection(collectionId)
+POST        /editions-api/collections                                       controllers.EditionsController.getCollections()
+GET         /editions-api/collections/:collectionId                         controllers.EditionsController.getCollection(collectionId)
+PUT         /editions-api/collections/:collectionId                         controllers.EditionsController.updateCollection(collectionId)
+PATCH       /editions-api/collections/:collectionId/name                    controllers.EditionsController.renameCollection(collectionId)
+GET         /editions-api/collections/:collectionId/prefill                 controllers.EditionsController.getPrefillForCollection(collectionId)

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -12,6 +12,7 @@ import scalikejdbc._
 import services.editions.GenerateEditionTemplateResult
 import services.editions.prefills.CapiQueryTimeWindow
 import org.scalatest.Assertions
+import services.editions.db.EditionsDB.NotFoundError
 
 class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with EditionsDBEvolutions with OptionValues {
 
@@ -656,6 +657,63 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
             Assertions.fail()
           case Left(error) =>
             error shouldBe an[EditionsDB.WriteError]
+        }
+      }
+    }
+
+    "Remove collection" - {
+      "should remove a given collection" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None), collection("sport", None), collection("culture", None)),
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+        frontFromIssue.collections.size shouldBe 3
+
+        editionsDB.removeCollectionFromFront(frontFromIssue.id, frontFromIssue.collections(2).id, user = user, now = now) match {
+          case Right(front) =>
+            front.collections.map(_.displayName) shouldBe List("politics", "sport")
+          case Left(error) =>
+            Assertions.fail(s"Error removing collection to front: ${error.getMessage()}")
+        }
+
+        editionsDB.removeCollectionFromFront(frontFromIssue.id, frontFromIssue.collections(0).id, user = user, now = now) match {
+          case Right(front) =>
+            front.collections.map(_.displayName) shouldBe List("sport")
+          case Left(error) =>
+            Assertions.fail(s"Error removing collection to front: ${error.getMessage()}")
+        }
+      }
+
+      "should fail when the front does not exist" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None), collection("sport", None), collection("culture", None)),
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+        frontFromIssue.collections.size shouldBe 3
+
+        editionsDB.removeCollectionFromFront("does-not-exist", frontFromIssue.collections(2).id, user = user, now = now) match {
+          case Right(front) =>
+            Assertions.fail(s"Removing a collection from a front that does not exist should not succeed")
+          case Left(error) =>
+            error shouldBe an[NotFoundError]
+        }
+      }
+
+      "should fail when the collection does not exist" taggedAs UsesDatabase in {
+        val issueId = insertSkeletonIssue(2020, 1, 1,
+          front("news/uk", collection("politics", None), collection("sport", None), collection("culture", None)),
+        )
+        val issue: EditionsIssue = editionsDB.getIssue(issueId).value
+        val frontFromIssue = issue.fronts.head
+        frontFromIssue.collections.size shouldBe 3
+
+        editionsDB.removeCollectionFromFront(frontFromIssue.id, "does-not-exist", user = user, now = now) match {
+          case Right(front) =>
+            Assertions.fail(s"Removing a collection that does not exist should not succeed")
+          case Left(error) =>
+            error shouldBe an[NotFoundError]
         }
       }
     }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -375,12 +375,12 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
     val items = EditionsArticle("654789", futureMillis, Some(simpleMetadata)) :: brexshit.items
 
-    val evenMoreBrexshit = brexshit.copy(
+    val evenMoreBrexshit = EditionsCollectionUpdate(
+      id = brexshit.id,
       lastUpdated = Some(futureMillis),
-      displayName = "i=am-ignored",
       updatedBy = Some("BoJo"),
       updatedEmail = Some("bojo@piffle.paffle"),
-      items = items
+      items = Some(items)
     )
 
     editionsDB.updateCollection(evenMoreBrexshit)
@@ -421,7 +421,13 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     val retrievedCollection = retrievedIssue.fronts.head.collections.head
 
     val recipeCard = EditionsRecipe("654789", now.toInstant.toEpochMilli)
-    val items = retrievedCollection.copy(items = retrievedCollection.items :+ recipeCard)
+    val items = EditionsCollectionUpdate(
+      id = retrievedCollection.id,
+      items = Some(retrievedCollection.items :+ recipeCard),
+      updatedBy = retrievedCollection.updatedBy,
+      updatedEmail = retrievedCollection.updatedEmail,
+      lastUpdated = retrievedCollection.lastUpdated
+    )
     editionsDB.updateCollection(items)
 
     val collections = editionsDB.getCollections(List(GetCollectionsFilter(retrievedCollection.id, None)))


### PR DESCRIPTION
## What's changed?
Building on #1622, adds an endpoint to remove a collection from a front, at 

`DELETE editions-api/front/:frontId/collection/:collectionId`

I think it makes sense to scope this action to the front, as we're removing a collection from the front, and reindexing the other collections as a result. It also means we can pass back the updated front to ensure the client can read its own writes.

## Implementation notes

- The automated tests should pass. They should cover happy and unhappy paths. A few unhappy paths are difficult to test because of the transactional nature of the operation (they should never fail!)
- Try pinging the endpoint locally or in CODE (you'll need to borrow a cookie from a valid browser-based request – I'd recommend importing a valid API call with 'copy to cURL' and Postman). The endpoint should work as expected.

Tested locally with cURL, and verified in client.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
