### PR TITLE
Revert "Merge pull request #1359 from guardian/firefox-banner"

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -24,12 +24,6 @@ object PageViewDataVisualisation extends FeatureSwitch(
   enabled = true
 )
 
-object ShowFirefoxPrompt extends FeatureSwitch(
-  key = "show-firefox-prompt",
-  title = "Show the prompt to use Firefox if applicable",
-  enabled = true
-)
-
 object TenImageSlideshows extends FeatureSwitch(
   key = "ten-image-slideshows",
   title = "Allow slideshows to contain 10 images rather than 5",
@@ -43,7 +37,7 @@ object UsePortraitCropsForSomeCollectionTypes extends FeatureSwitch(
 )
 
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, ShowFirefoxPrompt, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes)
+  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     val newSwitches = userDataSwitches match {

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -26,7 +26,6 @@ import { actionSetFeatureValue } from 'actions/FeatureSwitches';
 import { deleteIssue } from 'util/delete';
 import notifications from 'services/notifications';
 import { actionAddNotificationBanner } from 'bundles/notificationsBundle';
-import { saveFeatureSwitch } from 'services/userDataApi';
 
 initGA();
 
@@ -36,40 +35,6 @@ const store = configureStore();
 notifications.subscribe((notification) =>
   store.dispatch(actionAddNotificationBanner(notification))
 );
-
-// Recommend Chrome 87 users to use Firefox instead, due to drag-and drop
-// performance issue.
-const maybeWarnChromeUsers = () => {
-  if (!navigator.userAgent || !pageConfig.userData) {
-    return;
-  }
-  const chromeString = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
-  const chromeVersion = chromeString ? parseInt(chromeString[2], 10) : false;
-
-  const featureSwitch = pageConfig.userData.featureSwitches.find(
-    (feature) => feature.key === 'show-firefox-prompt'
-  );
-
-  if ((chromeVersion && chromeVersion < 87) || !featureSwitch?.enabled) {
-    return;
-  }
-
-  notifications.notify({
-    message: `There are known performance issues in Chrome ${chromeVersion} for this tool. If it feels slow, try using Firefox. \
-<br>For further information, please contact <a href="mailto:central.production@guardian.co.uk">Central Production.</a>`,
-    level: 'error',
-    dismissalCallback: () => {
-      const newSwitchValue = {
-        ...featureSwitch,
-        enabled: false,
-      };
-      store.dispatch(actionSetFeatureValue(newSwitchValue));
-      saveFeatureSwitch(newSwitchValue);
-    },
-  });
-};
-
-maybeWarnChromeUsers();
 
 // @ts-ignore -- Unbind is not used yet but can be used for removed all the
 // keyboard events. The keyboardActionMap contains a list of all active keyboard


### PR DESCRIPTION
## What's changed?

(Selectively) reverts #1359, which asks users to switch to Firefox if they experience performance problems. As @paperboyo says, 

> even though the warning is technically correct, it no longer serves the users well (?).

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
