### PR TITLE
API endpoint to move collections to new index

### DIFF
--- a/app/model/forms/MoveCollection.scala
+++ b/app/model/forms/MoveCollection.scala
@@ -1,0 +1,10 @@
+package model.forms
+
+import play.api.libs.json.OFormat
+import play.api.libs.json.Json
+
+case class MoveCollection(newIndex: Int)
+
+object MoveCollection {
+    implicit val formats: OFormat[MoveCollection] = Json.format[MoveCollection]
+}

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -109,7 +109,7 @@ trait CollectionsQueries {
         WHERE front_id = (
           SELECT front_id
           FROM collections
-          WHERE id=${collectionId}
+          WHERE id=$collectionId
         )
       """.map(_.string("id"))
         .list

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -97,6 +97,38 @@ trait CollectionsQueries {
     updatedCollections.head
   }
 
+  /**
+   * Move the collection to the given index, updating the index values for the
+   * other collections in that front to ensure a contiguous range.
+   */
+  def moveCollectionToIndex(collectionId: String, newIndex: Int)(implicit session: DBSession): Either[Error, Unit] = {
+    val currentCollectionIds = {
+      sql"""
+        SELECT id
+        FROM collections
+        WHERE front_id = (
+          SELECT front_id
+          FROM collections
+          WHERE id=${collectionId}
+        )
+      """.map(_.string("id"))
+        .list
+        .apply()
+    }
+
+    currentCollectionIds.indexOf(collectionId) match {
+      case -1 => Left(EditionsDB.NotFoundError(s"Tried to move collection $collectionId to $newIndex, but could not find collection with that ID"))
+      case currentIndex if currentIndex == newIndex => Right(()) // No move
+      case currentIndex =>
+        val indexOffset = if (newIndex > currentIndex) -1 else 0
+        val newCollectionIds = currentCollectionIds
+          .filter(_ != collectionId)
+          .patch(newIndex + indexOffset, List(collectionId), 0)
+
+        updateCollectionIndices(newCollectionIds)
+    }
+  }
+
   def updateCollection(collection: EditionsCollection): EditionsCollection = DB localTx { implicit session =>
     val lastUpdated = collection.lastUpdated.map(EditionsDB.dateTimeFromMillis)
     sql"""
@@ -162,7 +194,7 @@ trait CollectionsQueries {
               case (id, index) => sqls"""WHEN id=${id} THEN ${index}"""
             }, sqls.empty)}
           END
-          WHERE id IN (${collectionIds.mkString(", ")})
+          WHERE id IN (${sqls.join(collectionIds.map(id => sqls"$id"), sqls",")})
         """.update.apply()
     }
   }.toEither match {
@@ -242,7 +274,7 @@ trait CollectionsQueries {
           , $name
           , FALSE
           , $now
-          , ${EditionsDB.getUserName(user)}
+        , ${EditionsDB.getUserName(user)}
           , ${user.email}
         )
         RETURNING id;

--- a/conf/evolutions/default/12.sql
+++ b/conf/evolutions/default/12.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+
+ALTER TABLE collections
+    DROP CONSTRAINT collection_index_must_be_unique,
+    ADD CONSTRAINT collection_index_must_be_unique UNIQUE (front_id, index) deferrable initially immediate;
+
+# --- !Downs
+
+ALTER TABLE collections
+    DROP CONSTRAINT collection_index_must_be_unique,
+    ADD CONSTRAINT collection_index_must_be_unique UNIQUE (front_id, index);

--- a/conf/routes
+++ b/conf/routes
@@ -120,6 +120,7 @@ PUT         /editions-api/fronts/:frontId/metadata                          cont
 PUT         /editions-api/fronts/:frontId/is-hidden/:state                  controllers.EditionsController.putFrontHiddenState(frontId, state: Boolean)
 PUT         /editions-api/fronts/:frontId/collection                        controllers.EditionsController.addCollectionToFront(frontId)
 DELETE      /editions-api/fronts/:frontId/collection/:collectionId          controllers.EditionsController.removeCollectionFromFront(frontId, collectionId)
+PUT         /editions-api/fronts/:frontId/collection/:collectionId/move     controllers.EditionsController.moveCollection(frontId, collectionId)
 
 POST        /editions-api/collections                                       controllers.EditionsController.getCollections()
 GET         /editions-api/collections/:collectionId                         controllers.EditionsController.getCollection(collectionId)


### PR DESCRIPTION
## What's changed?

Adds an API endpoint to move a collection to a new index. It looks like:

`PUT editions-api/front/:frontId/collection/:collectionId/move`

and expects a JSON payload of type:

```ts 
{ newIndex: number }
```

## Implementation notes

I've altered the database as a part of this PR, as I was getting a constraint violation updating collection indicies. b1155e4e65bd3d7076557e5ac000ccc5f469ce49 adds `deferrable initially immediate` to the unique index. This ensures that we're able to violate the constraint while the relevant update clause is running, and then checking we're within bounds once the transaction commits.

## How to review and test

- The automated tests should pass. They cover moving an item to different indexes, including indexes which are out-of-bounds.
- For the brave – try the endpoint yourself! Here's an example cURL – you'll need to grab a cookie from a valid local Fronts session in your browser, or perhaps importing an existing POST request in Postman via 'copy-to-curl' is easier. You should be able to discover 

```
curl --location --request PUT 'https://fronts.local.dev-gutools.co.uk/editions-api/fronts/b37de266-f329-47a2-9781-8dbdd5880149/collection/82c0456d-c13f-418c-bded-490da1c79e35/move' \
--header 'Content-Type: application/json' \
--header 'Cookie: <add-your-own>' \
--data '{ "newIndex": 2 }'
```

Tested locally.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
