### PR TITLE
Default adding collection to top

### DIFF
--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -23,15 +23,15 @@ class EditionsDB(url: String, user: String, password: String) extends IssueQueri
     val truncatedNow = EditionsDB.truncateDateTime(now)
 
     for {
-      currentFront <- getFront(frontId).toRight(EditionsDB.NotFoundError(s"Front ${frontId} not found"))
+      currentFront <- getFront(frontId).toRight(EditionsDB.NotFoundError(s"Front $frontId not found"))
       collectionId <- insertCollection(
         frontId = currentFront.id,
-        collectionIndex = collectionIndex.getOrElse(currentFront.collections.size),
+        collectionIndex = collectionIndex.getOrElse(0),
         name = name.getOrElse("New collection"),
         user = user,
         now = truncatedNow
       )
-      updatedFront <- getFront(frontId).toRight(EditionsDB.InvariantError(s"Updated front ${frontId} not found in issue"))
+      updatedFront <- getFront(frontId).toRight(EditionsDB.InvariantError(s"Updated front $frontId not found in issue"))
       _ <- updatedFront.collections.find(_.id == collectionId).toRight(EditionsDB.InvariantError(s"New collection ${collectionId} not found in updated front ${frontId}"))
     } yield updatedFront
   }
@@ -76,6 +76,9 @@ object EditionsDB {
 
   // An entity the user expected to be there was not found
   case class NotFoundError(message: String) extends Error(message)
+
+  // The input data is incorrect
+  case class InvalidInput(message: String) extends Error(message)
 
   // There was a problem writing data to the DB
   case class WriteError(message: String) extends Error(message)

--- a/app/services/editions/db/EditionsDB.scala
+++ b/app/services/editions/db/EditionsDB.scala
@@ -5,9 +5,7 @@ import java.time.temporal.ChronoUnit
 
 import scalikejdbc._
 import com.gu.pandomainauth.model.User
-import services.editions.DbEditionsFront
 import model.editions.EditionsFront
-import scala.util.Try
 
 class EditionsDB(url: String, user: String, password: String) extends IssueQueries with FrontsQueries with CollectionsQueries {
   Class.forName("org.postgresql.Driver")

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -653,9 +653,9 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
         editionsDB.addCollectionToFront(frontFromIssue.id, name = Some("Test Collection"), user = user, now = now) match {
           case Right(front) =>
             front.collections.size shouldBe 2
-            front.collections.last.displayName shouldBe "Test Collection"
+            front.collections.head.displayName shouldBe "Test Collection"
           case Left(error) =>
-            Assertions.fail(s"Error adding collection to front: ${error.getMessage()}")
+            Assertions.fail(s"Error adding collection to front: ${error.getMessage}")
         }
       }
 
@@ -668,9 +668,9 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
         editionsDB.addCollectionToFront(frontFromIssue.id, user = user, now = now) match {
           case Right(front) =>
-            front.collections.last.displayName shouldBe "New collection"
+            front.collections.head.displayName shouldBe "New collection"
           case Left(error) =>
-            Assertions.fail(s"Error adding collection to front: ${error.getMessage()}")
+            Assertions.fail(s"Error adding collection to front: ${error.getMessage}")
         }
       }
 
@@ -689,13 +689,13 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
         )
         val issue: EditionsIssue = editionsDB.getIssue(issueId).value
         val frontFromIssue = issue.fronts.head
-        val invalidIndex = Some(0)
+        val invalidIndex = Some(16)
 
         editionsDB.addCollectionToFront(frontFromIssue.id, collectionIndex = invalidIndex, user = user, now = now) match {
-          case Right(front) =>
+          case Right(_) =>
             Assertions.fail()
           case Left(error) =>
-            error shouldBe an[EditionsDB.WriteError]
+            error shouldBe an[EditionsDB.InvalidInput]
         }
       }
     }


### PR DESCRIPTION
## What's changed?

Default adding the collection to the top of the Front, not the bottom.

![add-col](https://github.com/user-attachments/assets/6f59972d-4d19-4e97-8f42-931fb1b3956e)

## Implementation notes

Corrects an oversight in #1622 where adding collections in occupied indices threw unique constraint errors. We now move the existing collections out of the way before new collections are created at the specified index, throwing an error if the index is out of bounds.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
