### PR TITLE
Chef search from recipes

### DIFF
--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -8,8 +8,8 @@ import {
   stateWithCollection,
   capiArticle,
   stateWithDuplicateArticleIdsInCollection,
-  stateWithCollectionWithChefs,
-  stateWithCollectionWithDuplicateChefs,
+  // stateWithCollectionWithChefs,
+  // stateWithCollectionWithDuplicateChefs,
 } from 'fixtures/shared';
 import {
   getCollectionsApiResponse,
@@ -20,10 +20,10 @@ import {
   actions as externalArticleActions,
   actionNames as externalArticleActionNames,
 } from 'bundles/externalArticlesBundle';
-import {
-  actions as chefActions,
-  actionNames as chefActionNames,
-} from 'bundles/chefsBundle';
+// import {
+//   actions as chefActions,
+//   actionNames as chefActionNames,
+// } from 'bundles/chefsBundle';
 import {
   getCollections,
   fetchCardReferencedEntitiesForCollections,
@@ -517,39 +517,39 @@ describe('Collection actions', () => {
       });
     });
 
-    it('should dispatch start and success actions for chefs returned from getCollection()', async () => {
-      await assertFetchedEntities({
-        fixture: stateWithCollectionWithChefs,
-        action: fetchCardReferencedEntitiesForCollections(
-          ['exampleCollection'],
-          'live'
-        ),
-        mockEndpoint:
-          'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein%2Cprofile%2Ffelicity-cloake',
-        fetchStartAction: chefActions.fetchStart([
-          'profile/yotamottolenghi',
-          'profile/rick-stein',
-          'profile/felicity-cloake',
-        ]),
-        fetchCompleteActionType: chefActionNames.fetchSuccess,
-      });
-    });
-
-    it('should deduplicate chef ids', async () => {
-      await assertFetchedEntities({
-        fixture: stateWithCollectionWithDuplicateChefs,
-        action: fetchCardReferencedEntitiesForCollections(
-          ['exampleCollection'],
-          'live'
-        ),
-        mockEndpoint:
-          'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein',
-        fetchStartAction: chefActions.fetchStart([
-          'profile/yotamottolenghi',
-          'profile/rick-stein',
-        ]),
-        fetchCompleteActionType: chefActionNames.fetchSuccess,
-      });
-    });
+    // it('should dispatch start and success actions for chefs returned from getCollection()', async () => {
+    //   await assertFetchedEntities({
+    //     fixture: stateWithCollectionWithChefs,
+    //     action: fetchCardReferencedEntitiesForCollections(
+    //       ['exampleCollection'],
+    //       'live'
+    //     ),
+    //     mockEndpoint:
+    //       'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein%2Cprofile%2Ffelicity-cloake',
+    //     fetchStartAction: chefActions.fetchStart([
+    //       'profile/yotamottolenghi',
+    //       'profile/rick-stein',
+    //       'profile/felicity-cloake',
+    //     ]),
+    //     fetchCompleteActionType: chefActionNames.fetchSuccess,
+    //   });
+    // });
+    //
+    // it('should deduplicate chef ids', async () => {
+    //   await assertFetchedEntities({
+    //     fixture: stateWithCollectionWithDuplicateChefs,
+    //     action: fetchCardReferencedEntitiesForCollections(
+    //       ['exampleCollection'],
+    //       'live'
+    //     ),
+    //     mockEndpoint:
+    //       'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein',
+    //     fetchStartAction: chefActions.fetchStart([
+    //       'profile/yotamottolenghi',
+    //       'profile/rick-stein',
+    //     ]),
+    //     fetchCompleteActionType: chefActionNames.fetchSuccess,
+    //   });
+    // });
   });
 });

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -8,8 +8,8 @@ import {
   stateWithCollection,
   capiArticle,
   stateWithDuplicateArticleIdsInCollection,
-  // stateWithCollectionWithChefs,
-  // stateWithCollectionWithDuplicateChefs,
+  stateWithCollectionWithChefs,
+  stateWithCollectionWithDuplicateChefs,
 } from 'fixtures/shared';
 import {
   getCollectionsApiResponse,
@@ -20,10 +20,10 @@ import {
   actions as externalArticleActions,
   actionNames as externalArticleActionNames,
 } from 'bundles/externalArticlesBundle';
-// import {
-//   actions as chefActions,
-//   actionNames as chefActionNames,
-// } from 'bundles/chefsBundle';
+import {
+  actions as chefActions,
+  actionNames as chefActionNames,
+} from 'bundles/chefsBundle';
 import {
   getCollections,
   fetchCardReferencedEntitiesForCollections,
@@ -517,39 +517,97 @@ describe('Collection actions', () => {
       });
     });
 
-    // it('should dispatch start and success actions for chefs returned from getCollection()', async () => {
-    //   await assertFetchedEntities({
-    //     fixture: stateWithCollectionWithChefs,
-    //     action: fetchCardReferencedEntitiesForCollections(
-    //       ['exampleCollection'],
-    //       'live'
-    //     ),
-    //     mockEndpoint:
-    //       'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein%2Cprofile%2Ffelicity-cloake',
-    //     fetchStartAction: chefActions.fetchStart([
-    //       'profile/yotamottolenghi',
-    //       'profile/rick-stein',
-    //       'profile/felicity-cloake',
-    //     ]),
-    //     fetchCompleteActionType: chefActionNames.fetchSuccess,
-    //   });
-    // });
-    //
-    // it('should deduplicate chef ids', async () => {
-    //   await assertFetchedEntities({
-    //     fixture: stateWithCollectionWithDuplicateChefs,
-    //     action: fetchCardReferencedEntitiesForCollections(
-    //       ['exampleCollection'],
-    //       'live'
-    //     ),
-    //     mockEndpoint:
-    //       'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein',
-    //     fetchStartAction: chefActions.fetchStart([
-    //       'profile/yotamottolenghi',
-    //       'profile/rick-stein',
-    //     ]),
-    //     fetchCompleteActionType: chefActionNames.fetchSuccess,
-    //   });
-    // });
+    const capiChefTagsFixture = {
+      "response": {
+        "status": "ok",
+        "userTier": "internal",
+        "total": 3,
+        "startIndex": 1,
+        "pageSize": 10,
+        "currentPage": 1,
+        "pages": 1,
+        "results": [
+          {
+            "id": "profile/felicity-cloake",
+            "type": "contributor",
+            "webTitle": "Felicity Cloake",
+            "webUrl": "https://www.theguardian.com/profile/felicity-cloake",
+            "apiUrl": "https://content.guardianapis.com/profile/felicity-cloake",
+            "bio": "<p>Award-winning food writer Felicity Cloake has written five cookbooks, two food travelogues and is the author of the Guardian's <a href=\"https://www.theguardian.com/food/series/how-to-cook-the-perfect----\">How to Cook the Perfect ...</a> recipe series</p>",
+            "bylineImageUrl": "https://uploads.guim.co.uk/2018/01/29/Felicity-Cloake.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2018/01/29/Felicity_Cloake,_L.png",
+            "firstName": "Felicity",
+            "lastName": "Cloake",
+            "r2ContributorId": "32433",
+            "internalName": "Felicity Cloake"
+          },
+          {
+            "id": "profile/rick-stein",
+            "type": "contributor",
+            "webTitle": "Rick Stein",
+            "webUrl": "https://www.theguardian.com/profile/rick-stein",
+            "apiUrl": "https://content.guardianapis.com/profile/rick-stein",
+            "firstName": "stein",
+            "lastName": "rick",
+            "r2ContributorId": "33159",
+            "internalName": "Rick Stein (contributor)"
+          },
+          {
+            "id": "profile/yotamottolenghi",
+            "type": "contributor",
+            "sectionId": "lifeandstyle",
+            "sectionName": "Life and style",
+            "webTitle": "Yotam Ottolenghi",
+            "webUrl": "https://www.theguardian.com/profile/yotamottolenghi",
+            "apiUrl": "https://content.guardianapis.com/profile/yotamottolenghi",
+            "bio": "<p>Yotam Ottolenghi&nbsp;is  chef-patron of the <a href=\"https://ottolenghi.co.uk/\">Ottolenghi</a> delis and the Nopi and Rovi restaurants. He has  published 10 bestselling cookbooks</p>",
+            "bylineImageUrl": "https://uploads.guim.co.uk/2023/10/10/yotam_ottolenghi.jpg",
+            "bylineLargeImageUrl": "https://uploads.guim.co.uk/2023/10/10/yotam_ottolenghi.png",
+            "firstName": "Yotam",
+            "lastName": "Ottolenghi",
+            "twitterHandle": "ottolenghi",
+            "r2ContributorId": "25460",
+            "internalName": "Yotam Ottolenghi"
+          }
+        ]
+      }
+    }
+
+    it('should dispatch start and success actions for chefs returned from getCollection()', async () => {
+      await assertFetchedEntities({
+        fixture: stateWithCollectionWithChefs,
+        action: fetchCardReferencedEntitiesForCollections(
+          ['exampleCollection'],
+          'live'
+        ),
+        mockEndpoint:
+          'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein%2Cprofile%2Ffelicity-cloake',
+        fetchStartAction: chefActions.fetchStart([
+          'profile/yotamottolenghi',
+          'profile/rick-stein',
+          'profile/felicity-cloake',
+        ]),
+        fetchCompleteActionType: chefActionNames.fetchSuccess,
+        fetchMockResponse: capiChefTagsFixture
+      });
+    });
+
+    it('should deduplicate chef ids', async () => {
+      await assertFetchedEntities({
+        fixture: stateWithCollectionWithDuplicateChefs,
+        action: fetchCardReferencedEntitiesForCollections(
+          ['exampleCollection'],
+          'live'
+        ),
+        mockEndpoint:
+          'begin:/api/live/tags?type=contributor&ids=profile%2Fyotamottolenghi%2Cprofile%2Frick-stein',
+        fetchStartAction: chefActions.fetchStart([
+          'profile/yotamottolenghi',
+          'profile/rick-stein',
+        ]),
+        fetchCompleteActionType: chefActionNames.fetchSuccess,
+        fetchMockResponse: capiChefTagsFixture
+      });
+    });
   });
 });

--- a/fronts-client/src/bundles/__tests__/chefsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/chefsBundle.spec.ts
@@ -1,0 +1,131 @@
+import configureStore from 'util/configureStore';
+import fetchMock from 'fetch-mock';
+import { fetchChefs, fetchChefsById } from '../chefsBundle';
+import { selectors as chefSelectors } from 'bundles/chefsBundle';
+
+interface MockedResponse {
+  pattern: string;
+  response: any;
+}
+
+const createStoreAndFetchMock = (fetchResponses:MockedResponse[]) => {
+  fetchResponses.forEach((r)=>{
+    fetchMock.once(r.pattern, r.response, {overwriteRoutes: true});
+  })
+  return configureStore();
+};
+
+const annaMockRecipe = {
+  "hits": 7,
+  "results": [
+    {
+      "contributorType": "Profile",
+      "nameOrId": "profile/anna-jones",
+      "docCount": 182
+    },
+    {
+      "contributorType": "Byline",
+      "nameOrId": "Anna Haugh",
+      "docCount": 6
+    },
+    {
+      "contributorType": "Byline",
+      "nameOrId": "Anna Tobias",
+      "docCount": 4
+    },
+    {
+      "contributorType": "Profile",
+      "nameOrId": "profile/anna-del-conte",
+      "docCount": 3
+    },
+    {
+      "contributorType": "Byline",
+      "nameOrId": "Anna Higham",
+      "docCount": 2
+    },
+    {
+      "contributorType": "Byline",
+      "nameOrId": "Anna Jones",
+      "docCount": 1
+    },
+    {
+      "contributorType": "Byline",
+      "nameOrId": "Tim Lannan and James Annabel",
+      "docCount": 1
+    }
+  ]
+}
+const tagLookupResponse = {
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 2,
+    "startIndex": 1,
+    "pageSize": 10,
+    "currentPage": 1,
+    "pages": 1,
+    "results": [
+      {
+        "id": "profile/anna-del-conte",
+        "type": "contributor",
+        "webTitle": "Anna Del Conte",
+        "webUrl": "https://www.theguardian.com/profile/anna-del-conte",
+        "apiUrl": "https://content.guardianapis.com/profile/anna-del-conte",
+        "bio": "<p>Anna Del Conte is the doyenne of Italian cookery. In 2011 Nigella Lawson presented her with the Lifetime Achievement Award of the Guild of Food Writers.</p>",
+        "firstName": "del",
+        "lastName": "conteanna",
+        "r2ContributorId": "66638",
+        "internalName": "Anna Del Conte"
+      },
+      {
+        "id": "profile/anna-jones",
+        "type": "contributor",
+        "webTitle": "Anna Jones",
+        "webUrl": "https://www.theguardian.com/profile/anna-jones",
+        "apiUrl": "https://content.guardianapis.com/profile/anna-jones",
+        "bio": "<p>Anna Jones is a chef, writer​,​ and author of A Modern Way to Eat and A Modern Way to Cook</p>",
+        "bylineImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna-Jones.jpg",
+        "bylineLargeImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna_Jones,_L.png",
+        "firstName": "Anna",
+        "lastName": "Jones",
+        "r2ContributorId": "64120",
+        "internalName": "Anna Jones"
+      }
+    ]
+  }
+}
+const expectedResultForLookup = {"profile/anna-del-conte": {"apiUrl": "https://content.guardianapis.com/profile/anna-del-conte", "bio": "", "firstName": "del", "id": "profile/anna-del-conte", "internalName": "Anna Del Conte", "lastName": "conteanna", "r2ContributorId": "66638", "type": "contributor", "webTitle": "Anna Del Conte", "webUrl": "https://www.theguardian.com/profile/anna-del-conte"}, "profile/anna-jones": {"apiUrl": "https://content.guardianapis.com/profile/anna-jones", "bio": "", "bylineImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna-Jones.jpg", "bylineLargeImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna_Jones,_L.png", "firstName": "Anna", "id": "profile/anna-jones", "internalName": "Anna Jones", "lastName": "Jones", "r2ContributorId": "64120", "type": "contributor", "webTitle": "Anna Jones", "webUrl": "https://www.theguardian.com/profile/anna-jones"}}
+const quickTimeout = ()=>new Promise((resolve)=>window.setTimeout((resolve), 10));
+
+describe("chefsBundle", ()=>{
+  beforeEach(()=>fetchMock.reset());
+
+  it("fetchChefs should fetch chefs by param, look up CAPI details for profile tags, and add them to the state", async ()=>{
+    const store = createStoreAndFetchMock([
+      {
+        pattern: "https://recipes.guardianapis.com/keywords/contributors?q=anna",
+        response: annaMockRecipe
+      },
+      {
+        pattern: "/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all",
+        response: tagLookupResponse
+      }
+      ]);
+    await store.dispatch(fetchChefs({query: "anna"}) as any);
+    await quickTimeout(); //if we don't await again, the store has not been updated yet.
+    expect(chefSelectors.selectAll(store.getState())).toEqual(expectedResultForLookup);
+  });
+
+  it("fetchChefsById should look up CAPI details for profile tags", async ()=>{
+    const store = createStoreAndFetchMock([
+      {
+        pattern: "/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all",
+        response: tagLookupResponse
+      }
+    ]);
+    await store.dispatch(fetchChefsById(["profile/anna-jones","profile/anna-del-conte"]) as any);
+    expect(chefSelectors.selectAll(store.getState())).toEqual(expectedResultForLookup);
+  })
+})
+
+

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -33,9 +33,7 @@ export const fetchChefs =
     dispatch(actions.fetchStart(ids));
     try {
       const chefs = await liveRecipes.chefs(params);
-      console.log(`Got a total of ${chefs.results.length} hits`);
       const chefsWithTags = chefs.results.filter(chef=>chef.contributorType==="Profile");
-      console.log(`${chefsWithTags.length} had associated contributor tags`);
       if(chefsWithTags.length==0) {
         dispatch(actions.fetchSuccess([]));
         return;
@@ -60,16 +58,12 @@ export const fetchChefsById = (
   if(!alreadyStarted) dispatch(actions.fetchStart(tagIds));
 
   try {
-    console.log(`tags to look up: ${tagIds.join(",")}`)
     const chefTags = await liveCapi.chefs({
       'ids': tagIds.join(","),
       'show-elements': 'image',
       'show-fields': 'all',
     });
 
-    chefTags.response.results.forEach((t)=>
-      console.log(JSON.stringify(t))
-    );
     const payload: { ignoreOrder?: undefined; pagination?: IPagination; order?: string[] } = {
       pagination: {
         pageSize: chefTags.response.pageSize,

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -1,4 +1,4 @@
-import createAsyncResourceBundle from '../lib/createAsyncResourceBundle';
+import createAsyncResourceBundle, { IPagination } from '../lib/createAsyncResourceBundle';
 import { Chef } from '../types/Chef';
 import { selectCard } from 'selectors/shared';
 import { State } from 'types/State';
@@ -7,6 +7,7 @@ import { stripHtml } from 'util/sanitizeHTML';
 import { ThunkResult } from 'types/Store';
 import { liveCapi } from 'services/capiQuery';
 import { Tag } from '../types/Capi';
+import { ChefSearchParams, liveRecipes } from '../services/recipeQuery';
 
 const sanitizeTag = (tag: Tag) => ({
   ...tag,
@@ -18,27 +19,27 @@ const bundle = createAsyncResourceBundle<Chef>('chefs', {
   selectLocalState: (state) => state.chefs,
 });
 
-const fetchResourceOrResults = async (
-  capiService: typeof liveCapi,
-  params: Record<string, string[] | string | number>
-) => {
-  const capiEndpoint = capiService.chefs;
-  const { response } = await capiEndpoint(params);
-
-  return {
-    results: response.results,
-    pagination: {
-      totalPages: response.pages,
-      currentPage: response.currentPage,
-      pageSize: response.pageSize,
-    },
-  };
-};
+// const fetchResourceOrResults = async (
+//   capiService: typeof liveCapi,
+//   params: Record<string, string[] | string | number>
+// ) => {
+//   const capiEndpoint = capiService.chefs;
+//   const { response } = await capiEndpoint(params);
+//
+//   return {
+//     results: response.results,
+//     pagination: {
+//       totalPages: response.pages,
+//       currentPage: response.currentPage,
+//       pageSize: response.pageSize,
+//     },
+//   };
+// };
 
 export const fetchChefs =
   (
     // The params to include in the request
-    params: Record<string, string[] | string | number>,
+    params: ChefSearchParams,
     // The ids of the chefs being fetched, if known.
     // If we know which IDs we're searching for, we do not include their order
     // in our state. This lets us keep `lastFetchOrder` for order-sensitive
@@ -48,21 +49,18 @@ export const fetchChefs =
   async (dispatch) => {
     dispatch(actions.fetchStart(ids));
     try {
-      const resultData = await fetchResourceOrResults(liveCapi, params);
-      if (resultData) {
-        const payload = ids
-          ? { ignoreOrder: true }
-          : {
-              pagination: resultData.pagination || undefined,
-              order: resultData.results.map((_) => _.id),
-            };
-
+      const chefs = await liveRecipes.chefs(params);
+      console.log(`Got a total of ${chefs.results.length} hits`);
+      const chefsWithTags = chefs.results.filter(chef=>chef.contributorType==="Profile");
+      console.log(`${chefsWithTags.length} had associated contributor tags`);
+      if(chefsWithTags.length==0) {
         dispatch(
-          actions.fetchSuccess(resultData.results.map(sanitizeTag), payload)
+          actions.fetchSuccessIgnore([])
         );
-      } else {
-        dispatch(actions.fetchSuccessIgnore([]));
+        return;
       }
+
+      dispatch(fetchChefsById(chefsWithTags.map(chef =>chef.nameOrId)));
     } catch (e) {
       dispatch(actions.fetchError(e));
     }
@@ -72,14 +70,36 @@ export const fetchChefsById = (
   tagIds: string[],
   page = 1,
   pageSize = 20
-): ThunkResult<void> => {
-  const params = {
-    ids: tagIds,
-    page,
-    'page-size': pageSize,
+): ThunkResult<void> =>
+  async (dispatch) => {
+
+  try {
+    console.log(`tags to look up: ${tagIds.join(",")}`)
+    const chefTags = await liveCapi.chefs({
+      'ids': tagIds.join(","),
+      'show-elements': 'image',
+      'show-fields': 'all',
+    });
+
+    chefTags.response.results.forEach((t)=>
+      console.log(JSON.stringify(t))
+    );
+    const payload: { ignoreOrder?: undefined; pagination?: IPagination; order?: string[] } = {
+      pagination: {
+        pageSize: chefTags.response.pageSize,
+        totalPages: chefTags.response.pages,
+        currentPage: chefTags.response.currentPage
+      },
+      order: tagIds
+    };
+
+    dispatch(
+      actions.fetchSuccess(chefTags.response.results.map(sanitizeTag), payload)
+    )
+  } catch(err) {
+    dispatch(actions.fetchError(err))
+  }
   };
-  return fetchChefs(params, tagIds);
-};
 
 const selectChefDataFromCardId = (
   state: State,

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -19,23 +19,6 @@ const bundle = createAsyncResourceBundle<Chef>('chefs', {
   selectLocalState: (state) => state.chefs,
 });
 
-// const fetchResourceOrResults = async (
-//   capiService: typeof liveCapi,
-//   params: Record<string, string[] | string | number>
-// ) => {
-//   const capiEndpoint = capiService.chefs;
-//   const { response } = await capiEndpoint(params);
-//
-//   return {
-//     results: response.results,
-//     pagination: {
-//       totalPages: response.pages,
-//       currentPage: response.currentPage,
-//       pageSize: response.pageSize,
-//     },
-//   };
-// };
-
 export const fetchChefs =
   (
     // The params to include in the request
@@ -54,9 +37,7 @@ export const fetchChefs =
       const chefsWithTags = chefs.results.filter(chef=>chef.contributorType==="Profile");
       console.log(`${chefsWithTags.length} had associated contributor tags`);
       if(chefsWithTags.length==0) {
-        dispatch(
-          actions.fetchSuccessIgnore([])
-        );
+        dispatch(actions.fetchSuccess([]));
         return;
       }
 

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -41,7 +41,7 @@ export const fetchChefs =
         return;
       }
 
-      dispatch(fetchChefsById(chefsWithTags.map(chef =>chef.nameOrId)));
+      dispatch(fetchChefsById(chefsWithTags.map(chef =>chef.nameOrId), 1,20,true));
     } catch (e) {
       dispatch(actions.fetchError(e));
     }
@@ -50,9 +50,14 @@ export const fetchChefs =
 export const fetchChefsById = (
   tagIds: string[],
   page = 1,
-  pageSize = 20
+  pageSize = 20,
+  alreadyStarted:boolean = false
 ): ThunkResult<void> =>
   async (dispatch) => {
+
+  //we could be called as the second part of a two-stage fetch, OR we could be called directly.
+  //if called directly, indicate that we started a fetch. Otherwise, the first part should
+  if(!alreadyStarted) dispatch(actions.fetchStart(tagIds));
 
   try {
     console.log(`tags to look up: ${tagIds.join(",")}`)

--- a/fronts-client/src/components/feed/ChefFeedItem.tsx
+++ b/fronts-client/src/components/feed/ChefFeedItem.tsx
@@ -38,7 +38,7 @@ export const ChefFeedItemComponent = ({
     <FeedItem
       id={chef.id}
       type={CardTypesMap.CHEF}
-      title={`${chef.firstName ?? 'Unknown name'} ${chef.lastName ?? ''}`}
+      title={chef.internalName}
       hasVideo={false}
       isLive={true}
       liveUrl={`https://theguardian.com/${chef.apiUrl}`}

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -15,7 +15,6 @@ import Pagination from './Pagination';
 import ScrollContainer from '../ScrollContainer';
 import { ChefSearchParams, RecipeSearchParams } from '../../services/recipeQuery';
 import debounce from 'lodash/debounce';
-import * as sea from 'node:sea';
 
 const InputContainer = styled.div`
   margin-bottom: 10px;

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -13,8 +13,9 @@ import { Dispatch } from 'types/Store';
 import { IPagination } from 'lib/createAsyncResourceBundle';
 import Pagination from './Pagination';
 import ScrollContainer from '../ScrollContainer';
-import { RecipeSearchParams } from '../../services/recipeQuery';
+import { ChefSearchParams, RecipeSearchParams } from '../../services/recipeQuery';
 import debounce from 'lodash/debounce';
+import * as sea from 'node:sea';
 
 const InputContainer = styled.div`
   margin-bottom: 10px;
@@ -57,7 +58,7 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
   const [searchText, setSearchText] = useState('');
   const dispatch: Dispatch = useDispatch();
   const searchForChefs = useCallback(
-    (params: Record<string, string[] | string | number>) => {
+    (params: ChefSearchParams) => {
       dispatch(fetchChefs(params));
     },
     [dispatch]
@@ -92,20 +93,12 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
   const hasPages = (chefsPagination?.totalPages ?? 0) > 1;
 
-  const getParams = (query: string) => ({
-    'web-title': query,
-    'page-size': '20',
-    'show-elements': 'image',
-    'show-fields': 'all',
-  });
-
   const runSearch = useCallback(
     (page: number = 1) => {
       switch(selectedOption) {
         case FeedType.chefs:
           searchForChefs({
-            ...getParams(searchText),
-            page
+            query: searchText
           });
           break;
         case FeedType.recipes:

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -26,8 +26,15 @@ export interface RecipeSearchParams {
   filters?: RecipeSearchFilters;
 }
 
-export interface ChefSearchResponse {
+export interface ChefSearchHit {
+  contributorType: "Profile"|"Byline";
+  nameOrId: string;
+  docCount: number;
+}
 
+export interface ChefSearchResponse {
+  hits: number;
+  results: ChefSearchHit[];
 }
 
 export interface RecipeSearchResponse {

--- a/fronts-client/src/types/Chef.ts
+++ b/fronts-client/src/types/Chef.ts
@@ -3,6 +3,7 @@ export interface Chef {
   type: string;
   sectionId?: string;
   sectionName?: string;
+  internalName: string;
   webTitle: string;
   webUrl: string;
   apiUrl: string;


### PR DESCRIPTION
## What's changed?

- Make search for chefs from recipe backend.  This means that:
  - we don't see anyone who has a tag but doesn't write recipes
  - chefs are also ordered by the number of recipes that they have written in the app
  - fuzzy matching is now present, so `ana` matches `anna` and `ama` (see the notes in https://github.com/guardian/recipe-search-backend/pull/16 for more details on this)

Chefs can be clipboarded, added, removed, as before.

![test](https://github.com/user-attachments/assets/f7015eca-ec57-42ed-bff1-1551d53b0a45)

## Implementation notes

- There are two ways of identifying contributors in Feast. The first is by profile tag; the second, for contributors who do NOT have a profile tag, is to put the name into the `byline` array.  At present, "byline" contributors **are ignored**. This will be addressed in a future PR.
- The presentation of the chef card has been changed to use `webTitle` for the display name instead of `firstname lastname`.  This is because it turns out that the `firstName` and `lastName` fields are not appropriately filled in for all tags - in fact, they are often downcased and the wrong way around (i.e. last in `firstName`, first in `lastName`). Chatting with CP it transpired that these are old tags from before these fields were mandatory in the tooling - and in fact they are not set at all in the tags tool (therefore something, somewhere, must be auto-filling those values for the benefit of other tooling).  Anyhow, `webTitle` is apparently the field that is "expected"  to be used for display.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
