### PR TITLE
Start nginx if it isn't already running

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -22,7 +22,17 @@ hasCredentials() {
   fi
 }
 
+runNginx() {
+  if pgrep -f nginx >/dev/null; then
+    echo "nginx is already running"
+  else
+    echo "nginx isn't running, booting now..."
+    dev-nginx restart
+  fi
+}
+
 main() {
+    runNginx
     hasCredentials
 
     printf "\n\rStarting Yarn... \n\r\n\r"


### PR DESCRIPTION
## What's changed?

Start nginx if it isn't already running, [per Composer,](https://github.com/guardian/flexible-content/blob/ada1811f3e82b500916e479506075192e21f7a5f/dev-start.sh#L31) as it hasn't been clear what's wrong when `dev-start.sh` was running but the tool was inaccessible.
