### PR TITLE
Do not hard code CHEF card type when handling drag start in feed 🤦‍♂️

### DIFF
--- a/fronts-client/src/util/dragAndDrop.ts
+++ b/fronts-client/src/util/dragAndDrop.ts
@@ -2,7 +2,6 @@ import {
   dragOffsetX,
   dragOffsetY,
 } from 'components/FrontsEdit/CollectionComponents/ArticleDrag';
-import { CardTypesMap } from 'constants/cardTypes';
 import { CARD_TYPE } from 'lib/dnd/constants';
 import { InsertDropType } from './collectionUtils';
 
@@ -10,7 +9,7 @@ export const handleDragStartForCard =
   (cardType: InsertDropType, data: unknown) =>
   (event: React.DragEvent<HTMLDivElement>, dragNode: HTMLDivElement) => {
     event.dataTransfer.setData(cardType, JSON.stringify(data));
-    event.dataTransfer.setData(CARD_TYPE, CardTypesMap.CHEF);
+    event.dataTransfer.setData(CARD_TYPE, cardType);
     if (dragNode) {
       event.dataTransfer.setDragImage(dragNode, dragOffsetX, dragOffsetY);
     }

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -436,7 +436,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       testCases.foreach {
         case (newIndex, expectedOrder) =>
           s"moving to index $newIndex" taggedAs UsesDatabase in {
-            val id = insertSkeletonIssue(2019, 9, 30, testFront)
+            val id = insertSkeletonIssueForDaily(2019, 9, 30, testFront)
             val retrievedIssue = editionsDB.getIssue(id).value
             val retrievedFront = retrievedIssue.fronts.head
             val firstCollection = retrievedFront.collections.head
@@ -770,7 +770,7 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       }
 
       "should default to the top of the front as multiple collections are added" taggedAs UsesDatabase in {
-        val issueId = insertSkeletonIssue(2020, 1, 1,
+        val issueId = insertSkeletonIssue(2020, 1, 1, Edition.FeastNorthernHemisphere,
           front("news/uk", collection("politics", None))
         )
         val issue: EditionsIssue = editionsDB.getIssue(issueId).value


### PR DESCRIPTION
## What's changed?

Oops! 😀 

Be nice to have an integration test for this behaviour. We don't have the runway to add these before 🚢 for Feast. 

|Before|After|
|--|--|
|![add-recipe-to-feast-col-nope](https://github.com/user-attachments/assets/eff09057-3e71-4d16-9856-4e8e0014a7f0)|![add-recipe-to-feast-col](https://github.com/user-attachments/assets/37a34a30-4fd5-4b00-845c-952f547dc81d)|

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
