### PR TITLE
Remove tiny border on Feast cards

### DIFF
--- a/fronts-client/src/components/card/CardSettingsDisplay.tsx
+++ b/fronts-client/src/components/card/CardSettingsDisplay.tsx
@@ -2,21 +2,6 @@ import React from 'react';
 import { styled, theme } from 'constants/theme';
 import { FLEXIBLE_CONTAINER_SET } from 'constants/flexibleContainers';
 
-const ArticleMetadataProperties = styled.div`
-  padding: 0 4px 3px 0;
-  display: flex;
-  flex-direction: row;
-  font-size: 12px;
-  flex-wrap: wrap;
-`;
-
-const ArticleMetadataProperty = styled.div`
-  background-color: ${theme.colors.whiteDark};
-  padding: 1px 4px;
-  flex: 0 0 auto;
-  margin: 0 2px 1px 0;
-`;
-
 const shouldShowLegacyBoost = (collectionType?: string, isBoosted?: boolean) =>
   /* don't show old Boost option in flexible containers */
   isBoosted && !FLEXIBLE_CONTAINER_SET.includes(collectionType);
@@ -63,28 +48,28 @@ export default ({
   showQuotedHeadline ||
   showLargeHeadline ||
   isBoosted ? (
-    <ArticleMetadataProperties>
+    <div>
       {isBreaking && (
-        <ArticleMetadataProperty data-testid="breaking-news">
+        <span data-testid="breaking-news">
           Breaking news
-        </ArticleMetadataProperty>
+        </span>
       )}
       {showByline && (
-        <ArticleMetadataProperty>Show byline</ArticleMetadataProperty>
+        <span>Show byline</span>
       )}
       {showQuotedHeadline && (
-        <ArticleMetadataProperty>Quote headline</ArticleMetadataProperty>
+        <span>Quote headline</span>
       )}
       {showLargeHeadline && (
-        <ArticleMetadataProperty>Large headline</ArticleMetadataProperty>
+        <span>Large headline</span>
       )}
       {shouldShowBoostLevel(collectionType, boostLevel) && (
-        <ArticleMetadataProperty>
+        <span>
           {getBoostLevelLabel(boostLevel)}
-        </ArticleMetadataProperty>
+        </span>
       )}
       {shouldShowLegacyBoost(collectionType, isBoosted) && (
-        <ArticleMetadataProperty>Boost</ArticleMetadataProperty>
+        <span>Boost</span>
       )}
-    </ArticleMetadataProperties>
+    </div>
   ) : null;


### PR DESCRIPTION
## What's changed?
Remove the border displayed on Recipe and Chef cards

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included

Before: 
![Screenshot 2024-08-27 at 15 57 08](https://github.com/user-attachments/assets/a0eabacc-a6b4-435e-a1e4-510b78c6c149)

After:
![Screenshot 2024-08-27 at 15 56 45](https://github.com/user-attachments/assets/17a87b8e-0db9-4ad6-b4cb-e8bdf63450e3)

