### PR TITLE
Update Feast model

### DIFF
--- a/app/model/FeastAppModel.scala
+++ b/app/model/FeastAppModel.scala
@@ -9,18 +9,22 @@ import model.editions.Palette
 object FeastAppModel {
   sealed trait ContainerItem
 
-  case class RecipeIdentifier(id: String)
+  case class RecipeContent(id: String)
 
-  case class Recipe(recipe: RecipeIdentifier) extends ContainerItem
+  case class Recipe(recipe: RecipeContent) extends ContainerItem
 
-  case class Chef(id: String,
-    image: Option[String] = None,
-    bio:  Option[String] = None,
-    backgroundHex: Option[String] = None,
-    foregroundHex: Option[String] = None
-  ) extends ContainerItem
+  case class Chef(chef: ChefContent) extends ContainerItem
 
-  case class FeastCollection(
+  case class ChefContent(id: String,
+                         image: Option[String] = None,
+                         bio:  Option[String] = None,
+                         backgroundHex: Option[String] = None,
+                         foregroundHex: Option[String] = None
+  )
+
+  case class FeastCollection(collection: FeastCollectionContent) extends ContainerItem
+
+  case class FeastCollectionContent(
     byline: Option[String] = None,
     darkPalette: Option[Palette] = None,
     image: Option[String] = None,
@@ -28,7 +32,7 @@ object FeastAppModel {
     title: String,
     lightPalette: Option[Palette] = None,
     recipes: Seq[String]
-  ) extends ContainerItem
+  )
 
   case class FeastAppContainer(id:String, title:String, body:Option[String], items:Seq[ContainerItem])
   //type FeastAppCuration = Map[String, IndexedSeq[FeastAppContainer]]
@@ -41,10 +45,12 @@ object FeastAppModel {
                              fronts:Map[String,IndexedSeq[FeastAppContainer]]
                              )
 
-  implicit val recipeIdentifierFormat:Format[RecipeIdentifier] = Json.format[RecipeIdentifier]
+  implicit val recipeIdentifierFormat:Format[RecipeContent] = Json.format[RecipeContent]
   implicit val recipeFormat:Format[Recipe] = Json.format[Recipe]
+  implicit val chefContentFormat:Format[ChefContent] = Json.format[ChefContent]
   implicit val chefFormat:Format[Chef] = Json.format[Chef]
   implicit val paletteFormat:Format[Palette] = Json.format[Palette]
+  implicit val subCollectionContentFormat:Format[FeastCollectionContent] = Json.format[FeastCollectionContent]
   implicit val subCollectionFormat:Format[FeastCollection] = Json.format[FeastCollection]
 
   implicit val containerItemFormat:Format[ContainerItem] = Format.apply(
@@ -52,9 +58,9 @@ object FeastAppModel {
       recipeFormat.reads(jsValue) orElse chefFormat.reads(jsValue) orElse subCollectionFormat.reads(jsValue)
     },
     {
-      case o:Recipe=>recipeFormat.writes(o)
-      case o:Chef=>chefFormat.writes(o)
-      case o:FeastCollection=>subCollectionFormat.writes(o)
+      case o: Recipe => recipeFormat.writes(o)
+      case o: Chef => chefFormat.writes(o)
+      case o: FeastCollection => subCollectionFormat.writes(o)
     }
   )
   implicit val feastAppContainerFormat:Format[FeastAppContainer] = Json.format[FeastAppContainer]

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -3,7 +3,7 @@ package services.editions.publishing
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest}
 import conf.ApplicationConfiguration
-import model.FeastAppModel.{Chef, ContainerItem, FeastAppContainer, FeastAppCuration, FeastCollection, Recipe, RecipeIdentifier}
+import model.FeastAppModel.{Chef, ChefContent, ContainerItem, FeastAppContainer, FeastAppCuration, FeastCollection, FeastCollectionContent, Recipe, RecipeContent}
 import model.editions.PublishAction.PublishAction
 import model.editions.{EditionsArticle, EditionsCard, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsIssue, EditionsRecipe}
 import play.api.libs.json.{Json, Writes}
@@ -24,18 +24,18 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
   private def transformCards(source: EditionsCard): ContainerItem = {
     source match {
       case _: EditionsArticle => throw new Error("Article not permitted in a Feast Front")
-      case EditionsRecipe(id, _) => Recipe(RecipeIdentifier(id))
-      case EditionsChef(id, _, metadata) => Chef(id = id,
+      case EditionsRecipe(id, _) => Recipe(RecipeContent(id))
+      case EditionsChef(id, _, metadata) => Chef(ChefContent(id = id,
         image = metadata.flatMap(_.chefImageOverride.map(_.src)),
         bio = metadata.flatMap(_.bio),
         backgroundHex = metadata.flatMap(_.theme.map(_.palette.backgroundHex)),
-        foregroundHex = metadata.flatMap(_.theme.map(_.palette.foregroundHex)))
+        foregroundHex = metadata.flatMap(_.theme.map(_.palette.foregroundHex))))
       case EditionsFeastCollection(_, _, metadata) =>
         val recipes = metadata.map(_.collectionItems.map {
           case EditionsRecipe(id, _) => id
         }).getOrElse(List.empty)
 
-        FeastCollection(
+        FeastCollection(FeastCollectionContent(
           byline = None,
           darkPalette = metadata.flatMap(_.theme.map(_.darkPalette)),
           lightPalette = metadata.flatMap(_.theme.map(_.lightPalette)),
@@ -43,7 +43,7 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
           body = None,
           title = metadata.flatMap(_.title).getOrElse("No title"),
           recipes = recipes
-        )
+        ))
     }
   }
 

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{FreeSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 import play.api.libs.json.Json
-import model.FeastAppModel.{Chef, FeastCollection, FeastAppContainer, Recipe, RecipeIdentifier}
+import model.FeastAppModel.{Chef, ChefContent, FeastAppContainer, FeastCollection, FeastCollectionContent, Recipe, RecipeContent}
 import util.TimestampGenerator
 
 import java.time.LocalDate
@@ -117,8 +117,8 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
 
   "putIssueJson" - {
     val issue = Map(
-      "chefs" -> FeastAppContainer("chefs", "Chefs", None, Seq(Chef("bob-the-pirate", None, Some("Bob is a pirate"), None, None))),
-      "recipes" -> FeastAppContainer("recipes", "Recipes", None, Seq(Recipe(RecipeIdentifier("abcdefg"))))
+      "chefs" -> FeastAppContainer("chefs", "Chefs", None, Seq(Chef(ChefContent("bob-the-pirate", None, Some("Bob is a pirate"), None, None)))),
+      "recipes" -> FeastAppContainer("recipes", "Recipes", None, Seq(Recipe(RecipeContent("abcdefg"))))
     )
 
     "should push the relevant content into SNS" in {
@@ -188,28 +188,70 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
       allRecipesFront.head.body shouldBe Some("") //this is just how the `body` field is currently rendered
       allRecipesFront.head.id shouldBe "98e89761-fdf0-4903-b49d-2af7d66fc930"
       allRecipesFront.head.items shouldBe List(
-        Recipe(RecipeIdentifier("recipe-id")),
-        Chef(
+        Recipe(RecipeContent("recipe-id")),
+        Chef(ChefContent(
           id = "chef-id",
           image = Some("image-src"),
           bio = Some("bio"),
           backgroundHex = Some("#333"),
           foregroundHex = Some("#FFF")
-        ),
-        FeastCollection(
+        )),
+        FeastCollection(FeastCollectionContent(
           darkPalette = Some(Palette("#333", "#FFF")),
           lightPalette = Some(Palette("#FFF", "#333")),
           image = Some("https://example.com/an-image.jpg"),
           title = "Collection title",
           recipes = List("nested-recipe-id")
-        )
+        ))
       )
     }
   }
 
   "putIssue" - {
     "should output the transformed version of the content" in {
-      val serializedVersion = """{"id":"123456ABCD","edition":"feast-northern-hemisphere","issueDate":"2024-05-03","version":"v1","fronts":{"all-recipes":[{"id":"98e89761-fdf0-4903-b49d-2af7d66fc930","title":"Dish of the day","body":"","items":[{"recipe":{"id":"recipe-id"}},{"id":"chef-id","image":"image-src","bio":"bio","backgroundHex":"#333","foregroundHex":"#FFF"},{"darkPalette":{"foregroundHex":"#333","backgroundHex":"#FFF"},"image":"https://example.com/an-image.jpg","title":"Collection title","lightPalette":{"foregroundHex":"#FFF","backgroundHex":"#333"},"recipes":["nested-recipe-id"]}]}]}}"""
+      val serializedVersion = """{
+        |  "id": "123456ABCD",
+        |  "edition": "feast-northern-hemisphere",
+        |  "issueDate": "2024-05-03",
+        |  "version": "v1",
+        |  "fronts": {
+        |    "all-recipes": [
+        |      {
+        |        "id": "98e89761-fdf0-4903-b49d-2af7d66fc930",
+        |        "title": "Dish of the day",
+        |        "body": "",
+        |        "items": [
+        |          { "recipe": { "id": "recipe-id" } },
+        |          {
+        |            "chef": {
+        |              "id": "chef-id",
+        |              "image": "image-src",
+        |              "bio": "bio",
+        |              "backgroundHex": "#333",
+        |              "foregroundHex": "#FFF"
+        |            }
+        |          },
+        |          {
+        |            "collection": {
+        |              "darkPalette": {
+        |                "foregroundHex": "#333",
+        |                "backgroundHex": "#FFF"
+        |              },
+        |              "image": "https://example.com/an-image.jpg",
+        |              "title": "Collection title",
+        |              "lightPalette": {
+        |                "foregroundHex": "#FFF",
+        |                "backgroundHex": "#333"
+        |              },
+        |              "recipes": ["nested-recipe-id"]
+        |            }
+        |          }
+        |        ]
+        |      }
+        |    ]
+        |  }
+        |}
+        |""".stripMargin
 
       val mockSNS = mock[AmazonSNSClient]
       when(mockSNS.publish(any[PublishRequest])).thenReturn(new PublishResult())
@@ -219,7 +261,7 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
       toTest.putIssue(testIssue, "v1", PublishAction.publish)
       val expectedRequest = new PublishRequest()
         .withTopicArn("fake-publication-topic")
-        .withMessage(serializedVersion)
+        .withMessage(Json.parse(serializedVersion).toString())
         .withMessageAttributes(Map(
           "timestamp"->new MessageAttributeValue().withDataType("Number").withStringValue("12345678"),
           "type"->new MessageAttributeValue().withDataType("String").withStringValue("Issue")


### PR DESCRIPTION
## What's changed?

Updates the Fronts Feast model to reflect the changes made in the recipes-backend in https://github.com/guardian/recipes-backend/pull/60/files.

In practice this means adding an envelope around Chef and FeastCollection types, which is likely to reflect the way discriminated unions are handled downstream in apps.

## How to test

- The automated tests cover the serialisation and model logic.
- Running locally or in CODE, and with the latest version of recipes-backend deployed to CODE (which reflects the new types):
  - publish a Feast issue with cards of all types. 
  - Check the app logs. Publication should have succeeded.
  - Check the published curation data at `recipes.code.dev-guardianapis.com/${issueName}/${frontName}/${YYYY-MM-DD}/curation.json`, e.g. `recipes.code.dev-guardianapis.com/feast-northern-hemisphere/all-recipes/2024-08-01/curation.json`. It should reflect what has just been published.

Tested locally against https://github.com/guardian/recipes-backend/pull/54, works as expected 👍  – here's an example of a failed request, and one that succeeds with the updated model:

<img width="625" alt="Screenshot 2024-08-27 at 17 59 57" src="https://github.com/user-attachments/assets/521c6dc5-830e-4bdc-aa56-381255fada28">

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
