### PR TITLE
Correct position of Publish button

### DIFF
--- a/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
+++ b/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
@@ -64,8 +64,10 @@ const EditionDate = styled.div`
 `;
 
 const EditionPublish = styled.div`
-  float: right;
-  margin: 5px 10px 0 0;
+  margin-left: auto;
+  margin-right: 10px;
+  display: flex;
+  align-items: center;
 `;
 
 class EditionFeedSectionHeader extends React.Component<ComponentProps> {

--- a/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
+++ b/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
@@ -83,16 +83,6 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
           </EditionIssueInfo>
         </ManageLink>
         &nbsp;
-        <Button
-          data-testid="check-edition-button"
-          size="s"
-          priority="primary"
-          onClick={() => this.check()}
-          tabIndex={-1}
-          title="Check Edition"
-        >
-          Check
-        </Button>
         <EditionPublish>
           <EditModeVisibility visibleMode="editions">
             {editionsIssue.supportsProofing && (

--- a/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
+++ b/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
@@ -72,7 +72,7 @@ const EditionPublish = styled.div`
 
 class EditionFeedSectionHeader extends React.Component<ComponentProps> {
   public render() {
-    const { editionsIssue } = this.props;
+    const { editionsIssue, isFeast } = this.props;
 
     return (
       <>
@@ -85,6 +85,18 @@ class EditionFeedSectionHeader extends React.Component<ComponentProps> {
           </EditionIssueInfo>
         </ManageLink>
         &nbsp;
+        {!isFeast && (
+          <Button
+            data-testid="check-edition-button"
+            size="s"
+            priority="primary"
+            onClick={() => this.check()}
+            tabIndex={-1}
+            title="Check Edition"
+          >
+            Check
+          </Button>
+        )}
         <EditionPublish>
           <EditModeVisibility visibleMode="editions">
             {editionsIssue.supportsProofing && (
@@ -177,6 +189,7 @@ function displayTime(lastProofedVersion: string | undefined) {
 const mapStateToProps = () => {
   return (state: State) => ({
     editionsIssue: editionsIssueSelectors.selectAll(state),
+    isFeast: editionsIssueSelectors.selectAll(state)?.platform === 'feast',
   });
 };
 

--- a/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
+++ b/fronts-client/src/components/feed/EditionFeedSectionHeader.tsx
@@ -72,7 +72,8 @@ const EditionPublish = styled.div`
 
 class EditionFeedSectionHeader extends React.Component<ComponentProps> {
   public render() {
-    const { editionsIssue, isFeast } = this.props;
+    const { editionsIssue } = this.props;
+    const isFeast = editionsIssue?.platform === 'feast';
 
     return (
       <>
@@ -189,7 +190,6 @@ function displayTime(lastProofedVersion: string | undefined) {
 const mapStateToProps = () => {
   return (state: State) => ({
     editionsIssue: editionsIssueSelectors.selectAll(state),
-    isFeast: editionsIssueSelectors.selectAll(state)?.platform === 'feast',
   });
 };
 

--- a/fronts-client/src/components/feed/FeedSectionHeader.tsx
+++ b/fronts-client/src/components/feed/FeedSectionHeader.tsx
@@ -34,8 +34,12 @@ const FeedbackButton = styled(Button.withComponent('a'))<{
 `;
 
 const SectionHeaderContent = styled.div`
-  position: relative;
-  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 const LogoContainer = styled.div`


### PR DESCRIPTION
**(Justin here. I started a second branch of this because I didn't want to trample over your changes when I wasn't certain how it'd play out. However it went seemingly quite well so I opened [this PR](https://github.com/guardian/facia-tool/pull/1651)).**

## What's changed?
Ensures the Publish button is correctly positioned when the clipboard is closed.  The behaviour is consistent with how the header section is displayed for editions in the `Manage Editions app` list.

The Check button was also removed as this is not required in Feast.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included

Before (clipboard open): 
![Screenshot 2024-08-28 at 14 34 07](https://github.com/user-attachments/assets/4cc5ff35-1a12-4097-a3d7-05689587488e)

Before (clipboard closed):
![Screenshot 2024-08-28 at 14 34 21](https://github.com/user-attachments/assets/06e96885-9bd0-4600-9397-c57481baf9ec)

After (clipboard open): 
![Screenshot 2024-08-28 at 14 27 26](https://github.com/user-attachments/assets/28b3132d-cfee-4217-8c07-d4ff21c32c45)

After (clipboard closed):
![Screenshot 2024-08-28 at 14 27 37](https://github.com/user-attachments/assets/38145dab-5b79-4f5d-8371-41b5f56e143c)
