### PR TITLE
Add `scrollable/highlights` container type to replace `fixed/highlights`

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -36,7 +36,8 @@ class FixedContainers(val config: ApplicationConfiguration) {
     ("fixed/video/vertical", video),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcase),
-    // Scrollable is the newer term for a fixed container that might be scrollable horizontally
+    // TODO - 28/08/24 remove fixed/highlights once downstream uses have been migrated to scrollable/highlights
+    ("fixed/highlights", highlights),
     ("scrollable/highlights", highlights)
   ) ++ (if (config.faciatool.showTestContainers) Map(
     ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -61,6 +61,7 @@ export default {
         { name: 'news/most-popular' },
         { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
         { name: 'fixed/showcase' },
+        { name: 'fixed/highlights' },
         { name: 'scrollable/highlights' }
     ],
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

After [agreeing on a naming convention for the new front containers](https://docs.google.com/spreadsheets/d/1yVS2jFcZfCztJ3epLhsTcoShJWtdlzYyrpKLBZlYx94/edit?usp=sharing) we agreed to [rename `fixed/highlights` to `scrollable/highlights`](https://trello.com/c/YGbWyF1z/403-rename-fixed-highlights-to-scrollable-highlights)

This PR adds `scrollable/highlights` with the same configuration as `fixed/highlights` to the facia tool so that we can begin migrating uses of `fixed/highlights` to `scrollable/highlights`. 
This PR deliberately avoids removing `fixed/highlights` as this will be done once we have confirmed uses have been migrated across. This is a necessary step due to this container type being used in production environments already.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
