### PR TITLE
Move collection up and down, client side

### DIFF
--- a/app/model/editions/client/EditionsClientCollection.scala
+++ b/app/model/editions/client/EditionsClientCollection.scala
@@ -80,7 +80,7 @@ object EditionsSupportingClientCard {
     case EditionsRecipe(id, addedOn) => EditionsSupportingClientCard(id, Some(CardType.Recipe), addedOn)
   }
 
-  def toFeastCollectionItem(supportingCard: EditionsSupportingClientCard) = 
+  def toFeastCollectionItem(supportingCard: EditionsSupportingClientCard) =
     EditionsRecipe(supportingCard.id, supportingCard.frontPublicationDate)
 }
 
@@ -95,11 +95,14 @@ case class EditionsClientCollection(
   contentPrefillTimeWindow: Option[CapiQueryTimeWindow],
   items: List[EditionsClientCard]
 )
+
+object EditionsClientCollection {
+  implicit val collectionFormat: OFormat[EditionsClientCollection] = Json.format[EditionsClientCollection]
+}
+
 case class EditionsFrontendCollectionWrapper(id: String, collection: EditionsClientCollection)
 
 object EditionsFrontendCollectionWrapper {
-  implicit def cardFormat: OFormat[EditionsClientCard] = Json.format[EditionsClientCard]
-  implicit def collectionFormat: OFormat[EditionsClientCollection] = Json.format[EditionsClientCollection]
   implicit def collectionWrapperFormat: OFormat[EditionsFrontendCollectionWrapper] = Json.format[EditionsFrontendCollectionWrapper]
 
   def fromCollection(collection: EditionsCollection): EditionsFrontendCollectionWrapper = {

--- a/app/services/editions/db/CollectionsQueries.scala
+++ b/app/services/editions/db/CollectionsQueries.scala
@@ -106,18 +106,16 @@ trait CollectionsQueries extends Logging {
     for {
       currentCollectionIds <- getCollectionIdsInFrontFromCollectionId(collectionId)
     } yield {
-      logger.info(s"Moving $collectionId to index $newIndex")
       currentCollectionIds.indexOf(collectionId) match {
         case -1 => Left(EditionsDB.NotFoundError(s"Tried to move collection $collectionId to $newIndex, but could not find collection with that ID"))
         case currentIndex if currentIndex == newIndex =>
           logger.info(s"Collection $collectionId is already at index $newIndex")
           Right(()) // No move
         case currentIndex =>
-          val indexOffset = if (newIndex > currentIndex) -1 else 0
+          logger.info(s"Moving $collectionId at $currentIndex to index $newIndex")
           val newCollectionIds = currentCollectionIds
             .filter(_ != collectionId)
-            .patch(newIndex + indexOffset, List(collectionId), 0)
-
+            .patch(newIndex, List(collectionId), 0)
 
           updateCollectionIndices(newCollectionIds)
       }

--- a/app/services/editions/db/FrontsQueries.scala
+++ b/app/services/editions/db/FrontsQueries.scala
@@ -74,7 +74,7 @@ trait FrontsQueries extends Logging {
     }
   }
 
-  protected def getFront(frontId: String)(implicit session: DBSession): Option[EditionsFront] = {
+  def getFront(frontId: String)(implicit session: DBSession): Option[EditionsFront] = {
     val rows: List[FrontAndNestedEntitiesRow] =
       sql"""
         SELECT

--- a/fronts-client/src/actions/Editions.tsx
+++ b/fronts-client/src/actions/Editions.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import keyBy from 'lodash/keyBy';
 import {
   proofIssue,
   publishIssue,
@@ -23,7 +24,6 @@ import { batchActions } from 'redux-batched-actions';
 import { EditionsCollection } from '../types/Edition';
 import { State } from '../types/State';
 import { selectFront } from 'selectors/frontsSelectors';
-import { groupBy } from 'lodash';
 
 export const check =
   (id: string): ThunkResult<Promise<void>> =>
@@ -252,7 +252,7 @@ const processNewEditionFrontResponse = (
     },
     collections: {
       ...existingFrontsConfig.collections,
-      ...groupBy(collections, 'id'),
+      ...keyBy(collections, 'id'),
     },
   };
 

--- a/fronts-client/src/actions/__tests__/Editions.spec.ts
+++ b/fronts-client/src/actions/__tests__/Editions.spec.ts
@@ -1,5 +1,5 @@
 import {
-  apiResponse,
+  newCollectionApiResponse,
   finalState,
   initialState,
 } from './fixtures/Editions.fixture';
@@ -9,6 +9,7 @@ import { Dispatch } from '../../types/Store';
 import fetchMock from 'fetch-mock';
 
 jest.mock('uuid/v4', () => () => 'uuid');
+
 describe('Add new collection feature', () => {
   const { now } = Date;
   afterEach(fetchMock.restore);
@@ -24,11 +25,16 @@ describe('Add new collection feature', () => {
       initialState,
       '/v2/issues/ae2035fa-7864-4c73-aabd-70ab70526bf7'
     );
-    const frontId = '48bbbb7d-357f-4a07-9dac-646d6965cec2';
+    const frontId = '3b73ae36-1b99-4102-b6cb-51cc66768182';
 
-    fetchMock.once(`/editions-api/fronts/${frontId}/collection`, apiResponse, {
-      method: 'PUT',
-    });
+    fetchMock.once(
+      `/editions-api/fronts/${frontId}/collection`,
+      newCollectionApiResponse,
+      {
+        method: 'PUT',
+      }
+    );
+
     await (store.dispatch as Dispatch)(addFrontCollection(frontId));
 
     const state = store.getState();

--- a/fronts-client/src/actions/__tests__/Editions.spec.ts
+++ b/fronts-client/src/actions/__tests__/Editions.spec.ts
@@ -1,16 +1,16 @@
 import {
-  newCollectionApiResponse,
-  finalState,
+  apiResponse,
   initialState,
+  stateWithAddedCollection,
 } from './fixtures/Editions.fixture';
-import { addFrontCollection } from '../Editions';
+import { addFrontCollection, getNewCollectionIndexForMove } from '../Editions';
 import configureStore from '../../util/configureStore';
 import { Dispatch } from '../../types/Store';
 import fetchMock from 'fetch-mock';
 
 jest.mock('uuid/v4', () => () => 'uuid');
 
-describe('Add new collection feature', () => {
+describe('Editions actions', () => {
   const { now } = Date;
   afterEach(fetchMock.restore);
   beforeAll(() => {
@@ -20,24 +20,82 @@ describe('Add new collection feature', () => {
     (Date as any).now = now;
   });
 
-  it('should add new collection in the front', async () => {
-    const store = configureStore(
-      initialState,
-      '/v2/issues/ae2035fa-7864-4c73-aabd-70ab70526bf7'
-    );
-    const frontId = '3b73ae36-1b99-4102-b6cb-51cc66768182';
+  const frontId = '3b73ae36-1b99-4102-b6cb-51cc66768182';
 
-    fetchMock.once(
-      `/editions-api/fronts/${frontId}/collection`,
-      newCollectionApiResponse,
-      {
-        method: 'PUT',
-      }
-    );
+  describe('addFrontCollection', () => {
+    it('should add new collection in the front', async () => {
+      const store = configureStore(
+        initialState,
+        '/v2/issues/ae2035fa-7864-4c73-aabd-70ab70526bf7'
+      );
 
-    await (store.dispatch as Dispatch)(addFrontCollection(frontId));
+      fetchMock.once(
+        `/editions-api/fronts/${frontId}/collection`,
+        apiResponse,
+        {
+          method: 'PUT',
+        }
+      );
 
-    const state = store.getState();
-    expect(state).toEqual(finalState);
+      await (store.dispatch as Dispatch)(addFrontCollection(frontId));
+
+      const state = store.getState();
+      expect(state).toEqual(stateWithAddedCollection);
+    });
+  });
+
+  describe('getNewCollectionIndexForMove', () => {
+    const front =
+      stateWithAddedCollection.fronts.frontsConfig.data.fronts[frontId];
+
+    it('should get the correct index moving a collection up', async () => {
+      const newIndex = getNewCollectionIndexForMove(
+        front,
+        '165193d5-3761-466c-af9a-4fc09fd91133',
+        'down'
+      );
+
+      expect(newIndex).toBe(1);
+    });
+
+    it('should get the correct index moving a collection down', async () => {
+      const newIndex = getNewCollectionIndexForMove(
+        front,
+        '165193d5-3761-466c-af9a-4fc09fd91133',
+        'down'
+      );
+
+      expect(newIndex).toBe(1);
+    });
+
+    it('should get the correct index moving a collection down', async () => {
+      const newIndex = getNewCollectionIndexForMove(
+        front,
+        'bf3428ed-4ee8-4321-8099-6590d0b51fd6',
+        'up'
+      );
+
+      expect(newIndex).toBe(0);
+    });
+
+    it('should not return an index when moving a collection out of bounds upwards', async () => {
+      const newIndex = getNewCollectionIndexForMove(
+        front,
+        '165193d5-3761-466c-af9a-4fc09fd91133',
+        'up'
+      );
+
+      expect(newIndex).toBe(undefined);
+    });
+
+    it('should not return an index when moving a collection out of bounds upwards', async () => {
+      const newIndex = getNewCollectionIndexForMove(
+        front,
+        'bf3428ed-4ee8-4321-8099-6590d0b51fd6',
+        'down'
+      );
+
+      expect(newIndex).toBe(undefined);
+    });
   });
 });

--- a/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
+++ b/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
@@ -1,37 +1,28 @@
-export const apiResponse = {
-  id: '3b73ae36-1b99-4102-b6cb-51cc66768182',
-  displayName: 'Meat-Free',
-  index: 1,
-  isSpecial: false,
-  isHidden: false,
-  metadata: {
-    swatch: 'neutral',
+export const newCollectionApiResponse = [
+  {
+    id: '165193d5-3761-466c-af9a-4fc09fd91133',
+    displayName: 'Dish of the day',
+    isHidden: false,
+    lastUpdated: 1724241813095,
+    updatedBy: 'Divya Bhatt ',
+    updatedEmail: 'divya.bhatt@guardian.co.uk',
+    contentPrefillTimeWindow: {
+      fromDate: '2024-08-13T00:00:00Z',
+      toDate: '2024-08-13T00:00:00Z',
+    },
+    items: [],
   },
-  collections: [
-    {
-      id: '165193d5-3761-466c-af9a-4fc09fd91133',
-      displayName: 'Dish of the day',
-      isHidden: false,
-      lastUpdated: 1724241813095,
-      updatedBy: 'Divya Bhatt ',
-      updatedEmail: 'divya.bhatt@guardian.co.uk',
-      contentPrefillTimeWindow: {
-        fromDate: '2024-08-13T00:00:00Z',
-        toDate: '2024-08-13T00:00:00Z',
-      },
-      items: [],
-    },
-    {
-      id: 'bf3428ed-4ee8-4321-8099-6590d0b51fd6',
-      displayName: 'New collection',
-      isHidden: false,
-      lastUpdated: 1724241825186,
-      updatedBy: 'Divya Bhatt ',
-      updatedEmail: 'divya.bhatt@guardian.co.uk',
-      items: [],
-    },
-  ],
-};
+  {
+    id: 'bf3428ed-4ee8-4321-8099-6590d0b51fd6',
+    displayName: 'New collection',
+    isHidden: false,
+    lastUpdated: 1724241825186,
+    updatedBy: 'Divya Bhatt ',
+    updatedEmail: 'divya.bhatt@guardian.co.uk',
+    items: [],
+  },
+];
+
 export const initialState = {
   fronts: {
     frontsConfig: {

--- a/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
+++ b/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
@@ -1,4 +1,4 @@
-export const newCollectionApiResponse = [
+export const apiResponse = [
   {
     id: '165193d5-3761-466c-af9a-4fc09fd91133',
     displayName: 'Dish of the day',
@@ -34,7 +34,6 @@ export const initialState = {
             index: 1,
             isSpecial: false,
             isHidden: false,
-            metadata: { swatch: 'neutral' },
             collections: ['165193d5-3761-466c-af9a-4fc09fd91133'],
             priority: 'ae2035fa-7864-4c73-aabd-70ab70526bf7',
           },
@@ -751,7 +750,7 @@ export const initialState = {
   },
 };
 
-export const finalState = {
+export const stateWithAddedCollection = {
   fronts: {
     frontsConfig: {
       data: {
@@ -762,7 +761,6 @@ export const finalState = {
             index: 1,
             isSpecial: false,
             isHidden: false,
-            metadata: { swatch: 'neutral' },
             collections: [
               '165193d5-3761-466c-af9a-4fc09fd91133',
               'bf3428ed-4ee8-4321-8099-6590d0b51fd6',

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -93,6 +93,8 @@ const HeadlineContentContainer = styled.span`
   position: relative;
   margin-right: -11px;
   display: flex;
+  align-items: center;
+  gap: 2px;
 `;
 
 export const HeadlineContentButton = styled(Button).attrs({ size: 's' })`
@@ -100,7 +102,6 @@ export const HeadlineContentButton = styled(Button).attrs({ size: 's' })`
   padding: 0 5px;
   display: flex;
   align-items: center;
-  margin-left: 5px;
 `;
 
 const CollectionDisabledTheme = styled.div`

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -17,6 +17,7 @@ import {
   selectCollectionHasPrefill,
   selectCollectionIsHidden,
   selectCollectionDisplayName,
+  selectCollectionCanMoveToRelativeIndex,
 } from 'selectors/frontsSelectors';
 import { selectIsCollectionLocked } from 'selectors/collectionSelectors';
 import type { State } from 'types/State';
@@ -84,6 +85,8 @@ type CollectionProps = CollectionPropsBeforeState & {
   isHidden: boolean;
   displayName: string;
   removeFrontCollection: (frontId: string, collectionId: string) => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
   moveFrontCollection: (
     frontId: string,
     id: string,
@@ -251,6 +254,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
                       <ButtonCircularCaret
                         small
                         openDir="up"
+                        disabled={!this.props.canMoveUp}
                         onClick={() =>
                           this.props.moveFrontCollection(
                             this.props.frontId,
@@ -261,6 +265,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
                       />
                       <ButtonCircularCaret
                         small
+                        disabled={!this.props.canMoveDown}
                         onClick={() =>
                           this.props.moveFrontCollection(
                             this.props.frontId,
@@ -392,6 +397,18 @@ const createMapStateToProps = () => {
       frontId,
     }: CollectionPropsBeforeState
   ) => ({
+    canMoveUp: selectCollectionCanMoveToRelativeIndex(
+      state,
+      frontId,
+      collectionId,
+      -1
+    ),
+    canMoveDown: selectCollectionCanMoveToRelativeIndex(
+      state,
+      frontId,
+      collectionId,
+      1
+    ),
     isHidden: selectCollectionIsHidden(state, collectionId),
     displayName: selectCollectionDisplayName(state, collectionId),
     hasPrefill: selectCollectionHasPrefill(state, collectionId),

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -42,7 +42,10 @@ import { fetchPrefill } from 'bundles/capiFeedBundle';
 import LoadingGif from 'images/icons/loading.gif';
 import OpenFormsWarning from './OpenFormsWarning';
 import { selectors as editionsIssueSelectors } from '../../../bundles/editionsIssueBundle';
-import { removeFrontCollection } from '../../../actions/Editions';
+import {
+  moveFrontCollection,
+  removeFrontCollection,
+} from '../../../actions/Editions';
 
 interface CollectionPropsBeforeState {
   id: string;
@@ -81,6 +84,11 @@ type CollectionProps = CollectionPropsBeforeState & {
   isHidden: boolean;
   displayName: string;
   removeFrontCollection: (frontId: string, collectionId: string) => void;
+  moveFrontCollection: (
+    frontId: string,
+    id: string,
+    direction: 'up' | 'down'
+  ) => void;
 };
 
 interface CollectionState {
@@ -142,6 +150,12 @@ const OpenFormsWarningContainer = styled.div`
 
 const ActionButtonsContainer = styled.div`
   display: flex;
+`;
+
+const MoveButtonsContainer = styled.div`
+  margin-right: 8px;
+  display: flex;
+  gap: 3px;
 `;
 
 class Collection extends React.Component<CollectionProps, CollectionState> {
@@ -232,13 +246,38 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
                   </HeadlineContentButton>
                 )}
                 {isFeast && (
-                  <HeadlineContentButton
-                    priority="default"
-                    onClick={() => this.removeFrontCollection()}
-                    title="Delete the collection for this issue"
-                  >
-                    Delete
-                  </HeadlineContentButton>
+                  <>
+                    <MoveButtonsContainer>
+                      <ButtonCircularCaret
+                        small
+                        openDir="up"
+                        onClick={() =>
+                          this.props.moveFrontCollection(
+                            this.props.frontId,
+                            this.props.id,
+                            'up'
+                          )
+                        }
+                      />
+                      <ButtonCircularCaret
+                        small
+                        onClick={() =>
+                          this.props.moveFrontCollection(
+                            this.props.frontId,
+                            this.props.id,
+                            'down'
+                          )
+                        }
+                      />
+                    </MoveButtonsContainer>
+                    <HeadlineContentButton
+                      priority="default"
+                      onClick={() => this.removeFrontCollection()}
+                      title="Delete the collection for this issue"
+                    >
+                      Delete
+                    </HeadlineContentButton>
+                  </>
                 )}
                 {hasPrefill && (
                   <HeadlineContentButton
@@ -405,6 +444,11 @@ const mapDispatchToProps = (
   },
   removeFrontCollection: (frontId: string, id: string) =>
     dispatch(removeFrontCollection(frontId, id)),
+  moveFrontCollection: (
+    frontId: string,
+    id: string,
+    direction: 'up' | 'down'
+  ) => dispatch(moveFrontCollection(frontId, id, direction)),
 });
 
 export default connect(createMapStateToProps, mapDispatchToProps)(Collection);

--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -137,6 +137,23 @@ const selectCollectionIsHidden = (
   return !!collection && !!collection.isHidden;
 };
 
+export const selectCollectionCanMoveToRelativeIndex = (
+  state: State,
+  frontId: string,
+  collectionId: string,
+  relativeIndex: number
+): boolean => {
+  const front = selectFront(state, { frontId });
+  const currentIndex = front.collections.findIndex((id) => id === collectionId);
+  if (currentIndex === -1) {
+    return false;
+  }
+
+  const newIndex = currentIndex + relativeIndex;
+
+  return newIndex >= 0 && newIndex <= front.collections.length - 1;
+};
+
 const selectCollectionDisplayName = (
   state: State,
   collectionId: string

--- a/fronts-client/src/services/editionsApi.ts
+++ b/fronts-client/src/services/editionsApi.ts
@@ -121,7 +121,7 @@ export const putFrontHiddenState = (id: string, hidden: boolean) => {
 
 export const addCollectionToFront = (
   frontId: string
-): Promise<EditionsFront> => {
+): Promise<EditionsCollection[]> => {
   return pandaFetch(`/editions-api/fronts/${frontId}/collection`, {
     method: 'PUT',
   }).then((response) => response.json());
@@ -130,7 +130,7 @@ export const addCollectionToFront = (
 export const removeCollectionFromFront = (
   frontId: string,
   collectionId: string
-): Promise<EditionsFront> => {
+): Promise<EditionsCollection[]> => {
   return pandaFetch(
     `/editions-api/fronts/${frontId}/collection/${collectionId} `,
     {
@@ -143,7 +143,7 @@ export const moveCollection = (
   frontId: string,
   collectionId: string,
   index: number
-): Promise<EditionsFront> => {
+): Promise<EditionsCollection[]> => {
   return pandaFetch(
     `/editions-api/fronts/${frontId}/collection/${collectionId}/move`,
     {

--- a/fronts-client/src/services/editionsApi.ts
+++ b/fronts-client/src/services/editionsApi.ts
@@ -1,4 +1,4 @@
-import type { EditionsFront, EditionsIssue, IssueVersion } from 'types/Edition';
+import type { EditionsIssue, IssueVersion } from 'types/Edition';
 import type { CAPISearchQueryResponse } from './capiQuery';
 import type { EditionsFrontMetadata } from 'types/FaciaApi';
 import { Moment } from 'moment';

--- a/fronts-client/src/services/editionsApi.ts
+++ b/fronts-client/src/services/editionsApi.ts
@@ -139,6 +139,23 @@ export const removeCollectionFromFront = (
   ).then((response) => response.json());
 };
 
+export const moveCollection = (
+  frontId: string,
+  collectionId: string,
+  index: number
+): Promise<EditionsFront> => {
+  return pandaFetch(
+    `/editions-api/fronts/${frontId}/collection/${collectionId}/move`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ newIndex: index }),
+    }
+  ).then((response) => response.json());
+};
+
 export async function getIssueVersions(
   issueId: string
 ): Promise<IssueVersion[]> {

--- a/fronts-client/src/util/schema.ts
+++ b/fronts-client/src/util/schema.ts
@@ -5,8 +5,8 @@ import { Card } from 'types/Collection';
 const preProcessCard = (card: Card): object => ({
   ...card,
   // guard against missing meta from the server
-  meta: card.meta || {},
-  uuid: v4(),
+  meta: card.meta ?? {},
+  uuid: card.uuid ?? v4(),
 });
 
 const postProcessCard = (card: Card): object => {

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -414,6 +414,31 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
     updatedBrexshit.items.find(_.id == "76543").value.addedOn shouldBe now.toInstant.toEpochMilli
   }
 
+  "getFront" - {
+    "should get all the card content in a Front" taggedAs UsesDatabase in {
+      val feastFront = front("news/uk",
+        collection(
+          "politics",
+          None,
+          card("recipe", Some(CardType.Recipe)),
+          card("chef", Some(CardType.Chef), Some(EditionsChefMetadata(Some("bio")))),
+          card("feast-collection", Some(CardType.FeastCollection), Some(EditionsFeastCollectionMetadata(Some("title"))))
+        )
+      )
+
+      val id = insertSkeletonIssue(2019, 9, 30, Edition.FeastNorthernHemisphere, feastFront)
+
+      val frontId = editionsDB.getIssue(id).get.fronts.head.id
+
+      DB localTx { implicit session =>
+        val retrievedFront = editionsDB.getFront(frontId).get
+        retrievedFront.collections.head.items.map(_.toSkeleton) shouldBe List(
+          EditionsCardSkeleton("recipe", CardType.Recipe, None),
+          EditionsCardSkeleton("chef", CardType.Chef, Some(EditionsChefMetadata(Some("bio"),None,None))),
+          EditionsCardSkeleton("feast-collection", CardType.FeastCollection, Some(EditionsFeastCollectionMetadata(Some("title"),None,List()))))
+      }
+    }
+  }
 
   "moveCollection" - {
     val testFront = front("news/uk",

--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -425,11 +425,10 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
 
     val testCases = List(
       (0, List("politics", "international", "culture", "sport")),
-      (1, List("politics", "international", "culture", "sport")),
-      (2, List("international", "politics", "culture", "sport")),
-      (3, List("international", "culture", "politics", "sport")),
-      (4, List("international", "culture", "sport", "politics")),
-      (5, List("international", "culture", "sport", "politics"))
+      (1, List("international", "politics", "culture", "sport")),
+      (2, List("international", "culture", "politics", "sport")),
+      (3, List("international", "culture", "sport", "politics")),
+      (4, List("international", "culture", "sport", "politics"))
     )
 
     "should update the other collections in the front when the collection index is modified, reordering as needed" - {


### PR DESCRIPTION
## What's changed?

Adds the ability to move a collection up and down.

![move-collections](https://github.com/user-attachments/assets/184a001f-fac7-4b42-99c1-3eaf4c6ca122)

## Implementation notes

Previous implementations of client-side collection changes were relying on a response type from the server that was slightly faulty – the API was returning an `EditionsFront`, which contained `EditionsCollection`, not `EditionsClientCollection` instances, and thus `EditionsCard` not `EditionsClientCard` instances. This didn't matter when creating and deleting collections, because these were actions on empty or disappearing collections. When moving collections with content, however, this matters, because `EditionsCard` instances do not include a `cardType`, resulting in blank content.

This PR alters the backend to return `EditionsClientCollection[]` rather than `EditionsFront` across all the endpoints that alter collections in this way – we do not use the front data in any of those methods on rehydration, and there is no equivalent `EditionsClientFront`.

## How to test

- The automated tests should pass. They've been adjusted to reflect the new response types.
- Have a play moving collections up and down, perhaps in CODE. It should work as expected!

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
