### PR TITLE
Remove deprecated `fixed/highlights` container

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -36,8 +36,6 @@ class FixedContainers(val config: ApplicationConfiguration) {
     ("fixed/video/vertical", video),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcase),
-    // TODO - 28/08/24 remove fixed/highlights once downstream uses have been migrated to scrollable/highlights
-    ("fixed/highlights", highlights),
     ("scrollable/highlights", highlights)
   ) ++ (if (config.faciatool.showTestContainers) Map(
     ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -61,7 +61,6 @@ export default {
         { name: 'news/most-popular' },
         { name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
         { name: 'fixed/showcase' },
-        { name: 'fixed/highlights' },
         { name: 'scrollable/highlights' }
     ],
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

As a follow-up from https://github.com/guardian/facia-tool/pull/1641, this PR removes the `fixed/highlights` container now that usages have been migrated to the `scrollable/highlights` type

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

Removes `fixed/highlights` container type

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
