### PR TITLE
Ready Feast curation for production

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -22,7 +22,12 @@ import java.nio.charset.StandardCharsets
 
 class BadConfigurationException(msg: String) extends RuntimeException(msg)
 
-class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isProd: Boolean) extends Logging  {
+class ApplicationConfiguration(
+                                val playConfiguration: PlayConfiguration,
+                                val isProd: Boolean,
+                                // Override properties defined in configuration. Useful for testing.
+                                val propertyOverrides: Map[String, String] = Map.empty
+                              ) extends Logging  {
   private val propertiesFile = "/etc/gu/facia-tool.properties"
   private val installVars = new File(propertiesFile) match {
     case f if f.exists => IOUtils.toString(new FileInputStream(f), "UTF-8")
@@ -31,7 +36,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val isP
       ""
   }
 
-  private val properties = Properties(installVars)
+  private val properties = Properties(installVars) ++ propertyOverrides
   private val stageFromProperties = properties.getOrElse("STAGE", "CODE")
   private val stsRoleToAssumeFromProperties = properties.getOrElse("STS_ROLE", "unknown")
   private val frontPressedDynamoTable = properties.getOrElse("FRONT_PRESSED_TABLE", "unknown")

--- a/app/model/FeastAppModel.scala
+++ b/app/model/FeastAppModel.scala
@@ -1,6 +1,5 @@
 package model
 
-import model.editions.Edition
 import play.api.libs.json._
 
 import java.time.LocalDate
@@ -39,7 +38,7 @@ object FeastAppModel {
 
   case class FeastAppCuration(
                              id:String,
-                             edition:Edition,
+                             edition:String,
                              issueDate:LocalDate,
                              version:String,
                              fronts:Map[String,IndexedSeq[FeastAppContainer]]

--- a/app/model/FeastAppModel.scala
+++ b/app/model/FeastAppModel.scala
@@ -3,7 +3,7 @@ package model
 import play.api.libs.json._
 
 import java.time.LocalDate
-import model.editions.Palette
+import model.editions.{Edition, Palette}
 
 object FeastAppModel {
   sealed trait ContainerItem
@@ -37,11 +37,12 @@ object FeastAppModel {
   //type FeastAppCuration = Map[String, IndexedSeq[FeastAppContainer]]
 
   case class FeastAppCuration(
-                             id:String,
-                             edition:String,
-                             issueDate:LocalDate,
-                             version:String,
-                             fronts:Map[String,IndexedSeq[FeastAppContainer]]
+                               id:String,
+                               edition: Edition,
+                               path:String,
+                               issueDate:LocalDate,
+                               version:String,
+                               fronts:Map[String,IndexedSeq[FeastAppContainer]]
                              )
 
   implicit val recipeIdentifierFormat:Format[RecipeContent] = Json.format[RecipeContent]

--- a/app/model/editions/EditionsAppTemplates.scala
+++ b/app/model/editions/EditionsAppTemplates.scala
@@ -7,7 +7,7 @@ import enumeratum.{EnumEntry, PlayEnum}
 import model.editions.PathType.{PrintSent, Search}
 import model.editions.templates.TemplateHelpers.Defaults
 import model.editions.templates._
-import model.editions.templates.feast.{FeastNorthernHemisphere, FeastSouthernHemisphere}
+import model.editions.templates.feast.{FeastAppEdition, FeastNorthernHemisphere, FeastSouthernHemisphere}
 import org.postgresql.util.PGobject
 import play.api.libs.json.{Json, OFormat}
 import services.editions.prefills.CapiQueryTimeWindow
@@ -51,7 +51,7 @@ object EditionsAppTemplates {
 }
 
 object FeastAppTemplates {
-  val templates: Map[Edition, CuratedPlatformWithTemplate] = Map(
+  val templates: Map[Edition, FeastAppEdition] = Map(
     Edition.FeastNorthernHemisphere -> FeastNorthernHemisphere,
     Edition.FeastSouthernHemisphere -> FeastSouthernHemisphere
   )

--- a/app/model/editions/templates/feast/FeastHelpers.scala
+++ b/app/model/editions/templates/feast/FeastHelpers.scala
@@ -8,7 +8,7 @@ trait FeastAppEdition extends CuratedPlatformWithTemplate {
   override val subTitle = "Make inspiring mealtimes easy with the Guardian’s Feast app."
   override val platform = CuratedPlatform.Feast
 
-  // The name of the edition as published to the recipe backend
-  val backendEditionName: String
+  // The path of the edition as published to the recipe backend
+  val path: String
 }
 

--- a/app/model/editions/templates/feast/FeastHelpers.scala
+++ b/app/model/editions/templates/feast/FeastHelpers.scala
@@ -7,5 +7,8 @@ trait FeastAppEdition extends CuratedPlatformWithTemplate {
   override val title = "Feast app"
   override val subTitle = "Make inspiring mealtimes easy with the Guardian’s Feast app."
   override val platform = CuratedPlatform.Feast
+
+  // The name of the edition as published to the recipe backend
+  val backendEditionName: String
 }
 

--- a/app/model/editions/templates/feast/FeastNorthernHemisphere.scala
+++ b/app/model/editions/templates/feast/FeastNorthernHemisphere.scala
@@ -11,7 +11,7 @@ object FeastNorthernHemisphere extends FeastAppEdition {
   override val locale = Some("en_GB")
   override val notificationUTCOffset = 0
 
-  override val backendEditionName: String = "northern"
+  override val path: String = "northern"
 
   val MainFront: FrontTemplate = front(
     "All Recipes",

--- a/app/model/editions/templates/feast/FeastNorthernHemisphere.scala
+++ b/app/model/editions/templates/feast/FeastNorthernHemisphere.scala
@@ -11,6 +11,8 @@ object FeastNorthernHemisphere extends FeastAppEdition {
   override val locale = Some("en_GB")
   override val notificationUTCOffset = 0
 
+  override val backendEditionName: String = "northern"
+
   val MainFront: FrontTemplate = front(
     "All Recipes",
     collection("Dish of the day")

--- a/app/model/editions/templates/feast/FeastSouthernHemisphere.scala
+++ b/app/model/editions/templates/feast/FeastSouthernHemisphere.scala
@@ -1,6 +1,5 @@
 package model.editions.templates.feast
 
-import com.gu.mobile.notifications.client.models.Editions
 import model.editions.templates.TemplateHelpers.{collection, front}
 import model.editions.{CapiDateQueryParam, CapiTimeWindowConfigInDays, Daily, Edition, EditionTemplate, FrontTemplate}
 
@@ -11,6 +10,7 @@ object FeastSouthernHemisphere extends FeastAppEdition {
   override val edition = Edition.FeastSouthernHemisphere.entryName
   override val locale = Some("en_GB")
   override val notificationUTCOffset = 0
+  override val backendEditionName: String = "southern"
 
   val MainFront: FrontTemplate = front(
     "All Recipes",

--- a/app/model/editions/templates/feast/FeastSouthernHemisphere.scala
+++ b/app/model/editions/templates/feast/FeastSouthernHemisphere.scala
@@ -10,7 +10,7 @@ object FeastSouthernHemisphere extends FeastAppEdition {
   override val edition = Edition.FeastSouthernHemisphere.entryName
   override val locale = Some("en_GB")
   override val notificationUTCOffset = 0
-  override val backendEditionName: String = "southern"
+  override val path: String = "southern"
 
   val MainFront: FrontTemplate = front(
     "All Recipes",

--- a/app/services/editions/publishing/EditionsAppPublicationTarget.scala
+++ b/app/services/editions/publishing/EditionsAppPublicationTarget.scala
@@ -34,10 +34,10 @@ object EditionsAppPublicationTarget extends LazyLogging {
 }
 
 class EditionsAppPublicationTarget(s3Client: AmazonS3, bucketName: String) extends PublicationTarget with LazyLogging {
-  override def putIssue(issue: EditionsIssue, version: String, action: PublishAction): Unit = {
+  override def putIssue(issue: EditionsIssue, version: String, action: PublishAction): Either[String, Unit] = {
     val outputKey = createKey(issue, version)
     val publishableIssue = issue.toPublishableIssue(version, action)
-    putIssueJson(publishableIssue, outputKey)
+    Right(putIssueJson(publishableIssue, outputKey))
   }
 
   override def putIssueJson[T: Writes](content: T, key:String): Unit = {

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest}
 import conf.ApplicationConfiguration
 import model.FeastAppModel.{Chef, ChefContent, ContainerItem, FeastAppContainer, FeastAppCuration, FeastCollection, FeastCollectionContent, Recipe, RecipeContent}
 import model.editions.PublishAction.PublishAction
-import model.editions.{Edition, EditionsArticle, EditionsCard, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsIssue, EditionsRecipe}
+import model.editions.{Edition, EditionsArticle, EditionsCard, EditionsChef, EditionsCollection, EditionsFeastCollection, EditionsIssue, EditionsRecipe, FeastAppTemplates}
 import play.api.libs.json.{Json, Writes}
 import util.TimestampGenerator
 
@@ -73,9 +73,9 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
     )
 
   def transformContent(source: EditionsIssue, version: String): Either[String, FeastAppCuration] = {
-    editionToBackendEditionMap.get(source.edition) match {
-      case Some(backendEdition) =>
-        val backendEditionName = if (config.isProd) s"$backendEdition-test" else backendEdition
+    FeastAppTemplates.templates.get(source.edition) match {
+      case Some(template) =>
+        val backendEditionName = if (config.isProd) s"${template.backendEditionName}-test" else template.backendEditionName
         Right(FeastAppCuration(
           id = source.id,
           issueDate = source.issueDate,

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -23,11 +23,6 @@ object FeastPublicationTarget {
 }
 
 class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfiguration, timestamp: TimestampGenerator) extends PublicationTarget with Logging {
-  def editionToBackendEditionMap: Map[Edition, String] = Map(
-    Edition.FeastNorthernHemisphere -> "northern",
-    Edition.FeastSouthernHemisphere -> "southern"
-  )
-
   private def transformCards(source: EditionsCard): ContainerItem = {
     source match {
       case _: EditionsArticle => throw new Error("Article not permitted in a Feast Front")
@@ -75,7 +70,7 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
   def transformContent(source: EditionsIssue, version: String): Either[String, FeastAppCuration] = {
     FeastAppTemplates.templates.get(source.edition) match {
       case Some(template) =>
-        val backendEditionName = if (config.isProd) s"${template.backendEditionName}-test" else template.backendEditionName
+        val backendEditionName = if (config.environment.stage == "prod") s"${template.backendEditionName}-test" else template.backendEditionName
         Right(FeastAppCuration(
           id = source.id,
           issueDate = source.issueDate,

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -42,7 +42,7 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
           darkPalette = metadata.flatMap(_.theme.map(_.darkPalette)),
           lightPalette = metadata.flatMap(_.theme.map(_.lightPalette)),
           image = metadata.flatMap(_.theme.flatMap(_.imageURL)),
-          body = None,
+          body = Some(""), // The apps appear to require this to be present, even if it is empty
           title = metadata.flatMap(_.title).getOrElse("No title"),
           recipes = recipes
         ))
@@ -70,11 +70,12 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
   def transformContent(source: EditionsIssue, version: String): Either[String, FeastAppCuration] = {
     FeastAppTemplates.templates.get(source.edition) match {
       case Some(template) =>
-        val backendEditionName = if (config.environment.stage == "prod") s"${template.backendEditionName}-test" else template.backendEditionName
+        val path = if (config.environment.stage == "prod") s"${template.path}-test" else template.path
         Right(FeastAppCuration(
           id = source.id,
           issueDate = source.issueDate,
-          edition = backendEditionName,
+          edition = source.edition,
+          path = path,
           version = version,
           fronts = source.fronts.map(f => {
             (transformName(f.getName), f.collections.map(transformCollections).toIndexedSeq)

--- a/app/services/editions/publishing/PublicationTarget.scala
+++ b/app/services/editions/publishing/PublicationTarget.scala
@@ -5,7 +5,7 @@ import model.editions.PublishAction.PublishAction
 import play.api.libs.json.Writes
 
 trait PublicationTarget extends PublicationTargetHelpers {
-  def putIssue(issue: EditionsIssue, version:String, action: PublishAction): Unit
+  def putIssue(issue: EditionsIssue, version:String, action: PublishAction): Either[String, Unit]
 
   protected def putIssueJson[C: Writes](content: C, key:String): Unit
 

--- a/fronts-client/src/constants/url.ts
+++ b/fronts-client/src/constants/url.ts
@@ -23,6 +23,7 @@ export default {
   capiLiveUrl: '/api/live',
   capiPreviewUrl: '/api/preview',
   recipes: 'https://recipes.guardianapis.com',
+  codeRecipes: 'https://recipes.code.dev-guardianapis.com',
   manageEditions: '/manage-editions/',
   appRoot: 'v2',
   editionsCardBuilder: 'https://editions-card-builder.gutools.co.uk',

--- a/fronts-client/src/services/__tests__/recipeQuery.spec.ts
+++ b/fronts-client/src/services/__tests__/recipeQuery.spec.ts
@@ -1,6 +1,7 @@
 import { updateImageScalingParams, liveRecipes } from '../recipeQuery';
 import fetchMock from 'fetch-mock';
 
+jest.mock('')
 describe("updateImageScalingParams", ()=>{
   it("should correctly update a URL with scaling params", ()=>{
     expect(updateImageScalingParams("https://i.guim.co.uk/img/media/8c8aafb89d2467f41d5cf9d1324f815fee71d54c/0_168_4080_5101/master/4080.jpg?width=1600&dpr=1&s=none"))

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -178,5 +178,5 @@ const recipeQuery = (baseUrl:string) => {
   }
 }
 
-const isCode = ()=>window.location.hostname.includes("code") || window.location.hostname.includes("local");
+const isCode = ()=>window.location.hostname.includes("code.") || window.location.hostname.includes("local.");
 export const liveRecipes = recipeQuery( isCode() ? url.codeRecipes : url.recipes);

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -178,4 +178,5 @@ const recipeQuery = (baseUrl:string) => {
   }
 }
 
-export const liveRecipes = recipeQuery(url.recipes);
+const isCode = ()=>window.location.hostname.includes("code") || window.location.hostname.includes("local");
+export const liveRecipes = recipeQuery( isCode() ? url.codeRecipes : url.recipes);

--- a/scripts/recipes/insert-recipe-cards.mjs
+++ b/scripts/recipes/insert-recipe-cards.mjs
@@ -7,7 +7,10 @@ node ./insert-recipe-cards.mjs
     --fronts-issue-id "b45d7c3a-497f-4230-8aad-923ce5a8cd2f"
     --front-name "Meat-Free"
     --stage CODE
-    --cookie "<get this from a Fronts client request header for the appropriate stage>"`;
+    --cookie "<get this from a Fronts client request header for the appropriate stage>"
+
+Note that you must specify --dry-run=false in order to populate the collections with content
+`;
 
 const getArg = (flag, optional = false) => {
     const argIdx = process.argv.indexOf(flag);
@@ -21,19 +24,29 @@ const getArg = (flag, optional = false) => {
     return arg;
 };
 
+const getFrontsUri = () => {
+    switch(stage.toLocaleUpperCase()) {
+        case "PROD":
+            return "https://fronts.gutools.co.uk";
+        case "CODE":
+            return "https://fronts.code.dev-gutools.co.uk";
+        case "LOCAL":
+            return "https://fronts.local.dev-gutools.co.uk";
+        default:
+            throw new Error("--stage must be one of PROD, CODE or LOCAL")
+    }
+}
+
 const curationPath = getArg("--curation-path");
 const frontsIssueId = getArg("--fronts-issue-id");
 const frontName = getArg("--front-name");
 const stage = getArg("--stage");
 const cookie = getArg("--cookie");
-const dryRun = getArg("--dry-run", true) === "false" ? false : true;
+const dryRun = getArg("--dry-run", true) !== "false";
 
 const curationBaseUrl = "https://recipes.guardianapis.com";
 const curationUrl = `${curationBaseUrl}/${curationPath}/curation.json`;
-const frontsBaseUrl =
-    stage === "PROD"
-        ? "https://fronts.gutools.co.uk"
-        : "https://fronts.code.dev-gutools.co.uk";
+const frontsBaseUrl = getFrontsUri();
 const frontsHeaders = {
     "Content-Type": "application/json",
     Cookie: cookie,

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -180,7 +180,7 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
 
       val toTest = new FeastPublicationTarget(mockSNS, conf, mockTSG)
 
-      val result = toTest.transformContent(testIssue, "v1")
+      val result = toTest.transformContent(testIssue, "v1").toOption.get
       result.fronts.contains("all-recipes") shouldBe true
       val allRecipesFront = result.fronts("all-recipes")
       allRecipesFront.length shouldBe 1
@@ -205,13 +205,31 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
         ))
       )
     }
+
+    "should add the suffix -test to fronts published to PROD, for now" in {
+      val mockSNS = mock[AmazonSNSClient]
+      when(mockSNS.publish(any[PublishRequest])).thenReturn(new PublishResult())
+
+      val prodConf = new ApplicationConfiguration(
+        Configuration.from(Map(
+          "aws.region"->"eu-west-1",
+          "feast_app.publication_topic" -> "fake-publication-topic"
+        )),
+        true
+      )
+
+      val toTest = new FeastPublicationTarget(mockSNS, prodConf, mockTSG)
+
+      val result = toTest.transformContent(testIssue, "v1").toOption.get
+      result.edition shouldBe "northern-test"
+    }
   }
 
   "putIssue" - {
     "should output the transformed version of the content" in {
       val serializedVersion = """{
         |  "id": "123456ABCD",
-        |  "edition": "feast-northern-hemisphere",
+        |  "edition": "northern",
         |  "issueDate": "2024-05-03",
         |  "version": "v1",
         |  "fronts": {
@@ -267,6 +285,18 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
           "type"->new MessageAttributeValue().withDataType("String").withStringValue("Issue")
         ).asJava)
       verify(mockSNS).publish(expectedRequest)
+    }
+
+    "should not permit publishing issues without a suitable entry for the backend name" in {
+      val mockSNS = mock[AmazonSNSClient]
+      val toTest = new FeastPublicationTarget(mockSNS, conf, mockTSG)
+      val issueWithInvalidEdition = testIssue.copy(edition = Edition.DailyEdition)
+      val result = toTest.putIssue(issueWithInvalidEdition, "v1", PublishAction.publish)
+
+      result match {
+        case Left(error) => error should include("No backend edition name found")
+        case Right(_) => fail("should not be able to publish this sort of edition")
+      }
     }
   }
 }

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -201,7 +201,8 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
           lightPalette = Some(Palette("#FFF", "#333")),
           image = Some("https://example.com/an-image.jpg"),
           title = "Collection title",
-          recipes = List("nested-recipe-id")
+          recipes = List("nested-recipe-id"),
+          body = Some("")
         ))
       )
     }
@@ -222,7 +223,8 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
       val toTest = new FeastPublicationTarget(mockSNS, prodConf, mockTSG)
 
       val result = toTest.transformContent(testIssue, "v1").toOption.get
-      result.edition shouldBe "northern-test"
+      result.edition shouldBe Edition.FeastNorthernHemisphere
+      result.path shouldBe "northern-test"
     }
   }
 
@@ -230,7 +232,8 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
     "should output the transformed version of the content" in {
       val serializedVersion = """{
         |  "id": "123456ABCD",
-        |  "edition": "northern",
+        |  "edition": "feast-northern-hemisphere",
+        |  "path": "northern",
         |  "issueDate": "2024-05-03",
         |  "version": "v1",
         |  "fronts": {
@@ -257,6 +260,7 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
         |                "backgroundHex": "#FFF"
         |              },
         |              "image": "https://example.com/an-image.jpg",
+        |              "body": "",
         |              "title": "Collection title",
         |              "lightPalette": {
         |                "foregroundHex": "#FFF",

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -215,7 +215,8 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
           "aws.region"->"eu-west-1",
           "feast_app.publication_topic" -> "fake-publication-topic"
         )),
-        true
+        true,
+        propertyOverrides = Map("STAGE" -> "PROD")
       )
 
       val toTest = new FeastPublicationTarget(mockSNS, prodConf, mockTSG)

--- a/test/services/editions/publishing/PublishingTest.scala
+++ b/test/services/editions/publishing/PublishingTest.scala
@@ -21,7 +21,6 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
-      doNothing().when(feastAppPublicationTarget).putIssue(any,any,any)
       when(db.createIssueVersion(any,any,any)).thenReturn("new-version")
 
       val toTest = new Publishing(editionsAppPublicationBucket, editionsAppPreviewBucket, feastAppPublicationTarget, db)
@@ -54,7 +53,6 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
-      doNothing().when(editionsAppPublicationBucket).putIssue(any,any,any)
       when(db.createIssueVersion(any,any,any)).thenReturn("new-version")
 
       val toTest = new Publishing(editionsAppPublicationBucket, editionsAppPreviewBucket, feastAppPublicationTarget, db)
@@ -89,7 +87,6 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
-      doNothing().when(feastAppPublicationTarget).putIssue(any,any,any)
       when(db.createIssueVersion(any,any,any)).thenReturn("new-version")
 
       val toTest = new Publishing(editionsAppPublicationBucket, editionsAppPreviewBucket, feastAppPublicationTarget, db)
@@ -122,7 +119,6 @@ class PublishingTest extends FreeSpec with Matchers with MockitoSugar {
       val feastAppPublicationTarget = mock[FeastPublicationTarget]
       val db = mock[EditionsDB]
 
-      doNothing().when(feastAppPublicationTarget).putIssue(any,any,any)
       when(db.createIssueVersion(any,any,any)).thenReturn("new-version")
 
       val toTest = new Publishing(editionsAppPublicationBucket, editionsAppPreviewBucket, feastAppPublicationTarget, db)


### PR DESCRIPTION
## What's changed?

This PR makes three changes that were necessary to successfully test front publication end-to-end in the Feast app:

- correct front names for CODE
- add a temporary -test suffix for PROD fronts, to ensure that hitting publishing in PROD doesn't overwrite mis-en-place data yet
- add an empty 'body' property to feast collections for the Android app to display collections properly – it's necessary for [their model](https://github.com/guardian/android-feast/blob/6e647b2aec3a84aa22df1b663c7200f0bb30b684/core/model/src/main/kotlin/uk/co/guardian/feast/model/FeastArticle.kt#L11)

Re: front names, this PR has each Feast edition write the correct path name to `recipe-backend` (`FeastNorthernHemisphere` -> `northern`, `FeastSouthernHemisphere` -> `southern`) – with a caveat that at the moment, `PROD` will add the suffix `test` to the edition, to avoid stomping on mis-en-place's data.

Once we're happy, we can then remove the distinction between CODE and PROD.

## Implementation notes

I've added a test for the PROD behaviour, which meant wiring through property overrides into `ApplicationConfiguration` in b92a7992c99ce8763fca74cdd6797b5c5cd33455 to allow us to specify a stage in tests – hope that makes sense.

Other model changes are well covered in other tests.

## How to test

- Deploy the [sister branch in recipes-backend](https://github.com/guardian/recipes-backend/pull/62) to CODE. This includes some small but important model changes.
- Deploy this branch to CODE.
- If you publish a Front for the current day for a given issue, after a short delay, you should see it in the `/curation.json` for the appropriate recipes-backend URL (e.g. `recipes.code.dev-guardianapis.com/northern/all-recipes/curation.json`.)

If you'd like to see a nice full front, use the new [Feast -> Fronts script](https://github.com/guardian/facia-tool/pull/1645) to populate CODE issues with PROD data.

Tested end-to-end in CODE with the Feast app (Android):

|Recipes|Chefs and collections|
|-|-|
|<img src="https://github.com/user-attachments/assets/7ec8c585-6391-4224-a72e-a0cb95497579" height="700" />|<img src="https://github.com/user-attachments/assets/f4f35f1a-ff02-4196-a5b6-fe398da2e9af" height="700" />|

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
