### PR TITLE
Only create issues from previous issues of that edition

### DIFF
--- a/test/services/editions/db/EditionsDBTest.scala
+++ b/test/services/editions/db/EditionsDBTest.scala
@@ -731,6 +731,24 @@ class EditionsDBTest extends FreeSpec with Matchers with EditionsDBService with 
       }
     }
 
+    "should ignore any issues that don't match the edition type" taggedAs UsesDatabase in {
+      insertSkeletonIssue(2020, 1, 1, Edition.FeastNorthernHemisphere, front("feast", collection("feast", None)))
+      insertSkeletonIssue(2020, 1, 2, Edition.DailyEdition, front("editions-app", collection("not-feast", None)))
+
+      editionsDB.insertIssueFromClosestPreviousIssue(
+        Edition.FeastNorthernHemisphere,
+        LocalDate.of(2020, 1, 3),
+        user,
+        now
+      ) match {
+        case Right(issue) =>
+          issue.issueDate shouldBe LocalDate.of(2020, 1, 3)
+          val front = issue.fronts.head
+          front.displayName shouldBe "feast"
+        case Left(e) => fail(e.getMessage)
+      }
+    }
+
     "should only copy the fronts, collections and cards related to that issue" taggedAs UsesDatabase in {
       insertSkeletonIssue(2020, 1, 1, Edition.FeastNorthernHemisphere, front("first", collection("politics", None, cardsSkeleton: _*)))
       insertSkeletonIssue(2020, 1, 12, Edition.FeastNorthernHemisphere, front("second", collection("politics", None, cardsSkeleton: _*)))


### PR DESCRIPTION
## What's changed?

When attempting to create an issue from a previous issue, filter by `edition` name to avoid creating e.g. Feast issues from Editions app issues 🤦 

## How to test

- The automated tests should be pass – I've added a test for this case.
- Try creating an issue from a previous Feast issue, where an Editions App issue would be more recent. On `main`, you should find your new issue populated with the Editions App issue. On this branch, you should find that the Editions App issue is ignored for the correct Feast issue.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
