### PR TITLE
Remove -test suffix to Feast curation paths in PROD

### DIFF
--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -70,12 +70,11 @@ class FeastPublicationTarget(snsClient: AmazonSNS, config: ApplicationConfigurat
   def transformContent(source: EditionsIssue, version: String): Either[String, FeastAppCuration] = {
     FeastAppTemplates.templates.get(source.edition) match {
       case Some(template) =>
-        val path = if (config.environment.stage == "prod") s"${template.path}-test" else template.path
         Right(FeastAppCuration(
           id = source.id,
           issueDate = source.issueDate,
           edition = source.edition,
-          path = path,
+          path = template.path,
           version = version,
           fronts = source.fronts.map(f => {
             (transformName(f.getName), f.collections.map(transformCollections).toIndexedSeq)

--- a/test/services/editions/publishing/FeastPublicationTargetTest.scala
+++ b/test/services/editions/publishing/FeastPublicationTargetTest.scala
@@ -206,26 +206,6 @@ class FeastPublicationTargetTest extends FreeSpec with Matchers with MockitoSuga
         ))
       )
     }
-
-    "should add the suffix -test to fronts published to PROD, for now" in {
-      val mockSNS = mock[AmazonSNSClient]
-      when(mockSNS.publish(any[PublishRequest])).thenReturn(new PublishResult())
-
-      val prodConf = new ApplicationConfiguration(
-        Configuration.from(Map(
-          "aws.region"->"eu-west-1",
-          "feast_app.publication_topic" -> "fake-publication-topic"
-        )),
-        true,
-        propertyOverrides = Map("STAGE" -> "PROD")
-      )
-
-      val toTest = new FeastPublicationTarget(mockSNS, prodConf, mockTSG)
-
-      val result = toTest.transformContent(testIssue, "v1").toOption.get
-      result.edition shouldBe Edition.FeastNorthernHemisphere
-      result.path shouldBe "northern-test"
-    }
   }
 
   "putIssue" - {


### PR DESCRIPTION
## What's changed?

Remove the `-test` suffix to Feast curation paths in PROD, so publishing on PROD publishes to the production Feast apps.

Not to be merged until we and Feast are happy that Feast Fronts is ready to go 🍽️ 🎉 

## Checklist

### General
- [x] 🤖 Relevant tests ~added~ removed 😀 
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
