### PR TITLE
Remove unnecessary sbt settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,12 +120,6 @@ dependencyOverrides ++= Seq(
     "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1",
 )
 
-// Until all dependencies are on scala-java8-compat v1.x, this avoids unnecessary fatal eviction errors
-libraryDependencySchemes ++= Seq(
-    "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always,
-    "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)
-
 val UsesDatabaseTest = config("database-int") extend Test
 
 lazy val root = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,14 +3,7 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 
-resolvers ++= Seq(
-  Classpaths.typesafeReleases,
-  Resolver.sonatypeRepo("releases"),
-  Resolver.typesafeRepo("releases"),
-  Resolver.url("sbt-plugin-snapshots", new URL("https://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots/"))(Resolver.ivyStylePatterns),
-  "Guardian Github Releases" at "https://guardian.github.com/maven/repo-releases",
-  "Spy" at "https://files.couchbase.com/maven2/"
-)
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 


### PR DESCRIPTION
This just removes some sbt settings that have become unnecessary/unwanted, relating to these issues:

* https://github.com/guardian/maintaining-scala-projects/issues/11
* https://github.com/guardian/maintaining-scala-projects/issues/13

## Testing

To check that all the resolvers were genuinely unused, I deleted all [build caches in GitHub](https://github.com/guardian/facia-tool/actions/caches), and re-ran the build on this PR only, which completed [successfully](https://github.com/guardian/facia-tool/actions/runs/10736925510?pr=1652).