### PR TITLE
Check Java version and kill background processes on exit

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -11,6 +11,19 @@ do
     fi
 done
 
+cleanup() {
+    echo "Cleaning up background processes..."
+    YARN_PID=$(pgrep -f "yarn.*watch")
+    if [ ! -z "$YARN_PID" ]; then
+        echo "Killing yarn watch process (PID: $YARN_PID)"
+        kill $YARN_PID
+    else
+        echo "No yarn watch process found"
+    fi
+}
+
+trap cleanup EXIT
+
 hasCredentials() {
   STATUS=$(aws sts get-caller-identity --profile cmsFronts 2>&1 || true)
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -44,7 +44,19 @@ runNginx() {
   fi
 }
 
+checkJavaVersion() {
+    REQUIRED_JAVA_VERSION="11"
+    MAJOR_JAVA_VERSION=$(java -version 2>&1 | awk -F[\"_] '/version/ {print $2}' | cut -d '.' -f1)
+    if [[ "$MAJOR_JAVA_VERSION" != "$REQUIRED_JAVA_VERSION" ]]; then
+        echo -e "Incorrect Java version: requires Java $REQUIRED_JAVA_VERSION but found Java $MAJOR_JAVA_VERSION."
+        exit 1
+    else
+        echo "Correct Java version ($MAJOR_JAVA_VERSION) is installed."
+    fi
+}
+
 main() {
+    checkJavaVersion
     runNginx
     hasCredentials
 


### PR DESCRIPTION
## What's changed?
A couple of changes to the startup script:
- checks that the correct Java version is installed, exiting the script if not
- kills background processes on exit, so that the `5173 in use` error is no longer displayed when re-running the script

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
