### PR TITLE
Additions to the script to migrate historical feast data to Front

### DIFF
--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -178,5 +178,5 @@ const recipeQuery = (baseUrl:string) => {
   }
 }
 
-const isCode = ()=>window.location.hostname.includes("code.") || window.location.hostname.includes("local.");
+const isCode = ()=>window.location.hostname.includes("code."); //|| window.location.hostname.includes("local.");
 export const liveRecipes = recipeQuery( isCode() ? url.codeRecipes : url.recipes);

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -178,5 +178,5 @@ const recipeQuery = (baseUrl:string) => {
   }
 }
 
-const isCode = ()=>window.location.hostname.includes("code."); //|| window.location.hostname.includes("local.");
+const isCode = ()=>window.location.hostname.includes("code.") || window.location.hostname.includes("local.");
 export const liveRecipes = recipeQuery( isCode() ? url.codeRecipes : url.recipes);

--- a/scripts/recipes/insert-backdate-recipes.mjs
+++ b/scripts/recipes/insert-backdate-recipes.mjs
@@ -1,0 +1,505 @@
+import crypto from "crypto";
+
+const dateFormat = 'YYYY-MM-DD';
+const usage = `Example usage is
+
+node ./insert-recipe-cards.mjs
+    --curation-path "northern/meat-free"
+    --from-date "2024-05-01"
+    --to-date "2024-05-05"
+    --edition-name "feast-northern-hemisphere"
+    --front-name "Meat-Free"
+    --stage CODE
+    --cookie "<get this from a Fronts client request header for the appropriate stage>"
+
+Note that you must specify --dry-run=false in order to populate the collections with content
+`;
+
+const getArg = (flag, optional = false) => {
+    const argIdx = process.argv.indexOf(flag);
+    const arg = argIdx !== -1 ? process.argv[argIdx + 1] : "";
+
+    if (!arg && !optional) {
+        console.error(`No argument for ${flag} given. ${usage}`);
+        process.exit(2);
+    }
+
+    return arg;
+};
+
+const getFrontsUri = () => {
+    switch(stage.toLocaleUpperCase()) {
+        case "PROD":
+            return "https://fronts.gutools.co.uk";
+        case "CODE":
+            return "https://fronts.code.dev-gutools.co.uk";
+        case "LOCAL":
+            return "https://fronts.local.dev-gutools.co.uk";
+        default:
+            throw new Error("--stage must be one of PROD, CODE or LOCAL")
+    }
+}
+
+const getDate = (d) => {
+    var curr_date = d.getDate();
+    var curr_month = d.getMonth() + 1; //Months are zero based
+    var curr_year = d.getFullYear();
+    const resultData =   '' + curr_year + '-' + (curr_month<=9 ? '0' + curr_month : curr_month) + '-' + (curr_date <= 9 ? '0' + curr_date : curr_date);//curr_year + "-" + curr_month  + "-" + curr_date
+    console.log( " resultData = "+resultData);
+    return resultData
+}
+
+const curationPath = getArg("--curation-path");
+const frontName = getArg("--front-name");
+const fromDate = getArg("--from-date");
+const toDate = getArg("--to-date");
+const editionName = getArg("--edition-name")
+const stage = getArg("--stage");
+const cookie = getArg("--cookie");
+const dryRun = getArg("--dry-run", true) !== "false";
+
+const curationBaseUrl = "https://recipes.code.dev-guardianapis.com";
+const frontsBaseUrl = getFrontsUri();
+const frontsHeaders = {
+    "Content-Type": "application/json",
+    Cookie: cookie,
+};
+
+
+const startDate = new Date(fromDate);
+const endDate = new Date(toDate);
+var loopOnDate = startDate;//introduce loop to iterate through dates
+while(loopOnDate <= endDate) {
+    let newDate = loopOnDate.setDate(loopOnDate.getDate() + 1);
+    loopOnDate = new Date(newDate);
+    console.log(`loopOnDate is ${loopOnDate}`)
+    const date = getDate(loopOnDate)
+    console.log(`after date format, date is ${date}`)
+
+    //------Get CURATION.JSON --------//
+    const curationUrl = `${curationBaseUrl}/${curationPath}/${date}/curation.json`;
+
+    if (stage === "PROD") {
+        console.warn(
+            `This will run in the PROD environment in 5 seconds - Ctrl-C to cancel.`
+        );
+        await new Promise((r) => setTimeout(r, 5000));
+    }
+
+    console.log(`Fetching curation data from ${curationUrl} ...`);
+
+    const curationResponse = await fetch(curationUrl);
+
+
+    if (curationResponse.status !== 200) { //---Dont proceed if Curation.json does not exists for that date---//
+        console.error(
+            `Error getting issue data from Fronts tool: ${curationResponse.status} ${
+                curationResponse.statusText
+            } ${await curationResponse.text()}`
+        );
+        //process.exit(1);
+    }else { //---Proceed to FRONT work if curation.json is present---//
+        /**
+         * @type {Array<{
+         *  title: string,
+         *  body: string,
+         *  id: string,
+         *  items: Array<
+         *      { recipe: { id: string } } |
+         *      { chef: { id: string }} |
+         *      { collection: { recipes: string[] }}
+         *    >}
+         *  >}
+         */
+        const curation = await curationResponse.json();
+
+        const fetchIssueForTheDate = async (editionName, start, end) => {
+            const path = `${frontsBaseUrl}/editions-api/editions/${editionName}/issues?dateFrom=${start}&dateTo=${end}`
+            console.log("start fetching issue if available...")
+            const resp = await fetch(path, {
+                method: 'get',
+                mode: 'cors',
+                headers: frontsHeaders,
+                credentials: 'include',
+            }).then((response) => {
+                console.log("response when fetching issue if available = " + response.status)
+                return response.json();
+            }).then(({issues}) => issues[0])
+            return resp;
+        };
+
+        const issueFoundForTheDate = await fetchIssueForTheDate(editionName, date, date);
+
+        console.log(`DO we already have issue id?  ${issueFoundForTheDate.id}`)
+
+        let frontsIssueId = ""
+        if (issueFoundForTheDate && issueFoundForTheDate.id) { //Skip rest of work of data migration if issue exists on the date
+            console.log(`Yes we already have existing issue so Don't migrate! ${issueFoundForTheDate.id}`)
+            frontsIssueId = issueFoundForTheDate.id
+        } else { //Proceed to create new issue and migration of data in to it.
+            const createIssue = async (editionName, date) => {
+                const path = `${frontsBaseUrl}/editions-api/editions/${editionName}/issues`;
+                console.log("start creating issue...")
+                const resp = await fetch(path, {
+                    method: 'post',
+                    mode: 'cors',
+                    headers: frontsHeaders,
+                    credentials: 'include',
+                    body: JSON.stringify({issueDate: `${date}`}),
+                }).then((response) => {
+                    console.log("response = " + response.status)
+                    return response.json();
+                });
+                return resp
+            }
+
+            const frontsIssue = await createIssue(editionName, date)
+
+            frontsIssueId = frontsIssue.id
+            console.log(`Issue is created: ${frontsIssueId.id}`)
+
+        if (frontsIssueId.length > 0) {
+            console.log(`Migrating curation data from ${curationPath} to ${stage} Fronts tool, issue: ${frontsIssueId}, front name: ${frontName}, dry run: ${dryRun}.`);
+
+            const frontsIssueUrl = `${frontsBaseUrl}/editions-api/issues/${frontsIssueId}`;
+
+            console.log(`Got curation data.\nFetching fronts issue data from ${frontsIssueUrl}...`);
+
+            const fetchFrontFromIssue = async () => {
+                const frontsResponse = await fetch(frontsIssueUrl, {
+                    method: "GET",
+                    headers: frontsHeaders,
+                });
+
+                if (frontsResponse.status !== 200) {
+                    console.error(
+                        `Error getting issue data from Fronts tool: ${
+                            frontsResponse.status
+                        } ${frontsResponse.statusText} ${await frontsResponse.text()}`
+                    );
+                    process.exit(1);
+                }
+
+                /**
+                 * @type {{
+                 *   id: string;
+                 *   edition: string;
+                 *   issueDate: string; // YYYY-MM-dd
+                 *   createdOn: number;
+                 *   createdBy: string;
+                 *   createdEmail: string;
+                 *   launchedOn?: number;
+                 *   launchedBy: string;
+                 *   launchedEmail: string;
+                 *   fronts: Array<{
+                 *       id: string;
+                 *       displayName: string;
+                 *       isHidden: boolean;
+                 *       updatedOn?: number;
+                 *       updatedBy?: string;
+                 *       updatedEmail?: string;
+                 *       collections: Array<{
+                 *           id: string;
+                 *           displayName: string;
+                 *           prefill?: EditionsPrefill;
+                 *           isHidden: boolean;
+                 *           lastUpdated?: number;
+                 *           updatedBy?: string;
+                 *           updatedEmail?: string;
+                 *           items: any[];
+                 *         }>;
+                 *     }>;
+                 *   supportsProofing: boolean;
+                 *   lastProofedVersion?: string;
+                 *   platform: string;
+                 * }}
+                 */
+                const issueJson = await frontsResponse.json();
+
+                console.log("Got Fronts data.");
+
+                const front = issueJson.fronts.find(
+                    (front) => front.displayName === frontName
+                );
+
+                if (!front) {
+                    console.error(
+                        `No front found with name ${frontName} in issue ${frontsIssueId}`
+                    );
+                    process.exit(1);
+                }
+
+                return front;
+            };
+
+            let front = await fetchFrontFromIssue();
+
+            const collectionNamesInFrontsTool = front.collections.map(
+                (col) => col.displayName
+            );
+            const collectionTitlesMissingInFronts = curation
+                .filter((col) => !collectionNamesInFrontsTool.includes(col.title.trim()))
+                .map((col) => col.title);
+
+            if (collectionTitlesMissingInFronts.length) {
+                // Collections are added from the top, so we add the last collection first
+                for (const title of collectionTitlesMissingInFronts.reverse()) {
+                    const newCollectionResponse = await fetch(
+                        `${frontsBaseUrl}/editions-api/fronts/${front.id}/collection?name=${title}`,
+                        {
+                            method: "PUT",
+                            headers: frontsHeaders,
+                        }
+                    );
+
+                    if (newCollectionResponse.status !== 200) {
+                        console.error(
+                            `Error creating new collection: ${
+                                newCollectionResponse.status
+                            } ${
+                                newCollectionResponse.statusText
+                            } ${await newCollectionResponse.text()}`
+                        );
+                        process.exit(1);
+                    } else {
+                        console.log(
+                            `Collection with title ${title} added to front ${front.id}`
+                        );
+                    }
+                }
+
+                front = await fetchFrontFromIssue();
+            }
+
+            const titleMap = Object.values(front.collections).reduce(
+                (acc, collection) => ({
+                    ...acc,
+                    [collection.displayName]: collection,
+                }),
+                {}
+            );
+
+            console.log(
+                `Mapped titles to collections: \n\n${JSON.stringify(
+                    Object.entries(titleMap).map(([title, col]) => `${title}: ${col.id}`),
+                    undefined,
+                    "  "
+                )}`
+            );
+
+            const skippedCollections = [];
+
+            const updatedCollections = curation.flatMap((collection) => {
+                const frontCollection = titleMap[collection.title.trim()];
+                const frontCollectionId = frontCollection?.id;
+                if (!frontCollectionId) {
+                    console.log(
+                        `No id found mapping the title ${collection.title} to the existing front – skipping this collection`
+                    );
+                    skippedCollections.push(collection.title);
+                    return [];
+                }
+
+                const items = collection.items.flatMap((item, index) => {
+                    const cardMeta = {
+                        uuid: crypto.randomUUID(),
+                        frontPublicationDate: Date.now(),
+                    };
+
+                    const cardType = item.chef
+                        ? "chef"
+                        : item.recipe
+                            ? "recipe"
+                            : item.collection
+                                ? "collection"
+                                : undefined;
+
+                    if (!cardType) {
+                        console.log(`No card type for ${item}`);
+                        return [];
+                    }
+
+                    switch (cardType) {
+                        case "recipe": {
+                            return [
+                                {
+                                    ...cardMeta,
+                                    id: item.recipe.id,
+                                    cardType: "recipe",
+                                },
+                            ];
+                        }
+                        case "chef": {
+                            const {id, bio, image, foregroundHex, backgroundHex} =
+                                item.chef;
+                            return [
+                                {
+                                    ...cardMeta,
+                                    id: id,
+                                    frontPublicationDate: Date.now(),
+                                    cardType: "chef",
+                                    meta: {
+                                        bio: bio,
+                                        ...(foregroundHex
+                                            ? {
+                                                chefTheme: {
+                                                    id: "custom",
+                                                    palette: {
+                                                        foregroundHex: foregroundHex,
+                                                        backgroundHex: backgroundHex,
+                                                    },
+                                                },
+                                            }
+                                            : {}),
+                                        ...(image
+                                            ? {
+                                                chefImageOverride: {
+                                                    src: image,
+                                                    origin: image,
+                                                },
+                                            }
+                                            : {}),
+                                    },
+                                },
+                            ];
+                        }
+                        case "collection": {
+                            const {title, image, lightPalette, darkPalette, recipes} =
+                                item.collection;
+
+                            return [
+                                {
+                                    ...cardMeta,
+                                    id: crypto.randomUUID(),
+                                    cardType: "feast-collection",
+                                    meta: {
+                                        title,
+                                        supporting: recipes.map((id) => ({
+                                            cardType: "recipe",
+                                            id,
+                                            uuid: crypto.randomUUID(),
+                                            frontPublicationDate: Date.now(),
+                                        })),
+                                        ...(lightPalette && darkPalette
+                                            ? {
+                                                feastCollectionTheme: {
+                                                    id: "custom",
+                                                    lightPalette,
+                                                    darkPalette,
+                                                    ...(image ? {imageURL: image} : {}),
+                                                },
+                                            }
+                                            : {}),
+                                    },
+                                },
+                            ];
+                        }
+                        default: {
+                            console.warn("++?????++ Out of Cheese Error. Redo From Start.");
+                        }
+                    }
+                });
+
+                return {
+                    ...frontCollection,
+                    items,
+                };
+            });
+
+            if (dryRun) {
+                console.log(
+                    `Dry run, stopping. Would have updated ${
+                        updatedCollections.length
+                    } collections: \n\n ${JSON.stringify(
+                        updatedCollections,
+                        undefined,
+                        "  "
+                    )}`
+                );
+
+                process.exit(0);
+            }
+
+            let hasError = false;
+
+            for (const updatedCollection of updatedCollections) {
+                if (hasError) {
+                    console.warn(
+                        `Skipping ${updatedCollection.id} (${updatedCollection.name}), as there were errors.`
+                    );
+                    break;
+                }
+
+                const body = JSON.stringify({
+                    id: updatedCollection.id,
+                    collection: updatedCollection,
+                });
+                const bodySize = new Blob([body]).size;
+
+                const response = await fetch(
+                    `${frontsBaseUrl}/editions-api/collections/${updatedCollection.id}`,
+                    {
+                        method: "PUT",
+                        headers: frontsHeaders,
+                        body,
+                    }
+                );
+
+                if (response.status !== 200) {
+                    hasError = true;
+                    console.error(
+                        `Error putting new collection data for collection ${
+                            updatedCollection.id
+                        } from Fronts tool. Attempted to post \n\n ${JSON.stringify(
+                            updatedCollection,
+                            null,
+                            "  "
+                        )}. \n\n Response was: ${response.status} ${
+                            response.statusText
+                        } ${await response.text()}`
+                    );
+                } else {
+                    console.log(
+                        `Written updated collection with name: ${
+                            updatedCollection.displayName
+                        }, id: ${
+                            updatedCollection.id
+                        } payload ${new Intl.NumberFormat().format(bodySize)} bytes`
+                    );
+                }
+            }
+
+            console.log("Script complete.");
+
+            if (hasError) {
+                console.warn(
+                    `There were errors writing the updated collections to the issue.`
+                );
+            }
+
+            console.log(`Updated ${updatedCollections.length} collections`);
+
+            if (updatedCollections.length < curation.length) {
+                console.warn(
+                    `${
+                        curation.length - updatedCollections.length
+                    } collections were not mapped onto the front. Do the collection names match exactly? \n\n ${skippedCollections.join(
+                        "\n"
+                    )}`
+                );
+            }
+        } else {
+            console.error(`No Front is available in Fronts tool so unable to migrate: ${frontsIssueId.length}`);
+        }
+    }
+    }
+    console.log(" Ending the loop iteration for date = " + date)
+}
+
+process.exit(hasError ? 1 : 0);
+
+
+
+
+
+

--- a/scripts/recipes/insert-backdate-recipes.mjs
+++ b/scripts/recipes/insert-backdate-recipes.mjs
@@ -1,14 +1,14 @@
 import crypto from "crypto";
+import { migrateIssue } from './migrate-issue.mjs';
 
 const dateFormat = 'YYYY-MM-DD';
 const usage = `Example usage is
 
 node ./insert-recipe-cards.mjs
-    --curation-path "northern/meat-free"
+    --curation-path "northern"
     --from-date "2024-05-01"
     --to-date "2024-05-05"
     --edition-name "feast-northern-hemisphere"
-    --front-name "Meat-Free"
     --stage CODE
     --cookie "<get this from a Fronts client request header for the appropriate stage>"
 
@@ -50,7 +50,6 @@ const getDate = (d) => {
 }
 
 const curationPath = getArg("--curation-path");
-const frontName = getArg("--front-name");
 const fromDate = getArg("--from-date");
 const toDate = getArg("--to-date");
 const editionName = getArg("--edition-name")
@@ -58,13 +57,21 @@ const stage = getArg("--stage");
 const cookie = getArg("--cookie");
 const dryRun = getArg("--dry-run", true) !== "false";
 
-const curationBaseUrl = "https://recipes.code.dev-guardianapis.com";
+const curationBaseUrl = "https://recipes.guardianapis.com";
 const frontsBaseUrl = getFrontsUri();
 const frontsHeaders = {
     "Content-Type": "application/json",
     Cookie: cookie,
 };
 
+if (stage === "PROD") {
+    console.warn(
+        `This will run in the PROD environment in 5 seconds - Ctrl-C to cancel.`
+    );
+    await new Promise((r) => setTimeout(r, 5000));
+}
+
+if(dryRun) throw new Error("Boo");
 
 const startDate = new Date(fromDate);
 const endDate = new Date(toDate);
@@ -76,427 +83,15 @@ while(loopOnDate <= endDate) {
     const date = getDate(loopOnDate)
     console.log(`after date format, date is ${date}`)
 
-    //------Get CURATION.JSON --------//
-    const curationUrl = `${curationBaseUrl}/${curationPath}/${date}/curation.json`;
-
-    if (stage === "PROD") {
-        console.warn(
-            `This will run in the PROD environment in 5 seconds - Ctrl-C to cancel.`
-        );
+    try {
+        await migrateIssue(curationBaseUrl, curationPath, date, frontsBaseUrl, frontsHeaders, editionName, stage, dryRun);
+    } catch (err) {
+        console.error(err);
         await new Promise((r) => setTimeout(r, 5000));
-    }
-
-    console.log(`Fetching curation data from ${curationUrl} ...`);
-
-    const curationResponse = await fetch(curationUrl);
-
-
-    if (curationResponse.status !== 200) { //---Dont proceed if Curation.json does not exists for that date---//
-        console.error(
-            `Error getting issue data from Fronts tool: ${curationResponse.status} ${
-                curationResponse.statusText
-            } ${await curationResponse.text()}`
-        );
-        //process.exit(1);
-    }else { //---Proceed to FRONT work if curation.json is present---//
-        /**
-         * @type {Array<{
-         *  title: string,
-         *  body: string,
-         *  id: string,
-         *  items: Array<
-         *      { recipe: { id: string } } |
-         *      { chef: { id: string }} |
-         *      { collection: { recipes: string[] }}
-         *    >}
-         *  >}
-         */
-        const curation = await curationResponse.json();
-
-        const fetchIssueForTheDate = async (editionName, start, end) => {
-            const path = `${frontsBaseUrl}/editions-api/editions/${editionName}/issues?dateFrom=${start}&dateTo=${end}`
-            console.log("start fetching issue if available...")
-            const resp = await fetch(path, {
-                method: 'get',
-                mode: 'cors',
-                headers: frontsHeaders,
-                credentials: 'include',
-            }).then((response) => {
-                console.log("response when fetching issue if available = " + response.status)
-                return response.json();
-            }).then(({issues}) => issues[0])
-            return resp;
-        };
-
-        const issueFoundForTheDate = await fetchIssueForTheDate(editionName, date, date);
-
-        console.log(`DO we already have issue id?  ${issueFoundForTheDate.id}`)
-
-        let frontsIssueId = ""
-        if (issueFoundForTheDate && issueFoundForTheDate.id) { //Skip rest of work of data migration if issue exists on the date
-            console.log(`Yes we already have existing issue so Don't migrate! ${issueFoundForTheDate.id}`)
-            frontsIssueId = issueFoundForTheDate.id
-        } else { //Proceed to create new issue and migration of data in to it.
-            const createIssue = async (editionName, date) => {
-                const path = `${frontsBaseUrl}/editions-api/editions/${editionName}/issues`;
-                console.log("start creating issue...")
-                const resp = await fetch(path, {
-                    method: 'post',
-                    mode: 'cors',
-                    headers: frontsHeaders,
-                    credentials: 'include',
-                    body: JSON.stringify({issueDate: `${date}`}),
-                }).then((response) => {
-                    console.log("response = " + response.status)
-                    return response.json();
-                });
-                return resp
-            }
-
-            const frontsIssue = await createIssue(editionName, date)
-
-            frontsIssueId = frontsIssue.id
-            console.log(`Issue is created: ${frontsIssueId.id}`)
-
-        if (frontsIssueId.length > 0) {
-            console.log(`Migrating curation data from ${curationPath} to ${stage} Fronts tool, issue: ${frontsIssueId}, front name: ${frontName}, dry run: ${dryRun}.`);
-
-            const frontsIssueUrl = `${frontsBaseUrl}/editions-api/issues/${frontsIssueId}`;
-
-            console.log(`Got curation data.\nFetching fronts issue data from ${frontsIssueUrl}...`);
-
-            const fetchFrontFromIssue = async () => {
-                const frontsResponse = await fetch(frontsIssueUrl, {
-                    method: "GET",
-                    headers: frontsHeaders,
-                });
-
-                if (frontsResponse.status !== 200) {
-                    console.error(
-                        `Error getting issue data from Fronts tool: ${
-                            frontsResponse.status
-                        } ${frontsResponse.statusText} ${await frontsResponse.text()}`
-                    );
-                    process.exit(1);
-                }
-
-                /**
-                 * @type {{
-                 *   id: string;
-                 *   edition: string;
-                 *   issueDate: string; // YYYY-MM-dd
-                 *   createdOn: number;
-                 *   createdBy: string;
-                 *   createdEmail: string;
-                 *   launchedOn?: number;
-                 *   launchedBy: string;
-                 *   launchedEmail: string;
-                 *   fronts: Array<{
-                 *       id: string;
-                 *       displayName: string;
-                 *       isHidden: boolean;
-                 *       updatedOn?: number;
-                 *       updatedBy?: string;
-                 *       updatedEmail?: string;
-                 *       collections: Array<{
-                 *           id: string;
-                 *           displayName: string;
-                 *           prefill?: EditionsPrefill;
-                 *           isHidden: boolean;
-                 *           lastUpdated?: number;
-                 *           updatedBy?: string;
-                 *           updatedEmail?: string;
-                 *           items: any[];
-                 *         }>;
-                 *     }>;
-                 *   supportsProofing: boolean;
-                 *   lastProofedVersion?: string;
-                 *   platform: string;
-                 * }}
-                 */
-                const issueJson = await frontsResponse.json();
-
-                console.log("Got Fronts data.");
-
-                const front = issueJson.fronts.find(
-                    (front) => front.displayName === frontName
-                );
-
-                if (!front) {
-                    console.error(
-                        `No front found with name ${frontName} in issue ${frontsIssueId}`
-                    );
-                    process.exit(1);
-                }
-
-                return front;
-            };
-
-            let front = await fetchFrontFromIssue();
-
-            const collectionNamesInFrontsTool = front.collections.map(
-                (col) => col.displayName
-            );
-            const collectionTitlesMissingInFronts = curation
-                .filter((col) => !collectionNamesInFrontsTool.includes(col.title.trim()))
-                .map((col) => col.title);
-
-            if (collectionTitlesMissingInFronts.length) {
-                // Collections are added from the top, so we add the last collection first
-                for (const title of collectionTitlesMissingInFronts.reverse()) {
-                    const newCollectionResponse = await fetch(
-                        `${frontsBaseUrl}/editions-api/fronts/${front.id}/collection?name=${title}`,
-                        {
-                            method: "PUT",
-                            headers: frontsHeaders,
-                        }
-                    );
-
-                    if (newCollectionResponse.status !== 200) {
-                        console.error(
-                            `Error creating new collection: ${
-                                newCollectionResponse.status
-                            } ${
-                                newCollectionResponse.statusText
-                            } ${await newCollectionResponse.text()}`
-                        );
-                        process.exit(1);
-                    } else {
-                        console.log(
-                            `Collection with title ${title} added to front ${front.id}`
-                        );
-                    }
-                }
-
-                front = await fetchFrontFromIssue();
-            }
-
-            const titleMap = Object.values(front.collections).reduce(
-                (acc, collection) => ({
-                    ...acc,
-                    [collection.displayName]: collection,
-                }),
-                {}
-            );
-
-            console.log(
-                `Mapped titles to collections: \n\n${JSON.stringify(
-                    Object.entries(titleMap).map(([title, col]) => `${title}: ${col.id}`),
-                    undefined,
-                    "  "
-                )}`
-            );
-
-            const skippedCollections = [];
-
-            const updatedCollections = curation.flatMap((collection) => {
-                const frontCollection = titleMap[collection.title.trim()];
-                const frontCollectionId = frontCollection?.id;
-                if (!frontCollectionId) {
-                    console.log(
-                        `No id found mapping the title ${collection.title} to the existing front – skipping this collection`
-                    );
-                    skippedCollections.push(collection.title);
-                    return [];
-                }
-
-                const items = collection.items.flatMap((item, index) => {
-                    const cardMeta = {
-                        uuid: crypto.randomUUID(),
-                        frontPublicationDate: Date.now(),
-                    };
-
-                    const cardType = item.chef
-                        ? "chef"
-                        : item.recipe
-                            ? "recipe"
-                            : item.collection
-                                ? "collection"
-                                : undefined;
-
-                    if (!cardType) {
-                        console.log(`No card type for ${item}`);
-                        return [];
-                    }
-
-                    switch (cardType) {
-                        case "recipe": {
-                            return [
-                                {
-                                    ...cardMeta,
-                                    id: item.recipe.id,
-                                    cardType: "recipe",
-                                },
-                            ];
-                        }
-                        case "chef": {
-                            const {id, bio, image, foregroundHex, backgroundHex} =
-                                item.chef;
-                            return [
-                                {
-                                    ...cardMeta,
-                                    id: id,
-                                    frontPublicationDate: Date.now(),
-                                    cardType: "chef",
-                                    meta: {
-                                        bio: bio,
-                                        ...(foregroundHex
-                                            ? {
-                                                chefTheme: {
-                                                    id: "custom",
-                                                    palette: {
-                                                        foregroundHex: foregroundHex,
-                                                        backgroundHex: backgroundHex,
-                                                    },
-                                                },
-                                            }
-                                            : {}),
-                                        ...(image
-                                            ? {
-                                                chefImageOverride: {
-                                                    src: image,
-                                                    origin: image,
-                                                },
-                                            }
-                                            : {}),
-                                    },
-                                },
-                            ];
-                        }
-                        case "collection": {
-                            const {title, image, lightPalette, darkPalette, recipes} =
-                                item.collection;
-
-                            return [
-                                {
-                                    ...cardMeta,
-                                    id: crypto.randomUUID(),
-                                    cardType: "feast-collection",
-                                    meta: {
-                                        title,
-                                        supporting: recipes.map((id) => ({
-                                            cardType: "recipe",
-                                            id,
-                                            uuid: crypto.randomUUID(),
-                                            frontPublicationDate: Date.now(),
-                                        })),
-                                        ...(lightPalette && darkPalette
-                                            ? {
-                                                feastCollectionTheme: {
-                                                    id: "custom",
-                                                    lightPalette,
-                                                    darkPalette,
-                                                    ...(image ? {imageURL: image} : {}),
-                                                },
-                                            }
-                                            : {}),
-                                    },
-                                },
-                            ];
-                        }
-                        default: {
-                            console.warn("++?????++ Out of Cheese Error. Redo From Start.");
-                        }
-                    }
-                });
-
-                return {
-                    ...frontCollection,
-                    items,
-                };
-            });
-
-            if (dryRun) {
-                console.log(
-                    `Dry run, stopping. Would have updated ${
-                        updatedCollections.length
-                    } collections: \n\n ${JSON.stringify(
-                        updatedCollections,
-                        undefined,
-                        "  "
-                    )}`
-                );
-
-                process.exit(0);
-            }
-
-            let hasError = false;
-
-            for (const updatedCollection of updatedCollections) {
-                if (hasError) {
-                    console.warn(
-                        `Skipping ${updatedCollection.id} (${updatedCollection.name}), as there were errors.`
-                    );
-                    break;
-                }
-
-                const body = JSON.stringify({
-                    id: updatedCollection.id,
-                    collection: updatedCollection,
-                });
-                const bodySize = new Blob([body]).size;
-
-                const response = await fetch(
-                    `${frontsBaseUrl}/editions-api/collections/${updatedCollection.id}`,
-                    {
-                        method: "PUT",
-                        headers: frontsHeaders,
-                        body,
-                    }
-                );
-
-                if (response.status !== 200) {
-                    hasError = true;
-                    console.error(
-                        `Error putting new collection data for collection ${
-                            updatedCollection.id
-                        } from Fronts tool. Attempted to post \n\n ${JSON.stringify(
-                            updatedCollection,
-                            null,
-                            "  "
-                        )}. \n\n Response was: ${response.status} ${
-                            response.statusText
-                        } ${await response.text()}`
-                    );
-                } else {
-                    console.log(
-                        `Written updated collection with name: ${
-                            updatedCollection.displayName
-                        }, id: ${
-                            updatedCollection.id
-                        } payload ${new Intl.NumberFormat().format(bodySize)} bytes`
-                    );
-                }
-            }
-
-            console.log("Script complete.");
-
-            if (hasError) {
-                console.warn(
-                    `There were errors writing the updated collections to the issue.`
-                );
-            }
-
-            console.log(`Updated ${updatedCollections.length} collections`);
-
-            if (updatedCollections.length < curation.length) {
-                console.warn(
-                    `${
-                        curation.length - updatedCollections.length
-                    } collections were not mapped onto the front. Do the collection names match exactly? \n\n ${skippedCollections.join(
-                        "\n"
-                    )}`
-                );
-            }
-        } else {
-            console.error(`No Front is available in Fronts tool so unable to migrate: ${frontsIssueId.length}`);
-        }
-    }
     }
     console.log(" Ending the loop iteration for date = " + date)
 }
 
-process.exit(hasError ? 1 : 0);
 
 
 

--- a/scripts/recipes/migrate-issue.mjs
+++ b/scripts/recipes/migrate-issue.mjs
@@ -1,0 +1,452 @@
+async function visualDelay(time) {
+    return new Promise((resolve)=>setTimeout(resolve, time));
+}
+
+async function fetchFrontFromIssue (frontsIssueUrl, frontsIssueId, frontsHeaders, frontName){
+    const frontsResponse = await fetch(frontsIssueUrl, {
+        method: "GET",
+        headers: frontsHeaders,
+    });
+
+    if (frontsResponse.status !== 200) {
+        console.error(
+            `Error getting issue data from Fronts tool: ${
+                frontsResponse.status
+            } ${frontsResponse.statusText} ${await frontsResponse.text()}`
+        );
+        process.exit(1);
+    }
+
+    /**
+     * @type {{
+     *   id: string;
+     *   edition: string;
+     *   issueDate: string; // YYYY-MM-dd
+     *   createdOn: number;
+     *   createdBy: string;
+     *   createdEmail: string;
+     *   launchedOn?: number;
+     *   launchedBy: string;
+     *   launchedEmail: string;
+     *   fronts: Array<{
+     *       id: string;
+     *       displayName: string;
+     *       isHidden: boolean;
+     *       updatedOn?: number;
+     *       updatedBy?: string;
+     *       updatedEmail?: string;
+     *       collections: Array<{
+     *           id: string;
+     *           displayName: string;
+     *           prefill?: EditionsPrefill;
+     *           isHidden: boolean;
+     *           lastUpdated?: number;
+     *           updatedBy?: string;
+     *           updatedEmail?: string;
+     *           items: any[];
+     *         }>;
+     *     }>;
+     *   supportsProofing: boolean;
+     *   lastProofedVersion?: string;
+     *   platform: string;
+     * }}
+     */
+    const issueJson = await frontsResponse.json();
+
+    console.log("Got Fronts data.");
+
+    const front = issueJson.fronts.find(
+        (front) => front.displayName === frontName
+    );
+
+    if (!front) {
+        console.error(
+            `No front found with name ${frontName} in issue ${frontsIssueId}`
+        );
+        throw new Error(`No front found with name ${frontName} in issue ${frontsIssueId}`)
+    }
+
+    return front;
+}
+
+async function migrateFront(
+    frontsIssueId,
+    curationPath,
+    curation,
+    stage,
+    frontName,
+    frontsHeaders,
+    frontsBaseUrl,
+    dryRun
+) {
+    console.log(`Migrating curation data from ${curationPath} to ${stage} Fronts tool, issue: ${frontsIssueId}, front name: ${frontName}, dry run: ${dryRun}.`);
+    await visualDelay(1000);
+
+    const frontsIssueUrl = `${frontsBaseUrl}/editions-api/issues/${frontsIssueId}`;
+
+    console.log(`Got curation data.\nFetching fronts issue data from ${frontsIssueUrl}...`);
+
+    let front = await fetchFrontFromIssue(frontsIssueUrl, frontsIssueId, frontsHeaders, frontName);
+
+    const collectionNamesInFrontsTool = front.collections.map(
+        (col) => col.displayName
+    );
+    const collectionTitlesMissingInFronts = curation
+        .filter((col) => !collectionNamesInFrontsTool.includes(col.title.trim()))
+        .map((col) => col.title);
+
+    if (collectionTitlesMissingInFronts.length) {
+        // Collections are added from the top, so we add the last collection first
+        for (const title of collectionTitlesMissingInFronts.reverse()) {
+            const newCollectionResponse = await fetch(
+                `${frontsBaseUrl}/editions-api/fronts/${front.id}/collection?name=${title}`,
+                {
+                    method: "PUT",
+                    headers: frontsHeaders,
+                }
+            );
+
+            if (newCollectionResponse.status !== 200) {
+                console.error(
+                    `Error creating new collection: ${
+                        newCollectionResponse.status
+                    } ${
+                        newCollectionResponse.statusText
+                    } ${await newCollectionResponse.text()}`
+                );
+                process.exit(1);
+            } else {
+                console.log(
+                    `Collection with title ${title} added to front ${front.id}`
+                );
+            }
+        }
+        //reload the fronts to ensure we have up-to-date data
+        front = await fetchFrontFromIssue(frontsIssueUrl, frontsIssueId, frontsHeaders, frontName);
+    }
+
+    const titleMap = Object.values(front.collections).reduce(
+        (acc, collection) => ({
+            ...acc,
+            [collection.displayName]: collection,
+        }),
+        {}
+    );
+
+    console.log(
+        `Mapped titles to collections: \n\n${JSON.stringify(
+            Object.entries(titleMap).map(([title, col]) => `${title}: ${col.id}`),
+            undefined,
+            "  "
+        )}`
+    );
+
+    const skippedCollections = [];
+
+    const updatedCollections = curation.flatMap((collection) => {
+        const frontCollection = titleMap[collection.title.trim()];
+        const frontCollectionId = frontCollection?.id;
+        if (!frontCollectionId) {
+            console.log(
+                `No id found mapping the title ${collection.title} to the existing front – skipping this collection`
+            );
+            skippedCollections.push(collection.title);
+            return [];
+        }
+
+        const items = collection.items.flatMap((item, index) => {
+            const cardMeta = {
+                uuid: crypto.randomUUID(),
+                frontPublicationDate: Date.now(),
+            };
+
+            const cardType = item.chef
+                ? "chef"
+                : item.recipe
+                    ? "recipe"
+                    : item.collection
+                        ? "collection"
+                        : undefined;
+
+            if (!cardType) {
+                console.log(`No card type for ${item}`);
+                return [];
+            }
+
+            switch (cardType) {
+                case "recipe": {
+                    return [
+                        {
+                            ...cardMeta,
+                            id: item.recipe.id,
+                            cardType: "recipe",
+                        },
+                    ];
+                }
+                case "chef": {
+                    const {id, bio, image, foregroundHex, backgroundHex} =
+                        item.chef;
+                    return [
+                        {
+                            ...cardMeta,
+                            id: id,
+                            frontPublicationDate: Date.now(),
+                            cardType: "chef",
+                            meta: {
+                                bio: bio,
+                                ...(foregroundHex
+                                    ? {
+                                        chefTheme: {
+                                            id: "custom",
+                                            palette: {
+                                                foregroundHex: foregroundHex,
+                                                backgroundHex: backgroundHex,
+                                            },
+                                        },
+                                    }
+                                    : {}),
+                                ...(image
+                                    ? {
+                                        chefImageOverride: {
+                                            src: image,
+                                            origin: image,
+                                        },
+                                    }
+                                    : {}),
+                            },
+                        },
+                    ];
+                }
+                case "collection": {
+                    const {title, image, lightPalette, darkPalette, recipes} =
+                        item.collection;
+
+                    return [
+                        {
+                            ...cardMeta,
+                            id: crypto.randomUUID(),
+                            cardType: "feast-collection",
+                            meta: {
+                                title,
+                                supporting: recipes.map((id) => ({
+                                    cardType: "recipe",
+                                    id,
+                                    uuid: crypto.randomUUID(),
+                                    frontPublicationDate: Date.now(),
+                                })),
+                                ...(lightPalette && darkPalette
+                                    ? {
+                                        feastCollectionTheme: {
+                                            id: "custom",
+                                            lightPalette,
+                                            darkPalette,
+                                            ...(image ? {imageURL: image} : {}),
+                                        },
+                                    }
+                                    : {}),
+                            },
+                        },
+                    ];
+                }
+                default: {
+                    console.warn("++?????++ Out of Cheese Error. Redo From Start.");
+                }
+            }
+        });
+
+        return {
+            ...frontCollection,
+            items,
+        };
+    });
+
+    if (dryRun) {
+        console.log(
+            `Dry run, stopping. Would have updated ${
+                updatedCollections.length
+            } collections: \n\n ${JSON.stringify(
+                updatedCollections,
+                undefined,
+                "  "
+            )}`
+        );
+    } else {
+        for (const updatedCollection of updatedCollections) {
+            const body = JSON.stringify({
+                id: updatedCollection.id,
+                collection: updatedCollection,
+            });
+            const bodySize = new Blob([body]).size;
+
+            const response = await fetch(
+                `${frontsBaseUrl}/editions-api/collections/${updatedCollection.id}`,
+                {
+                    method: "PUT",
+                    headers: frontsHeaders,
+                    body,
+                }
+            );
+
+            if (response.status !== 200) {
+                console.error(
+                    `Error putting new collection data for collection ${
+                        updatedCollection.id
+                    } from Fronts tool. Attempted to post \n\n ${JSON.stringify(
+                        updatedCollection,
+                        null,
+                        "  "
+                    )}. \n\n Response was: ${response.status} ${
+                        response.statusText
+                    } ${await response.text()}`
+                );
+                throw new Error("Error putting new collection");
+            } else {
+                console.log(
+                    `Written updated collection with name: ${
+                        updatedCollection.displayName
+                    }, id: ${
+                        updatedCollection.id
+                    } payload ${new Intl.NumberFormat().format(bodySize)} bytes`
+                );
+            }
+        }
+
+        console.log(`Updated ${updatedCollections.length} collections`);
+
+        if (updatedCollections.length < curation.length) {
+            console.warn(
+                `${
+                    curation.length - updatedCollections.length
+                } collections were not mapped onto the front. Do the collection names match exactly? \n\n ${skippedCollections.join(
+                    "\n"
+                )}`
+            );
+        }
+    }
+}
+
+async function getCuration(curationBaseUrl, curationPath, curationType, date) {
+    //------Get CURATION.JSON --------//
+    const curationUrl = `${curationBaseUrl}/${curationPath}/${curationType}/${date}/curation.json`;
+
+    console.log(`Fetching curation data from ${curationUrl} ...`);
+
+    const curationResponse = await fetch(curationUrl);
+
+
+    if (curationResponse.status === 200) {
+        return curationResponse.json();
+    } else { //---Dont proceed if Curation.json does not exists for that date---//
+        console.error(
+            `Error getting issue data from Fronts tool: ${curationResponse.status} ${
+                curationResponse.statusText
+            } ${await curationResponse.text()}`
+        );
+        return undefined;
+    }
+}
+
+export async function migrateIssue(
+    curationBaseUrl,
+    curationPath,
+    date,
+    frontsBaseUrl,
+    frontsHeaders,
+    editionName,
+    stage,
+    dryRun
+) {
+
+    const curation = {
+        allRecipes: await getCuration(curationBaseUrl, curationPath, 'all-recipes', date),
+        meatFree: await getCuration(curationBaseUrl, curationPath, 'meat-free', date)
+    }
+
+    if(!curation.allRecipes && !!curation.meatFree) {
+        throw new Error(`Missing all-recipes curation for ${date}`);
+    } else if(!curation.meatFree && !!curation.allRecipes) {
+        throw new Error(`Missing meat-free curation for ${date}`)
+    } else if(!curation.allRecipes && !curation.meatFree) {
+        throw new Error(`Missing both meat-free and all-recipes curation for ${date}`);
+    }
+
+    //---Proceed to FRONT work if curation.json is present---//
+    /**
+     * @type {Array<{
+     *  title: string,
+     *  body: string,
+     *  id: string,
+     *  items: Array<
+     *      { recipe: { id: string } } |
+     *      { chef: { id: string }} |
+     *      { collection: { recipes: string[] }}
+     *    >}
+     *  >}
+     */
+
+    const fetchIssueForTheDate = async (editionName, start, end) => {
+        const path = `${frontsBaseUrl}/editions-api/editions/${editionName}/issues?dateFrom=${start}&dateTo=${end}`
+        console.log(`start fetching issue ${path} if available...`)
+        const resp = await fetch(path, {
+            method: 'get',
+            mode: 'cors',
+            headers: frontsHeaders,
+            credentials: 'include',
+        });
+        console.log("response when fetching issue if available = " + resp.status)
+        const content = await resp.json();
+        console.log(content);
+        return content[0];
+    };
+
+    const issueFoundForTheDate = await fetchIssueForTheDate(editionName, date, date);
+
+    let frontsIssueId = ""
+    if (issueFoundForTheDate && issueFoundForTheDate.id) { //Skip rest of work of data migration if issue exists on the date
+        console.log(`Yes we already have existing issue ${issueFoundForTheDate.id}`)
+        frontsIssueId = issueFoundForTheDate.id
+    } else { //Proceed to create new issue and migration of data in to it.
+        const createIssue = async (editionName, date) => {
+            const path = `${frontsBaseUrl}/editions-api/editions/${editionName}/issues`;
+            console.log("start creating issue...")
+            const resp = await fetch(path, {
+                method: 'post',
+                mode: 'cors',
+                headers: frontsHeaders,
+                credentials: 'include',
+                body: JSON.stringify({ issueDate: `${date}` }),
+            }).then((response) => {
+                console.log("response = " + response.status)
+                return response.json();
+            });
+            return resp
+        }
+        const frontsIssue = await createIssue(editionName, date);
+        frontsIssueId = frontsIssue.id;
+    }
+
+
+        if(!frontsIssueId) {
+            console.error(`No Front is available in Fronts tool so unable to migrate: ${editionName} ${date}`);
+        } else {
+            console.log(`Issue is created: ${frontsIssueId}`);
+            for(const frontName of ['All Recipes', 'Meat-Free']) {
+                try {
+                    await migrateFront(
+                        frontsIssueId,
+                        curationPath,
+                        frontName === 'All Recipes' ? curation.allRecipes : curation.meatFree,
+                        stage,
+                        frontName,
+                        frontsHeaders,
+                        frontsBaseUrl,
+                        dryRun
+                    );
+                } catch(err) {
+                    console.error(`Unable to migrate from ${frontName} for ${editionName} ${date}: ${err}`);
+                    await visualDelay(5000);
+                }
+            }
+        }
+
+}


### PR DESCRIPTION
## What's changed?
Addition to script that was created in PR: https://github.com/guardian/facia-tool/pull/1645 
The added changes will Iterate through historical curated data on the basis of the dates and migrate it to Front tool by creating those dates issues on Feast edition and then pushing curated data to the appropriate Front.

Example test case:
```
node ./insert-backdate-recipes.mjs \
    --curation-path "northern/meat-free" \
    --from-date "2024-09-01" \
    --to-date "2024-09-06" \
    --edition-name "feast-northern-hemisphere" \
    --front-name "Meat-Free" \
    --stage LOCAL \
    --cookie "<get this from a Fronts client request header for the appropriate stage>"
    --dry-run false
```

Script should:
- Check if curation.json is available in S3 then only proceed to check Issue
- Check if issue is not already exists then only proceed for Front
- Create new issue if none found 
- Migrate the curated date to the Front


### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
