### PR TITLE
Ensure US election global alert sends to all edition topics

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -34,10 +34,20 @@ object BreakingNewsUpdate {
     BreakingNewsSportEurope
   )
 
+  val UsElectionsGlobalTopicName = "global-us-election"
+  val UsElectionsBreakingNewsTopics = List(
+    BreakingNewsUsElectionUk,
+    BreakingNewsUsElectionUs,
+    BreakingNewsUsElectionAu,
+    BreakingNewsUsElectionInternational,
+    BreakingNewsUsElectionEurope
+  )
+
   def createPayload(trail: ClientHydratedTrail, email: String): BreakingNewsPayload = {
     val title = trail.topic match {
       case Some("uk-general-election") => Some("UK general election")
       case Some(topic) if (SportBreakingNewsTopics.map(_.name) :+ SportGlobalTopicName).contains(topic) => Some("Sport breaking news")
+      case Some(topic) if (UsElectionsBreakingNewsTopics.map(_.name) :+ UsElectionsGlobalTopicName).contains(topic) => Some("US election")
       case _ => None
     }
 
@@ -83,7 +93,7 @@ object BreakingNewsUpdate {
       case Some("international-sport") => List(BreakingNewsSportInternational)
       case Some(SportGlobalTopicName) => SportBreakingNewsTopics
       case Some("uk-general-election") => List(BreakingNewsElection)
-      case Some("global-us-election") => List(BreakingNewsUsElectionGlobal)
+      case Some(UsElectionsGlobalTopicName) => UsElectionsBreakingNewsTopics
       case Some("uk-us-election") => List(BreakingNewsUsElectionUk)
       case Some("us-us-election") => List(BreakingNewsUsElectionUs)
       case Some("au-us-election") => List(BreakingNewsUsElectionAu)


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
The PR ensures that when sending a global alert to the US election topic we send to all editions. It also updates the title of the US election notification to better reflect the content.

**Notification title change**

| `Before` | `After` |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/8ac60566-4e91-4fa1-82dc-3e0eca27f46f" width="300px" /> | <img src="https://github.com/user-attachments/assets/97ba6651-9e66-4f1b-ba3b-b3c64646ba1d" width="300px" /> |

The global alert has been tested on CODE and was successfully received (see `After` screenshot).

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included