### PR TITLE
Add scrollable small to config

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -16,6 +16,7 @@ class FixedContainers(val config: ApplicationConfiguration) {
   val showcase = slices(ShowcaseSingleStories)
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
   val highlights = slices(Highlights)
+  val scrollableSmall = slices(ScrollableSmall)
   val video = slices(TTT).copy(customCssClasses = Set("fc-container--video"))
 
   val all: Map[String, ContainerDefinition] = Map(
@@ -36,7 +37,8 @@ class FixedContainers(val config: ApplicationConfiguration) {
     ("fixed/video/vertical", video),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcase),
-    ("scrollable/highlights", highlights)
+    ("scrollable/highlights", highlights),
+    ("scrollable/small", scrollableSmall)
   ) ++ (if (config.faciatool.showTestContainers) Map(
     ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))
   ) else Map.empty)

--- a/app/slices/Slice.scala
+++ b/app/slices/Slice.scala
@@ -1007,3 +1007,89 @@ case object Highlights extends Slice {
     ),
   )
 }
+
+
+/*
+ * The Scrollable small layout is implemented via a carousel.
+ * The implementation on platforms limits the display to 8 cards altogether, and only 2-3 cards at a time.
+ * In the tool, we're satisfied with using a 8 card layout to hint at the maximum number of stories.
+ *
+ * Desktop:
+ * .____________.____________.____________.____________.____________.____________.____________.____________.
+ * |       #####|       #####|       #####|       #####|       #####|       #####|       #####|       #####|
+ * |       #####|       #####|       #####|       #####|       #####|       #####|       #####|       #####|
+ * |       #####|       #####|       #####|       #####|       #####|       #####|       #####|       #####|
+ * '-------------------------------------------------------------------------------------------------------'
+ *
+ * Mobile:
+ * .___________.___________.___________.___________.___________.___________.___________.___________.
+ * |           |           |           |           |           |           |           |           |
+ * |           |           |           |           |           |           |           |           |
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * `-----------------------------------------------------------------------------------------------'
+ */
+case object ScrollableSmall extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "t-t-t-t-t-t-t-t",
+    columns = Seq(
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+        SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+        SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+    ),
+  )
+}

--- a/app/slices/Slice.scala
+++ b/app/slices/Slice.scala
@@ -1033,63 +1033,14 @@ case object Highlights extends Slice {
 case object ScrollableSmall extends Slice {
   val layout = SliceLayout(
     cssClassName = "t-t-t-t-t-t-t-t",
-    columns = Seq(
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-        SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-        SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = Standard,
-          tablet = MediaList,
-        ),
-      ),
-    ),
+    columns = Seq(Rows(
+      colSpan = 1,
+      columns = 8,
+      rows = 1,
+      ItemClasses(
+        mobile = ListItem,
+        tablet = ListItem,
+      )
+    ))
   )
 }

--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -28,7 +28,9 @@ export function init (res) {
                 'standard',
                 'snap'
               ]
-            });
+            },
+              {'name': 'scrollable/small'}
+            );
     }
 }
 


### PR DESCRIPTION
## What's changed?
Small initial PR to add the new container type to the fronts tool. In the same manner as the new flexible containers, these will only appear as a container if not in a production environment. 

The slices definition is similar to the highlights container, as in we describe it as a container with up to eight stories, with the platforms rendering a carousel of up to eight stories. 

There'll be a follow up PR to ensure the various configuration requirements are respected (notably in terms of images), as well as hopefully tweaking the slight oddity that the tool displays lines between the 6th and 7th cards, when that line shouldn't exist (see pic).

## Images

In the config tool:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/762ee76d-e446-494f-83df-d04b40c41537">

In the tool itself: 
<img width="1754" alt="image" src="https://github.com/user-attachments/assets/c37d0ed5-e556-4937-a075-0dcea51d5324">



### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
