### PR TITLE
Fix migration bug for missing data in the collection

### DIFF
--- a/scripts/recipes/insert-backdate-recipes.mjs
+++ b/scripts/recipes/insert-backdate-recipes.mjs
@@ -4,7 +4,7 @@ import { migrateIssue } from './migrate-issue.mjs';
 const dateFormat = 'YYYY-MM-DD';
 const usage = `Example usage is
 
-node ./insert-recipe-cards.mjs
+node ./insert-backdate-recipes.mjs
     --curation-path "northern"
     --from-date "2024-05-01"
     --to-date "2024-05-05"

--- a/scripts/recipes/migrate-issue.mjs
+++ b/scripts/recipes/migrate-issue.mjs
@@ -99,7 +99,7 @@ async function migrateFront(
         // Collections are added from the top, so we add the last collection first
         for (const title of collectionTitlesMissingInFronts.reverse()) {
             const newCollectionResponse = await fetch(
-                `${frontsBaseUrl}/editions-api/fronts/${front.id}/collection?name=${title}`,
+                `${frontsBaseUrl}/editions-api/fronts/${front.id}/collection?name=${encodeURIComponent(title)}`,
                 {
                     method: "PUT",
                     headers: frontsHeaders,


### PR DESCRIPTION
## What's changed?

We have recently encountered an issue on migration that one particular collection was missing the data (recipes) in it.
The collection title was `Season finale: pickles & preserves to make with late summer produce` in `curation.json` for date 14th Sept 24 whereas our migrated Front was showing empty collection with title `Season finale: pickles` for the same.
Before: 0 items in that collection 
![image](https://github.com/user-attachments/assets/931ce420-3c77-4861-9674-387364e1597f)
After: 18 items in that collection
![image](https://github.com/user-attachments/assets/abe71c24-8581-44cd-919d-7202639c92e7)

Reason was around new Collection creation via `fetch` call with one of parameter as `name=${title}` at the end, in this case, the part of the `title` was treated as `query string` and was getting dropper because of presence of `&` inside it.

The fix will encode the `title` to be considered as a valid part of the URI to avoid such case.


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
