### PR TITLE
Remove extra templated containers from southern 

### DIFF
--- a/app/model/editions/templates/feast/FeastSouthernHemisphere.scala
+++ b/app/model/editions/templates/feast/FeastSouthernHemisphere.scala
@@ -14,23 +14,12 @@ object FeastSouthernHemisphere extends FeastAppEdition {
 
   val MainFront: FrontTemplate = front(
     "All Recipes",
-    collection("Dish of the day"),
-    collection("Collection 2"),
-    collection("Collection 3"),
-    collection("Collection 4"),
-    collection("Collection 5"),
-    collection("Collection 6"),
-    collection("Collection 7"),
-    collection("Collection 8"),
-    collection("Collection 9")
+    collection("Dish of the day")
   )
 
   val MeatFreeFront: FrontTemplate = front(
     "Meat-Free",
-    collection("Dish of the day"),
-    collection("Collection 2"),
-    collection("Collection 3"),
-    collection("Collection 4"),
+    collection("Dish of the day")
   )
 
   val template: EditionTemplate = EditionTemplate(


### PR DESCRIPTION
## What's changed?

We don't require templated containers in the Fronts under southern feast as we are able to migrate historical data to FRONT with the help of script.
so removing them. 


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
