### PR TITLE
Fix frontend crash on chef search

### DIFF
--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -117,7 +117,9 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
           <RecipeFeedItem key={id} id={id} />
         ));
       case FeedType.chefs:
-        return chefSearchIds.map((chefId) => (
+        //Fixing https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true
+        //It seems that some null values got into the `chefSearchIds` list
+        return chefSearchIds.filter(chefId=>!!chefId).map((chefId) => (
           <ChefFeedItem key={chefId} id={chefId} />
         ));
     }


### PR DESCRIPTION
## What's changed?

A user reported that the screen went white (frontend crash) when she clicked on the 'Chefs' search radio button.

Sentry traces showed that this was because of an unexpected `undefined` value for the chef id when rendering a chef card - https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true

![Screenshot 2024-09-24 at 12 55 16](https://github.com/user-attachments/assets/555aea50-709f-4a35-b1b2-4117b70e575b)

## Implementation notes
This obviously _shouldn't_ happen, but it did, so I added a `filter` before the `map` to strip out any null/undefined values before attempting to render cards

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
