### PR TITLE
Fix - Chefs more than 10 does not get loaded on refresh

### DIFF
--- a/fronts-client/src/bundles/__tests__/chefsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/chefsBundle.spec.ts
@@ -8,124 +8,161 @@ interface MockedResponse {
   response: any;
 }
 
-const createStoreAndFetchMock = (fetchResponses:MockedResponse[]) => {
-  fetchResponses.forEach((r)=>{
-    fetchMock.once(r.pattern, r.response, {overwriteRoutes: true});
-  })
+const createStoreAndFetchMock = (fetchResponses: MockedResponse[]) => {
+  fetchResponses.forEach((r) => {
+    fetchMock.once(r.pattern, r.response, { overwriteRoutes: true });
+  });
   return configureStore();
 };
 
 const annaMockRecipe = {
-  "hits": 7,
-  "results": [
+  hits: 7,
+  results: [
     {
-      "contributorType": "Profile",
-      "nameOrId": "profile/anna-jones",
-      "docCount": 182
+      contributorType: 'Profile',
+      nameOrId: 'profile/anna-jones',
+      docCount: 182,
     },
     {
-      "contributorType": "Byline",
-      "nameOrId": "Anna Haugh",
-      "docCount": 6
+      contributorType: 'Byline',
+      nameOrId: 'Anna Haugh',
+      docCount: 6,
     },
     {
-      "contributorType": "Byline",
-      "nameOrId": "Anna Tobias",
-      "docCount": 4
+      contributorType: 'Byline',
+      nameOrId: 'Anna Tobias',
+      docCount: 4,
     },
     {
-      "contributorType": "Profile",
-      "nameOrId": "profile/anna-del-conte",
-      "docCount": 3
+      contributorType: 'Profile',
+      nameOrId: 'profile/anna-del-conte',
+      docCount: 3,
     },
     {
-      "contributorType": "Byline",
-      "nameOrId": "Anna Higham",
-      "docCount": 2
+      contributorType: 'Byline',
+      nameOrId: 'Anna Higham',
+      docCount: 2,
     },
     {
-      "contributorType": "Byline",
-      "nameOrId": "Anna Jones",
-      "docCount": 1
+      contributorType: 'Byline',
+      nameOrId: 'Anna Jones',
+      docCount: 1,
     },
     {
-      "contributorType": "Byline",
-      "nameOrId": "Tim Lannan and James Annabel",
-      "docCount": 1
-    }
-  ]
-}
+      contributorType: 'Byline',
+      nameOrId: 'Tim Lannan and James Annabel',
+      docCount: 1,
+    },
+  ],
+};
 const tagLookupResponse = {
-  "response": {
-    "status": "ok",
-    "userTier": "internal",
-    "total": 2,
-    "startIndex": 1,
-    "pageSize": 10,
-    "currentPage": 1,
-    "pages": 1,
-    "results": [
+  response: {
+    status: 'ok',
+    userTier: 'internal',
+    total: 2,
+    startIndex: 1,
+    pageSize: 100,
+    currentPage: 1,
+    pages: 1,
+    results: [
       {
-        "id": "profile/anna-del-conte",
-        "type": "contributor",
-        "webTitle": "Anna Del Conte",
-        "webUrl": "https://www.theguardian.com/profile/anna-del-conte",
-        "apiUrl": "https://content.guardianapis.com/profile/anna-del-conte",
-        "bio": "<p>Anna Del Conte is the doyenne of Italian cookery. In 2011 Nigella Lawson presented her with the Lifetime Achievement Award of the Guild of Food Writers.</p>",
-        "firstName": "del",
-        "lastName": "conteanna",
-        "r2ContributorId": "66638",
-        "internalName": "Anna Del Conte"
+        id: 'profile/anna-del-conte',
+        type: 'contributor',
+        webTitle: 'Anna Del Conte',
+        webUrl: 'https://www.theguardian.com/profile/anna-del-conte',
+        apiUrl: 'https://content.guardianapis.com/profile/anna-del-conte',
+        bio: '<p>Anna Del Conte is the doyenne of Italian cookery. In 2011 Nigella Lawson presented her with the Lifetime Achievement Award of the Guild of Food Writers.</p>',
+        firstName: 'del',
+        lastName: 'conteanna',
+        r2ContributorId: '66638',
+        internalName: 'Anna Del Conte',
       },
       {
-        "id": "profile/anna-jones",
-        "type": "contributor",
-        "webTitle": "Anna Jones",
-        "webUrl": "https://www.theguardian.com/profile/anna-jones",
-        "apiUrl": "https://content.guardianapis.com/profile/anna-jones",
-        "bio": "<p>Anna Jones is a chef, writer​,​ and author of A Modern Way to Eat and A Modern Way to Cook</p>",
-        "bylineImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna-Jones.jpg",
-        "bylineLargeImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna_Jones,_L.png",
-        "firstName": "Anna",
-        "lastName": "Jones",
-        "r2ContributorId": "64120",
-        "internalName": "Anna Jones"
-      }
-    ]
-  }
-}
-const expectedResultForLookup = {"profile/anna-del-conte": {"apiUrl": "https://content.guardianapis.com/profile/anna-del-conte", "bio": "", "firstName": "del", "id": "profile/anna-del-conte", "internalName": "Anna Del Conte", "lastName": "conteanna", "r2ContributorId": "66638", "type": "contributor", "webTitle": "Anna Del Conte", "webUrl": "https://www.theguardian.com/profile/anna-del-conte"}, "profile/anna-jones": {"apiUrl": "https://content.guardianapis.com/profile/anna-jones", "bio": "", "bylineImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna-Jones.jpg", "bylineLargeImageUrl": "https://uploads.guim.co.uk/2018/01/29/Anna_Jones,_L.png", "firstName": "Anna", "id": "profile/anna-jones", "internalName": "Anna Jones", "lastName": "Jones", "r2ContributorId": "64120", "type": "contributor", "webTitle": "Anna Jones", "webUrl": "https://www.theguardian.com/profile/anna-jones"}}
-const quickTimeout = ()=>new Promise((resolve)=>window.setTimeout((resolve), 10));
+        id: 'profile/anna-jones',
+        type: 'contributor',
+        webTitle: 'Anna Jones',
+        webUrl: 'https://www.theguardian.com/profile/anna-jones',
+        apiUrl: 'https://content.guardianapis.com/profile/anna-jones',
+        bio: '<p>Anna Jones is a chef, writer​,​ and author of A Modern Way to Eat and A Modern Way to Cook</p>',
+        bylineImageUrl: 'https://uploads.guim.co.uk/2018/01/29/Anna-Jones.jpg',
+        bylineLargeImageUrl:
+          'https://uploads.guim.co.uk/2018/01/29/Anna_Jones,_L.png',
+        firstName: 'Anna',
+        lastName: 'Jones',
+        r2ContributorId: '64120',
+        internalName: 'Anna Jones',
+      },
+    ],
+  },
+};
+const expectedResultForLookup = {
+  'profile/anna-del-conte': {
+    apiUrl: 'https://content.guardianapis.com/profile/anna-del-conte',
+    bio: '',
+    firstName: 'del',
+    id: 'profile/anna-del-conte',
+    internalName: 'Anna Del Conte',
+    lastName: 'conteanna',
+    r2ContributorId: '66638',
+    type: 'contributor',
+    webTitle: 'Anna Del Conte',
+    webUrl: 'https://www.theguardian.com/profile/anna-del-conte',
+  },
+  'profile/anna-jones': {
+    apiUrl: 'https://content.guardianapis.com/profile/anna-jones',
+    bio: '',
+    bylineImageUrl: 'https://uploads.guim.co.uk/2018/01/29/Anna-Jones.jpg',
+    bylineLargeImageUrl:
+      'https://uploads.guim.co.uk/2018/01/29/Anna_Jones,_L.png',
+    firstName: 'Anna',
+    id: 'profile/anna-jones',
+    internalName: 'Anna Jones',
+    lastName: 'Jones',
+    r2ContributorId: '64120',
+    type: 'contributor',
+    webTitle: 'Anna Jones',
+    webUrl: 'https://www.theguardian.com/profile/anna-jones',
+  },
+};
+const quickTimeout = () =>
+  new Promise((resolve) => window.setTimeout(resolve, 10));
 
-describe("chefsBundle", ()=>{
-  beforeEach(()=>fetchMock.reset());
+describe('chefsBundle', () => {
+  beforeEach(() => fetchMock.reset());
 
-  it("fetchChefs should fetch chefs by param, look up CAPI details for profile tags, and add them to the state", async ()=>{
+  it('fetchChefs should fetch chefs by param, look up CAPI details for profile tags, and add them to the state', async () => {
     const store = createStoreAndFetchMock([
       {
-        pattern: "https://recipes.guardianapis.com/keywords/contributors?q=anna",
-        response: annaMockRecipe
+        pattern:
+          'https://recipes.guardianapis.com/keywords/contributors?q=anna',
+        response: annaMockRecipe,
       },
       {
-        pattern: "/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all",
-        response: tagLookupResponse
-      }
-      ]);
-    await store.dispatch(fetchChefs({query: "anna"}) as any);
+        pattern:
+          '/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all&page-size=100',
+        response: tagLookupResponse,
+      },
+    ]);
+    await store.dispatch(fetchChefs({ query: 'anna' }) as any);
     await quickTimeout(); //if we don't await again, the store has not been updated yet.
-    expect(chefSelectors.selectAll(store.getState())).toEqual(expectedResultForLookup);
+    expect(chefSelectors.selectAll(store.getState())).toEqual(
+      expectedResultForLookup
+    );
   });
 
-  it("fetchChefsById should look up CAPI details for profile tags", async ()=>{
+  it('fetchChefsById should look up CAPI details for profile tags', async () => {
     const store = createStoreAndFetchMock([
       {
-        pattern: "/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all",
-        response: tagLookupResponse
-      }
+        pattern:
+          '/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all&page-size=100',
+        response: tagLookupResponse,
+      },
     ]);
-    await store.dispatch(fetchChefsById(["profile/anna-jones","profile/anna-del-conte"]) as any);
-    expect(chefSelectors.selectAll(store.getState())).toEqual(expectedResultForLookup);
-  })
-})
-
-
+    await store.dispatch(
+      fetchChefsById(['profile/anna-jones', 'profile/anna-del-conte']) as any
+    );
+    expect(chefSelectors.selectAll(store.getState())).toEqual(
+      expectedResultForLookup
+    );
+  });
+});

--- a/fronts-client/src/bundles/__tests__/chefsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/chefsBundle.spec.ts
@@ -61,7 +61,7 @@ const tagLookupResponse = {
     userTier: 'internal',
     total: 2,
     startIndex: 1,
-    pageSize: 100,
+    pageSize: 20,
     currentPage: 1,
     pages: 1,
     results: [
@@ -139,7 +139,7 @@ describe('chefsBundle', () => {
       },
       {
         pattern:
-          '/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all&page-size=100',
+          '/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all&page-size=20',
         response: tagLookupResponse,
       },
     ]);
@@ -154,12 +154,17 @@ describe('chefsBundle', () => {
     const store = createStoreAndFetchMock([
       {
         pattern:
-          '/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all&page-size=100',
+          '/api/live/tags?type=contributor&ids=profile%2Fanna-jones%2Cprofile%2Fanna-del-conte&show-elements=image&show-fields=all&page-size=20',
         response: tagLookupResponse,
       },
     ]);
     await store.dispatch(
-      fetchChefsById(['profile/anna-jones', 'profile/anna-del-conte']) as any
+      fetchChefsById(
+        ['profile/anna-jones', 'profile/anna-del-conte'],
+        1,
+        20,
+        true
+      ) as any
     );
     expect(chefSelectors.selectAll(store.getState())).toEqual(
       expectedResultForLookup

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -1,4 +1,6 @@
-import createAsyncResourceBundle, { IPagination } from '../lib/createAsyncResourceBundle';
+import createAsyncResourceBundle, {
+  IPagination,
+} from '../lib/createAsyncResourceBundle';
 import { Chef } from '../types/Chef';
 import { selectCard } from 'selectors/shared';
 import { State } from 'types/State';
@@ -33,52 +35,69 @@ export const fetchChefs =
     dispatch(actions.fetchStart(ids));
     try {
       const chefs = await liveRecipes.chefs(params);
-      const chefsWithTags = chefs.results.filter(chef=>chef.contributorType==="Profile");
-      if(chefsWithTags.length==0) {
+      const chefsWithTags = chefs.results.filter(
+        (chef) => chef.contributorType === 'Profile'
+      );
+      if (chefsWithTags.length == 0) {
         dispatch(actions.fetchSuccess([]));
         return;
       }
 
-      dispatch(fetchChefsById(chefsWithTags.map(chef =>chef.nameOrId), 1,20,true));
+      dispatch(
+        fetchChefsById(
+          chefsWithTags.map((chef) => chef.nameOrId),
+          1,
+          20,
+          true
+        )
+      );
     } catch (e) {
       dispatch(actions.fetchError(e));
     }
   };
 
-export const fetchChefsById = (
-  tagIds: string[],
-  page = 1,
-  pageSize = 20,
-  alreadyStarted:boolean = false
-): ThunkResult<void> =>
+export const fetchChefsById =
+  (
+    tagIds: string[],
+    page = 1,
+    pageSize = 20,
+    alreadyStarted: boolean = false
+  ): ThunkResult<void> =>
   async (dispatch) => {
+    //we could be called as the second part of a two-stage fetch, OR we could be called directly.
+    //if called directly, indicate that we started a fetch. Otherwise, the first part should
+    if (!alreadyStarted) dispatch(actions.fetchStart(tagIds));
 
-  //we could be called as the second part of a two-stage fetch, OR we could be called directly.
-  //if called directly, indicate that we started a fetch. Otherwise, the first part should
-  if(!alreadyStarted) dispatch(actions.fetchStart(tagIds));
+    try {
+      const chefTags = await liveCapi.chefs({
+        ids: tagIds.join(','),
+        'show-elements': 'image',
+        'show-fields': 'all',
+        'page-size': 100,
+      });
 
-  try {
-    const chefTags = await liveCapi.chefs({
-      'ids': tagIds.join(","),
-      'show-elements': 'image',
-      'show-fields': 'all',
-    });
+      const payload: {
+        ignoreOrder?: undefined;
+        pagination?: IPagination;
+        order?: string[];
+      } = {
+        pagination: {
+          pageSize: chefTags.response.pageSize,
+          totalPages: chefTags.response.pages,
+          currentPage: chefTags.response.currentPage,
+        },
+        order: tagIds,
+      };
 
-    const payload: { ignoreOrder?: undefined; pagination?: IPagination; order?: string[] } = {
-      pagination: {
-        pageSize: chefTags.response.pageSize,
-        totalPages: chefTags.response.pages,
-        currentPage: chefTags.response.currentPage
-      },
-      order: tagIds
-    };
-
-    dispatch(
-      actions.fetchSuccess(chefTags.response.results.map(sanitizeTag), payload)
-    )
-  } catch(err) {
-    dispatch(actions.fetchError(err))
-  }
+      dispatch(
+        actions.fetchSuccess(
+          chefTags.response.results.map(sanitizeTag),
+          payload
+        )
+      );
+    } catch (err) {
+      dispatch(actions.fetchError(err));
+    }
   };
 
 const selectChefDataFromCardId = (

--- a/fronts-client/src/bundles/chefsBundle.ts
+++ b/fronts-client/src/bundles/chefsBundle.ts
@@ -60,7 +60,7 @@ export const fetchChefsById =
   (
     tagIds: string[],
     page = 1,
-    pageSize = 20,
+    pageSize = 100,
     alreadyStarted: boolean = false
   ): ThunkResult<void> =>
   async (dispatch) => {
@@ -73,7 +73,7 @@ export const fetchChefsById =
         ids: tagIds.join(','),
         'show-elements': 'image',
         'show-fields': 'all',
-        'page-size': 100,
+        'page-size': pageSize,
       });
 
       const payload: {


### PR DESCRIPTION
## What's changed?

Solution suggested by: Andy Gallagher <fredex42@gmail.com>

If more than 10 chefs are present in a container, the 11th and subsequent tend to show as “No Chef Found”.
It has been found that the Fronts tool issues HTTP request proxied to CAPI for contributor tags on which the response is getting split across two pages due to pageSize being 10.
Solution to try pageSize to be 100 as we doubt we'll need more than 100 chefs in a container!

**Before**:

![image](https://github.com/user-attachments/assets/3332d327-2914-438a-8ab6-fcda2c4d7c1b)


**After**:

![image](https://github.com/user-attachments/assets/5279f7e0-ef75-45f4-b3ae-170df23460ff)


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [X] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [X] 📷 Screenshots / GIFs of relevant UI changes included
