### PR TITLE
Fix chef card overrides

### DIFF
--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -258,7 +258,8 @@ class Card extends React.Component<CardContainerProps> {
                 {...getNodeProps()}
                 onDelete={this.onDelete}
                 onAddToClipboard={this.handleAddToClipboard}
-                /* No need for an OnClick here - there are no editable forms */
+                // Chef has overrides so we need to edit it
+                onClick={isUneditable ? undefined : () => onSelect(uuid)}
                 size={size}
                 textSize={textSize}
                 showMeta={showMeta}


### PR DESCRIPTION
## What's changed?
- Restores the `onClick` handler for a chef card, which was inadvertently removed in https://github.com/guardian/facia-tool/pull/1658.

This is because the chef card _does_ have an internal form, which is used for supplying overrides including Feast palette settings and a new image. These are used extensively in Feast curation when adjusting "Meet Our Chefs"; unfortunately this is not done frequently!.

Note the correct behaviour of the `!` icon in the Overview to indicate an open form. It goes away as it should when the form is closed.

_1. Before customisation_
![Screenshot 2024-10-02 at 17 21 15](https://github.com/user-attachments/assets/30c6accc-6575-4327-8fb7-a8bb8dfb5d56)

_2. Click to open_
![Screenshot 2024-10-02 at 17 21 34](https://github.com/user-attachments/assets/7dbe7f3f-2d88-4915-8f3d-169cb099a0ef)

_3. Customise_
![Screenshot 2024-10-02 at 17 22 03](https://github.com/user-attachments/assets/fa2cd816-0fe9-41b6-907f-2880047a0866)

_4. Saved_
![Screenshot 2024-10-02 at 17 22 10](https://github.com/user-attachments/assets/f14bf88e-b681-4394-a003-710c61ad44c4)

## Implementation notes

n/a

## Checklist

### General
- ~~🤖 Relevant tests added~~ _n/a: this code is not tested 😞_
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
