### PR TITLE
📌 load pinboard for V2 fronts tool if user has Pinboard permission (and feature switch on)

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -65,14 +65,16 @@ class ApplicationConfiguration(
 
     val applicationName = "facia-tool"
 
-    // isProd is derived from the enviroment mode which is given
+    // isProd is derived from the environment mode which is given
     // to us by play, it is true for both prod and code. Stage is a variable coming
     // from the config and tells us which bucket we are reading fronts and collections from.
     // Stage is prod for production environment and code for code and dev environemnts.
     // These two variables together allow us to determine the application url.
-    val applicationUrl = if (isProd && stage == "code") "https://fronts.code.dev-gutools.co.uk"
-      else if (isProd) "https://fronts.gutools.co.uk"
-      else "https://fronts.local.dev-gutools.co.uk"
+    val correspondingToolsDomainSuffix = if (isProd && stage == "code") "code.dev-gutools.co.uk"
+      else if (isProd) "gutools.co.uk"
+      else "local.dev-gutools.co.uk"
+
+    val applicationUrl = s"https://fronts.${correspondingToolsDomainSuffix}"
   }
 
   object ophanApi {

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -101,7 +101,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, db: Edit
       Json.toJson(conf).toString(),
       isDev,
       maybePinboardUrl = pinboardPermission match {
-        case AccessGranted if maybePinboardFeatureSwitch.exists(_.enabled) =>
+        case AccessGranted if config.environment.stage != "prod" || maybePinboardFeatureSwitch.exists(_.enabled) =>
 					Some(s"https://pinboard.${config.environment.correspondingToolsDomainSuffix}/pinboard.loader.js")
         case _ =>
 					None

--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -3,7 +3,7 @@ package controllers
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.scanamo._
 import org.scanamo.syntax._
-import model.{ClipboardCard, FeatureSwitch, UserData, UserDataForDefaults}
+import model.{ClipboardCard, FeatureSwitch, PinboardIntegration, UserData, UserDataForDefaults}
 
 import scala.concurrent.ExecutionContext
 import com.gu.facia.client.models.{Metadata, TargetedTerritory}
@@ -14,7 +14,7 @@ import play.api.libs.json.Json
 import services.editions.db.EditionsDB
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import switchboard.SwitchManager
-import util.{Acl, AclJson}
+import util.{AccessGranted, Acl, AclJson}
 
 class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, db: EditionsDB, val deps: BaseFaciaControllerComponents)(implicit ec: ExecutionContext) extends BaseFaciaController(deps) {
 
@@ -39,6 +39,7 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, db: Edit
     val hasBreakingNews = acl.testUser(Permissions.BreakingNewsAlert, "facia-tool-allow-breaking-news-for-all")(req.user.email)
     val hasConfigureFronts = acl.testUser(Permissions.ConfigureFronts, "facia-tool-allow-config-for-all")(req.user.email)
     val hasEditionsPermissions = acl.testUser(Permissions.EditEditions, "facia-tool-allow-edit-editions-for-all")(req.user.email)
+    val pinboardPermission = acl.testUser(Permissions.Pinboard, "facia-tool-allow-pinboard-for-all")(req.user.email)
 
     val acls = AclJson(
       fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
@@ -51,7 +52,9 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, db: Edit
     val maybeUserData: Option[UserData] = Scanamo(dynamoClient).exec(
       userDataTable.get("email" === userEmail)).flatMap(_.toOption)
 
-    val clipboardCards = if (editingEdition) {
+		val maybePinboardFeatureSwitch = maybeUserData.flatMap(_.featureSwitches.flatMap(_.find(_.key == PinboardIntegration.key)))
+
+		val clipboardCards = if (editingEdition) {
       if(isFeast)
         maybeUserData.map(_.feastEditionsClipboardCards.getOrElse(List()).map(ClipboardCard.apply))
       else
@@ -96,7 +99,13 @@ class V2App(isDev: Boolean, val acl: Acl, dynamoClient: DynamoDbClient, db: Edit
       cssLocation,
       faviconLocation,
       Json.toJson(conf).toString(),
-      isDev
+      isDev,
+      maybePinboardUrl = pinboardPermission match {
+        case AccessGranted if maybePinboardFeatureSwitch.exists(_.enabled) =>
+					Some(s"https://pinboard.${config.environment.correspondingToolsDomainSuffix}/pinboard.loader.js")
+        case _ =>
+					None
+      }
     ))
   }
 

--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -36,8 +36,14 @@ object UsePortraitCropsForSomeCollectionTypes extends FeatureSwitch(
   enabled = false
 )
 
+object PinboardIntegration extends FeatureSwitch(
+	key = "pinboard",
+	title = "Enable Pinboard integration",
+	enabled = false
+)
+
 object FeatureSwitches {
-  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes)
+  val all: List[FeatureSwitch] = List(ObscureFeed, PageViewDataVisualisation, TenImageSlideshows, UsePortraitCropsForSomeCollectionTypes, PinboardIntegration)
 
   def updateFeatureSwitchesForUser(userDataSwitches: Option[List[FeatureSwitch]], switch: FeatureSwitch): List[FeatureSwitch] = {
     val newSwitches = userDataSwitches match {

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -3,12 +3,15 @@ package permissions
 import com.gu.permissions.PermissionDefinition
 
 object Permissions {
-  val FrontsAccess = PermissionDefinition("fronts_access", "fronts")
-  val ConfigureFronts = PermissionDefinition("configure_fronts", "fronts")
-  val BreakingNewsAlert = PermissionDefinition("breaking_news_alert", "fronts")
-  val LaunchCommercialFronts = PermissionDefinition("launch_commercial_fronts", "fronts")
-  val LaunchEditorialFronts = PermissionDefinition("launch_editorial_fronts", "fronts")
-  val EditEditorialFronts = PermissionDefinition("edit_editorial_fronts", "fronts")
-  val EditEditions = PermissionDefinition("edit_editions", "fronts")
-  val LaunchAndEditEmailFronts = PermissionDefinition("edit_and_launch_email_fronts", "fronts")
+  private val app = "fronts"
+  val FrontsAccess = PermissionDefinition("fronts_access", app)
+  val ConfigureFronts = PermissionDefinition("configure_fronts", app)
+  val BreakingNewsAlert = PermissionDefinition("breaking_news_alert", app)
+  val LaunchCommercialFronts = PermissionDefinition("launch_commercial_fronts", app)
+  val LaunchEditorialFronts = PermissionDefinition("launch_editorial_fronts", app)
+  val EditEditorialFronts = PermissionDefinition("edit_editorial_fronts", app)
+  val EditEditions = PermissionDefinition("edit_editions", app)
+  val LaunchAndEditEmailFronts = PermissionDefinition("edit_and_launch_email_fronts", app)
+
+  val Pinboard = PermissionDefinition("pinboard", "pinboard")
 }

--- a/app/views/V2App/app.scala.html
+++ b/app/views/V2App/app.scala.html
@@ -1,5 +1,12 @@
-@(title: String, jsLocation: String, cssLocation: String, faviconLocation: String, clientConfigJson:
-String, isDev: Boolean)
+@(
+    title: String,
+    jsLocation: String,
+    cssLocation: String,
+    faviconLocation: String,
+    clientConfigJson: String,
+    isDev: Boolean,
+    maybePinboardUrl: Option[String]
+)
 <!DOCTYPE html>
 <html lang="en">
 
@@ -51,6 +58,10 @@ String, isDev: Boolean)
     } else {
         <link rel="stylesheet" href="@cssLocation">
         <script type="module" src="@jsLocation" type="application/javascript"></script>
+    }
+
+    @maybePinboardUrl.map { pinboardUrl =>
+        <script async defer src="@pinboardUrl"></script>
     }
 </body>
 


### PR DESCRIPTION
## What's changed?
This integrates https://github.com/guardian/pinboard in its current form, **IF both**...

- the user has Pinboard permission, and
- the new (temporary) feature switch is turned ON for the user (`/v2/features` to see features switches)
   <img width="413" alt="image" src="https://github.com/user-attachments/assets/3366122b-0a41-4655-a58b-096cb7bd91dc">
   IMPORTANT: this switch is ignored in all envs except PROD, i.e. pinboard is loaded in CODE etc. if the user has pinboard permission

This is just the initial integration phase, and hopefully some additional/deeper integrations will follow (mostly on the pinboard side most likely - see https://github.com/guardian/pinboard/pull/312 plus https://github.com/guardian/facia-tool/pull/1695).

![image](https://github.com/user-attachments/assets/4541249f-0fd0-4b53-99f5-cd157d6ccd65)


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
