### PR TITLE
[Fairground] Hide config fields if scrollable small container

### DIFF
--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -221,9 +221,11 @@
             <input type="text" data-bind="
                 value: meta.href"/>
 
+            <!-- ko if: meta.type() !== 'scrollable/small' -->
             <label>Description</label>
                 <input type="text" data-bind="
                     value: meta.description"/>
+            <!-- /ko -->
 
             <config-collection-backfill params="backfill: meta.backfill"></config-collection-backfill>
 
@@ -260,17 +262,23 @@
             <label for="hideKickers" >Suppress tone kickers</label>
             <input id="hideKickers" type="checkbox" data-bind="checked: meta.hideKickers" />
 
+            <!-- ko if: meta.type() !== 'scrollable/small' -->
             <label for="showDateHeader">Show date in header</label>
             <input id="showDateHeader" type="checkbox" data-bind="checked: meta.showDateHeader" />
+            <!-- /ko -->
 
+            <!-- ko if: meta.type() !== 'scrollable/small' -->
             <label for="showLatestUpdate">Show latest update in header</label>
             <input id="showLatestUpdate" type="checkbox" data-bind="checked: meta.showLatestUpdate" />
+            <!-- /ko -->
 
             <label for="excludeFromRss">Exclude from RSS</label>
             <input id="excludeFromRss" type="checkbox" data-bind="checked: meta.excludeFromRss" />
 
+            <!-- ko if: meta.type() !== 'scrollable/small' -->
             <label for="hideShowMore">Hide show more</label>
             <input id="hideShowMore" type="checkbox" data-bind="checked: meta.hideShowMore" />
+            <!-- /ko -->
 
             <label>No curation</label>
             <input type="checkbox" data-bind="


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Part of this [ticket](https://trello.com/c/jQWWRVIr/404-small-story-carousel-tooling-respect-configuration-requirements-including-adding-option-to-hide-display-image-in-fronts-tool)

There's a few options which we don't support in the scrollable/small container, and so want to hide in the config tool. 

<img width="716" alt="image" src="https://github.com/user-attachments/assets/1c062e11-db77-4e6d-8c79-e9430d43d25d">


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
