### PR TITLE
Downgrade ubuntu version to match PROD

### DIFF
--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     generate_build_number:
         name: Generate build number
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         outputs:
             BUILD_NUMBER: ${{ steps.create-build-number.outputs.BUILD_NUMBER }}
         steps:
@@ -21,7 +21,7 @@ jobs:
                     echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> "$GITHUB_OUTPUT"
 
     build_client_v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -60,7 +60,7 @@ jobs:
                   path: public/src/jspm_packages
                   if-no-files-found: error
     test_client_v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -91,7 +91,7 @@ jobs:
                     grunt --stack test
 
     build_client_v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -112,7 +112,7 @@ jobs:
                   path: public/fronts-client-v2
                   if-no-files-found: error
     test_client_v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -129,7 +129,7 @@ jobs:
               working-directory: fronts-client
 
     integrationtest_client_v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -152,7 +152,7 @@ jobs:
               working-directory: fronts-client
 
     test_backend:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -183,7 +183,7 @@ jobs:
               run: sbt 'test; database-int:test'
 
     build_backend:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read
@@ -222,7 +222,7 @@ jobs:
                   if-no-files-found: error
                   compression-level: '0' #no point, it's already compressed
     upload:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             id-token: write
             contents: read


### PR DESCRIPTION
## What's changed?

Github’s standard ubuntu version for Github Actions runners has recently changed to 24.04. This appears to have broken CI on this repository because it broke the ChromeHeadless usage in tests.

To fix it, we could revert to 22.04, which was being used before the recent change. However, it appears fronts is using 20.04 in PROD (based on [the amigo recipe](https://amigo.gutools.co.uk/recipes/editorial-tools-focal-java11-ARM-WITH-cdk-base) specified [in riff-raff.yaml](https://github.com/guardian/facia-tool/blob/6e0804dca3eed7a7d1dee8238fad8b0bba6d0e71/riff-raff.yaml#L14)). So instead I think it’s probably best to revert to 20.04.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
