### PR TITLE
add empty element per article card, to act as handle for Pinboard 📌 to attach to (using `urlPath` as data attribute)

### DIFF
--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -358,6 +358,7 @@ const articleBodyDefault = React.memo(
 						size={size}
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
+						urlPath={urlPath}
 						renderButtons={(props) => (
 							<>
 								{urlPath && (

--- a/fronts-client/src/components/card/chef/ChefCard.tsx
+++ b/fronts-client/src/components/card/chef/ChefCard.tsx
@@ -61,7 +61,6 @@ export const ChefCard = ({
 	const chef = useSelector((state: State) =>
 		chefsSelectors.selectChefFromCard(state, card.uuid),
 	);
-
 	return (
 		<CardContainer {...rest}>
 			<CardBody data-testid="snap" size={size} fade={fade}>
@@ -115,6 +114,7 @@ export const ChefCard = ({
 					<HoverActionsButtonWrapper
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
+						urlPath={undefined}
 						renderButtons={(props) => (
 							<>
 								<HoverViewButton

--- a/fronts-client/src/components/card/feastCollection/FeastCollectionCard.tsx
+++ b/fronts-client/src/components/card/feastCollection/FeastCollectionCard.tsx
@@ -132,6 +132,7 @@ export const FeastCollectionCard = ({
 						<HoverActionsButtonWrapper
 							toolTipPosition={'top'}
 							toolTipAlign={'right'}
+							urlPath={undefined}
 							renderButtons={(props) => (
 								<>
 									<HoverAddToClipboardButton

--- a/fronts-client/src/components/card/recipe/RecipeCard.tsx
+++ b/fronts-client/src/components/card/recipe/RecipeCard.tsx
@@ -108,6 +108,7 @@ export const RecipeCard = ({
 					<HoverActionsButtonWrapper
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
+						urlPath={paths?.live}
 						renderButtons={(props) => (
 							<>
 								<HoverViewButton

--- a/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
+++ b/fronts-client/src/components/card/snapLink/SnapLinkCard.tsx
@@ -196,6 +196,7 @@ const SnapLinkCard = ({
 						size={size}
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
+						urlPath={urlPath}
 						renderButtons={(props) => (
 							<>
 								{urlPath && (

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -220,6 +220,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 					<HoverActionsButtonWrapper
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
+						urlPath={liveUrl}
 						renderButtons={(props) => (
 							<>
 								<HoverViewButton hoverText="View" href={href} {...props} />

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -537,6 +537,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						groupSizeId &&
 						groupSizeId > 0)));
 
+		const cardCriteria = this.determineCardCriteria();
+
 		return (
 			<FormContainer
 				data-testid="edit-form"
@@ -735,9 +737,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 										component={InputImage}
 										disabled={imageHide || coverCardImageReplace}
 										criteria={
-											isEditionsMode
-												? editionsCardImageCriteria
-												: this.determineCardCriteria()
+											isEditionsMode ? editionsCardImageCriteria : cardCriteria
 										}
 										frontId={frontId}
 										defaultImageUrl={
@@ -847,7 +847,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									frontId={frontId}
 									component={RenderSlideshow}
 									change={change}
-									criteria={this.determineCardCriteria()}
+									criteria={cardCriteria}
 									slideshowHasAtLeastTwoImages={slideshowHasAtLeastTwoImages}
 								/>
 							</SlideshowRowContainer>
@@ -904,6 +904,15 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						</RowContainer>
 					)}
 				</FormContent>
+				{articleCapiFieldValues.urlPath && (
+					// the below tag is empty and meaningless to the fronts tool itself, but serves as a handle for
+					// Pinboard to attach itself via, identified/distinguished by the urlPath data attribute
+					// @ts-ignore
+					<pinboard-article-button
+						data-url-path={articleCapiFieldValues.urlPath}
+						data-with-draggable-thumbs-of-ratio={`${cardCriteria.widthAspectRatio}:${cardCriteria.heightAspectRatio}`}
+					/>
+				)}
 				<FormButtonContainer>
 					<Button onClick={this.handleCancel} type="button" size="l">
 						Cancel
@@ -988,7 +997,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	private getHeadlineLabel = () =>
 		this.props.snapType === 'html' ? 'Content' : 'Headline';
 
-	private determineCardCriteria = (): Criteria => {
+	private determineCardCriteria = (): Criteria & {
+		widthAspectRatio: number;
+		heightAspectRatio: number;
+	} => {
 		const { collectionType } = this.props;
 		if (!collectionType) {
 			return landScapeCardImageCriteria;

--- a/fronts-client/src/components/form/ChefMetaForm.tsx
+++ b/fronts-client/src/components/form/ChefMetaForm.tsx
@@ -83,7 +83,7 @@ const Form = ({
 					{`This collection has been edited since you started editing this article. Your changes have not been saved. Please refresh the page to get the latest data.`}
 				</CollectionEditedError>
 			)}
-			<FormContent size={size}>
+			<FormContent size={size} marginBottom="40px">
 				<TextOptionsInputGroup>
 					<Field
 						name="bio"

--- a/fronts-client/src/components/form/FeastCollectionMetaForm.tsx
+++ b/fronts-client/src/components/form/FeastCollectionMetaForm.tsx
@@ -78,7 +78,7 @@ const Form = ({
 					{`This collection has been edited since you started editing this article. Your changes have not been saved. Please refresh the page to get the latest data.`}
 				</CollectionEditedError>
 			)}
-			<FormContent size={size}>
+			<FormContent size={size} marginBottom="40px">
 				<TextOptionsInputGroup>
 					<Field
 						name="title"

--- a/fronts-client/src/components/form/FormContent.tsx
+++ b/fronts-client/src/components/form/FormContent.tsx
@@ -1,10 +1,13 @@
 import { styled } from 'constants/theme';
 import { CardSizes } from 'types/Collection';
 
-export const FormContent = styled.div`
+interface FormContentProps {
+	size?: CardSizes;
+	marginBottom?: string;
+}
+export const FormContent = styled.div<FormContentProps>`
 	flex: 3;
 	display: flex;
-	flex-direction: ${(props: { size?: CardSizes }) =>
-		props.size !== 'wide' ? 'column' : 'row'};
-	margin-bottom: 40px;
+	flex-direction: ${({ size }) => (size !== 'wide' ? 'column' : 'row')};
+	margin-bottom: ${({ marginBottom }) => marginBottom ?? 0};
 `;

--- a/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
@@ -43,6 +43,7 @@ interface WrapperProps {
 	size?: CardSizes; // Article Component size
 	toolTipPosition: 'top' | 'left' | 'bottom' | 'right';
 	toolTipAlign: 'left' | 'center' | 'right';
+	urlPath: string | undefined;
 	renderButtons: (renderProps: ButtonProps) => JSX.Element;
 }
 
@@ -50,6 +51,7 @@ export const HoverActionsButtonWrapper = ({
 	toolTipPosition,
 	toolTipAlign,
 	size,
+	urlPath,
 	renderButtons,
 }: WrapperProps) => {
 	const [toolTipText, setToolTipText] = useState<string | undefined>(undefined);
@@ -77,6 +79,15 @@ export const HoverActionsButtonWrapper = ({
 				hideToolTip,
 				size,
 			})}
+			{urlPath && (
+				// the below tag is empty and meaningless to the fronts tool itself, but serves as a handle for
+				// Pinboard to attach itself via, identified/distinguished by the urlPath data attribute
+				// @ts-ignore
+				<pinboard-article-button
+					style={{ verticalAlign: 'top', marginLeft: '2px' }}
+					data-url-path={urlPath}
+				/>
+			)}
 		</HoverActionsWrapper>
 	);
 };

--- a/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
+++ b/fronts-client/src/components/inputs/__tests__/HoverActions.spec.tsx
@@ -23,6 +23,7 @@ const HoverWrapper = (
 		<HoverActionsButtonWrapper
 			toolTipPosition={'top'}
 			toolTipAlign={'center'}
+			urlPath={undefined}
 			renderButtons={(props) => (
 				<>
 					<HoverViewButton hoverText="View" href={'test-string'} {...props} />

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -49,6 +49,7 @@ export interface CapiFields {
 	trailText: string;
 	byline: string;
 	thumbnail?: string | void;
+	urlPath: string;
 }
 
 export const strToInt = (str: string | void) =>
@@ -65,6 +66,7 @@ export const getCapiValuesForArticleFields = (
 			trailText: '',
 			byline: '',
 			thumbnail: '',
+			urlPath: '',
 		};
 	}
 	return {
@@ -72,6 +74,7 @@ export const getCapiValuesForArticleFields = (
 		trailText: article.fields.trailText || '',
 		byline: article.fields.byline || '',
 		thumbnail: article.fields.thumbnail,
+		urlPath: article.urlPath,
 	};
 };
 


### PR DESCRIPTION
_Replaces https://github.com/guardian/facia-tool/pull/1680 (closed in error)_

**_Follows on from https://github.com/guardian/facia-tool/pull/1679_**

**This PR facilitates https://github.com/guardian/pinboard/pull/312 to do anything useful**

## What's changed?
As the title suggests, this PR mainly just adds placeholder elements for pinboard to attach to (see https://github.com/guardian/pinboard/pull/312)

- It passes the `urlPath` via `data-url-path` which allows pinboard to link it to a workflow item (i.e. a pinboard) thanks to https://github.com/guardian/workflow/pull/1119 - to display item counts, crop counts etc for each card.
- in `ArticleMetaForm.tsx` (i.e. expanded article card, where headline, trail etc. can be overridden) it also passes `data-with-draggable-thumbs-of-ratio` attribute with the required ratio of the container (e.g. `5:3`, `5:4` or `4:5`) - which pinboard can use to display draggable thumbnails of `grid-crops` matching that ratio which have been shared via Pinboard (typically from https://github.com/guardian/flexible-content/pull/4984) 

It also removes some margin-bottom from the article card form, as it was just adding dead space (I suspect in the past it used to collapse into the Cancel/Save button row).

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
