### PR TITLE
Recrop option to disable if image is not from Grid

### DIFF
--- a/fronts-client/src/components/form/ChefMetaForm.tsx
+++ b/fronts-client/src/components/form/ChefMetaForm.tsx
@@ -119,6 +119,7 @@ const Form = ({
 									name="chefImageOverride"
 									component={InputImage}
 									criteria={squareImageCriteria}
+									defaultImageUrl={chef?.bylineImageUrl}
 								/>
 							</ImageCol>
 						</Row>

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -257,6 +257,8 @@ interface ComponentState {
 const dragImage = new Image();
 dragImage.src = imageDragIcon;
 
+const regexToCheckGridImage: RegExp = /^https?:\/\/(www\.)?media\.(?:dev-|)guim\.co\.uk\/([0-9a-fA-F]+)\//;
+
 class InputImage extends React.Component<ComponentProps, ComponentState> {
 	private inputRef = React.createRef<HTMLInputElement>();
 
@@ -305,6 +307,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 				</div>
 			);
 		}
+
+		const isImgFromGrid = defaultImageUrl ? regexToCheckGridImage.test(defaultImageUrl) : false;
 
 		const hasImage = !useDefault && !!input.value && !!input.value.thumb;
 		const imageUrl =
@@ -411,7 +415,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 										<AddImageIcon size="l" />
 										{!!small ? null : <Label size="sm">{message}</Label>}
 									</AddImageButton>
-									<AddImageButton
+									{isImgFromGrid && (<AddImageButton
 										type="button"
 										onClick={this.openModal(true)}
 										small={small}
@@ -419,7 +423,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 									>
 										<CropIcon size="l" fill={theme.colors.white} />
 										{!!small ? null : <Label size="sm">Recrop image</Label>}
-									</AddImageButton>
+									</AddImageButton>)}
 								</AddImageViaGridModalButton>
 							)}
 							{hasVideo && useDefault && (

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -257,7 +257,8 @@ interface ComponentState {
 const dragImage = new Image();
 dragImage.src = imageDragIcon;
 
-const regexToCheckGridImage: RegExp = /^https?:\/\/(www\.)?media\.(?:dev-|)guim\.co\.uk\/([0-9a-fA-F]+)\//;
+const regexToCheckGridImage: RegExp =
+	/^https?:\/\/(www\.)?media\.(?:dev-|)guim\.co\.uk\/([0-9a-fA-F]+)\//;
 
 class InputImage extends React.Component<ComponentProps, ComponentState> {
 	private inputRef = React.createRef<HTMLInputElement>();
@@ -308,7 +309,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 			);
 		}
 
-		const isImgFromGrid = defaultImageUrl ? regexToCheckGridImage.test(defaultImageUrl) : false;
+		const isImgFromGrid = defaultImageUrl
+			? regexToCheckGridImage.test(defaultImageUrl)
+			: false;
 
 		const hasImage = !useDefault && !!input.value && !!input.value.thumb;
 		const imageUrl =
@@ -415,15 +418,17 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 										<AddImageIcon size="l" />
 										{!!small ? null : <Label size="sm">{message}</Label>}
 									</AddImageButton>
-									{isImgFromGrid && (<AddImageButton
-										type="button"
-										onClick={this.openModal(true)}
-										small={small}
-										disabled={disabled}
-									>
-										<CropIcon size="l" fill={theme.colors.white} />
-										{!!small ? null : <Label size="sm">Recrop image</Label>}
-									</AddImageButton>)}
+									{isImgFromGrid && (
+										<AddImageButton
+											type="button"
+											onClick={this.openModal(true)}
+											small={small}
+											disabled={disabled}
+										>
+											<CropIcon size="l" fill={theme.colors.white} />
+											{!!small ? null : <Label size="sm">Recrop image</Label>}
+										</AddImageButton>
+									)}
 								</AddImageViaGridModalButton>
 							)}
 							{hasVideo && useDefault && (


### PR DESCRIPTION
## What's changed?

- This will fix missing background image when we open the form to edit it.
- This will remove `Recrop Image` option from Chef card because we found that the image is not available on the grid to edit on. At present chef images are uploaded on S3.

Note: Need to check with CoPro team on using `Recrop Image` when article has author's cutout images. I think `recrop` will not be working on those images too.

_________

### Before:

#### On CHEF card
https://github.com/user-attachments/assets/b46628bd-d712-4653-b116-c127ecc1d8bb

#### On UK Daily Edition, one of the article
https://github.com/user-attachments/assets/8fccce99-f206-4a57-86a7-90b17d013d04


_________

### After:

#### On CHEF card
https://github.com/user-attachments/assets/3a15de4e-3bdf-4c2b-8f42-676bdd148aec


#### On UK Daily Edition, one of the article

https://github.com/user-attachments/assets/a17ff7c2-ec9f-4010-ad0e-9856d04d6ece




## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General



- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
