### PR TITLE
Add pre-commit hook that runs prettier

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if command -v fronts-client/node_modules/.bin/prettier > /dev/null; then
+    echo "Checking file formatting with prettier…"
+    echo ""
+    # For files which have staged changes and no unstaged changes, let prettier format them
+    filesWithOnlyStagedChanges=$(
+        comm -1 -3 \
+            <(git diff --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort) \
+            <(git diff --cached --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort))
+    prettierFormattedOutput=$(
+        comm -1 -3 \
+            <(git diff --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort) \
+            <(git diff --cached --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort) \
+        | tr "\n" "\0" \
+        | xargs -0 fronts-client/node_modules/.bin/prettier --write --list-different)
+    # For files which have both staged and unstaged changes, check them with prettier but don’t modify them
+    prettierCheckedOutput=$(
+        comm -1 -2 \
+            <(git diff --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort) \
+            <(git diff --cached --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort) \
+        | tr "\n" "\0" \
+        | xargs -0 fronts-client/node_modules/.bin/prettier --list-different)
+    if test -z "$prettierFormattedOutput" -a -z "$prettierCheckedOutput" ; then
+        echo "All good"
+        exit 0
+    else
+        if test -n "$prettierFormattedOutput" ; then
+            echo "The following staged files needed formatting by prettier! Formatting has been
+applied but the files have not been re-staged: please verify the changes, stage,
+and commit again."
+            echo ""
+            filesWhichHaveBeenFormatted=$(
+                comm -1 -2 \
+                    <(git diff --name-only --diff-filter=ACMR | grep "\.tsx\?\$" | sort) \
+                    <(echo "$filesWithOnlyStagedChanges"))
+            echo "$filesWhichHaveBeenFormatted"
+            echo ""
+        fi
+        if test -n "$prettierCheckedOutput" ; then
+            echo "The following staged files with additional unstaged changes were reported by
+prettier as needing formatting: these files have not been formatted, to avoid
+overwriting unstaged changes. Please format them yourself or bypass this hook with
+--no-verify."
+            echo ""
+            echo "$prettierCheckedOutput"
+            echo ""
+        fi
+        exit 1
+    fi
+else
+    echo "Note: fronts-client/node_modules/.bin/prettier not found, so skipping formatting check"
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -95,6 +95,7 @@ fetch_config(){
 configure_git() {
   echo "Configuring git…"
   git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+  git config --local core.hooksPath scripts/git-hooks
 }
 
 main() {


### PR DESCRIPTION
## What's changed?

As a convenience, this PR adds a hook which checks the formatting of your files, formatting any which it’s safe to.

## Implementation notes

I’ve copied the one I implemented in https://github.com/guardian/datawrapper-import/pull/12 and tweaked it to account for the differences between prettier and scalafmt.

In particular, the hook is careful not to overwrite any unstaged changes: if a file has both staged and unstaged changes, running a formatter on it could (if something goes wrong) cause you to lose changes that git is unaware of, and they might be difficult to recover.

## To Test

- Run the setup script, or manually run `git config --local core.hooksPath scripts/git-hooks`.
- Test the behaviour of the hook with combinations of:
  - typescript files with only staged changes which need formatting
  - typescript files with only unstaged changes which need formatting
  - typescript files with staged and unstaged changes, which need formatting
  - non-typescript files with staged or unstaged changes
