### PR TITLE
Remove `scrollable/feature` container in list of 5:4 landscape trails

### DIFF
--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -43,7 +43,6 @@ export const COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS: string[] = [
 	FLEXIBLE_SPECIAL_NAME,
 	'scrollable/small',
 	'scrollable/medium',
-	'scrollable/feature',
 	'static/medium/4',
 ];
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Fixes bug introduced in https://github.com/guardian/facia-tool/pull/1677 where the `scrollable/feature` container was not respecting the portrait (4:5) trail configuration option because it was also listed as accepting landscape 5:4 images.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
