### PR TITLE
Fix top elements disappearance when selecting Overview

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -121,7 +121,7 @@ const CollectionOverview = ({
 					el.scrollIntoView({
 						behavior: 'smooth',
 						inline: 'start',
-						block: 'start',
+						block: 'nearest',
 					});
 				}
 				openCollection(collection.id);


### PR DESCRIPTION
## What's changed?

We observed when we select any collection name in `Overview` the top elements present in the Front (above the containers) are getting disappeared means shifts at top and go out of the viewport.

### Before:


https://github.com/user-attachments/assets/ddd1a37d-f67d-4498-8d5a-bfa3c524c15e



### After



https://github.com/user-attachments/assets/65b59edd-2e22-43b9-91a3-2419e5a189ed



## Implementation notes
The block: 'nearest' option will scroll the element to the nearest edge of the viewport, instead of always forcing it to the very top.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
