### PR TITLE
Date ordering preference for recipes

### DIFF
--- a/fronts-client/src/bundles/recipesBundle.ts
+++ b/fronts-client/src/bundles/recipesBundle.ts
@@ -43,7 +43,7 @@ export const fetchRecipesById =
 			const recipes = await liveRecipes.recipesById(idList);
 			dispatch(
 				actions.fetchSuccess(recipes, {
-					order: recipes.map((_) => _.id),
+					ignoreOrder: true,
 				}),
 			);
 		} catch (e) {

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -126,6 +126,7 @@ interface FeedItemProps {
 	) => void;
 	shouldObscureFeed?: boolean;
 	byline?: string;
+	noPinboard?: boolean;
 }
 
 export class FeedItem extends React.Component<FeedItemProps, {}> {
@@ -151,6 +152,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 			hasVideo,
 			handleDragStart,
 			byline,
+			noPinboard,
 		} = this.props;
 
 		const { preview, live, ophan } = getPaths(id);
@@ -229,6 +231,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
 						urlPath={liveUrl}
+						noPinboard={noPinboard}
 						renderButtons={(props) => (
 							<>
 								<HoverViewButton hoverText="View" href={href} {...props} />

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -209,7 +209,6 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 								{byline ? (
 									<Byline data-testid="byline">{byline}</Byline>
 								) : undefined}
-								)
 							</>
 						)}
 					</Body>

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -53,7 +53,7 @@ const Byline = styled.h2`
 	font-weight: bold;
 `;
 
-const Title = styled.h2`
+export const Title = styled.h2`
 	margin: 2px 2px 0 0;
 	vertical-align: top;
 	font-family: TS3TextSans;
@@ -111,6 +111,7 @@ interface FeedItemProps {
 	id: string;
 	type: CardTypes;
 	title: string;
+	bodyContent?: JSX.Element;
 	liveUrl?: string;
 	metaContent?: JSX.Element;
 	scheduledPublicationDate?: string;
@@ -138,6 +139,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 			id,
 			type,
 			title,
+			bodyContent,
 			liveUrl,
 			isLive,
 			metaContent,
@@ -199,10 +201,17 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 						<ShortVerticalPinline />
 					</MetaContainer>
 					<Body>
-						<Title data-testid="headline">{title}</Title>
-						{byline ? (
-							<Byline data-testid="byline">{byline}</Byline>
-						) : undefined}
+						{bodyContent ? (
+							bodyContent
+						) : (
+							<>
+								<Title data-testid="headline">{title}</Title>
+								{byline ? (
+									<Byline data-testid="byline">{byline}</Byline>
+								) : undefined}
+								)
+							</>
+						)}
 					</Body>
 					<ArticleThumbnail
 						style={{

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -126,7 +126,7 @@ interface FeedItemProps {
 	) => void;
 	shouldObscureFeed?: boolean;
 	byline?: string;
-	noPinboard?: boolean;
+	showPinboard?: boolean;
 }
 
 export class FeedItem extends React.Component<FeedItemProps, {}> {
@@ -152,7 +152,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 			hasVideo,
 			handleDragStart,
 			byline,
-			noPinboard,
+			showPinboard,
 		} = this.props;
 
 		const { preview, live, ophan } = getPaths(id);
@@ -231,7 +231,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 						toolTipPosition={'top'}
 						toolTipAlign={'right'}
 						urlPath={liveUrl}
-						noPinboard={noPinboard}
+						showPinboard={showPinboard}
 						renderButtons={(props) => (
 							<>
 								<HoverViewButton hoverText="View" href={href} {...props} />

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -67,7 +67,7 @@ export const RecipeFeedItem = ({ id, showTimes }: ComponentProps) => {
 					) : undefined}
 					{recipe?.publishedDate && showTimes ? (
 						<ContentExtra>
-							First published {renderTimestamp(recipe.publishedDate)}
+							Published {renderTimestamp(recipe.publishedDate)}
 						</ContentExtra>
 					) : undefined}
 				</>

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -33,46 +33,46 @@ export const RecipeFeedItem = ({ id }: ComponentProps) => {
 		);
 	}, [recipe]);
 
-  const shortenTimestamp = (iso: string) => {
-    const parts = iso.split('T');
-    return parts[0];
-  };
+	const shortenTimestamp = (iso: string) => {
+		const parts = iso.split('T');
+		return parts[0];
+	};
 
-  return (
-    <FeedItem
-      type={CardTypesMap.RECIPE}
-      id={recipe.canonicalArticle}
-      title={recipe.title}
-      thumbnail={recipe.previewImage?.url ?? recipe.featuredImage?.url ?? ""}
-      liveUrl={`https://theguardian.com/${recipe.canonicalArticle}`}
-      hasVideo={false}
-      isLive={true} // We do not yet serve preview recipes
-      handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
-      onAddToClipboard={onAddToClipboard}
-      shouldObscureFeed={shouldObscureFeed}
-      metaContent={
-        <>
-          <ContentInfo>Recipe</ContentInfo>
-          <ContentExtra>
-            {recipe?.score && recipe.score < 1
-              ? `Relevance ${Math.ceil(recipe.score * 100)}%`
-              : ''}
-            <br />
-            {recipe?.lastModifiedDate
-              ? `M ${shortenTimestamp(recipe.lastModifiedDate)}`
-              : undefined}
-            <br />
-            {recipe?.publishedDate
-              ? `P ${shortenTimestamp(recipe.publishedDate)}`
-              : undefined}
-            <br />
-            {recipe?.firstPublishedDate
-              ? `F ${shortenTimestamp(recipe.firstPublishedDate)}`
-              : undefined}
-            <br />
-          </ContentExtra>
-        </>
-      }
-    />
-  );
+	return (
+		<FeedItem
+			type={CardTypesMap.RECIPE}
+			id={recipe.canonicalArticle}
+			title={recipe.title}
+			thumbnail={recipe.previewImage?.url ?? recipe.featuredImage?.url ?? ''}
+			liveUrl={`https://theguardian.com/${recipe.canonicalArticle}`}
+			hasVideo={false}
+			isLive={true} // We do not yet serve preview recipes
+			handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
+			onAddToClipboard={onAddToClipboard}
+			shouldObscureFeed={shouldObscureFeed}
+			metaContent={
+				<>
+					<ContentInfo>Recipe</ContentInfo>
+					<ContentExtra>
+						{recipe?.score && recipe.score < 1
+							? `Relevance ${Math.ceil(recipe.score * 100)}%`
+							: ''}
+						<br />
+						{recipe?.lastModifiedDate
+							? `M ${shortenTimestamp(recipe.lastModifiedDate)}`
+							: undefined}
+						<br />
+						{recipe?.publishedDate
+							? `P ${shortenTimestamp(recipe.publishedDate)}`
+							: undefined}
+						<br />
+						{recipe?.firstPublishedDate
+							? `F ${shortenTimestamp(recipe.firstPublishedDate)}`
+							: undefined}
+						<br />
+					</ContentExtra>
+				</>
+			}
+		/>
+	);
 };

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -9,12 +9,15 @@ import { useDispatch } from 'react-redux';
 import { insertCardWithCreate } from 'actions/Cards';
 import { selectors as recipeSelectors } from 'bundles/recipesBundle';
 import { handleDragStartForCard } from 'util/dragAndDrop';
+import { Title as FeedItemTitle } from './FeedItem';
+import format from 'date-fns/format';
 
 interface ComponentProps {
 	id: string;
+	showTimes: boolean;
 }
 
-export const RecipeFeedItem = ({ id }: ComponentProps) => {
+export const RecipeFeedItem = ({ id, showTimes }: ComponentProps) => {
 	const shouldObscureFeed = useSelector<State, boolean>((state) =>
 		selectFeatureValue(state, 'obscure-feed'),
 	);
@@ -33,11 +36,15 @@ export const RecipeFeedItem = ({ id }: ComponentProps) => {
 		);
 	}, [recipe]);
 
-	const shortenTimestamp = (iso: string) => {
-		const parts = iso.split('T');
-		return parts[0];
+	const renderTimestamp = (iso: string) => {
+		try {
+			const date = new Date(iso);
+			return format(date, 'HH:mm on do MMM YYYY');
+		} catch (err) {
+			console.warn(err);
+			return iso;
+		}
 	};
-
 	return (
 		<FeedItem
 			type={CardTypesMap.RECIPE}
@@ -50,6 +57,21 @@ export const RecipeFeedItem = ({ id }: ComponentProps) => {
 			handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
 			onAddToClipboard={onAddToClipboard}
 			shouldObscureFeed={shouldObscureFeed}
+			bodyContent={
+				<>
+					<FeedItemTitle>{recipe.title}</FeedItemTitle>
+					{recipe?.lastModifiedDate && showTimes ? (
+						<ContentExtra>
+							Modified {renderTimestamp(recipe.lastModifiedDate)}
+						</ContentExtra>
+					) : undefined}
+					{recipe?.publishedDate && showTimes ? (
+						<ContentExtra>
+							First published {renderTimestamp(recipe.publishedDate)}
+						</ContentExtra>
+					) : undefined}
+				</>
+			}
 			metaContent={
 				<>
 					<ContentInfo>Recipe</ContentInfo>
@@ -57,19 +79,6 @@ export const RecipeFeedItem = ({ id }: ComponentProps) => {
 						{recipe?.score && recipe.score < 1
 							? `Relevance ${Math.ceil(recipe.score * 100)}%`
 							: ''}
-						<br />
-						{recipe?.lastModifiedDate
-							? `M ${shortenTimestamp(recipe.lastModifiedDate)}`
-							: undefined}
-						<br />
-						{recipe?.publishedDate
-							? `P ${shortenTimestamp(recipe.publishedDate)}`
-							: undefined}
-						<br />
-						{recipe?.firstPublishedDate
-							? `F ${shortenTimestamp(recipe.firstPublishedDate)}`
-							: undefined}
-						<br />
 					</ContentExtra>
 				</>
 			}

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -57,6 +57,7 @@ export const RecipeFeedItem = ({ id, showTimes }: ComponentProps) => {
 			handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
 			onAddToClipboard={onAddToClipboard}
 			shouldObscureFeed={shouldObscureFeed}
+			noPinboard={true}
 			bodyContent={
 				<>
 					<FeedItemTitle>{recipe.title}</FeedItemTitle>

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -57,7 +57,7 @@ export const RecipeFeedItem = ({ id, showTimes }: ComponentProps) => {
 			handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
 			onAddToClipboard={onAddToClipboard}
 			shouldObscureFeed={shouldObscureFeed}
-			noPinboard={true}
+			showPinboard={false}
 			bodyContent={
 				<>
 					<FeedItemTitle>{recipe.title}</FeedItemTitle>

--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -33,28 +33,46 @@ export const RecipeFeedItem = ({ id }: ComponentProps) => {
 		);
 	}, [recipe]);
 
-	return (
-		<FeedItem
-			type={CardTypesMap.RECIPE}
-			id={recipe.canonicalArticle}
-			title={recipe.title}
-			thumbnail={recipe.previewImage?.url ?? recipe.featuredImage?.url ?? ''}
-			liveUrl={`https://theguardian.com/${recipe.canonicalArticle}`}
-			hasVideo={false}
-			isLive={true} // We do not yet serve preview recipes
-			handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
-			onAddToClipboard={onAddToClipboard}
-			shouldObscureFeed={shouldObscureFeed}
-			metaContent={
-				<>
-					<ContentInfo>Recipe</ContentInfo>
-					<ContentExtra>
-						{recipe?.score && recipe.score < 1
-							? `Relevance ${Math.ceil(recipe.score * 100)}%`
-							: ''}
-					</ContentExtra>
-				</>
-			}
-		/>
-	);
+  const shortenTimestamp = (iso: string) => {
+    const parts = iso.split('T');
+    return parts[0];
+  };
+
+  return (
+    <FeedItem
+      type={CardTypesMap.RECIPE}
+      id={recipe.canonicalArticle}
+      title={recipe.title}
+      thumbnail={recipe.previewImage?.url ?? recipe.featuredImage?.url ?? ""}
+      liveUrl={`https://theguardian.com/${recipe.canonicalArticle}`}
+      hasVideo={false}
+      isLive={true} // We do not yet serve preview recipes
+      handleDragStart={handleDragStartForCard(CardTypesMap.RECIPE, recipe)}
+      onAddToClipboard={onAddToClipboard}
+      shouldObscureFeed={shouldObscureFeed}
+      metaContent={
+        <>
+          <ContentInfo>Recipe</ContentInfo>
+          <ContentExtra>
+            {recipe?.score && recipe.score < 1
+              ? `Relevance ${Math.ceil(recipe.score * 100)}%`
+              : ''}
+            <br />
+            {recipe?.lastModifiedDate
+              ? `M ${shortenTimestamp(recipe.lastModifiedDate)}`
+              : undefined}
+            <br />
+            {recipe?.publishedDate
+              ? `P ${shortenTimestamp(recipe.publishedDate)}`
+              : undefined}
+            <br />
+            {recipe?.firstPublishedDate
+              ? `F ${shortenTimestamp(recipe.firstPublishedDate)}`
+              : undefined}
+            <br />
+          </ContentExtra>
+        </>
+      }
+    />
+  );
 };

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -16,7 +16,11 @@ import { Dispatch } from 'types/Store';
 import { IPagination } from 'lib/createAsyncResourceBundle';
 import Pagination from './Pagination';
 import ScrollContainer from '../ScrollContainer';
-import { ChefSearchParams, DateParamField, RecipeSearchParams } from '../../services/recipeQuery';
+import {
+	ChefSearchParams,
+	DateParamField,
+	RecipeSearchParams,
+} from '../../services/recipeQuery';
 import debounce from 'lodash/debounce';
 import { isNaN } from 'lodash';
 import ButtonDefault from '../inputs/ButtonDefault';
@@ -58,33 +62,33 @@ enum FeedType {
 }
 
 export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
-  const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
-  const [searchText, setSearchText] = useState('');
+	const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
+	const [searchText, setSearchText] = useState('');
 
-  const [showAdvancedRecipes, setShowAdvancedRecipes] = useState(false);
-  const [dateField, setDateField] = useState<DateParamField>(undefined);
-  const [uprateDropoffScale, setUprateDropoffScale] = useState<
-    number | undefined
-  >(90);
-  const [uprateOffsetDays, setUprateOffsetDays] = useState(7);
-  const [uprateDecay, setUprateDecay] = useState(0.95);
+	const [showAdvancedRecipes, setShowAdvancedRecipes] = useState(false);
+	const [dateField, setDateField] = useState<DateParamField>(undefined);
+	const [uprateDropoffScale, setUprateDropoffScale] = useState<
+		number | undefined
+	>(90);
+	const [uprateOffsetDays, setUprateOffsetDays] = useState(7);
+	const [uprateDecay, setUprateDecay] = useState(0.95);
 
-  const dispatch: Dispatch = useDispatch();
-  const searchForChefs = useCallback(
-    (params: ChefSearchParams) => {
-      dispatch(fetchChefs(params));
-    },
-    [dispatch]
-  );
-  const searchForRecipes = useCallback(
-    (params: RecipeSearchParams) => {
-      dispatch(fetchRecipes(params));
-    },
-    [dispatch]
-  );
-  const recipeSearchIds = useSelector((state: State) =>
-    recipeSelectors.selectLastFetchOrder(state)
-  );
+	const dispatch: Dispatch = useDispatch();
+	const searchForChefs = useCallback(
+		(params: ChefSearchParams) => {
+			dispatch(fetchChefs(params));
+		},
+		[dispatch],
+	);
+	const searchForRecipes = useCallback(
+		(params: RecipeSearchParams) => {
+			dispatch(fetchRecipes(params));
+		},
+		[dispatch],
+	);
+	const recipeSearchIds = useSelector((state: State) =>
+		recipeSelectors.selectLastFetchOrder(state),
+	);
 
 	const chefSearchIds = useSelector((state: State) =>
 		chefSelectors.selectLastFetchOrder(state),
@@ -94,19 +98,19 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
 	/*const debouncedRunSearch = debounce(() => runSearch(page), 750); TODO need to check if needed for chef-search? if yes then how to improve implementing it*/
 
-  useEffect(() => {
-    const dbf = debounce(() => runSearch(page), 750);
-    dbf();
-    return () => dbf.cancel();
-  }, [
-    selectedOption,
-    searchText,
-    page,
-    dateField,
-    uprateDecay,
-    uprateDropoffScale,
-    uprateOffsetDays
-  ]);
+	useEffect(() => {
+		const dbf = debounce(() => runSearch(page), 750);
+		dbf();
+		return () => dbf.cancel();
+	}, [
+		selectedOption,
+		searchText,
+		page,
+		dateField,
+		uprateDecay,
+		uprateDropoffScale,
+		uprateOffsetDays,
+	]);
 
 	const chefsPagination: IPagination | null = useSelector((state: State) =>
 		chefSelectors.selectPagination(state),
@@ -114,186 +118,186 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
 	const hasPages = (chefsPagination?.totalPages ?? 0) > 1;
 
-  const runSearch = useCallback(
-    (page: number = 1) => {
-      switch (selectedOption) {
-        case FeedType.chefs:
-          searchForChefs({
-            query: searchText
-          });
-          break;
-        case FeedType.recipes:
-          searchForRecipes({
-            queryText: searchText,
-            uprateByDate: dateField,
-            uprateConfig: {
-              decay: uprateDecay,
-              dropoffScaleDays: uprateDropoffScale,
-              offsetDays: uprateOffsetDays
-            }
-          });
-          break;
-      }
-    },
-    [
-      selectedOption,
-      searchText,
-      page,
-      dateField,
-      uprateDecay,
-      uprateDropoffScale,
-      uprateOffsetDays
-    ]
-  );
+	const runSearch = useCallback(
+		(page: number = 1) => {
+			switch (selectedOption) {
+				case FeedType.chefs:
+					searchForChefs({
+						query: searchText,
+					});
+					break;
+				case FeedType.recipes:
+					searchForRecipes({
+						queryText: searchText,
+						uprateByDate: dateField,
+						uprateConfig: {
+							decay: uprateDecay,
+							dropoffScaleDays: uprateDropoffScale,
+							offsetDays: uprateOffsetDays,
+						},
+					});
+					break;
+			}
+		},
+		[
+			selectedOption,
+			searchText,
+			page,
+			dateField,
+			uprateDecay,
+			uprateDropoffScale,
+			uprateOffsetDays,
+		],
+	);
 
-  const renderTheFeed = () => {
-    switch (selectedOption) {
-      case FeedType.recipes:
-        return recipeSearchIds.map((id) => (
-          <RecipeFeedItem key={id} id={id} />
-        ));
-      case FeedType.chefs:
-        //Fixing https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true
-        //It seems that some null values got into the `chefSearchIds` list
-        return chefSearchIds.filter(chefId => !!chefId).map((chefId) => (
-          <ChefFeedItem key={chefId} id={chefId} />
-        ));
-    }
-  };
+	const renderTheFeed = () => {
+		switch (selectedOption) {
+			case FeedType.recipes:
+				return recipeSearchIds.map((id) => <RecipeFeedItem key={id} id={id} />);
+			case FeedType.chefs:
+				//Fixing https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true
+				//It seems that some null values got into the `chefSearchIds` list
+				return chefSearchIds
+					.filter((chefId) => !!chefId)
+					.map((chefId) => <ChefFeedItem key={chefId} id={chefId} />);
+		}
+	};
 
-  return (
-    <React.Fragment>
-      <InputContainer>
-        <TextInputContainer>
-          <TextInput
-            placeholder={
-              selectedOption === FeedType.recipes
-                ? 'Search recipes'
-                : 'Search chefs'
-            }
-            displaySearchIcon
-            onChange={(event) => {
-              setPage(1);
-              setSearchText(event.target.value);
-            }}
-            onClick={() => setShowAdvancedRecipes(true)}
-            value={searchText}
-          />
-        </TextInputContainer>
-        <ClipboardHeader />
-      </InputContainer>
+	return (
+		<React.Fragment>
+			<InputContainer>
+				<TextInputContainer>
+					<TextInput
+						placeholder={
+							selectedOption === FeedType.recipes
+								? 'Search recipes'
+								: 'Search chefs'
+						}
+						displaySearchIcon
+						onChange={(event) => {
+							setPage(1);
+							setSearchText(event.target.value);
+						}}
+						onClick={() => setShowAdvancedRecipes(true)}
+						value={searchText}
+					/>
+				</TextInputContainer>
+				<ClipboardHeader />
+			</InputContainer>
 
-      {showAdvancedRecipes ? (
-        <>
-          <TopOptions style={{marginBottom: "0.4em"}}>
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
-              <div style={{ flex: 1 }}>
-                <TextInput
-                  style={{ padding: 0 }}
-                  displaySearchIcon={false}
-                  id="uprateDropoffScale"
-                  type="number"
-                  value={uprateDropoffScale?.toString() ?? ''}
-                  onChange={(evt) => {
-                    const newVal = parseInt(evt.target.value);
-                    if (!isNaN(newVal)) setUprateDropoffScale(newVal);
-                  }}
-                />
-              </div>
-              <div style={{ flex: 1 }}>
-                <TextInput
-                  style={{ padding: 0 }}
-                  displaySearchIcon={false}
-                  id="uprateOffset"
-                  type="number"
-                  value={uprateOffsetDays?.toString() ?? ''}
-                  onChange={(evt) => {
-                    const newVal = parseInt(evt.target.value);
-                    if (!isNaN(newVal)) setUprateOffsetDays(newVal);
-                  }}
-                />
-              </div>
-              <div style={{ flex: 1 }}>
-                <TextInput
-                  style={{ padding: 0 }}
-                  displaySearchIcon={false}
-                  id="uprateOffset"
-                  type="number"
-                  value={uprateDecay?.toString() ?? ''}
-                  onChange={(evt) => {
-                    const newVal = parseFloat(evt.target.value);
-                    if (!isNaN(newVal)) setUprateDecay(newVal);
-                  }}
-                />
-              </div>
-            </div>
-          </TopOptions>
-          <TopOptions>
-            <div style={{ display: 'block' }}>
-              <label htmlFor="dateSelector">Ordering priority</label>
-              <select
-                id="dateSelector"
-                value={dateField}
-                onChange={(evt) => {
-                  console.log(evt.target);
-                  setDateField(
-                    evt.target.value === 'Relevance'
-                      ? undefined
-                      : (evt.target.value as DateParamField)
-                  );
-                }}
-              >
-                <option value={'Relevance'}>
-                  Most relevant, regardless of time
-                </option>
-                <option value={'publishedDate'}>Most recently published</option>
-                <option value={'firstPublishedDate'}>
-                  Most recent first publication
-                </option>
-                <option value={'lastModifiedDate'}>
-                  Most recently modified
-                </option>
-              </select>
-            </div>
-          </TopOptions>
-          <TopOptions style={{marginBottom: "1.2em"}}>
-            <ButtonDefault onClick={()=>setShowAdvancedRecipes(false)}>Close</ButtonDefault>
-          </TopOptions>
-        </>
-      ) : undefined}
+			{showAdvancedRecipes ? (
+				<>
+					<TopOptions style={{ marginBottom: '0.4em' }}>
+						<div style={{ display: 'flex', flexDirection: 'row' }}>
+							<div style={{ flex: 1 }}>
+								<TextInput
+									style={{ padding: 0 }}
+									displaySearchIcon={false}
+									id="uprateDropoffScale"
+									type="number"
+									value={uprateDropoffScale?.toString() ?? ''}
+									onChange={(evt) => {
+										const newVal = parseInt(evt.target.value);
+										if (!isNaN(newVal)) setUprateDropoffScale(newVal);
+									}}
+								/>
+							</div>
+							<div style={{ flex: 1 }}>
+								<TextInput
+									style={{ padding: 0 }}
+									displaySearchIcon={false}
+									id="uprateOffset"
+									type="number"
+									value={uprateOffsetDays?.toString() ?? ''}
+									onChange={(evt) => {
+										const newVal = parseInt(evt.target.value);
+										if (!isNaN(newVal)) setUprateOffsetDays(newVal);
+									}}
+								/>
+							</div>
+							<div style={{ flex: 1 }}>
+								<TextInput
+									style={{ padding: 0 }}
+									displaySearchIcon={false}
+									id="uprateOffset"
+									type="number"
+									value={uprateDecay?.toString() ?? ''}
+									onChange={(evt) => {
+										const newVal = parseFloat(evt.target.value);
+										if (!isNaN(newVal)) setUprateDecay(newVal);
+									}}
+								/>
+							</div>
+						</div>
+					</TopOptions>
+					<TopOptions>
+						<div style={{ display: 'block' }}>
+							<label htmlFor="dateSelector">Ordering priority</label>
+							<select
+								id="dateSelector"
+								value={dateField}
+								onChange={(evt) => {
+									console.log(evt.target);
+									setDateField(
+										evt.target.value === 'Relevance'
+											? undefined
+											: (evt.target.value as DateParamField),
+									);
+								}}
+							>
+								<option value={'Relevance'}>
+									Most relevant, regardless of time
+								</option>
+								<option value={'publishedDate'}>Most recently published</option>
+								<option value={'firstPublishedDate'}>
+									Most recent first publication
+								</option>
+								<option value={'lastModifiedDate'}>
+									Most recently modified
+								</option>
+							</select>
+						</div>
+					</TopOptions>
+					<TopOptions style={{ marginBottom: '1.2em' }}>
+						<ButtonDefault onClick={() => setShowAdvancedRecipes(false)}>
+							Close
+						</ButtonDefault>
+					</TopOptions>
+				</>
+			) : undefined}
 
-      <TopOptions>
-        <RadioGroup>
-          <RadioButton
-            checked={selectedOption === FeedType.recipes}
-            onChange={() => setSelectedOption(FeedType.recipes)}
-            label="Recipes"
-            inline
-            name="recipeFeed"
-          />
-          <RadioButton
-            checked={selectedOption === FeedType.chefs}
-            onChange={() => setSelectedOption(FeedType.chefs)}
-            label="Chefs"
-            inline
-            name="chefFeed"
-          />
-        </RadioGroup>
-        {selectedOption === FeedType.chefs && chefsPagination && hasPages && (
-          <PaginationContainer>
-            <Pagination
-              pageChange={(page) => setPage(page)}
-              currentPage={chefsPagination.currentPage}
-              totalPages={chefsPagination.totalPages}
-            />
-          </PaginationContainer>
-        )}
-      </TopOptions>
-      <FeedsContainerWrapper>
-        <ScrollContainer fixed={<h3>Results</h3>}>
-          <ResultsContainer>{renderTheFeed()}</ResultsContainer>
-        </ScrollContainer>
-      </FeedsContainerWrapper>
-    </React.Fragment>
-  );
+			<TopOptions>
+				<RadioGroup>
+					<RadioButton
+						checked={selectedOption === FeedType.recipes}
+						onChange={() => setSelectedOption(FeedType.recipes)}
+						label="Recipes"
+						inline
+						name="recipeFeed"
+					/>
+					<RadioButton
+						checked={selectedOption === FeedType.chefs}
+						onChange={() => setSelectedOption(FeedType.chefs)}
+						label="Chefs"
+						inline
+						name="chefFeed"
+					/>
+				</RadioGroup>
+				{selectedOption === FeedType.chefs && chefsPagination && hasPages && (
+					<PaginationContainer>
+						<Pagination
+							pageChange={(page) => setPage(page)}
+							currentPage={chefsPagination.currentPage}
+							totalPages={chefsPagination.totalPages}
+						/>
+					</PaginationContainer>
+				)}
+			</TopOptions>
+			<FeedsContainerWrapper>
+				<ScrollContainer fixed={<h3>Results</h3>}>
+					<ResultsContainer>{renderTheFeed()}</ResultsContainer>
+				</ScrollContainer>
+			</FeedsContainerWrapper>
+		</React.Fragment>
+	);
 };

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -109,8 +109,6 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
 	const getUpdateConfig = () => {
 		switch (orderingForce) {
-			case 'default':
-				return undefined;
 			case 'gentle':
 				return {
 					decay: 0.95,
@@ -123,6 +121,9 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 					dropoffScaleDays: 180,
 					offsetDays: 14,
 				};
+			case 'default':
+			default:
+				return undefined;
 		}
 	};
 
@@ -212,7 +213,7 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 									);
 								}}
 							>
-								<option value={'Relevance'}>
+								<option value={'relevance'}>
 									Most relevant, regardless of time
 								</option>
 								<option value={'publishedDate'}>Most recently published</option>

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -1,7 +1,7 @@
 import ClipboardHeader from 'components/ClipboardHeader';
 import TextInput from 'components/inputs/TextInput';
 import { styled } from 'constants/theme';
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
 	fetchRecipes,
@@ -16,11 +16,10 @@ import { Dispatch } from 'types/Store';
 import { IPagination } from 'lib/createAsyncResourceBundle';
 import Pagination from './Pagination';
 import ScrollContainer from '../ScrollContainer';
-import {
-	ChefSearchParams,
-	RecipeSearchParams,
-} from '../../services/recipeQuery';
+import { ChefSearchParams, DateParamField, RecipeSearchParams } from '../../services/recipeQuery';
 import debounce from 'lodash/debounce';
+import { isNaN } from 'lodash';
+import ButtonDefault from '../inputs/ButtonDefault';
 
 const InputContainer = styled.div`
 	margin-bottom: 10px;
@@ -59,24 +58,33 @@ enum FeedType {
 }
 
 export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
-	const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
-	const [searchText, setSearchText] = useState('');
-	const dispatch: Dispatch = useDispatch();
-	const searchForChefs = useCallback(
-		(params: ChefSearchParams) => {
-			dispatch(fetchChefs(params));
-		},
-		[dispatch],
-	);
-	const searchForRecipes = useCallback(
-		(params: RecipeSearchParams) => {
-			dispatch(fetchRecipes(params));
-		},
-		[dispatch],
-	);
-	const recipeSearchIds = useSelector((state: State) =>
-		recipeSelectors.selectLastFetchOrder(state),
-	);
+  const [selectedOption, setSelectedOption] = useState(FeedType.recipes);
+  const [searchText, setSearchText] = useState('');
+
+  const [showAdvancedRecipes, setShowAdvancedRecipes] = useState(false);
+  const [dateField, setDateField] = useState<DateParamField>(undefined);
+  const [uprateDropoffScale, setUprateDropoffScale] = useState<
+    number | undefined
+  >(90);
+  const [uprateOffsetDays, setUprateOffsetDays] = useState(7);
+  const [uprateDecay, setUprateDecay] = useState(0.95);
+
+  const dispatch: Dispatch = useDispatch();
+  const searchForChefs = useCallback(
+    (params: ChefSearchParams) => {
+      dispatch(fetchChefs(params));
+    },
+    [dispatch]
+  );
+  const searchForRecipes = useCallback(
+    (params: RecipeSearchParams) => {
+      dispatch(fetchRecipes(params));
+    },
+    [dispatch]
+  );
+  const recipeSearchIds = useSelector((state: State) =>
+    recipeSelectors.selectLastFetchOrder(state)
+  );
 
 	const chefSearchIds = useSelector((state: State) =>
 		chefSelectors.selectLastFetchOrder(state),
@@ -86,11 +94,19 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
 	/*const debouncedRunSearch = debounce(() => runSearch(page), 750); TODO need to check if needed for chef-search? if yes then how to improve implementing it*/
 
-	useEffect(() => {
-		const dbf = debounce(() => runSearch(page), 750);
-		dbf();
-		return () => dbf.cancel();
-	}, [selectedOption, searchText, page]);
+  useEffect(() => {
+    const dbf = debounce(() => runSearch(page), 750);
+    dbf();
+    return () => dbf.cancel();
+  }, [
+    selectedOption,
+    searchText,
+    page,
+    dateField,
+    uprateDecay,
+    uprateDropoffScale,
+    uprateOffsetDays
+  ]);
 
 	const chefsPagination: IPagination | null = useSelector((state: State) =>
 		chefSelectors.selectPagination(state),
@@ -98,89 +114,186 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 
 	const hasPages = (chefsPagination?.totalPages ?? 0) > 1;
 
-	const runSearch = useCallback(
-		(page: number = 1) => {
-			switch (selectedOption) {
-				case FeedType.chefs:
-					searchForChefs({
-						query: searchText,
-					});
-					break;
-				case FeedType.recipes:
-					searchForRecipes({
-						queryText: searchText,
-					});
-					break;
-			}
-		},
-		[selectedOption, searchText, page],
-	);
+  const runSearch = useCallback(
+    (page: number = 1) => {
+      switch (selectedOption) {
+        case FeedType.chefs:
+          searchForChefs({
+            query: searchText
+          });
+          break;
+        case FeedType.recipes:
+          searchForRecipes({
+            queryText: searchText,
+            uprateByDate: dateField,
+            uprateConfig: {
+              decay: uprateDecay,
+              dropoffScaleDays: uprateDropoffScale,
+              offsetDays: uprateOffsetDays
+            }
+          });
+          break;
+      }
+    },
+    [
+      selectedOption,
+      searchText,
+      page,
+      dateField,
+      uprateDecay,
+      uprateDropoffScale,
+      uprateOffsetDays
+    ]
+  );
 
-	const renderTheFeed = () => {
-		switch (selectedOption) {
-			case FeedType.recipes:
-				return recipeSearchIds.map((id) => <RecipeFeedItem key={id} id={id} />);
-			case FeedType.chefs:
-				//Fixing https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true
-				//It seems that some null values got into the `chefSearchIds` list
-				return chefSearchIds
-					.filter((chefId) => !!chefId)
-					.map((chefId) => <ChefFeedItem key={chefId} id={chefId} />);
-		}
-	};
+  const renderTheFeed = () => {
+    switch (selectedOption) {
+      case FeedType.recipes:
+        return recipeSearchIds.map((id) => (
+          <RecipeFeedItem key={id} id={id} />
+        ));
+      case FeedType.chefs:
+        //Fixing https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true
+        //It seems that some null values got into the `chefSearchIds` list
+        return chefSearchIds.filter(chefId => !!chefId).map((chefId) => (
+          <ChefFeedItem key={chefId} id={chefId} />
+        ));
+    }
+  };
 
-	return (
-		<React.Fragment>
-			<InputContainer>
-				<TextInputContainer>
-					<TextInput
-						placeholder={
-							selectedOption === FeedType.recipes
-								? 'Search recipes'
-								: 'Search chefs'
-						}
-						displaySearchIcon
-						onChange={(event) => {
-							setPage(1);
-							setSearchText(event.target.value);
-						}}
-						value={searchText}
-					/>
-				</TextInputContainer>
-				<ClipboardHeader />
-			</InputContainer>
-			<TopOptions>
-				<RadioGroup>
-					<RadioButton
-						checked={selectedOption === FeedType.recipes}
-						onChange={() => setSelectedOption(FeedType.recipes)}
-						label="Recipes"
-						inline
-						name="recipeFeed"
-					/>
-					<RadioButton
-						checked={selectedOption === FeedType.chefs}
-						onChange={() => setSelectedOption(FeedType.chefs)}
-						label="Chefs"
-						inline
-						name="chefFeed"
-					/>
-				</RadioGroup>
-				{selectedOption === FeedType.chefs && chefsPagination && hasPages && (
-					<PaginationContainer>
-						<Pagination
-							pageChange={(page) => setPage(page)}
-							currentPage={chefsPagination.currentPage}
-							totalPages={chefsPagination.totalPages}
-						/>
-					</PaginationContainer>
-				)}
-			</TopOptions>
-			<FeedsContainerWrapper>
-				<ScrollContainer fixed={<h3>Results</h3>}>
-					<ResultsContainer>{renderTheFeed()}</ResultsContainer>
-				</ScrollContainer>
-			</FeedsContainerWrapper>
-		</React.Fragment>
-	);
+  return (
+    <React.Fragment>
+      <InputContainer>
+        <TextInputContainer>
+          <TextInput
+            placeholder={
+              selectedOption === FeedType.recipes
+                ? 'Search recipes'
+                : 'Search chefs'
+            }
+            displaySearchIcon
+            onChange={(event) => {
+              setPage(1);
+              setSearchText(event.target.value);
+            }}
+            onClick={() => setShowAdvancedRecipes(true)}
+            value={searchText}
+          />
+        </TextInputContainer>
+        <ClipboardHeader />
+      </InputContainer>
+
+      {showAdvancedRecipes ? (
+        <>
+          <TopOptions style={{marginBottom: "0.4em"}}>
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <div style={{ flex: 1 }}>
+                <TextInput
+                  style={{ padding: 0 }}
+                  displaySearchIcon={false}
+                  id="uprateDropoffScale"
+                  type="number"
+                  value={uprateDropoffScale?.toString() ?? ''}
+                  onChange={(evt) => {
+                    const newVal = parseInt(evt.target.value);
+                    if (!isNaN(newVal)) setUprateDropoffScale(newVal);
+                  }}
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <TextInput
+                  style={{ padding: 0 }}
+                  displaySearchIcon={false}
+                  id="uprateOffset"
+                  type="number"
+                  value={uprateOffsetDays?.toString() ?? ''}
+                  onChange={(evt) => {
+                    const newVal = parseInt(evt.target.value);
+                    if (!isNaN(newVal)) setUprateOffsetDays(newVal);
+                  }}
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <TextInput
+                  style={{ padding: 0 }}
+                  displaySearchIcon={false}
+                  id="uprateOffset"
+                  type="number"
+                  value={uprateDecay?.toString() ?? ''}
+                  onChange={(evt) => {
+                    const newVal = parseFloat(evt.target.value);
+                    if (!isNaN(newVal)) setUprateDecay(newVal);
+                  }}
+                />
+              </div>
+            </div>
+          </TopOptions>
+          <TopOptions>
+            <div style={{ display: 'block' }}>
+              <label htmlFor="dateSelector">Ordering priority</label>
+              <select
+                id="dateSelector"
+                value={dateField}
+                onChange={(evt) => {
+                  console.log(evt.target);
+                  setDateField(
+                    evt.target.value === 'Relevance'
+                      ? undefined
+                      : (evt.target.value as DateParamField)
+                  );
+                }}
+              >
+                <option value={'Relevance'}>
+                  Most relevant, regardless of time
+                </option>
+                <option value={'publishedDate'}>Most recently published</option>
+                <option value={'firstPublishedDate'}>
+                  Most recent first publication
+                </option>
+                <option value={'lastModifiedDate'}>
+                  Most recently modified
+                </option>
+              </select>
+            </div>
+          </TopOptions>
+          <TopOptions style={{marginBottom: "1.2em"}}>
+            <ButtonDefault onClick={()=>setShowAdvancedRecipes(false)}>Close</ButtonDefault>
+          </TopOptions>
+        </>
+      ) : undefined}
+
+      <TopOptions>
+        <RadioGroup>
+          <RadioButton
+            checked={selectedOption === FeedType.recipes}
+            onChange={() => setSelectedOption(FeedType.recipes)}
+            label="Recipes"
+            inline
+            name="recipeFeed"
+          />
+          <RadioButton
+            checked={selectedOption === FeedType.chefs}
+            onChange={() => setSelectedOption(FeedType.chefs)}
+            label="Chefs"
+            inline
+            name="chefFeed"
+          />
+        </RadioGroup>
+        {selectedOption === FeedType.chefs && chefsPagination && hasPages && (
+          <PaginationContainer>
+            <Pagination
+              pageChange={(page) => setPage(page)}
+              currentPage={chefsPagination.currentPage}
+              totalPages={chefsPagination.totalPages}
+            />
+          </PaginationContainer>
+        )}
+      </TopOptions>
+      <FeedsContainerWrapper>
+        <ScrollContainer fixed={<h3>Results</h3>}>
+          <ResultsContainer>{renderTheFeed()}</ResultsContainer>
+        </ScrollContainer>
+      </FeedsContainerWrapper>
+    </React.Fragment>
+  );
 };

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -70,6 +70,7 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 	const [showAdvancedRecipes, setShowAdvancedRecipes] = useState(false);
 	const [dateField, setDateField] = useState<DateParamField>(undefined);
 	const [orderingForce, setOrderingForce] = useState<string>('default');
+	const [forceDates, setForceDates] = useState(false);
 
 	const dispatch: Dispatch = useDispatch();
 	const searchForChefs = useCallback(
@@ -148,7 +149,13 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 	const renderTheFeed = () => {
 		switch (selectedOption) {
 			case FeedType.recipes:
-				return recipeSearchIds.map((id) => <RecipeFeedItem key={id} id={id} />);
+				return recipeSearchIds.map((id) => (
+					<RecipeFeedItem
+						key={id}
+						id={id}
+						showTimes={forceDates || !!dateField}
+					/>
+				));
 			case FeedType.chefs:
 				//Fixing https://the-guardian.sentry.io/issues/5820707430/?project=35467&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true
 				//It seems that some null values got into the `chefSearchIds` list
@@ -180,16 +187,22 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 				<ClipboardHeader />
 			</InputContainer>
 
-			{showAdvancedRecipes ? (
+			{showAdvancedRecipes && selectedOption === FeedType.recipes ? (
 				<>
 					<TopOptions>
 						<div>
-							<label htmlFor="dateSelector">Ordering priority</label>
+							<label
+								htmlFor="dateSelector"
+								style={{ color: searchText == '' ? 'gray' : 'inherit' }}
+							>
+								Ordering priority
+							</label>
 						</div>
 						<div>
 							<select
 								id="dateSelector"
 								value={dateField}
+								disabled={searchText == ''}
 								onChange={(evt) => {
 									console.log(evt.target);
 									setDateField(
@@ -232,6 +245,18 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 								<option value={'gentle'}>Prefer relevance</option>
 								<option value={'forceful'}>Prefer date</option>
 							</select>
+						</div>
+					</TopOptions>
+					<TopOptions>
+						<div>
+							<label htmlFor="forceDateDisplay">Always show dates</label>
+						</div>
+						<div>
+							<input
+								type="checkbox"
+								checked={forceDates}
+								onChange={(evt) => setForceDates(evt.target.checked)}
+							/>
 						</div>
 					</TopOptions>
 					<TopOptions

--- a/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
@@ -45,6 +45,7 @@ interface WrapperProps {
 	toolTipAlign: 'left' | 'center' | 'right';
 	urlPath: string | undefined;
 	renderButtons: (renderProps: ButtonProps) => JSX.Element;
+	noPinboard?: boolean;
 }
 
 export const HoverActionsButtonWrapper = ({
@@ -53,6 +54,7 @@ export const HoverActionsButtonWrapper = ({
 	size,
 	urlPath,
 	renderButtons,
+	noPinboard,
 }: WrapperProps) => {
 	const [toolTipText, setToolTipText] = useState<string | undefined>(undefined);
 
@@ -79,7 +81,7 @@ export const HoverActionsButtonWrapper = ({
 				hideToolTip,
 				size,
 			})}
-			{urlPath && (
+			{urlPath && !noPinboard && (
 				// the below tag is empty and meaningless to the fronts tool itself, but serves as a handle for
 				// Pinboard to attach itself via, identified/distinguished by the urlPath data attribute
 				// @ts-ignore

--- a/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
+++ b/fronts-client/src/components/inputs/HoverActionButtonWrapper.tsx
@@ -45,7 +45,7 @@ interface WrapperProps {
 	toolTipAlign: 'left' | 'center' | 'right';
 	urlPath: string | undefined;
 	renderButtons: (renderProps: ButtonProps) => JSX.Element;
-	noPinboard?: boolean;
+	showPinboard?: boolean; //Note- defaults to `true`
 }
 
 export const HoverActionsButtonWrapper = ({
@@ -54,7 +54,7 @@ export const HoverActionsButtonWrapper = ({
 	size,
 	urlPath,
 	renderButtons,
-	noPinboard,
+	showPinboard,
 }: WrapperProps) => {
 	const [toolTipText, setToolTipText] = useState<string | undefined>(undefined);
 
@@ -81,7 +81,7 @@ export const HoverActionsButtonWrapper = ({
 				hideToolTip,
 				size,
 			})}
-			{urlPath && !noPinboard && (
+			{urlPath && (showPinboard || showPinboard === undefined) && (
 				// the below tag is empty and meaningless to the fronts tool itself, but serves as a handle for
 				// Pinboard to attach itself via, identified/distinguished by the urlPath data attribute
 				// @ts-ignore

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -12,40 +12,40 @@ export interface ChefSearchParams {
 }
 
 export interface RecipeSearchFilters {
-  diets?: string[];
-  contributors?: string[];
-  filterType: 'During' | 'Post';
+	diets?: string[];
+	contributors?: string[];
+	filterType: 'During' | 'Post';
 }
 
 export type DateParamField =
-  | undefined
-  | 'publishedDate'
-  | 'firstPublishedDate'
-  | 'lastModifiedDate';
+	| undefined
+	| 'publishedDate'
+	| 'firstPublishedDate'
+	| 'lastModifiedDate';
 
 export interface RecipeSearchParams {
-  queryText: string;
-  searchType?: 'Embedded' | 'Match' | 'Lucene';
-  fields?: string[];
-  kfactor?: number;
-  limit?: number;
-  filters?: RecipeSearchFilters;
-  uprateByDate?: DateParamField;
-  uprateConfig?: {
-    originDate?: string; //should be ISO format date, defaults to today
-    //take this and add it to `offsetDays`. Then, weights will be modified so that
-    //at originDate +/- this many days results will be downweighted by `decay`
-    dropoffScaleDays?: number;
-    offsetDays?: number;
-    decay?: number;
-  };
-  format?: 'Full' | 'Titles';
+	queryText: string;
+	searchType?: 'Embedded' | 'Match' | 'Lucene';
+	fields?: string[];
+	kfactor?: number;
+	limit?: number;
+	filters?: RecipeSearchFilters;
+	uprateByDate?: DateParamField;
+	uprateConfig?: {
+		originDate?: string; //should be ISO format date, defaults to today
+		//take this and add it to `offsetDays`. Then, weights will be modified so that
+		//at originDate +/- this many days results will be downweighted by `decay`
+		dropoffScaleDays?: number;
+		offsetDays?: number;
+		decay?: number;
+	};
+	format?: 'Full' | 'Titles';
 }
 
 export interface ChefSearchHit {
-  contributorType: 'Profile' | 'Byline';
-  nameOrId: string;
-  docCount: number;
+	contributorType: 'Profile' | 'Byline';
+	nameOrId: string;
+	docCount: number;
 }
 
 export interface ChefSearchResponse {
@@ -65,180 +65,180 @@ interface RecipeSearchTitlesResponse {
 }
 
 export type RecipeSearchHit = Recipe & {
-  score: number;
+	score: number;
 };
 
 export interface DietSearchResponse {
-  'diet-ids': KeyAndCount[];
+	'diet-ids': KeyAndCount[];
 }
 
 const widthParam = /width=(\d+)/;
 export const updateImageScalingParams = (url: string) => {
-  return url.replace(widthParam, 'width=83');
+	return url.replace(widthParam, 'width=83');
 };
 
 const setupRecipeThumbnails = (recep: Recipe) => {
-  try {
-    return {
-      ...recep,
-      previewImage: recep.previewImage
-        ? {
-            ...recep.previewImage,
-            url: updateImageScalingParams(recep.previewImage.url),
-          }
-        : undefined,
-      featuredImage: recep.featuredImage
-        ? {
-            ...recep.featuredImage,
-            url: updateImageScalingParams(recep.featuredImage.url),
-          }
-        : undefined,
-    };
-  } catch (err) {
-    console.error(err);
-    return recep;
-  }
+	try {
+		return {
+			...recep,
+			previewImage: recep.previewImage
+				? {
+						...recep.previewImage,
+						url: updateImageScalingParams(recep.previewImage.url),
+					}
+				: undefined,
+			featuredImage: recep.featuredImage
+				? {
+						...recep.featuredImage,
+						url: updateImageScalingParams(recep.featuredImage.url),
+					}
+				: undefined,
+		};
+	} catch (err) {
+		console.error(err);
+		return recep;
+	}
 };
 
 const recipeQuery = (baseUrl: string) => {
-  const fetchOne = async (href: string): Promise<Recipe | undefined> => {
-    const response = await fetch(`${baseUrl}${href}`);
+	const fetchOne = async (href: string): Promise<Recipe | undefined> => {
+		const response = await fetch(`${baseUrl}${href}`);
 
-    switch (response.status) {
-      case 200:
-        const content = await response.json();
-        return setupRecipeThumbnails(content as unknown as Recipe);
-      case 404:
-      case 403:
-        console.warn(
-          `Search response returned outdated recipe ${baseUrl}${href}`
-        );
-        return undefined;
-      default:
-        console.error(`Could not retrieve recipe ${href}: ${response.status}`);
-        return undefined;
-    }
-  };
+		switch (response.status) {
+			case 200:
+				const content = await response.json();
+				return setupRecipeThumbnails(content as unknown as Recipe);
+			case 404:
+			case 403:
+				console.warn(
+					`Search response returned outdated recipe ${baseUrl}${href}`,
+				);
+				return undefined;
+			default:
+				console.error(`Could not retrieve recipe ${href}: ${response.status}`);
+				return undefined;
+		}
+	};
 
-  const fetchAllRecipes = async (
-    forRecipes: RecipeSearchTitlesResponse[]
-  ): Promise<RecipeSearchHit[]> => {
-    const results = await Promise.all(
-      forRecipes.map((r) =>
-        fetchOne(r.href)
-          .then((recep) =>
-            recep
-              ? {
-                  ...recep,
-                  score: r.score,
-                }
-              : undefined
-          )
-          .catch(console.warn)
-      )
-    );
+	const fetchAllRecipes = async (
+		forRecipes: RecipeSearchTitlesResponse[],
+	): Promise<RecipeSearchHit[]> => {
+		const results = await Promise.all(
+			forRecipes.map((r) =>
+				fetchOne(r.href)
+					.then((recep) =>
+						recep
+							? {
+									...recep,
+									score: r.score,
+								}
+							: undefined,
+					)
+					.catch(console.warn),
+			),
+		);
 
-    return results.filter((r) => !!r) as RecipeSearchHit[];
-  };
+		return results.filter((r) => !!r) as RecipeSearchHit[];
+	};
 
-  return {
-    chefs: async (params: ChefSearchParams): Promise<ChefSearchResponse> => {
-      const args = [
-        params.query ? `q=${encodeURIComponent(params.query)}` : undefined,
-        params.limit ? `limit=${encodeURIComponent(params.limit)}` : undefined,
-      ].filter((arg) => !!arg);
+	return {
+		chefs: async (params: ChefSearchParams): Promise<ChefSearchResponse> => {
+			const args = [
+				params.query ? `q=${encodeURIComponent(params.query)}` : undefined,
+				params.limit ? `limit=${encodeURIComponent(params.limit)}` : undefined,
+			].filter((arg) => !!arg);
 
-      const queryString = args.length > 0 ? '?' + args.join('&') : '';
-      const url = `${baseUrl}/keywords/contributors${queryString}`;
-      const response = await fetch(url);
-      const content = await response.json();
-      if (response.status == 200) {
-        return content as ChefSearchResponse;
-      } else {
-        console.error(content);
-        throw new Error(`Unable to contact recipe API: ${response.status}`);
-      }
-    },
-    diets: async (): Promise<DietSearchResponse> => {
-      const response = await fetch(`${baseUrl}/keywords/diet-ids`);
-      const content = await response.json();
-      if (response.status == 200) {
-        return content as DietSearchResponse;
-      } else {
-        console.error(content);
-        throw new Error(`Unable to contact recipe API: ${response.status}`);
-      }
-    },
-    recipes: async (
-      params: RecipeSearchParams
-    ): Promise<RecipeSearchResponse> => {
-      const queryDoc = JSON.stringify(params);
-      const response = await fetch(`${baseUrl}/search`, {
-        method: 'POST',
-        body: queryDoc,
-        mode: 'cors',
-        headers: new Headers({ 'Content-Type': 'application/json' }),
-      });
-      const content = await response.json();
-      if (response.status == 200) {
-        const recipes = await fetchAllRecipes(content.results);
-        return {
-          hits: content.hits,
-          maxScore: content.maxScore,
-          recipes,
-        };
-      } else {
-        console.error(content);
-        throw new Error(`Unable to contact recipe API: ${response.status}`);
-      }
-    },
-    recipesById: async (idList: string[]): Promise<Recipe[]> => {
-      const doTheFetch = async (idsToFind: string[]) => {
-        const indexResponse = await fetch(
-          `/recipes/api/content/by-uid?ids=${idsToFind.join(',')}`,
-          {
-            credentials: 'include',
-          }
-        );
-        if (indexResponse.status != 200) {
-          throw new Error(
-            `Unable to retrieve partial index: server error ${indexResponse.status}`
-          );
-        }
+			const queryString = args.length > 0 ? '?' + args.join('&') : '';
+			const url = `${baseUrl}/keywords/contributors${queryString}`;
+			const response = await fetch(url);
+			const content = await response.json();
+			if (response.status == 200) {
+				return content as ChefSearchResponse;
+			} else {
+				console.error(content);
+				throw new Error(`Unable to contact recipe API: ${response.status}`);
+			}
+		},
+		diets: async (): Promise<DietSearchResponse> => {
+			const response = await fetch(`${baseUrl}/keywords/diet-ids`);
+			const content = await response.json();
+			if (response.status == 200) {
+				return content as DietSearchResponse;
+			} else {
+				console.error(content);
+				throw new Error(`Unable to contact recipe API: ${response.status}`);
+			}
+		},
+		recipes: async (
+			params: RecipeSearchParams,
+		): Promise<RecipeSearchResponse> => {
+			const queryDoc = JSON.stringify(params);
+			const response = await fetch(`${baseUrl}/search`, {
+				method: 'POST',
+				body: queryDoc,
+				mode: 'cors',
+				headers: new Headers({ 'Content-Type': 'application/json' }),
+			});
+			const content = await response.json();
+			if (response.status == 200) {
+				const recipes = await fetchAllRecipes(content.results);
+				return {
+					hits: content.hits,
+					maxScore: content.maxScore,
+					recipes,
+				};
+			} else {
+				console.error(content);
+				throw new Error(`Unable to contact recipe API: ${response.status}`);
+			}
+		},
+		recipesById: async (idList: string[]): Promise<Recipe[]> => {
+			const doTheFetch = async (idsToFind: string[]) => {
+				const indexResponse = await fetch(
+					`/recipes/api/content/by-uid?ids=${idsToFind.join(',')}`,
+					{
+						credentials: 'include',
+					},
+				);
+				if (indexResponse.status != 200) {
+					throw new Error(
+						`Unable to retrieve partial index: server error ${indexResponse.status}`,
+					);
+				}
 
-        const content =
-          (await indexResponse.json()) as RecipePartialIndexContent;
-        const recipeResponses = await Promise.all(
-          content.results.map((entry) =>
-            fetch(`${baseUrl}/content/${entry.checksum}`)
-          )
-        );
-        const successes = recipeResponses.filter((_) => _.status === 200);
-        return Promise.all(successes.map((_) => _.json())) as Promise<Recipe[]>;
-      };
+				const content =
+					(await indexResponse.json()) as RecipePartialIndexContent;
+				const recipeResponses = await Promise.all(
+					content.results.map((entry) =>
+						fetch(`${baseUrl}/content/${entry.checksum}`),
+					),
+				);
+				const successes = recipeResponses.filter((_) => _.status === 200);
+				return Promise.all(successes.map((_) => _.json())) as Promise<Recipe[]>;
+			};
 
-      const recurseTheList = async (
-        idsToFind: string[],
-        prevResults: Recipe[]
-      ): Promise<Recipe[]> => {
-        const thisBatch = idsToFind.slice(0, 50); //we need to avoid a 414 URI Too Long error so batch into 50s
-        const results = (await doTheFetch(thisBatch)).concat(prevResults);
-        if (thisBatch.length == idsToFind.length) {
-          //we finished the list
-          return results;
-        } else {
-          return recurseTheList(idsToFind.slice(50), results);
-        }
-      };
+			const recurseTheList = async (
+				idsToFind: string[],
+				prevResults: Recipe[],
+			): Promise<Recipe[]> => {
+				const thisBatch = idsToFind.slice(0, 50); //we need to avoid a 414 URI Too Long error so batch into 50s
+				const results = (await doTheFetch(thisBatch)).concat(prevResults);
+				if (thisBatch.length == idsToFind.length) {
+					//we finished the list
+					return results;
+				} else {
+					return recurseTheList(idsToFind.slice(50), results);
+				}
+			};
 
-      return recurseTheList(idList, []);
-    },
-  };
+			return recurseTheList(idList, []);
+		},
+	};
 };
 
 const isCode = () =>
-  window.location.hostname.includes('code.') ||
-  window.location.hostname.includes('local.');
+	window.location.hostname.includes('code.') ||
+	window.location.hostname.includes('local.');
 export const liveRecipes = recipeQuery(
-  isCode() ? url.codeRecipes : url.recipes
+	isCode() ? url.codeRecipes : url.recipes,
 );

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -12,24 +12,40 @@ export interface ChefSearchParams {
 }
 
 export interface RecipeSearchFilters {
-	diets?: string[];
-	contributors?: string[];
-	filterType: 'During' | 'Post';
+  diets?: string[];
+  contributors?: string[];
+  filterType: 'During' | 'Post';
 }
 
+export type DateParamField =
+  | undefined
+  | 'publishedDate'
+  | 'firstPublishedDate'
+  | 'lastModifiedDate';
+
 export interface RecipeSearchParams {
-	queryText: string;
-	searchType?: 'Embedded' | 'Match' | 'Lucene';
-	fields?: string[];
-	kfactor?: number;
-	limit?: number;
-	filters?: RecipeSearchFilters;
+  queryText: string;
+  searchType?: 'Embedded' | 'Match' | 'Lucene';
+  fields?: string[];
+  kfactor?: number;
+  limit?: number;
+  filters?: RecipeSearchFilters;
+  uprateByDate?: DateParamField;
+  uprateConfig?: {
+    originDate?: string; //should be ISO format date, defaults to today
+    //take this and add it to `offsetDays`. Then, weights will be modified so that
+    //at originDate +/- this many days results will be downweighted by `decay`
+    dropoffScaleDays?: number;
+    offsetDays?: number;
+    decay?: number;
+  };
+  format?: 'Full' | 'Titles';
 }
 
 export interface ChefSearchHit {
-	contributorType: 'Profile' | 'Byline';
-	nameOrId: string;
-	docCount: number;
+  contributorType: 'Profile' | 'Byline';
+  nameOrId: string;
+  docCount: number;
 }
 
 export interface ChefSearchResponse {
@@ -49,180 +65,180 @@ interface RecipeSearchTitlesResponse {
 }
 
 export type RecipeSearchHit = Recipe & {
-	score: number;
+  score: number;
 };
 
 export interface DietSearchResponse {
-	'diet-ids': KeyAndCount[];
+  'diet-ids': KeyAndCount[];
 }
 
 const widthParam = /width=(\d+)/;
 export const updateImageScalingParams = (url: string) => {
-	return url.replace(widthParam, 'width=83');
+  return url.replace(widthParam, 'width=83');
 };
 
 const setupRecipeThumbnails = (recep: Recipe) => {
-	try {
-		return {
-			...recep,
-			previewImage: recep.previewImage
-				? {
-						...recep.previewImage,
-						url: updateImageScalingParams(recep.previewImage.url),
-					}
-				: undefined,
-			featuredImage: recep.featuredImage
-				? {
-						...recep.featuredImage,
-						url: updateImageScalingParams(recep.featuredImage.url),
-					}
-				: undefined,
-		};
-	} catch (err) {
-		console.error(err);
-		return recep;
-	}
+  try {
+    return {
+      ...recep,
+      previewImage: recep.previewImage
+        ? {
+            ...recep.previewImage,
+            url: updateImageScalingParams(recep.previewImage.url),
+          }
+        : undefined,
+      featuredImage: recep.featuredImage
+        ? {
+            ...recep.featuredImage,
+            url: updateImageScalingParams(recep.featuredImage.url),
+          }
+        : undefined,
+    };
+  } catch (err) {
+    console.error(err);
+    return recep;
+  }
 };
 
 const recipeQuery = (baseUrl: string) => {
-	const fetchOne = async (href: string): Promise<Recipe | undefined> => {
-		const response = await fetch(`${baseUrl}${href}`);
+  const fetchOne = async (href: string): Promise<Recipe | undefined> => {
+    const response = await fetch(`${baseUrl}${href}`);
 
-		switch (response.status) {
-			case 200:
-				const content = await response.json();
-				return setupRecipeThumbnails(content as unknown as Recipe);
-			case 404:
-			case 403:
-				console.warn(
-					`Search response returned outdated recipe ${baseUrl}${href}`,
-				);
-				return undefined;
-			default:
-				console.error(`Could not retrieve recipe ${href}: ${response.status}`);
-				return undefined;
-		}
-	};
+    switch (response.status) {
+      case 200:
+        const content = await response.json();
+        return setupRecipeThumbnails(content as unknown as Recipe);
+      case 404:
+      case 403:
+        console.warn(
+          `Search response returned outdated recipe ${baseUrl}${href}`
+        );
+        return undefined;
+      default:
+        console.error(`Could not retrieve recipe ${href}: ${response.status}`);
+        return undefined;
+    }
+  };
 
-	const fetchAllRecipes = async (
-		forRecipes: RecipeSearchTitlesResponse[],
-	): Promise<RecipeSearchHit[]> => {
-		const results = await Promise.all(
-			forRecipes.map((r) =>
-				fetchOne(r.href)
-					.then((recep) =>
-						recep
-							? {
-									...recep,
-									score: r.score,
-								}
-							: undefined,
-					)
-					.catch(console.warn),
-			),
-		);
+  const fetchAllRecipes = async (
+    forRecipes: RecipeSearchTitlesResponse[]
+  ): Promise<RecipeSearchHit[]> => {
+    const results = await Promise.all(
+      forRecipes.map((r) =>
+        fetchOne(r.href)
+          .then((recep) =>
+            recep
+              ? {
+                  ...recep,
+                  score: r.score,
+                }
+              : undefined
+          )
+          .catch(console.warn)
+      )
+    );
 
-		return results.filter((r) => !!r) as RecipeSearchHit[];
-	};
+    return results.filter((r) => !!r) as RecipeSearchHit[];
+  };
 
-	return {
-		chefs: async (params: ChefSearchParams): Promise<ChefSearchResponse> => {
-			const args = [
-				params.query ? `q=${encodeURIComponent(params.query)}` : undefined,
-				params.limit ? `limit=${encodeURIComponent(params.limit)}` : undefined,
-			].filter((arg) => !!arg);
+  return {
+    chefs: async (params: ChefSearchParams): Promise<ChefSearchResponse> => {
+      const args = [
+        params.query ? `q=${encodeURIComponent(params.query)}` : undefined,
+        params.limit ? `limit=${encodeURIComponent(params.limit)}` : undefined,
+      ].filter((arg) => !!arg);
 
-			const queryString = args.length > 0 ? '?' + args.join('&') : '';
-			const url = `${baseUrl}/keywords/contributors${queryString}`;
-			const response = await fetch(url);
-			const content = await response.json();
-			if (response.status == 200) {
-				return content as ChefSearchResponse;
-			} else {
-				console.error(content);
-				throw new Error(`Unable to contact recipe API: ${response.status}`);
-			}
-		},
-		diets: async (): Promise<DietSearchResponse> => {
-			const response = await fetch(`${baseUrl}/keywords/diet-ids`);
-			const content = await response.json();
-			if (response.status == 200) {
-				return content as DietSearchResponse;
-			} else {
-				console.error(content);
-				throw new Error(`Unable to contact recipe API: ${response.status}`);
-			}
-		},
-		recipes: async (
-			params: RecipeSearchParams,
-		): Promise<RecipeSearchResponse> => {
-			const queryDoc = JSON.stringify(params);
-			const response = await fetch(`${baseUrl}/search`, {
-				method: 'POST',
-				body: queryDoc,
-				mode: 'cors',
-				headers: new Headers({ 'Content-Type': 'application/json' }),
-			});
-			const content = await response.json();
-			if (response.status == 200) {
-				const recipes = await fetchAllRecipes(content.results);
-				return {
-					hits: content.hits,
-					maxScore: content.maxScore,
-					recipes,
-				};
-			} else {
-				console.error(content);
-				throw new Error(`Unable to contact recipe API: ${response.status}`);
-			}
-		},
-		recipesById: async (idList: string[]): Promise<Recipe[]> => {
-			const doTheFetch = async (idsToFind: string[]) => {
-				const indexResponse = await fetch(
-					`/recipes/api/content/by-uid?ids=${idsToFind.join(',')}`,
-					{
-						credentials: 'include',
-					},
-				);
-				if (indexResponse.status != 200) {
-					throw new Error(
-						`Unable to retrieve partial index: server error ${indexResponse.status}`,
-					);
-				}
+      const queryString = args.length > 0 ? '?' + args.join('&') : '';
+      const url = `${baseUrl}/keywords/contributors${queryString}`;
+      const response = await fetch(url);
+      const content = await response.json();
+      if (response.status == 200) {
+        return content as ChefSearchResponse;
+      } else {
+        console.error(content);
+        throw new Error(`Unable to contact recipe API: ${response.status}`);
+      }
+    },
+    diets: async (): Promise<DietSearchResponse> => {
+      const response = await fetch(`${baseUrl}/keywords/diet-ids`);
+      const content = await response.json();
+      if (response.status == 200) {
+        return content as DietSearchResponse;
+      } else {
+        console.error(content);
+        throw new Error(`Unable to contact recipe API: ${response.status}`);
+      }
+    },
+    recipes: async (
+      params: RecipeSearchParams
+    ): Promise<RecipeSearchResponse> => {
+      const queryDoc = JSON.stringify(params);
+      const response = await fetch(`${baseUrl}/search`, {
+        method: 'POST',
+        body: queryDoc,
+        mode: 'cors',
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      });
+      const content = await response.json();
+      if (response.status == 200) {
+        const recipes = await fetchAllRecipes(content.results);
+        return {
+          hits: content.hits,
+          maxScore: content.maxScore,
+          recipes,
+        };
+      } else {
+        console.error(content);
+        throw new Error(`Unable to contact recipe API: ${response.status}`);
+      }
+    },
+    recipesById: async (idList: string[]): Promise<Recipe[]> => {
+      const doTheFetch = async (idsToFind: string[]) => {
+        const indexResponse = await fetch(
+          `/recipes/api/content/by-uid?ids=${idsToFind.join(',')}`,
+          {
+            credentials: 'include',
+          }
+        );
+        if (indexResponse.status != 200) {
+          throw new Error(
+            `Unable to retrieve partial index: server error ${indexResponse.status}`
+          );
+        }
 
-				const content =
-					(await indexResponse.json()) as RecipePartialIndexContent;
-				const recipeResponses = await Promise.all(
-					content.results.map((entry) =>
-						fetch(`${baseUrl}/content/${entry.checksum}`),
-					),
-				);
-				const successes = recipeResponses.filter((_) => _.status === 200);
-				return Promise.all(successes.map((_) => _.json())) as Promise<Recipe[]>;
-			};
+        const content =
+          (await indexResponse.json()) as RecipePartialIndexContent;
+        const recipeResponses = await Promise.all(
+          content.results.map((entry) =>
+            fetch(`${baseUrl}/content/${entry.checksum}`)
+          )
+        );
+        const successes = recipeResponses.filter((_) => _.status === 200);
+        return Promise.all(successes.map((_) => _.json())) as Promise<Recipe[]>;
+      };
 
-			const recurseTheList = async (
-				idsToFind: string[],
-				prevResults: Recipe[],
-			): Promise<Recipe[]> => {
-				const thisBatch = idsToFind.slice(0, 50); //we need to avoid a 414 URI Too Long error so batch into 50s
-				const results = (await doTheFetch(thisBatch)).concat(prevResults);
-				if (thisBatch.length == idsToFind.length) {
-					//we finished the list
-					return results;
-				} else {
-					return recurseTheList(idsToFind.slice(50), results);
-				}
-			};
+      const recurseTheList = async (
+        idsToFind: string[],
+        prevResults: Recipe[]
+      ): Promise<Recipe[]> => {
+        const thisBatch = idsToFind.slice(0, 50); //we need to avoid a 414 URI Too Long error so batch into 50s
+        const results = (await doTheFetch(thisBatch)).concat(prevResults);
+        if (thisBatch.length == idsToFind.length) {
+          //we finished the list
+          return results;
+        } else {
+          return recurseTheList(idsToFind.slice(50), results);
+        }
+      };
 
-			return recurseTheList(idList, []);
-		},
-	};
+      return recurseTheList(idList, []);
+    },
+  };
 };
 
 const isCode = () =>
-	window.location.hostname.includes('code.') ||
-	window.location.hostname.includes('local.');
+  window.location.hostname.includes('code.') ||
+  window.location.hostname.includes('local.');
 export const liveRecipes = recipeQuery(
-	isCode() ? url.codeRecipes : url.recipes,
+  isCode() ? url.codeRecipes : url.recipes
 );

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -172,7 +172,10 @@ const recipeQuery = (baseUrl: string) => {
 		recipes: async (
 			params: RecipeSearchParams,
 		): Promise<RecipeSearchResponse> => {
-			const queryDoc = JSON.stringify(params);
+			const queryDoc = JSON.stringify({
+				...params,
+				noStats: true, //we are not reading stats, so no point slowing the query down by retrieving them.
+			});
 			const response = await fetch(`${baseUrl}/search`, {
 				method: 'POST',
 				body: queryDoc,

--- a/fronts-client/src/types/Recipe.ts
+++ b/fronts-client/src/types/Recipe.ts
@@ -15,15 +15,15 @@ export interface RecipeImage {
 // Incomplete – add as we need more properties. Eventually, this would
 // be useful to derive from a package.
 export interface Recipe {
-  id: string;
-  title: string;
-  canonicalArticle: string;
-  difficultyLevel: string;
-  featuredImage?: RecipeImage; // the latter is an old image format that appears in our test fixtures
-  previewImage?: RecipeImage;
-  firstPublishedDate?: string;
-  lastModifiedDate?: string;
-  publishedDate?: string;
+	id: string;
+	title: string;
+	canonicalArticle: string;
+	difficultyLevel: string;
+	featuredImage?: RecipeImage; // the latter is an old image format that appears in our test fixtures
+	previewImage?: RecipeImage;
+	firstPublishedDate?: string;
+	lastModifiedDate?: string;
+	publishedDate?: string;
 }
 
 export interface RecipeIndexData {

--- a/fronts-client/src/types/Recipe.ts
+++ b/fronts-client/src/types/Recipe.ts
@@ -15,12 +15,15 @@ export interface RecipeImage {
 // Incomplete – add as we need more properties. Eventually, this would
 // be useful to derive from a package.
 export interface Recipe {
-	id: string;
-	title: string;
-	canonicalArticle: string;
-	difficultyLevel: string;
-	featuredImage?: RecipeImage; // the latter is an old image format that appears in our test fixtures
-	previewImage?: RecipeImage;
+  id: string;
+  title: string;
+  canonicalArticle: string;
+  difficultyLevel: string;
+  featuredImage?: RecipeImage; // the latter is an old image format that appears in our test fixtures
+  previewImage?: RecipeImage;
+  firstPublishedDate?: string;
+  lastModifiedDate?: string;
+  publishedDate?: string;
 }
 
 export interface RecipeIndexData {


### PR DESCRIPTION
## What's changed?

- Compatibility with https://github.com/guardian/recipe-search-backend/pull/48, which adds the ability to prefer most recent recipes in the search results
- Fix long-standing bug where the search results disappear when recipes are loaded in from the clipboard or a container
- Adds the option to completely override the feed item body in `FeedItem`
- Optionally shows the modified and last published times for recipes in the Feed

![date_priority_search](https://github.com/user-attachments/assets/71449584-8ded-4dee-ae00-f754a90a64a9)

## Implementation notes
See the recipe-search-backend PR for an explanation of what "prefer" actually means

## Checklist

### General
- [ ] 🤖 ~~Relevant tests added~~ - _None of the touched code currently has tests_
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
