### PR TITLE
Revert "Fix top elements disappearance when selecting Overview"

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -121,7 +121,7 @@ const CollectionOverview = ({
 					el.scrollIntoView({
 						behavior: 'smooth',
 						inline: 'start',
-						block: 'nearest',
+						block: 'start',
 					});
 				}
 				openCollection(collection.id);


### PR DESCRIPTION
Reverts guardian/facia-tool#1701

We've had a report from editorial team as follows

"Hey Devs, 

We've had a couple of reports related to odd experiences while using the 'Overview' tab in the fronts tool. 

Per Warren's email, he's having to double click on each container - one click to scroll to it, and another to open it. I'm unable to replicate as one click will both scroll to the container and open it for me. Warren is WFH and on the latest version of Chrome. 

Overnight, UK also experienced a scrolling issue:"

Following discussion with @Divs-B , we think reverting this issue will fix the immediate problem. Divya will then explore options for fixing the issue this PR aimed to fix in due course.

https://github.com/user-attachments/assets/6aaf4245-f687-4e59-ad26-1a9f73979945

