### PR TITLE
Fix date format string

### DIFF
--- a/fronts-client/src/components/feed/RecipeFeedItem.tsx
+++ b/fronts-client/src/components/feed/RecipeFeedItem.tsx
@@ -39,7 +39,7 @@ export const RecipeFeedItem = ({ id, showTimes }: ComponentProps) => {
 	const renderTimestamp = (iso: string) => {
 		try {
 			const date = new Date(iso);
-			return format(date, 'HH:mm on do MMM YYYY');
+			return format(date, 'HH:mm on Do MMM YYYY');
 		} catch (err) {
 			console.warn(err);
 			return iso;


### PR DESCRIPTION
## What's changed?

The feast date indicator accidentally used `do` (day of week) instead of `Do` (day of month) leading to a confusing display. Updates the format string

## Implementation notes

n/a

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
