### PR TITLE
Update fronts config tool with new container level tags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-aws" % "0.6",
     "com.gu" %% "content-api-client-default" % capiClientVersion,
     "com.gu" %% "editorial-permissions-client" % "3.0.0",
-    "com.gu" %% "fapi-client-play30" % "12.0.0",
+    "com.gu" %% "fapi-client-play30" % "12.1.0",
     "com.gu" %% "mobile-notifications-api-models" % "3.0.0",
     "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
 

--- a/public/src/js/models/common-handlers.js
+++ b/public/src/js/models/common-handlers.js
@@ -49,7 +49,10 @@ ko.bindingHandlers.tagSelector = {
                     });
                     return parsed;
                 }, []);
-                return parsedData;
+				// The primary tag is the default for specific containers (e.g. scrollable/small).
+				// Because of this, we don't want it as an option in the dropdown menu.
+				const parsedDataWithoutPrimaryTag = parsedData.filter(item => item.text !== 'Primary');
+				return parsedDataWithoutPrimaryTag;
             }
         });
     }

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -163,8 +163,12 @@ export default class ConfigCollection extends DropTarget {
 				this.meta.metadata([{ type: 'Primary' }]);
 			}
 			if (!this.meta.metadata().some(tag => tag.type === 'Primary') && !this.meta.metadata().some(tag => tag.type === 'Secondary')) {
-				this.meta.metadata().push({ type: 'Primary' });
-		}}
+				this.meta.metadata().push({ type: 'Primary' });}
+			if (this.meta.metadata().some(tag => tag.type === 'Primary') && this.meta.metadata().some(tag => tag.type === 'Secondary')) {
+				const updatedTags = this.meta.metadata().filter(tag => tag.type !== 'Primary');
+				this.meta.metadata(updatedTags);
+			}
+		}
 
         this.meta.href(urlAbsPath(this.meta.href()));
 

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -133,7 +133,6 @@ export default class ConfigCollection extends DropTarget {
     }
 
     save(frontEdited) {
-
         const potentialErrors = [
             {key: 'displayName', errMsg: 'enter a title'},
             {key: 'type', errMsg: 'choose a layout'}
@@ -158,13 +157,20 @@ export default class ConfigCollection extends DropTarget {
             return;
         }
 
+		// The BetaCollection containers need a Primary or Secondary tag indicating its level.
 		if (this.thisIsBetaCollection()) {
+			const hasPrimaryTag = this.meta.metadata().some(tag => tag.type === 'Primary');
+			const hasSecondaryTag = this.meta.metadata().some(tag => tag.type === 'Secondary');
+
+			// If no tags are set, or if neither Primary nor Secondary tags are set, we default the container to Primary.
 			if (this.meta.metadata() === undefined) {
 				this.meta.metadata([{ type: 'Primary' }]);
 			}
-			if (!this.meta.metadata().some(tag => tag.type === 'Primary') && !this.meta.metadata().some(tag => tag.type === 'Secondary')) {
+			if (!hasPrimaryTag && !hasSecondaryTag) {
 				this.meta.metadata().push({ type: 'Primary' });}
-			if (this.meta.metadata().some(tag => tag.type === 'Primary') && this.meta.metadata().some(tag => tag.type === 'Secondary')) {
+			if (hasPrimaryTag && hasSecondaryTag) {
+				// If both tags are present, we assume the intention was to set the container to Secondary
+				// So we remove the primary tag from the metadata.
 				const updatedTags = this.meta.metadata().filter(tag => tag.type !== 'Primary');
 				this.meta.metadata(updatedTags);
 			}

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -133,6 +133,7 @@ export default class ConfigCollection extends DropTarget {
     }
 
     save(frontEdited) {
+
         const potentialErrors = [
             {key: 'displayName', errMsg: 'enter a title'},
             {key: 'type', errMsg: 'choose a layout'}
@@ -156,6 +157,14 @@ export default class ConfigCollection extends DropTarget {
             alert('Oops! You must ' + errs.join(', ') + lastErrorJoiner + lastError + '...');
             return;
         }
+
+		if (this.thisIsBetaCollection()) {
+			if (this.meta.metadata() === undefined) {
+				this.meta.metadata([{ type: 'Primary' }]);
+			}
+			if (!this.meta.metadata().some(tag => tag.type === 'Primary') && !this.meta.metadata().some(tag => tag.type === 'Secondary')) {
+				this.meta.metadata().push({ type: 'Primary' });
+		}}
 
         this.meta.href(urlAbsPath(this.meta.href()));
 


### PR DESCRIPTION
## What's changed?

Part of this ticket for the [fairground project](https://trello.com/c/NV8mgfsp/616-add-primary-secondary-container-level-to-config-tool)

Bumps the fronts tool to use the latest facia-scala-client release from [this PR](https://github.com/guardian/facia-scala-client/pull/331), which adds primary and secondary to the list of tags.

## Implementation notes
The primary tag is the default setting for the new containers (such as scrollable/small). We don't make it visible in the dropdown, and assign it when the container gets saved, if a secondary tag hasn't been selected. We also remove the primary tag in the case where a primary tag was already been set, and someone tries to add a Secondary tag without explicitly removing the primary tag. 

![image](https://github.com/user-attachments/assets/e61aeeea-51c9-46a3-b517-728b81e495de)



## How to test

Try adding or editing one of the new container types. 

- Primary shouldn't come up as an option in the list of tags

- If there is no tag currently set, when hitting "save container" it should add a primary tag automatically. 

- If you try saving a container with both primary and secondary as tags, it should remove the primary tag. 

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
