### PR TITLE
Allow `scrollable/small`, `scrollable/medium`  and `static/medium/4` containers in PROD

### DIFF
--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -15,11 +15,8 @@ export function init (res) {
     // They will need to be added to the types list in ../constants/default.js when ready.
     if (res.defaults.env.toLowerCase() !== 'prod') {
         CONST.types.push(
-            {'name': 'scrollable/small'},
-            {'name': 'scrollable/medium'},
             {'name': 'scrollable/feature'},
-            {'name': 'static/feature/2'},
-            {'name': 'static/medium/4'}
+            {'name': 'static/feature/2'}
             );
     }
 }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

- Removed `scrollable/small`, `scrollable/medium`  and `static/medium/4` from list of containers not available in production environments

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
