### PR TITLE
Support feature card containers in production environments

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -78,7 +78,9 @@ export default {
         },
 		{ 'name': 'scrollable/small' },
 		{ 'name': 'scrollable/medium' },
-		{ 'name': 'static/medium/4' }
+		{ 'name': 'scrollable/feature' },
+		{ 'name': 'static/medium/4' },
+		{ 'name': 'static/feature/2' }
     ],
 
     emailTypes: [

--- a/public/src/js/modules/vars.js
+++ b/public/src/js/modules/vars.js
@@ -11,14 +11,6 @@ export function init (res) {
     if (res.defaults.switches['']) {
         CONST.types.push({ 'name': 'all-items/not-for-production' });
     }
-    // These containers are under development and are not yet ready for production.
-    // They will need to be added to the types list in ../constants/default.js when ready.
-    if (res.defaults.env.toLowerCase() !== 'prod') {
-        CONST.types.push(
-            {'name': 'scrollable/feature'},
-            {'name': 'static/feature/2'}
-            );
-    }
 }
 
 export function getPriority (priority) {


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Removes prod restriction for `scrollable/feature` and `static/feature/2` containers

This allows editorial staff to test these containers on training fronts ahead of launch for earlier feedback on potential issues.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
