### PR TITLE
Re-implement "Update fronts config tool with new container level tags" with bug fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "12.0.0",
+  "com.gu" %% "fapi-client-play30" % "12.1.0",
   "com.gu" %% "mobile-notifications-api-models" % "3.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/public/src/js/models/common-handlers.js
+++ b/public/src/js/models/common-handlers.js
@@ -49,7 +49,10 @@ ko.bindingHandlers.tagSelector = {
                     });
                     return parsed;
                 }, []);
-                return parsedData;
+				// The primary tag is the default for specific containers (e.g. scrollable/small).
+				// Because of this, we don't want it as an option in the dropdown menu.
+				const parsedDataWithoutPrimaryTag = parsedData.filter(item => item.text !== 'Primary');
+				return parsedDataWithoutPrimaryTag;
             }
         });
     }

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -157,6 +157,25 @@ export default class ConfigCollection extends DropTarget {
             return;
         }
 
+		// The BetaCollection containers need a Primary or Secondary tag indicating its level.
+		if (this.thisIsBetaCollection()) {
+			const hasPrimaryTag = this.meta.metadata().some(tag => tag.type === 'Primary');
+			const hasSecondaryTag = this.meta.metadata().some(tag => tag.type === 'Secondary');
+
+			// If no tags are set, or if neither Primary nor Secondary tags are set, we default the container to Primary.
+			if (this.meta.metadata() === undefined) {
+				this.meta.metadata([{ type: 'Primary' }]);
+			}
+			if (!hasPrimaryTag && !hasSecondaryTag) {
+				this.meta.metadata().push({ type: 'Primary' });}
+			if (hasPrimaryTag && hasSecondaryTag) {
+				// If both tags are present, we assume the intention was to set the container to Secondary
+				// So we remove the primary tag from the metadata.
+				const updatedTags = this.meta.metadata().filter(tag => tag.type !== 'Primary');
+				this.meta.metadata(updatedTags);
+			}
+		}
+
         this.meta.href(urlAbsPath(this.meta.href()));
 
         this.state.isOpen(false);

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -159,15 +159,18 @@ export default class ConfigCollection extends DropTarget {
 
 		// The BetaCollection containers need a Primary or Secondary tag indicating its level.
 		if (this.thisIsBetaCollection()) {
-			const hasPrimaryTag = this.meta.metadata().some(tag => tag.type === 'Primary');
-			const hasSecondaryTag = this.meta.metadata().some(tag => tag.type === 'Secondary');
+			const hasMetadata = !!this.meta.metadata();
+			let hasPrimaryTag = hasMetadata && this.meta.metadata().some(tag => tag.type === 'Primary');
+			const hasSecondaryTag = hasMetadata && this.meta.metadata().some(tag => tag.type === 'Secondary');
 
 			// If no tags are set, or if neither Primary nor Secondary tags are set, we default the container to Primary.
 			if (this.meta.metadata() === undefined) {
 				this.meta.metadata([{ type: 'Primary' }]);
+				hasPrimaryTag = true;
 			}
-			if (!hasPrimaryTag && !hasSecondaryTag) {
+			if (hasMetadata && !hasPrimaryTag && !hasSecondaryTag) {
 				this.meta.metadata().push({ type: 'Primary' });}
+				hasPrimaryTag = true;
 			if (hasPrimaryTag && hasSecondaryTag) {
 				// If both tags are present, we assume the intention was to set the container to Secondary
 				// So we remove the primary tag from the metadata.

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -134,8 +134,8 @@ export default class ConfigCollection extends DropTarget {
 
     save(frontEdited) {
         const potentialErrors = [
-            {key: 'displayName', errMsg: 'enter a title'},
-            {key: 'type', errMsg: 'choose a layout'}
+            { key: 'displayName', errMsg: 'enter a title' },
+            { key: 'type', errMsg: 'choose a layout' }
         ];
 
         const errs = _.chain(potentialErrors)
@@ -157,27 +157,8 @@ export default class ConfigCollection extends DropTarget {
             return;
         }
 
-		// The BetaCollection containers need a Primary or Secondary tag indicating its level.
-		if (this.thisIsBetaCollection()) {
-			const hasMetadata = !!this.meta.metadata();
-			let hasPrimaryTag = hasMetadata && this.meta.metadata().some(tag => tag.type === 'Primary');
-			const hasSecondaryTag = hasMetadata && this.meta.metadata().some(tag => tag.type === 'Secondary');
-
-			// If no tags are set, or if neither Primary nor Secondary tags are set, we default the container to Primary.
-			if (this.meta.metadata() === undefined) {
-				this.meta.metadata([{ type: 'Primary' }]);
-				hasPrimaryTag = true;
-			}
-			if (hasMetadata && !hasPrimaryTag && !hasSecondaryTag) {
-				this.meta.metadata().push({ type: 'Primary' });}
-				hasPrimaryTag = true;
-			if (hasPrimaryTag && hasSecondaryTag) {
-				// If both tags are present, we assume the intention was to set the container to Secondary
-				// So we remove the primary tag from the metadata.
-				const updatedTags = this.meta.metadata().filter(tag => tag.type !== 'Primary');
-				this.meta.metadata(updatedTags);
-			}
-		}
+        const resolvedMetadata = decideContainerLevelTags(this.meta.metadata(), isBetaCollection(this.meta.type()));
+        this.meta.metadata(resolvedMetadata);
 
         this.meta.href(urlAbsPath(this.meta.href()));
 
@@ -199,7 +180,7 @@ export default class ConfigCollection extends DropTarget {
     }
 }
 
-function findParents (collectionId) {
+function findParents(collectionId) {
     const frontsMap = vars.model.frontsMap();
     const state = vars.model.state();
     return _.chain(deepGet(state, '.config.fronts'))
@@ -210,6 +191,30 @@ function findParents (collectionId) {
         .value();
 }
 
-function isBetaCollection (collectionId) {
+function isBetaCollection(collectionId) {
     return vars.CONST.betaCollectionTypes.includes(collectionId);
 }
+
+/** Decides whether Primary or Secondary tags should be assigned to the collection,
+ * or if any of these should be removed.
+ * @see /public/test/spec/config.spec.js for test cases
+*/
+export function decideContainerLevelTags(tags, isBetaCollection = false) {
+    const hasTags = !!tags && tags.length > 0;
+    const hasPrimaryTag = hasTags && tags.some((tag) => tag.type === 'Primary');
+    const hasSecondaryTag = hasTags && tags.some((tag) => tag.type === 'Secondary');
+
+    // For beta collections with no Primary or Secondary tags, we add a Primary tag by default
+    if (isBetaCollection &&!hasPrimaryTag && !hasSecondaryTag) {
+        return [...(hasTags ? tags : []), { type: 'Primary' }];
+    }
+
+    // If both Primary and Secondary tags are present, we strip the Primary tag from the list
+    // since we assume the intention was to set the container to Secondary
+    if (hasPrimaryTag && hasSecondaryTag) {
+        return tags.filter(tag => tag.type !== 'Primary');
+    }
+
+    return tags;
+}
+

--- a/public/test/spec/config.spec.js
+++ b/public/test/spec/config.spec.js
@@ -6,203 +6,269 @@ import ConfigLoader from 'test/utils/config-loader';
 import textInside from 'test/utils/text-inside';
 import * as wait from 'test/utils/wait';
 import * as mockjax from 'test/utils/mockjax';
+import { decideContainerLevelTags } from '../../src/js/models/config/collection';
 
 describe('Config', function () {
 
-    beforeEach(function () {
-        this.scope = mockjax.scope();
-        this.scope({
-            url: '/metadata',
-            status: 200,
-            responseText: [
-                {
-                    'type': 'tag'
-                },
-                {
-                    'type': 'secondTag'
-                }
+    describe('old tests', function () {
 
-            ]
+        beforeEach(function () {
+            this.scope = mockjax.scope();
+            this.scope({
+                url: '/metadata',
+                status: 200,
+                responseText: [
+                    {
+                        'type': 'tag'
+                    },
+                    {
+                        'type': 'secondTag'
+                    }
+
+                ]
+            });
         });
-    });
-    afterEach(function () {
-        this.testInstance.dispose();
-        this.scope.clear();
-    });
+        afterEach(function () {
+            this.testInstance.dispose();
+            this.scope.clear();
+        });
 
 
-    it('/config/fronts', function (done) {
+        it('/config/fronts', function (done) {
 
-        this.testInstance = new ConfigLoader();
-        var mockConfig = this.testInstance.mockConfig,
-            baseModel;
+            this.testInstance = new ConfigLoader();
+            var mockConfig = this.testInstance.mockConfig,
+                baseModel;
 
-        this.testInstance.load()
-        .then(model => {
-            baseModel = model;
+            this.testInstance.load()
+                .then(model => {
+                    baseModel = model;
 
-            return createFrontWithCollection();
-        })
-        .then(function (request) {
-            var data = request.data;
-            expect(data.id).toEqual('test/front');
-            expect(data.initialCollection.displayName).toEqual('gossip');
-            expect(data.initialCollection.type).toEqual('fixed/small/slow-IV');
-            expect(data.priority).toEqual('test');
+                    return createFrontWithCollection();
+                })
+                .then(function (request) {
+                    var data = request.data;
+                    expect(data.id).toEqual('test/front');
+                    expect(data.initialCollection.displayName).toEqual('gossip');
+                    expect(data.initialCollection.type).toEqual('fixed/small/slow-IV');
+                    expect(data.priority).toEqual('test');
 
-            $('.contentPane:nth(1) .title--text:nth(1)').click();
-            return dragAnotherCollectionInsideFirstColumn(mockConfig, baseModel, $('.contentPane:nth(1) .cnf-collection')[1], {
-                fronts: {
-                    'test/front': {
-                        collections: ['sport', 'gossip'],
-                        priority: 'test'
-                    }
-                }
-            });
-        })
-        .then(function (request) {
-            expect(request.front).toEqual('test/front');
-            var data = request.data;
-            expect(data.id).toEqual('test/front');
-            expect(data.priority).toEqual('test');
-            expect(data.collections).toEqual(['sport', 'gossip']);
-
-            expect(textInside('.contentPane:nth(0) .cnf-collection:nth(0)')).toBe('1 Sport also on uk');
-            expect(textInside('.contentPane:nth(1) .cnf-collection:nth(1)')).toBe('2 Sport also on test/front');
-
-            return dragInsideTheSameCollection();
-        })
-        .then(function (request) {
-            expect(request.front).toEqual('test/front');
-            var data = request.data;
-            expect(data.id).toEqual('test/front');
-            expect(data.priority).toEqual('test');
-            expect(data.collections).toEqual(['gossip', 'sport']);
-        })
-        .then(function () {
-            var front = dom.$('.cnf-front.open');
-
-            dom.click(front.querySelector('.tool--container'));
-            dom.type(front.querySelector('.cnf-form input[type=text]'), 'with-tags');
-            dom.click(front.querySelector('.cnf-form .type-option-chosen'));
-            dom.click(front.querySelector('.cnf-form .type-picker .type-option'));
-            return addTag(1)
-            .then(() => {
-                expect(textInside('.fstResultItem:first-child')).toBe('tag');
-                expect(textInside('.fstResultItem:nth-child(2)')).toBe('secondTag');
-                expect(textInside('.fstChoiceItem').slice(0, -1)).toBe('tag');
-                return saveCollection({
-                    fronts: {
-                        'test/front': {
-                            collections: ['gossip', 'Sport', 'with-tags'],
-                            priority: 'test'
+                    $('.contentPane:nth(1) .title--text:nth(1)').click();
+                    return dragAnotherCollectionInsideFirstColumn(mockConfig, baseModel, $('.contentPane:nth(1) .cnf-collection')[1], {
+                        fronts: {
+                            'test/front': {
+                                collections: ['sport', 'gossip'],
+                                priority: 'test'
+                            }
                         }
-                    },
-                    collections: {
-                        'with-tags': {
-                            type: 'fixed/small/slow-IV',
-                            displayName: 'with-tags',
-                            metadata: [{ type: 'tag'}]
-                        }
-                    }
+                    });
+                })
+                .then(function (request) {
+                    expect(request.front).toEqual('test/front');
+                    var data = request.data;
+                    expect(data.id).toEqual('test/front');
+                    expect(data.priority).toEqual('test');
+                    expect(data.collections).toEqual(['sport', 'gossip']);
+
+                    expect(textInside('.contentPane:nth(0) .cnf-collection:nth(0)')).toBe('1 Sport also on uk');
+                    expect(textInside('.contentPane:nth(1) .cnf-collection:nth(1)')).toBe('2 Sport also on test/front');
+
+                    return dragInsideTheSameCollection();
+                })
+                .then(function (request) {
+                    expect(request.front).toEqual('test/front');
+                    var data = request.data;
+                    expect(data.id).toEqual('test/front');
+                    expect(data.priority).toEqual('test');
+                    expect(data.collections).toEqual(['gossip', 'sport']);
+                })
+                .then(function () {
+                    var front = dom.$('.cnf-front.open');
+
+                    dom.click(front.querySelector('.tool--container'));
+                    dom.type(front.querySelector('.cnf-form input[type=text]'), 'with-tags');
+                    dom.click(front.querySelector('.cnf-form .type-option-chosen'));
+                    dom.click(front.querySelector('.cnf-form .type-picker .type-option'));
+                    return addTag(1)
+                        .then(() => {
+                            expect(textInside('.fstResultItem:first-child')).toBe('tag');
+                            expect(textInside('.fstResultItem:nth-child(2)')).toBe('secondTag');
+                            expect(textInside('.fstChoiceItem').slice(0, -1)).toBe('tag');
+                            return saveCollection({
+                                fronts: {
+                                    'test/front': {
+                                        collections: ['gossip', 'Sport', 'with-tags'],
+                                        priority: 'test'
+                                    }
+                                },
+                                collections: {
+                                    'with-tags': {
+                                        type: 'fixed/small/slow-IV',
+                                        displayName: 'with-tags',
+                                        metadata: [{ type: 'tag' }]
+                                    }
+                                }
+                            });
+                        })
+                        .then(function (response) {
+                            var data = response.data;
+                            expect(data.collection.displayName).toEqual('with-tags');
+                            expect(data.collection.metadata[0].type).toEqual('tag');
+                            front.querySelector('.cnf-collection:nth-child(2) > .cnf-collection__name').click();
+                            removeTag();
+                            return addTag(2);
+                        })
+                        .then(() => {
+                            expect(textInside('.fstChoiceItem').slice(0, -1)).toBe('secondTag');
+                            return saveCollection({
+                                fronts: {
+                                    'test/front': {
+                                        collections: ['gossip', 'with-tags'],
+                                        priority: 'test'
+                                    }
+                                },
+                                collections: {
+                                    'with-tags': {
+                                        type: 'fixed/small/slow-IV',
+                                        displayName: 'with-tags',
+                                        metadata: [{ type: 'tag' }]
+                                    }
+                                }
+                            });
+                        })
+                        .then((response) => {
+                            var data = response.data;
+                            expect(data.collection.metadata[0].type).toEqual('secondTag');
+                            return;
+                        });
+                })
+                .then(() => done())
+                .catch(done.fail);
+
+            function removeTag() {
+                var deleteButton = dom.$('.fstChoiceItem > .fstChoiceRemove');
+                deleteButton.click();
+            }
+
+            function saveCollection(response) {
+                return configAction(mockConfig, baseModel, () => {
+                    $('button.tool').click();
+                    return response;
                 });
-            })
-            .then(function(response) {
-                var data = response.data;
-                expect(data.collection.displayName).toEqual('with-tags');
-                expect(data.collection.metadata[0].type).toEqual('tag');
-                front.querySelector('.cnf-collection:nth-child(2) > .cnf-collection__name').click();
-                removeTag();
-                return addTag(2);
-            })
-            .then(() => {
-                expect(textInside('.fstChoiceItem').slice(0, -1)).toBe('secondTag');
-                return saveCollection({
-                    fronts: {
-                        'test/front': {
-                            collections: ['gossip', 'with-tags'],
-                            priority: 'test'
+            }
+
+            function addTag(index) {
+                const tagSelect = dom.$('.multipleInputDynamic');
+                const fastselect = $.data(tagSelect, 'fastselect');
+                fastselect.show();
+                dom.click(tagSelect);
+                return wait.ms(300)
+                    .then(() => {
+                        var result = dom.$('.fstResultItem:nth-child(' + index + ')');
+                        return dom.click(result);
+                    });
+            }
+
+            function createFrontWithCollection() {
+                return configAction(mockConfig, baseModel, () => {
+                    dom.click(dom.$('.title .linky'));
+                    dom.type($('.cnf-form input[type=text]'), 'test/front');
+                    dom.click(dom.$('.create-new-front'));
+
+                    var newFront = dom.$('.cnf-front.open');
+                    dom.click(newFront.querySelector('.tool--container'));
+                    dom.type(newFront.querySelector('.cnf-form input[type=text]'), 'gossip');
+
+                    dom.click(newFront.querySelector('.cnf-form .type-option-chosen'));
+                    dom.click(newFront.querySelector('.cnf-form .type-picker .type-option'));
+
+                    dom.click(newFront.querySelector('button.tool-save-container'));
+
+                    return {
+                        fronts: {
+                            'test/front': {
+                                collections: ['gossip'],
+                                priority: 'test'
+                            }
+                        },
+                        collections: {
+                            'gossip': {
+                                type: 'fixed/small/slow-IV',
+                                displayName: 'gossip'
+                            }
                         }
-                    },
-                    collections: {
-                        'with-tags': {
-                            type: 'fixed/small/slow-IV',
-                            displayName: 'with-tags',
-                            metadata: [{ type: 'tag'}]
-                        }
-                    }
+                    };
                 });
-            })
-            .then((response) => {
-                var data = response.data;
-                expect(data.collection.metadata[0].type).toEqual('secondTag');
-                return;
-            });
-        })
-        .then(() => done())
-        .catch(done.fail);
+            }
 
-        function removeTag() {
-            var deleteButton = dom.$('.fstChoiceItem > .fstChoiceRemove');
-            deleteButton.click();
-        }
+            function dragInsideTheSameCollection() {
+                return configAction(mockConfig, baseModel, () => {
+                    // Open the front in the second panel
+                    var collectionToDrag = $('.contentPane:nth(0) .cnf-collection')[1];
+                    var collectionToDropTo = $('.contentPane:nth(0) .cnf-collection')[0];
+                    var droppableContainer = $('.contentPane:nth(0) .cnf-fronts .droppable')[0];
+                    var droppableTarget = drag.droppable(droppableContainer);
+                    var sourceCollection = new drag.Collection(collectionToDrag);
 
-        function saveCollection(response) {
-            return configAction(mockConfig, baseModel, () => {
-                $('button.tool').click();
-                return response;
-            });
-        }
+                    droppableTarget.dragstart(collectionToDrag, sourceCollection);
+                    droppableTarget.drop(collectionToDropTo, sourceCollection);
 
-        function addTag(index) {
-            const tagSelect = dom.$('.multipleInputDynamic');
-            const fastselect = $.data(tagSelect, 'fastselect');
-            fastselect.show();
-            dom.click(tagSelect);
-            return wait.ms(300)
-            .then(() => {
-                var result = dom.$('.fstResultItem:nth-child(' + index+ ')');
-                return dom.click(result);
-            });
-        }
-
-        function createFrontWithCollection () {
-            return configAction(mockConfig, baseModel, () => {
-                dom.click(dom.$('.title .linky'));
-                dom.type($('.cnf-form input[type=text]'), 'test/front');
-                dom.click(dom.$('.create-new-front'));
-
-                var newFront = dom.$('.cnf-front.open');
-                dom.click(newFront.querySelector('.tool--container'));
-                dom.type(newFront.querySelector('.cnf-form input[type=text]'), 'gossip');
-
-                dom.click(newFront.querySelector('.cnf-form .type-option-chosen'));
-                dom.click(newFront.querySelector('.cnf-form .type-picker .type-option'));
-
-                dom.click(newFront.querySelector('button.tool-save-container'));
-
-                return {
-                    fronts: {
-                        'test/front': {
-                            collections: ['gossip'],
-                            priority: 'test'
+                    return {
+                        fronts: {
+                            'test/front': {
+                                collections: ['gossip', 'sport'],
+                                priority: 'test'
+                            }
                         }
-                    },
-                    collections: {
-                        'gossip': {
-                            type: 'fixed/small/slow-IV',
-                            displayName: 'gossip'
-                        }
-                    }
-                };
-            });
-        }
+                    };
+                });
+            }
+        });
 
-        function dragInsideTheSameCollection () {
+        it('allows for searching fronts', function (done) {
+            this.testInstance = new ConfigLoader('?layout=config,search');
+            var mockConfig = this.testInstance.mockConfig,
+                baseModel;
+
+            this.testInstance.load()
+                .then(model => {
+                    baseModel = model;
+                    return dom.type($('input'), 'uk');
+                })
+                .then(() => {
+
+                    expect(textInside($('.contentPane:nth(1) .title--text:nth(0)'))).toEqual('uk');
+                    expect(textInside($('.contentPane:nth(1) .cnf-collection__name')[0])).toEqual('Latest News');
+
+                    $('.contentPane:nth(0) .title--text:nth(1)').click();
+
+                    return dragAnotherCollectionInsideFirstColumn(mockConfig, baseModel, $('.contentPane:nth(1) .cnf-collection')[0], {
+                        fronts: {
+                            'world': {
+                                collections: ['latest', 'environment'],
+                                priority: 'test'
+                            }
+                        }
+                    });
+                })
+                .then(function (request) {
+                    expect(request.front).toEqual('world');
+                    var data = request.data;
+                    expect(data.id).toEqual('world');
+                    expect(data.priority).toEqual('test');
+                    expect(data.collections).toEqual(['latest', 'environment']);
+                    expect(textInside($('.contentPane:nth(0) .cnf-fronts .droppable .cnf-collection__name')[0])).toEqual('Latest News');
+                    expect(textInside($('.contentPane:nth(0) .cnf-fronts .droppable .cnf-collection__name')[1])).toEqual('Environment');
+                })
+                .then(() => done())
+                .catch(done.fail);
+
+        });
+
+
+        function dragAnotherCollectionInsideFirstColumn(mockConfig, baseModel, collectionToDrag, returnObject) {
             return configAction(mockConfig, baseModel, () => {
-                // Open the front in the second panel
-                var collectionToDrag = $('.contentPane:nth(0) .cnf-collection')[1];
-                var collectionToDropTo = $('.contentPane:nth(0) .cnf-collection')[0];
+                var collectionToDropTo = $('.contentPane:nth(0) .cnf-fronts .cnf-collection')[0];
                 var droppableContainer = $('.contentPane:nth(0) .cnf-fronts .droppable')[0];
                 var droppableTarget = drag.droppable(droppableContainer);
                 var sourceCollection = new drag.Collection(collectionToDrag);
@@ -210,70 +276,47 @@ describe('Config', function () {
                 droppableTarget.dragstart(collectionToDrag, sourceCollection);
                 droppableTarget.drop(collectionToDropTo, sourceCollection);
 
-                return {
-                    fronts: {
-                        'test/front': {
-                            collections: ['gossip', 'sport'],
-                            priority: 'test'
-                        }
-                    }
-                };
+                return returnObject;
             });
         }
     });
 
-    it('allows for searching fronts', function (done) {
-        this.testInstance = new ConfigLoader('?layout=config,search');
-        var mockConfig = this.testInstance.mockConfig,
-            baseModel;
 
-        this.testInstance.load()
-        .then(model => {
-            baseModel = model;
-            return dom.type($('input'), 'uk');
-        })
-        .then(() => {
-
-            expect(textInside($('.contentPane:nth(1) .title--text:nth(0)'))).toEqual('uk');
-            expect(textInside($('.contentPane:nth(1) .cnf-collection__name')[0])).toEqual('Latest News');
-
-            $('.contentPane:nth(0) .title--text:nth(1)').click();
-
-            return dragAnotherCollectionInsideFirstColumn(mockConfig, baseModel, $('.contentPane:nth(1) .cnf-collection')[0], {
-                fronts: {
-                    'world': {
-                        collections: ['latest', 'environment'],
-                        priority: 'test'
-                    }
-                }
-            });
-        })
-        .then(function (request) {
-            expect(request.front).toEqual('world');
-            var data = request.data;
-            expect(data.id).toEqual('world');
-            expect(data.priority).toEqual('test');
-            expect(data.collections).toEqual(['latest', 'environment']);
-            expect(textInside($('.contentPane:nth(0) .cnf-fronts .droppable .cnf-collection__name')[0])).toEqual('Latest News');
-            expect(textInside($('.contentPane:nth(0) .cnf-fronts .droppable .cnf-collection__name')[1])).toEqual('Environment');
-        })
-        .then(() => done())
-        .catch(done.fail);
-
-    });
-
-    function dragAnotherCollectionInsideFirstColumn(mockConfig, baseModel, collectionToDrag, returnObject) {
-        return configAction(mockConfig, baseModel, () => {
-            var collectionToDropTo = $('.contentPane:nth(0) .cnf-fronts .cnf-collection')[0];
-            var droppableContainer = $('.contentPane:nth(0) .cnf-fronts .droppable')[0];
-            var droppableTarget = drag.droppable(droppableContainer);
-            var sourceCollection = new drag.Collection(collectionToDrag);
-
-            droppableTarget.dragstart(collectionToDrag, sourceCollection);
-            droppableTarget.drop(collectionToDropTo, sourceCollection);
-
-            return returnObject;
+    describe('decideContainerLevelTags', function () {
+        it('should return existing metadata if not a beta collection', function () {
+            const metadata = [{ 'type': 'InvestigationPalette' }];
+            const isBetaCollection = false;
+            expect(decideContainerLevelTags(metadata, isBetaCollection)).toEqual(metadata);
         });
-    }
 
+        it('should return existing metadata if it is a beta collection with a Secondary tag only', function () {
+            const metadata = [{ 'type': 'InvestigationPalette' }, { 'type': 'Secondary' }];
+            const isBetaCollection = false;
+            expect(decideContainerLevelTags(metadata, isBetaCollection)).toEqual(metadata);
+        });
+
+        it('should default to Primary if no tags exist (undefined)', function () {
+            const metadata = undefined;
+            const isBetaCollection = true;
+            expect(decideContainerLevelTags(metadata, isBetaCollection)).toEqual([{ 'type': 'Primary' }]);
+        });
+
+        it('should default to Primary if no tags exist (empty array)', function () {
+            const metadata = [];
+            const isBetaCollection = true;
+            expect(decideContainerLevelTags(metadata, isBetaCollection)).toEqual([{ 'type': 'Primary' }]);
+        });
+
+        it('should add a Primary tag if it is a beta collection and no Primary or Secondary tags exist', function () {
+            const metadata = [{ 'type': 'InvestigationPalette' }];
+            const isBetaCollection = true;
+            expect(decideContainerLevelTags(metadata, isBetaCollection)).toEqual([{ 'type': 'InvestigationPalette' }, { 'type': 'Primary' }]);
+        });
+
+        it('should strip out Primary tag if both Primary and Secondary tags exist', function () {
+            const metadata = [{ 'type': 'InvestigationPalette' }, { 'type': 'Primary' }, { 'type': 'Secondary' }];
+            const isBetaCollection = true;
+            expect(decideContainerLevelTags(metadata, isBetaCollection)).toEqual([{ 'type': 'InvestigationPalette' }, { 'type': 'Secondary' }]);
+        });
+    });
 });


### PR DESCRIPTION
Reverts #1718 to re-implement guardian/facia-tool#1712 with a fix for the bug that was identified in the training front. 

The main change from the first PR is to actually check the metadata exists before assigning hasPrimaryTag a value. 

Tested this using a training front locally in different permutations and it _seemed_ to work as intended. 