### PR TITLE
Restore/set margin bottom to 60px on article forms

### DIFF
--- a/fronts-client/src/components/form/FormContent.tsx
+++ b/fronts-client/src/components/form/FormContent.tsx
@@ -9,5 +9,5 @@ export const FormContent = styled.div<FormContentProps>`
 	flex: 3;
 	display: flex;
 	flex-direction: ${({ size }) => (size !== 'wide' ? 'column' : 'row')};
-	margin-bottom: ${({ marginBottom }) => marginBottom ?? 0};
+	margin-bottom: ${({ marginBottom }) => marginBottom ?? "60px"};
 `;

--- a/fronts-client/src/components/form/FormContent.tsx
+++ b/fronts-client/src/components/form/FormContent.tsx
@@ -9,5 +9,5 @@ export const FormContent = styled.div<FormContentProps>`
 	flex: 3;
 	display: flex;
 	flex-direction: ${({ size }) => (size !== 'wide' ? 'column' : 'row')};
-	margin-bottom: ${({ marginBottom }) => marginBottom ?? "60px"};
+	margin-bottom: ${({ marginBottom }) => marginBottom ?? '60px'};
 `;


### PR DESCRIPTION
## What's changed?
The margin bottom was [recently removed as it looked to be unused,](https://github.com/guardian/facia-tool/commit/0cf072efcc6132d229c8a2a03dab9375d3acf0f9) but it comes in useful when more elements appear on the form, e.g. captions in the slideshow.

The margin bottom was originally 40px, but on my screen this still overlaps a touch with the save button, so I've set it to 60px instead. I've left the feast forms to 40px as a) I'm not sure what they look like, and b) that presumably has been fine. 

## Images

| Before, without margin bottom      | With 40px margin bottom (not quite right)     
| ----------- | ---------- | 
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/2bee36d3-ab15-4d43-b387-f33f799759e5
[after]: https://github.com/user-attachments/assets/b702f929-3ae6-4641-bdbc-82463a0cea2a
[afteragain]: https://github.com/user-attachments/assets/f082cf56-be47-48c8-a592-0dc583de4763



 | After, with 60px      | After, with 60px but without slideshow      | 
|---------- | ----------- |
| ![afteragain][] | ![afterwithout][] | 

[afterwithout]: https://github.com/user-attachments/assets/adaed78b-2826-49cb-833f-ab09a8d15eab



<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
