### PR TITLE
Move 60px margin bottom from form to caption input

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -182,6 +182,7 @@ const CaptionLabel = styled(InputLabel)`
 `;
 
 const CaptionInput = styled(InputBase)`
+  margin-bottom: 60px;
   color: ${(props: { invalid: boolean }) =>
 		props.invalid ? error.primary : 'default'}}
   border-color: ${(props: { invalid: boolean }) =>

--- a/fronts-client/src/components/form/FormContent.tsx
+++ b/fronts-client/src/components/form/FormContent.tsx
@@ -9,5 +9,5 @@ export const FormContent = styled.div<FormContentProps>`
 	flex: 3;
 	display: flex;
 	flex-direction: ${({ size }) => (size !== 'wide' ? 'column' : 'row')};
-	margin-bottom: ${({ marginBottom }) => marginBottom ?? '60px'};
+	margin-bottom: ${({ marginBottom }) => marginBottom ?? 0};
 `;


### PR DESCRIPTION
## What's changed?

The standard article form has a 60px margin set to it (following [this PR](https://github.com/guardian/facia-tool/pull/1721)), but in hindsight we'd prefer to only display it if the slideshow is in place. The caption input, at the bottom of the slideshow, now has the property, as it only appears when there's a slideshow.

The article form _can_ still have a margin bottom; this has been left in for feast related things. 

## Screenshots

Before - always 60px margin bottom:

https://github.com/user-attachments/assets/2cb0e1f4-38b5-4ea7-9767-45942037e035

After - 60px margin bottom only when showing the caption input:

https://github.com/user-attachments/assets/2ba3866d-bab5-4470-8139-f80a663a22b0








## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
