### PR TITLE
Update content-api-client-aws to 0.7.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "com.gu" %% "content-api-models-scala" % capiModelsVersion,
   "com.gu" %% "content-api-models-json" % capiModelsVersion,
-  "com.gu" %% "content-api-client-aws" % "0.6",
+  "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
   "com.gu" %% "fapi-client-play30" % "12.0.0",


### PR DESCRIPTION
## What's changed?

This PR updates to [version 0.7.6 of content-api-client-aws](https://github.com/guardian/content-api-client-aws/releases/tag/v0.7.6). I used facia-tool to test [the PR that produced this release](https://github.com/guardian/content-api-client-aws/pull/2) of content-api-client-aws, which happily also serves to demonstrate that facia-tool can update to this new version! 

My testing process was:

- run facia-tool locally with a snapshot release 0.7.6-SNAPSHOT of content-api-client-aws
- open a front (Au Business)
- see that both live and draft content loads correctly in the left-hand bar
- check the application logs for any obvious errors

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE
- [x] 🔍 Checked locally

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
