### PR TITLE
 Fix issue where scrollIntoView was shifting the page to bring containers into view in recipes feed

### DIFF
--- a/fronts-client/src/components/feed/FeedSection.tsx
+++ b/fronts-client/src/components/feed/FeedSection.tsx
@@ -22,10 +22,12 @@ const FeedSectionContainer = styled.div`
 
 const FeedSectionContent = styled(SectionContent)`
 	padding-right: 0px;
-	padding-top: 10px;
+	padding-bottom: 0;
 `;
 
 const FeedWrapper = styled.div<{ isClipboardOpen: boolean }>`
+	display: flex;
+	flex-direction: column;
 	width: 409px;
 	${media.large`width: 335px;`}
 	border-right: ${({ isClipboardOpen }) =>

--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -52,6 +52,7 @@ const TopOptions = styled.div`
 
 const FeedsContainerWrapper = styled.div`
 	height: 100%;
+	min-height: 0;
 `;
 
 const ResultsContainer = styled.div`


### PR DESCRIPTION
## What's changed?

Right-size recipes feed component height, fixing an issue where scrollIntoView was shifting the page to bring containers into view.

Before, the recipe feed expanded beyond the viewport, via `height: 100%`:

|Height of feed|Height of container — these should not be the same!|
|-|-|
|![Screenshot 2024-11-14 at 16 04 54](https://github.com/user-attachments/assets/dfcb8498-8996-4489-a278-c97d0b6f9398)|![Screenshot 2024-11-14 at 16 05 31](https://github.com/user-attachments/assets/4850d023-dc9a-4951-97d7-6cc2a4c8eb10)|

This was reasonably benign (the very last recipe in the feed was always offscreen, but no-one noticed), until a user used the front summary to auto-scroll to a container:

![scroll-bug-facia](https://github.com/user-attachments/assets/1ad11e5e-8a81-42c4-997d-35ee480f6742)

Now, the recipe feed fits into the container:

|Height of feed, now within container|Height of container|
|-|-|
|![Screenshot 2024-11-14 at 16 06 25](https://github.com/user-attachments/assets/e6bb98f2-c32c-479b-a149-40abdbdd0896)|![Screenshot 2024-11-14 at 16 06 50](https://github.com/user-attachments/assets/bcdfcf9d-d6be-4f5f-bf25-cf6ddee43a4c)|

And the autoscroll works as expected:

![scroll-bug-facia-fix](https://github.com/user-attachments/assets/e4f31051-5b23-4388-adfa-2a9747ceddf7)

Tested in editorial fronts, too.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
