### PR TITLE
Move aspect ratio badge to other side of container

### DIFF
--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -290,7 +290,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 			>
 				<CollectionHeadingSticky tabIndex={-1}>
 					<CollectionHeadingInner>
-						{usePortrait && <AspectRatioBadge {...portraitCardImageCriteria} />}
 						<CollectionHeadlineWithConfigContainer>
 							{this.state.editingContainerName ? (
 								<CollectionHeaderInput
@@ -347,6 +346,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 								</CollectionHeadingText>
 							)}
 						</CollectionHeadlineWithConfigContainer>
+						{usePortrait && <AspectRatioBadge {...portraitCardImageCriteria} />}
 						{isLocked ? (
 							<LockedCollectionFlag>Locked</LockedCollectionFlag>
 						) : headlineContent ? (

--- a/fronts-client/src/components/icons/AspectRatioBadge.tsx
+++ b/fronts-client/src/components/icons/AspectRatioBadge.tsx
@@ -18,8 +18,8 @@ const AspectText = styled.span`
 `;
 
 const Container = styled(CircularIconContainer)`
-	margin-right: 10px;
 	background-color: ${theme.colors.blackLight};
+	margin: 4px;
 `;
 
 const getAspectDescription = (


### PR DESCRIPTION
## What's changed?

Moves the aspect ratio badge to the other side of the container in the fronts tool as the current position is thought to provide UX issues for editorial users due to it appearing in front of the title.

Resolves [this Trello ticket](https://trello.com/c/FYpf6nyD/733-remove-45-indicators-from-fronts-tool)

## Screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][]|

[before]:https://github.com/user-attachments/assets/05367853-b539-457d-8fe8-7a2654399b84
[after]:https://github.com/user-attachments/assets/054fa6b2-d6c3-49a5-9f25-f6242fa9a01a


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
