### PR TITLE
Allow portrait crops in production and reword feature switch description

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,10 +33,10 @@ object TenImageSlideshows
       enabled = false
     )
 
-object UsePortraitCropsForSomeCollectionTypes
+object SupportPortraitCrops
     extends FeatureSwitch(
       key = "support-portrait-crops",
-      title = "Use portrait crops for the experimental feature card containers",
+      title = "Support portrait crops for feature card containers",
       enabled = false
     )
 
@@ -52,7 +52,7 @@ object FeatureSwitches {
     ObscureFeed,
     PageViewDataVisualisation,
     TenImageSlideshows,
-    UsePortraitCropsForSomeCollectionTypes,
+    SupportPortraitCrops,
     PinboardIntegration
   )
 

--- a/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
+++ b/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
@@ -161,7 +161,7 @@ export const initialState = {
 			featureSwitches: [
 				{
 					key: 'support-portrait-crops',
-					title: 'Use portrait crops for the experimental big card containers',
+					title: 'Support portrait crops for feature card containers',
 					enabled: false,
 				},
 				{
@@ -666,7 +666,7 @@ export const initialState = {
 	featureSwitches: {
 		'support-portrait-crops': {
 			key: 'support-portrait-crops',
-			title: 'Use portrait crops for the experimental big card containers',
+			title: 'Support portrait crops for feature card containers',
 			enabled: false,
 		},
 		'obscure-feed': {
@@ -902,7 +902,7 @@ export const finalStateWhenAddNewCollection = {
 			featureSwitches: [
 				{
 					key: 'support-portrait-crops',
-					title: 'Use portrait crops for the experimental big card containers',
+					title: 'Support portrait crops for feature card containers',
 					enabled: false,
 				},
 				{
@@ -1408,7 +1408,7 @@ export const finalStateWhenAddNewCollection = {
 	featureSwitches: {
 		'support-portrait-crops': {
 			key: 'support-portrait-crops',
-			title: 'Use portrait crops for the experimental big card containers',
+			title: 'Support portrait crops for feature card containers',
 			enabled: false,
 		},
 		'obscure-feed': {
@@ -1654,7 +1654,7 @@ export const finalStateWhenRemoveACollection = {
 			featureSwitches: [
 				{
 					key: 'support-portrait-crops',
-					title: 'Use portrait crops for the experimental big card containers',
+					title: 'Support portrait crops for feature card containers',
 					enabled: false,
 				},
 				{
@@ -2159,7 +2159,7 @@ export const finalStateWhenRemoveACollection = {
 	featureSwitches: {
 		'support-portrait-crops': {
 			key: 'support-portrait-crops',
-			title: 'Use portrait crops for the experimental big card containers',
+			title: 'Support portrait crops for feature card containers',
 			enabled: false,
 		},
 		'obscure-feed': {

--- a/fronts-client/src/components/Features/FeaturesForm.tsx
+++ b/fronts-client/src/components/Features/FeaturesForm.tsx
@@ -5,7 +5,6 @@ import type { State } from 'types/State';
 import { selectAllFeatures } from 'selectors/featureSwitchesSelectors';
 import { FeatureSwitch } from 'types/Features';
 import { Dispatch } from 'types/Store';
-import pageConfig from 'util/extractConfigFromPage';
 import { actionSetFeatureValue } from 'actions/FeatureSwitches';
 import { saveFeatureSwitch } from 'services/userDataApi';
 
@@ -14,24 +13,13 @@ interface Props {
 	setFeatureValue: (featureSwitch: FeatureSwitch) => void;
 }
 
-const STAGE = pageConfig.env;
-
-// We don't yet have any collectionTypes that use portrait crops
-// but even when we do, we might not want to show the option on PROD
-// it might lead to some broken visuals if used before implemented
-// on platforms.
-const SWITCHES_TO_HIDE_ON_PROD = ['support-portrait-crops'];
-
-const filterSwitchesByStage = (featureSwitch: FeatureSwitch): boolean =>
-	STAGE === 'code' || !SWITCHES_TO_HIDE_ON_PROD.includes(featureSwitch.key);
-
 class FeaturesForm extends React.Component<Props> {
 	public render() {
 		const { featureSwitches } = this.props;
 		console.log(featureSwitches);
 		return (
 			<form>
-				{featureSwitches.filter(filterSwitchesByStage).map((featureSwitch) => (
+				{featureSwitches.map((featureSwitch) => (
 					<InputCheckboxToggle
 						key={featureSwitch.key}
 						label={featureSwitch.title}


### PR DESCRIPTION
## What's changed?

Removes the logic added in https://github.com/guardian/facia-tool/pull/1591 which prevented portrait crops from being added to cards in non CODE environments. We no longer restrict the feature switch by environment and allow opting in everywhere.

When this feature was added initially, the containers and cards had not been built downstream. Now that these containers are supported, we can allow the feature in production. 

> [!NOTE]
> You still need to opt into the feature via the feature switch page.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
