### PR TITLE
default pinboard feature switch to ON in all envs

### DIFF
--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -148,8 +148,7 @@ class V2App(
           isDev,
           maybePinboardUrl = pinboardPermission match {
             case AccessGranted
-                if config.environment.stage != "prod" || maybePinboardFeatureSwitch
-                  .exists(_.enabled) =>
+                if maybePinboardFeatureSwitch.exists(_.enabled) =>
               Some(
                 s"https://pinboard.${config.environment.correspondingToolsDomainSuffix}/pinboard.loader.js"
               )

--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -44,7 +44,7 @@ object PinboardIntegration
     extends FeatureSwitch(
       key = "pinboard",
       title = "Enable Pinboard integration",
-      enabled = false
+      enabled = true
     )
 
 object FeatureSwitches {


### PR DESCRIPTION
(and remove previous stage specific default) following release of https://github.com/guardian/pinboard/pull/312 - which has its own feature switch mechanism for controlling whether pinboard should 'display', but this feature switch was as to whether pinboard script is loaded at all, which we need it to be for it to evaluate pinboard's own feature switch, but stopped short of removing the feature switch entirely in case something goes wrong and users need to be able to explicitly turn it off (removal PR is https://github.com/guardian/facia-tool/pull/1734 though)
