### PR TITLE
Indicate highlights container should use square crop

### DIFF
--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -33,6 +33,8 @@ import {
 	defaultCardTrailImageCriteria,
 	landscape5To4CardImageCriteria,
 	COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS,
+	squareImageCriteria,
+	COLLECTIONS_USING_SQUARE_TRAILS,
 } from 'constants/image';
 import Sublinks from '../FrontsEdit/CollectionComponents/Sublinks';
 import {
@@ -458,6 +460,10 @@ class Card extends React.Component<CardContainerProps> {
 
 		if (COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
 			return landscape5To4CardImageCriteria;
+		}
+
+		if (COLLECTIONS_USING_SQUARE_TRAILS.includes(collectionType)) {
+			return squareImageCriteria;
 		}
 
 		if (!SUPPORT_PORTRAIT_CROPS) {

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -36,7 +36,7 @@ import ImageAndGraphWrapper from 'components/image/ImageAndGraphWrapper';
 import { getPaths } from 'util/paths';
 import { getMaybeDimensionsFromWidthAndHeight } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
-import { landscape5To4CardImageCriteria } from 'constants/image';
+import { landscape5To4CardImageCriteria, squareImageCriteria } from 'constants/image';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
 	flex-shrink: 0;
@@ -208,6 +208,12 @@ const articleBodyDefault = React.memo(
 				landscape5To4CardImageCriteria.widthAspectRatio &&
 			imageCriteria.heightAspectRatio ===
 				landscape5To4CardImageCriteria.heightAspectRatio;
+		const showSquareThumbnail =
+			imageCriteria &&
+			imageCriteria.widthAspectRatio ===
+				squareImageCriteria.widthAspectRatio &&
+			imageCriteria.heightAspectRatio ===
+				squareImageCriteria.heightAspectRatio;
 
 		return (
 			<>
@@ -326,6 +332,7 @@ const articleBodyDefault = React.memo(
 									isDraggingImageOver={isDraggingImageOver}
 									isPortrait={thumbnailIsPortrait}
 									showLandscape54={showThumbnailInLandscape54}
+									showSquareThumbnail={showSquareThumbnail}
 								>
 									{cutoutThumbnail ? (
 										<ThumbnailCutout src={cutoutThumbnail} />

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -36,7 +36,10 @@ import ImageAndGraphWrapper from 'components/image/ImageAndGraphWrapper';
 import { getPaths } from 'util/paths';
 import { getMaybeDimensionsFromWidthAndHeight } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
-import { landscape5To4CardImageCriteria, squareImageCriteria } from 'constants/image';
+import {
+	landscape5To4CardImageCriteria,
+	squareImageCriteria,
+} from 'constants/image';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
 	flex-shrink: 0;
@@ -210,10 +213,8 @@ const articleBodyDefault = React.memo(
 				landscape5To4CardImageCriteria.heightAspectRatio;
 		const showSquareThumbnail =
 			imageCriteria &&
-			imageCriteria.widthAspectRatio ===
-				squareImageCriteria.widthAspectRatio &&
-			imageCriteria.heightAspectRatio ===
-				squareImageCriteria.heightAspectRatio;
+			imageCriteria.widthAspectRatio === squareImageCriteria.widthAspectRatio &&
+			imageCriteria.heightAspectRatio === squareImageCriteria.heightAspectRatio;
 
 		return (
 			<>

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -50,6 +50,8 @@ import {
 	SUPPORT_PORTRAIT_CROPS,
 	COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS,
 	landscape5To4CardImageCriteria,
+	COLLECTIONS_USING_SQUARE_TRAILS,
+	squareImageCriteria,
 } from 'constants/image';
 import { selectors as collectionSelectors } from 'bundles/collectionsBundle';
 import { getContributorImage } from 'util/CAPIUtils';
@@ -1008,6 +1010,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		}
 		if (COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
 			return landscape5To4CardImageCriteria;
+		}
+		if (COLLECTIONS_USING_SQUARE_TRAILS.includes(collectionType)) {
+			return squareImageCriteria;
 		}
 		if (!SUPPORT_PORTRAIT_CROPS) {
 			return landScapeCardImageCriteria;

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -92,7 +92,10 @@ const ImageComponent = styled.div<{
 		`aspect-ratio: 1/1;
     background-size: cover;
     background-repeat: no-repeat;
-    background-position: center;`}
+    background-position: center;
+	width: 95%;
+	height: 95%;
+	align-self: center;`}
   flex-grow: 1;
 	cursor: grab;
 `;

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -641,9 +641,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 				cropType: 'Landscape',
 				customRatio: 'Landscape,5,4',
 			};
-		} else if (
-			this.compareAspectRatio(squareImageCriteria, criteria)
-		) {
+		} else if (this.compareAspectRatio(squareImageCriteria, criteria)) {
 			return {
 				cropType: 'Square',
 				customRatio: 'Square',

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -62,6 +62,7 @@ const ImageComponent = styled.div<{
 	small: boolean;
 	portrait: boolean;
 	shouldShowLandscape54: boolean;
+	showSquare: boolean;
 }>`
 	${({ small }) =>
 		small
@@ -83,6 +84,12 @@ const ImageComponent = styled.div<{
 	${({ shouldShowLandscape54 }) =>
 		shouldShowLandscape54 &&
 		`aspect-ratio: 5/4;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;`}
+	${({ showSquare }) =>
+		showSquare &&
+		`aspect-ratio: 1/1;
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;`}
@@ -622,7 +629,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 		}
 
 		// assumes the only criteria that will be passed as props the defined
-		// constants for portrait(4:5), landscape (5:3) and landscape (5:4)
+		// constants for portrait(4:5), landscape (5:3), landscape (5:4) or square
 		if (this.compareAspectRatio(portraitCardImageCriteria, criteria)) {
 			return {
 				cropType: 'portrait',
@@ -633,6 +640,13 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 			return {
 				cropType: 'Landscape',
 				customRatio: 'Landscape,5,4',
+			};
+		} else if (
+			this.compareAspectRatio(squareImageCriteria, criteria)
+		) {
+			return {
+				cropType: 'Square',
+				customRatio: 'Square',
 			};
 		} else {
 			return {

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -633,7 +633,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 		}
 
 		// assumes the only criteria that will be passed as props the defined
-		// constants for portrait(4:5), landscape (5:3), landscape (5:4) or square
+		// constants for portrait(4:5), landscape (5:3), landscape (5:4) or square (1:1)
 		if (this.compareAspectRatio(portraitCardImageCriteria, criteria)) {
 			return {
 				cropType: 'portrait',
@@ -648,7 +648,6 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 		} else if (this.compareAspectRatio(squareImageCriteria, criteria)) {
 			return {
 				cropType: 'square',
-				customRatio: 'Square',
 			};
 		} else {
 			return {

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -644,7 +644,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 			};
 		} else if (this.compareAspectRatio(squareImageCriteria, criteria)) {
 			return {
-				cropType: 'Square',
+				cropType: 'square',
 				customRatio: 'Square',
 			};
 		} else {

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -389,6 +389,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 							small={small}
 							portrait={portraitImage}
 							shouldShowLandscape54={shouldShowLandscape54}
+							showSquare={showSquare}
 						>
 							{hasImage ? (
 								<>

--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -46,6 +46,10 @@ export const COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS: string[] = [
 	'static/medium/4',
 ];
 
+export const COLLECTIONS_USING_SQUARE_TRAILS: string[] = [
+	'scrollable/highlights',
+];
+
 export const defaultCardTrailImageCriteria = landScapeCardImageCriteria;
 
 export const editionsCardImageCriteria = {

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -155,8 +155,8 @@ const thumbnailImage = {
 };
 
 const thumbnailImageSquare = {
-	width: '50px',
-	height: '50px',
+	width: '80px',
+	height: '80px',
 };
 
 export const theme = {


### PR DESCRIPTION
## What's changed?

Images in the highlights container are expected to use an aspect ratio of 1:1 (i.e. square). We've previously switched to [5:4 aspect ratios](https://github.com/guardian/facia-tool/pull/1601) for the appropriate collections and here are making similar changes for the highlights container to use 1:1.

So similarly to that previous PR...

- the `InputImage` component should open the Grid view with a 1:1 square crop when users replace the trail image
- The `ThumbnailSmall` component should use a 1:1 image crop
- The trail image preview in the `ArticleMetaForm` should use a 1:1 image (the width/height and alignment have been slightly adjusted as otherwise the image ends up taking too much space)
- Various components (`Card`, `ArticleCard`, etc.) have been updated to pass on the image criteria.

The only function I've not been able to test is `Recrop image` which - for me - consistently returns "image not found" regardless of the container type, but I'm assuming that's environment related and the functionality should work as intended. 



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
