### PR TITLE
[Fairground] Display image as 4:5 in relevant collections

### DIFF
--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -210,11 +210,10 @@ const articleBodyDefault = React.memo(
 			imageCriteria.heightAspectRatio === squareImageCriteria.heightAspectRatio;
 		const showPortraitThumbnail =
 			imageCriteria &&
-				imageCriteria.widthAspectRatio ===
-					portraitCardImageCriteria.widthAspectRatio &&
-				imageCriteria.heightAspectRatio ===
-				portraitCardImageCriteria.heightAspectRatio
-
+			imageCriteria.widthAspectRatio ===
+				portraitCardImageCriteria.widthAspectRatio &&
+			imageCriteria.heightAspectRatio ===
+				portraitCardImageCriteria.heightAspectRatio;
 
 		return (
 			<>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -38,6 +38,7 @@ import { getMaybeDimensionsFromWidthAndHeight } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
 import {
 	landscape5To4CardImageCriteria,
+	portraitCardImageCriteria,
 	squareImageCriteria,
 } from 'constants/image';
 
@@ -197,14 +198,6 @@ const articleBodyDefault = React.memo(
 		const now = Date.now();
 		const paths = urlPath ? getPaths(urlPath) : undefined;
 
-		const thumbnailDims = getMaybeDimensionsFromWidthAndHeight(
-			imageSrcWidth,
-			imageSrcHeight,
-		);
-		const thumbnailIsPortrait =
-			!!imageReplace &&
-			thumbnailDims &&
-			thumbnailDims.height > thumbnailDims.width;
 		const showThumbnailInLandscape54 =
 			imageCriteria &&
 			imageCriteria.widthAspectRatio ===
@@ -215,6 +208,13 @@ const articleBodyDefault = React.memo(
 			imageCriteria &&
 			imageCriteria.widthAspectRatio === squareImageCriteria.widthAspectRatio &&
 			imageCriteria.heightAspectRatio === squareImageCriteria.heightAspectRatio;
+		const showPortraitThumbnail =
+			imageCriteria &&
+				imageCriteria.widthAspectRatio ===
+					portraitCardImageCriteria.widthAspectRatio &&
+				imageCriteria.heightAspectRatio ===
+				portraitCardImageCriteria.heightAspectRatio
+
 
 		return (
 			<>
@@ -331,7 +331,7 @@ const articleBodyDefault = React.memo(
 									imageHide={imageHide}
 									url={thumbnail}
 									isDraggingImageOver={isDraggingImageOver}
-									isPortrait={thumbnailIsPortrait}
+									showPortrait={showPortraitThumbnail}
 									showLandscape54={showThumbnailInLandscape54}
 									showSquareThumbnail={showSquareThumbnail}
 								>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -34,7 +34,6 @@ import EditModeVisibility from 'components/util/EditModeVisibility';
 import PageViewDataWrapper from '../../PageViewDataWrapper';
 import ImageAndGraphWrapper from 'components/image/ImageAndGraphWrapper';
 import { getPaths } from 'util/paths';
-import { getMaybeDimensionsFromWidthAndHeight } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
 import {
 	landscape5To4CardImageCriteria,

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -32,6 +32,8 @@ const normalLandscapeStyle = `
   width: 100%;
   maxWidth: 180px;
   height: 115px;
+  border-color: red;
+  border-solid: 1px;
 `;
 
 const smallLandscape54Style = `

--- a/fronts-client/src/components/image/ImageInputImageContainer.tsx
+++ b/fronts-client/src/components/image/ImageInputImageContainer.tsx
@@ -16,7 +16,7 @@ const smallPortaitStyle = `
 const normalPortraitStyle = `
   width: ${NORMAL_PORTRAIT_WIDTH}px;
   height: ${Math.floor(
-		NORMAL_PORTRAIT_WIDTH * PORTRAIT_RATIO + TEXTINPUT_HEIGHT,
+		NORMAL_PORTRAIT_WIDTH * PORTRAIT_RATIO + TEXTINPUT_HEIGHT + 10,
 	)}px;
   `;
 
@@ -32,8 +32,6 @@ const normalLandscapeStyle = `
   width: 100%;
   maxWidth: 180px;
   height: 115px;
-  border-color: red;
-  border-solid: 1px;
 `;
 
 const smallLandscape54Style = `
@@ -54,20 +52,20 @@ const squareStyle = `
   `;
 
 const getVariableImageContainerStyle = ({
-	portrait = false,
+	shouldShowPortrait = false,
 	small = false,
 	shouldShowLandscape54: shouldShowLandscape54 = false,
 	showSquare = false,
 }: {
 	small?: boolean;
-	portrait?: boolean;
+	shouldShowPortrait?: boolean;
 	shouldShowLandscape54?: boolean;
 	showSquare?: boolean;
 }) => {
 	switch (true) {
 		case showSquare:
 			return squareStyle;
-		case portrait:
+		case shouldShowPortrait:
 			return small ? smallPortaitStyle : normalPortraitStyle;
 		case shouldShowLandscape54:
 			return small ? smallLandscape54Style : normalLandscape54Style;
@@ -81,7 +79,7 @@ const getVariableImageContainerStyle = ({
 // the image container
 export const ImageInputImageContainer = styled.div<{
 	small?: boolean;
-	portrait?: boolean;
+	shouldShowPortrait?: boolean;
 	shouldShowLandscape54?: boolean;
 	showSquare?: boolean;
 }>`

--- a/fronts-client/src/components/image/Thumbnail.tsx
+++ b/fronts-client/src/components/image/Thumbnail.tsx
@@ -9,7 +9,7 @@ const ThumbnailSmall = styled(ThumbnailBase)<{
 	url?: string | void;
 	isDraggingImageOver?: boolean;
 	imageHide?: boolean;
-	isPortrait?: boolean;
+	showPortrait?: boolean;
 	showLandscape54?: boolean;
 	showSquareThumbnail?: boolean;
 }>`
@@ -22,12 +22,13 @@ const ThumbnailSmall = styled(ThumbnailBase)<{
 	opacity: ${({ imageHide }) => (imageHide && imageHide ? '0.5' : '1')};
 	background-image: ${({ url }) => `url('${url}')`};
 
-	${({ isPortrait }) =>
-		isPortrait &&
-		`
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position-x: center;
+	${({ showPortrait }) =>
+		showPortrait &&
+		`aspect-ratio: 4/5;
+		background-position-x: center;
+		width: ${theme.thumbnailImagePortrait.width};
+		min-width: ${theme.thumbnailImagePortrait.width};
+		height: ${theme.thumbnailImagePortrait.height}
   `}
 	${({ showLandscape54 }) =>
 		showLandscape54

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -63,6 +63,7 @@ const ImageComponent = styled.div<{
 	portrait: boolean;
 	shouldShowLandscape54: boolean;
 	showSquare: boolean;
+	shouldShowPortrait: boolean;
 }>`
 	${({ small }) =>
 		small
@@ -96,6 +97,12 @@ const ImageComponent = styled.div<{
 	width: 95%;
 	height: 95%;
 	align-self: center;`}
+	${({ shouldShowPortrait }) =>
+		shouldShowPortrait &&
+		`aspect-ratio: 4/5;
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: center;`}
   flex-grow: 1;
 	cursor: grab;
 `;
@@ -349,6 +356,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 			imageDims &&
 			imageDims.height > imageDims.width
 		);
+		const shouldShowPortrait =
+			criteria != null &&
+			this.compareAspectRatio(portraitCardImageCriteria, criteria);
 		const shouldShowLandscape54 =
 			criteria != null &&
 			this.compareAspectRatio(landscape5To4CardImageCriteria, criteria);
@@ -381,6 +391,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 						portrait={portraitImage}
 						shouldShowLandscape54={shouldShowLandscape54}
 						showSquare={showSquare}
+
 					>
 						<ImageComponent
 							style={{
@@ -393,6 +404,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 							portrait={portraitImage}
 							shouldShowLandscape54={shouldShowLandscape54}
 							showSquare={showSquare}
+							shouldShowPortrait={shouldShowPortrait}
 						>
 							{hasImage ? (
 								<>

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -388,10 +388,9 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 				>
 					<ImageContainer
 						small={small}
-						portrait={portraitImage}
+						shouldShowPortrait={shouldShowPortrait}
 						shouldShowLandscape54={shouldShowLandscape54}
 						showSquare={showSquare}
-
 					>
 						<ImageComponent
 							style={{

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -178,7 +178,7 @@ export const theme = {
 	collection,
 	thumbnailImage,
 	thumbnailImageSquare,
-	thumbnailImagePortrait
+	thumbnailImagePortrait,
 };
 
 export type Theme = typeof theme;

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -159,6 +159,11 @@ const thumbnailImageSquare = {
 	height: '80px',
 };
 
+const thumbnailImagePortrait = {
+	width: '68px',
+	height: '85px',
+};
+
 export const theme = {
 	base,
 	front,
@@ -173,6 +178,7 @@ export const theme = {
 	collection,
 	thumbnailImage,
 	thumbnailImageSquare,
+	thumbnailImagePortrait
 };
 
 export type Theme = typeof theme;


### PR DESCRIPTION
## What's changed?

Part of [this ticket](https://trello.com/c/aky2eS03/651-feature-card-display-53-or-54-trail-image-as-a-45-in-the-fronts-tool). Displays trail and thumbnail images with a 4:5 aspect ratio for relevant collections. 

## Implementation note

This was made using the same pattern previously implemented for square/landscape54 images being displayed. We're at the point of having the same logic effectively being repeated three times, so it's an opportunity for a refactor, which I've started putting together, but thought that change was best left for a separate PR.  

## Screenshots
These examples contrast a scrollable feature collection, which uses 4:5 images, and a scrollable small, which uses landscape 5:4. The image getting displayed is the one automatically selected when adding the story to the collection (so no manual replacing/cropping of the image). 

Thumbnail:

<img width="747" alt="image" src="https://github.com/user-attachments/assets/f1db2493-fd57-4ff9-b743-8149cacd6971" />


Trail image: 

<img width="1407" alt="image" src="https://github.com/user-attachments/assets/33e785e5-26cd-4769-b55a-2b3199dd7db1" />





### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
