### PR TITLE
Enable limiting the number of stories in flexible general containers

### DIFF
--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -22,7 +22,7 @@ class StoriesVisibleController(
   def storiesVisible(containerType: String) =
     AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
       val storiesVisible =
-        containerService.getStoriesVisible(containerType, request.body.stories)
+        containerService.getStoriesVisible(containerType, request.body.stories, collectionConfigJson = null)
 
       logger.info(
         s"got stories-visible=$storiesVisible for containerType=$containerType"

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -25,7 +25,7 @@ class StoriesVisibleController(
         containerService.getStoriesVisible(
           containerType,
           request.body.stories,
-          collectionConfigJson = null
+          collectionConfigJson = None
         )
 
       logger.info(

--- a/app/controllers/StoriesVisibleController.scala
+++ b/app/controllers/StoriesVisibleController.scala
@@ -22,7 +22,11 @@ class StoriesVisibleController(
   def storiesVisible(containerType: String) =
     AccessAPIAuthAction(parse.json[StoriesVisibleRequest]) { implicit request =>
       val storiesVisible =
-        containerService.getStoriesVisible(containerType, request.body.stories, collectionConfigJson = null)
+        containerService.getStoriesVisible(
+          containerType,
+          request.body.stories,
+          collectionConfigJson = null
+        )
 
       logger.info(
         s"got stories-visible=$storiesVisible for containerType=$containerType"

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -101,15 +101,15 @@ object CollectionService {
       CollectionService.getStoriesForCollectionStages(collectionId, collection)
     config.collections.get(collectionId).flatMap(_.`type`) match {
       case Some(cType) =>
-        val cConfigJson = config.collections(collectionId)
+        val cConfigJson = config.collections.get(collectionId)
         Some(
           StoriesVisibleByStage(
             containerService
-              .getStoriesVisible(cType, stages._1, Some(cConfigJson)),
+              .getStoriesVisible(cType, stages._1, cConfigJson),
             containerService.getStoriesVisible(
               cType,
               stages._2,
-              Some(cConfigJson)
+              cConfigJson
             )
           )
         )

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -97,14 +97,15 @@ object CollectionService {
       config: ConfigJson,
       containerService: ContainerService
   ): Option[StoriesVisibleByStage] = {
+		val cConfigJson = config.collections.get(collectionId).get
     val stages =
       CollectionService.getStoriesForCollectionStages(collectionId, collection)
     config.collections.get(collectionId).flatMap(_.`type`) match {
       case Some(cType) =>
         Some(
           StoriesVisibleByStage(
-            containerService.getStoriesVisible(cType, stages._1),
-            containerService.getStoriesVisible(cType, stages._2)
+            containerService.getStoriesVisible(cType, stages._1, cConfigJson),
+            containerService.getStoriesVisible(cType, stages._2, cConfigJson)
           )
         )
       case None => None

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -97,7 +97,7 @@ object CollectionService {
       config: ConfigJson,
       containerService: ContainerService
   ): Option[StoriesVisibleByStage] = {
-		val cConfigJson = config.collections.get(collectionId).get
+    val cConfigJson = config.collections.get(collectionId).get
     val stages =
       CollectionService.getStoriesForCollectionStages(collectionId, collection)
     config.collections.get(collectionId).flatMap(_.`type`) match {

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -97,15 +97,20 @@ object CollectionService {
       config: ConfigJson,
       containerService: ContainerService
   ): Option[StoriesVisibleByStage] = {
-    val cConfigJson = config.collections.get(collectionId).get
     val stages =
       CollectionService.getStoriesForCollectionStages(collectionId, collection)
     config.collections.get(collectionId).flatMap(_.`type`) match {
       case Some(cType) =>
+        val cConfigJson = config.collections(collectionId)
         Some(
           StoriesVisibleByStage(
-            containerService.getStoriesVisible(cType, stages._1, cConfigJson),
-            containerService.getStoriesVisible(cType, stages._2, cConfigJson)
+            containerService
+              .getStoriesVisible(cType, stages._1, Some(cConfigJson)),
+            containerService.getStoriesVisible(
+              cType,
+              stages._2,
+              Some(cConfigJson)
+            )
           )
         )
       case None => None

--- a/app/services/CollectionService.scala
+++ b/app/services/CollectionService.scala
@@ -99,21 +99,19 @@ object CollectionService {
   ): Option[StoriesVisibleByStage] = {
     val stages =
       CollectionService.getStoriesForCollectionStages(collectionId, collection)
-    config.collections.get(collectionId).flatMap(_.`type`) match {
-      case Some(cType) =>
-        val cConfigJson = config.collections.get(collectionId)
-        Some(
-          StoriesVisibleByStage(
-            containerService
-              .getStoriesVisible(cType, stages._1, cConfigJson),
-            containerService.getStoriesVisible(
-              cType,
-              stages._2,
-              cConfigJson
-            )
-          )
+    for {
+      cConfigJson <- config.collections.get(collectionId)
+      cType <- cConfigJson.`type`
+    } yield {
+      StoriesVisibleByStage(
+        containerService
+          .getStoriesVisible(cType, stages._1, Some(cConfigJson)),
+        containerService.getStoriesVisible(
+          cType,
+          stages._2,
+          Some(cConfigJson)
         )
-      case None => None
+      )
     }
   }
 

--- a/app/services/ContainerService.scala
+++ b/app/services/ContainerService.scala
@@ -18,7 +18,7 @@ class ContainerService(val containers: Containers) {
   def getStoriesVisible(
       containerType: String,
       stories: Seq[Story],
-      collectionConfigJson: CollectionConfigJson
+      collectionConfigJson: Option[CollectionConfigJson]
   ) = {
     val numberOfStories = stories.length
     containers.all.get(containerType) map {
@@ -55,7 +55,7 @@ class ContainerService(val containers: Containers) {
       case Flexible(container) =>
         val numberVisible = container.storiesVisible(
           stories,
-          collectionConfigJson: CollectionConfigJson
+          collectionConfigJson
         )
         StoriesVisibleResponse(
           Some(numberVisible),

--- a/app/services/ContainerService.scala
+++ b/app/services/ContainerService.scala
@@ -2,6 +2,7 @@ package services
 
 import play.api.libs.json.{Json, OFormat}
 import slices._
+import com.gu.facia.client.models.CollectionConfigJson
 
 case class StoriesVisibleResponse(
     desktop: Option[Int],
@@ -14,7 +15,7 @@ object StoriesVisibleResponse {
 }
 
 class ContainerService(val containers: Containers) {
-  def getStoriesVisible(containerType: String, stories: Seq[Story]) = {
+  def getStoriesVisible(containerType: String, stories: Seq[Story], collectionConfigJson: CollectionConfigJson) = {
     val numberOfStories = stories.length
     containers.all.get(containerType) map {
       case Fixed(container) =>
@@ -48,7 +49,7 @@ class ContainerService(val containers: Containers) {
         )
 
       case Flexible(container) =>
-        val numberVisible = container.storiesVisible(stories)
+        val numberVisible = container.storiesVisible(stories, collectionConfigJson: CollectionConfigJson)
         StoriesVisibleResponse(
           Some(numberVisible),
           Some(numberVisible)

--- a/app/services/ContainerService.scala
+++ b/app/services/ContainerService.scala
@@ -15,7 +15,11 @@ object StoriesVisibleResponse {
 }
 
 class ContainerService(val containers: Containers) {
-  def getStoriesVisible(containerType: String, stories: Seq[Story], collectionConfigJson: CollectionConfigJson) = {
+  def getStoriesVisible(
+      containerType: String,
+      stories: Seq[Story],
+      collectionConfigJson: CollectionConfigJson
+  ) = {
     val numberOfStories = stories.length
     containers.all.get(containerType) map {
       case Fixed(container) =>
@@ -49,7 +53,10 @@ class ContainerService(val containers: Containers) {
         )
 
       case Flexible(container) =>
-        val numberVisible = container.storiesVisible(stories, collectionConfigJson: CollectionConfigJson)
+        val numberVisible = container.storiesVisible(
+          stories,
+          collectionConfigJson: CollectionConfigJson
+        )
         StoriesVisibleResponse(
           Some(numberVisible),
           Some(numberVisible)

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -18,18 +18,16 @@ object FlexibleGeneral extends FlexibleContainer {
       byGroup.getOrElse(2, Seq.empty) ++
       byGroup.getOrElse(1, Seq.empty)
     val numOfSplash = splash.size min 1
-    val numOfStandard = stories.size - numOfSplash
-    val defaultStandardStoryLimit = 8
-
-    val standardStoryLimit = collectionConfigJson match {
-      case Some(config) =>
-        config.displayHints
-          .flatMap(_.maxItemsToDisplay)
-          .getOrElse(defaultStandardStoryLimit)
-      case None => defaultStandardStoryLimit
-    }
-
-    numOfSplash + (numOfStandard min standardStoryLimit)
+		val defaultStoryLimit = 9
+		val standardStoryLimit = collectionConfigJson match {
+			case Some(config) =>
+				config.displayHints
+					.flatMap(_.maxItemsToDisplay)
+					.getOrElse(defaultStoryLimit)
+			case None => defaultStoryLimit
+		}
+		val numOfStandard = standardStoryLimit - numOfSplash
+    numOfSplash + numOfStandard
   }
 }
 

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -13,18 +13,12 @@ object FlexibleGeneral extends FlexibleContainer {
       stories: Seq[Story],
       collectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
-    val byGroup = Story.segmentByGroup(stories)
-    val splash = byGroup.getOrElse(3, Seq.empty) ++
-      byGroup.getOrElse(2, Seq.empty) ++
-      byGroup.getOrElse(1, Seq.empty)
-    val numOfSplash = splash.size min 1
     val defaultStoryLimit = 9
     val standardStoryLimit = collectionConfigJson
       .flatMap(_.displayHints)
       .flatMap(_.maxItemsToDisplay)
       .getOrElse(defaultStoryLimit)
-    val numOfStandard = standardStoryLimit - numOfSplash
-    numOfSplash + numOfStandard
+    standardStoryLimit
   }
 }
 

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -18,15 +18,15 @@ object FlexibleGeneral extends FlexibleContainer {
       byGroup.getOrElse(2, Seq.empty) ++
       byGroup.getOrElse(1, Seq.empty)
     val numOfSplash = splash.size min 1
-		val defaultStoryLimit = 9
-		val standardStoryLimit = collectionConfigJson match {
-			case Some(config) =>
-				config.displayHints
-					.flatMap(_.maxItemsToDisplay)
-					.getOrElse(defaultStoryLimit)
-			case None => defaultStoryLimit
-		}
-		val numOfStandard = standardStoryLimit - numOfSplash
+    val defaultStoryLimit = 9
+    val standardStoryLimit = collectionConfigJson match {
+      case Some(config) =>
+        config.displayHints
+          .flatMap(_.maxItemsToDisplay)
+          .getOrElse(defaultStoryLimit)
+      case None => defaultStoryLimit
+    }
+    val numOfStandard = standardStoryLimit - numOfSplash
     numOfSplash + numOfStandard
   }
 }

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -19,13 +19,10 @@ object FlexibleGeneral extends FlexibleContainer {
       byGroup.getOrElse(1, Seq.empty)
     val numOfSplash = splash.size min 1
     val defaultStoryLimit = 9
-    val standardStoryLimit = collectionConfigJson match {
-      case Some(config) =>
-        config.displayHints
-          .flatMap(_.maxItemsToDisplay)
-          .getOrElse(defaultStoryLimit)
-      case None => defaultStoryLimit
-    }
+    val standardStoryLimit = collectionConfigJson
+      .flatMap(_.displayHints)
+      .flatMap(_.maxItemsToDisplay)
+      .getOrElse(defaultStoryLimit)
     val numOfStandard = standardStoryLimit - numOfSplash
     numOfSplash + numOfStandard
   }

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -2,18 +2,24 @@ package slices
 import com.gu.facia.client.models.CollectionConfigJson
 
 trait FlexibleContainer {
-  def storiesVisible(stories: Seq[Story], collectionConfigJson: CollectionConfigJson): Int
+  def storiesVisible(
+      stories: Seq[Story],
+      collectionConfigJson: CollectionConfigJson
+  ): Int
 }
 
 object FlexibleGeneral extends FlexibleContainer {
-  def storiesVisible(stories: Seq[Story], collectionConfigJson: CollectionConfigJson): Int = {
+  def storiesVisible(
+      stories: Seq[Story],
+      collectionConfigJson: CollectionConfigJson
+  ): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val splash = byGroup.getOrElse(3, Seq.empty) ++
       byGroup.getOrElse(2, Seq.empty) ++
       byGroup.getOrElse(1, Seq.empty)
     val numOfSplash = splash.size min 1
     val numOfStandard = stories.size - numOfSplash
-  	val defaultStandardStoryLimit = 8
+    val defaultStandardStoryLimit = 8
 
     val standardStoryLimit = collectionConfigJson.displayHints
       .flatMap(_.maxItemsToDisplay)
@@ -24,7 +30,10 @@ object FlexibleGeneral extends FlexibleContainer {
 }
 
 object FlexibleSpecial extends FlexibleContainer {
-  def storiesVisible(stories: Seq[Story], collectionConfigJson: CollectionConfigJson): Int = {
+  def storiesVisible(
+      stories: Seq[Story],
+      collectionConfigJson: CollectionConfigJson
+  ): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val snap = byGroup.getOrElse(3, Seq.empty) ++
       byGroup.getOrElse(2, Seq.empty) ++

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -4,14 +4,14 @@ import com.gu.facia.client.models.CollectionConfigJson
 trait FlexibleContainer {
   def storiesVisible(
       stories: Seq[Story],
-      collectionConfigJson: CollectionConfigJson
+      collectionConfigJson: Option[CollectionConfigJson]
   ): Int
 }
 
 object FlexibleGeneral extends FlexibleContainer {
   def storiesVisible(
       stories: Seq[Story],
-      collectionConfigJson: CollectionConfigJson
+      collectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val splash = byGroup.getOrElse(3, Seq.empty) ++
@@ -21,9 +21,13 @@ object FlexibleGeneral extends FlexibleContainer {
     val numOfStandard = stories.size - numOfSplash
     val defaultStandardStoryLimit = 8
 
-    val standardStoryLimit = collectionConfigJson.displayHints
-      .flatMap(_.maxItemsToDisplay)
-      .getOrElse(defaultStandardStoryLimit)
+    val standardStoryLimit = collectionConfigJson match {
+      case Some(config) =>
+        config.displayHints
+          .flatMap(_.maxItemsToDisplay)
+          .getOrElse(defaultStandardStoryLimit)
+      case None => defaultStandardStoryLimit
+    }
 
     numOfSplash + (numOfStandard min standardStoryLimit)
   }
@@ -32,7 +36,7 @@ object FlexibleGeneral extends FlexibleContainer {
 object FlexibleSpecial extends FlexibleContainer {
   def storiesVisible(
       stories: Seq[Story],
-      collectionConfigJson: CollectionConfigJson
+      collectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val snap = byGroup.getOrElse(3, Seq.empty) ++

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -1,24 +1,30 @@
 package slices
+import com.gu.facia.client.models.CollectionConfigJson
 
 trait FlexibleContainer {
-  def storiesVisible(stories: Seq[Story]): Int
+  def storiesVisible(stories: Seq[Story], collectionConfigJson: CollectionConfigJson): Int
 }
 
 object FlexibleGeneral extends FlexibleContainer {
-  def storiesVisible(stories: Seq[Story]): Int = {
+  def storiesVisible(stories: Seq[Story], collectionConfigJson: CollectionConfigJson): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val splash = byGroup.getOrElse(3, Seq.empty) ++
       byGroup.getOrElse(2, Seq.empty) ++
       byGroup.getOrElse(1, Seq.empty)
     val numOfSplash = splash.size min 1
     val numOfStandard = stories.size - numOfSplash
+  	val defaultStandardStoryLimit = 8
 
-    numOfSplash + (numOfStandard min 8)
+    val standardStoryLimit = collectionConfigJson.displayHints
+      .flatMap(_.maxItemsToDisplay)
+      .getOrElse(defaultStandardStoryLimit)
+
+    numOfSplash + (numOfStandard min standardStoryLimit)
   }
 }
 
 object FlexibleSpecial extends FlexibleContainer {
-  def storiesVisible(stories: Seq[Story]): Int = {
+  def storiesVisible(stories: Seq[Story], collectionConfigJson: CollectionConfigJson): Int = {
     val byGroup = Story.segmentByGroup(stories)
     val snap = byGroup.getOrElse(3, Seq.empty) ++
       byGroup.getOrElse(2, Seq.empty) ++

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -13,12 +13,10 @@ object FlexibleGeneral extends FlexibleContainer {
       stories: Seq[Story],
       collectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
-    val defaultStoryLimit = 9
-    val standardStoryLimit = collectionConfigJson
+    collectionConfigJson
       .flatMap(_.displayHints)
       .flatMap(_.maxItemsToDisplay)
-      .getOrElse(defaultStoryLimit)
-    standardStoryLimit
+      .getOrElse(9)
   }
 }
 

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -258,6 +258,12 @@
                 <label>Groups</label>
                 <span class="cnf-form__value" data-bind="text: meta.groups"></span>
             <!-- /ko -->
+
+			<!-- ko if: meta.type() === "flexible/general"-->
+			<label for="flexGenStoryLimit">flexGenStoryAmount</label>
+			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" placeholder="6">
+			<!-- /ko -->
+
             <label for="userVisibility">User visibility</label>
             <select id="userVisibility" data-bind="
                 optionsCaption: 'Select user visibility',

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -261,7 +261,7 @@
 
 			<!-- ko if: meta.type() === "flexible/general"-->
 			<label for="flexGenStoryLimit">Max stories to display</label>
-			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 0 } max="20" min="0" placeholder="9">
+			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 1 } max="20" min="1" placeholder="9">
 			<!-- /ko -->
 
             <label for="userVisibility">User visibility</label>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -260,8 +260,8 @@
             <!-- /ko -->
 
 			<!-- ko if: meta.type() === "flexible/general"-->
-			<label for="flexGenStoryLimit">flexGenStoryAmount</label>
-			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" placeholder="6">
+			<label for="flexGenStoryLimit">Max standard stories to display</label>
+			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" placeholder="8">
 			<!-- /ko -->
 
             <label for="userVisibility">User visibility</label>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -261,7 +261,7 @@
 
 			<!-- ko if: meta.type() === "flexible/general"-->
 			<label for="flexGenStoryLimit">Max standard stories to display</label>
-			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" placeholder="8">
+			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 1 } max="20" min="1" placeholder="8">
 			<!-- /ko -->
 
             <label for="userVisibility">User visibility</label>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -260,8 +260,8 @@
             <!-- /ko -->
 
 			<!-- ko if: meta.type() === "flexible/general"-->
-			<label for="flexGenStoryLimit">Max standard stories to display</label>
-			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 0 } max="20" min="0" placeholder="8">
+			<label for="flexGenStoryLimit">Max stories to display</label>
+			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 0 } max="20" min="0" placeholder="9">
 			<!-- /ko -->
 
             <label for="userVisibility">User visibility</label>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -261,7 +261,7 @@
 
 			<!-- ko if: meta.type() === "flexible/general"-->
 			<label for="flexGenStoryLimit">Max standard stories to display</label>
-			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 1 } max="20" min="1" placeholder="8">
+			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 0 } max="20" min="0" placeholder="8">
 			<!-- /ko -->
 
             <label for="userVisibility">User visibility</label>


### PR DESCRIPTION
## What's changed?

Part of this [fairground ticket](https://trello.com/c/ACnDaVW8/697-flexible-general-tooling-set-story-limit-in-config-tool)

This allows editorial to set the number of stories in a flexible general container, by making use of an existing value, `maxItemsToDisplay`, nested in the `DisplayHints` section of a collection's config. 

The input has a placeholder of 9, which will also be a default/fallback number used throughout the codebases, to replicate existing behaviour. At the most there can be up to 20 stories, at the least there can be a single one.

Aside from adding the input, this PR uses the value to adjust the dividing line separation in the fronts tool (see screenshot); this is currently used by editorial as an indicator of which stories will appear - those below the line are effectively queued up, and so not intended to be displayed. 

As the amount of stories actually displayed on the platforms is determined in their respective codebases, follow up work is in process in frontend/mapi so they can also pick up on the desired value and ensure the right amount of stories gets displayed. 

## `maxItemsToDisplay` usage note

As mentioned this is an existing value, but it is currently only used for email fronts (which don't have access to flexible general containers), and has a similar intention to limit the number of visible stories. I would normally feel uneasy about piggybacking like this, but it feels like there's enough similarities while also having sufficient separation between the two use cases that this can be a working solution. 

This wasn't my first choice though, I intended to add a separate field (through this [facia scala client PR](https://github.com/guardian/facia-scala-client/pull/340/files)) but implementing this proved to be non trivial, hence this approach. 

## Fronts tool (v2) implementation note

The dividing lines are getting adjusted depending on the `maxItemsToDisplay` value, which for the most part seems to be working as intended, but the behaviour can be temperamental when manipulating splash cards (e.g. adding one or more, or moving a splash card to the list of standard stories, which seems to shift the dividing line up or down rather than keeping it at the desired number of stories). 

There's a separate ticket to limit the [number of splash cards to one story](https://trello.com/c/HAnWsQvN/353-flexible-general-restrict-splash-to-one-story), which feels best to tackle first and separately. I would expect the undesired behaviours to be resolved as part of that PR (or possibly a follow up). 

## Screenshots

Config tool:
<img width="653" alt="image" src="https://github.com/user-attachments/assets/deb8b75c-46cf-4def-8e44-958bb778a9cb" />

Fronts tool - showing the dividing line appearing below the 5th standard story (with 1 splash)
<img width="547" alt="image" src="https://github.com/user-attachments/assets/2f9128ae-813b-4ba6-9ab7-6b4868aff0ab" />

## How to test

In the config tool, on a front, create a new flexible general container. You should see the field appear with the placeholder 9, and if you save the container, the tool should display a dividing line at 9 standard stories (you may need to refresh the tool once or twice). If you then edit the field in the config tool to a lower value, the dividing line should go up to the relevant spot. 

If these [frontend](https://github.com/guardian/frontend/pull/27708) and [DCR](https://github.com/guardian/dotcom-rendering/pull/13135) PRs are also deployed to code, you can check that the value is getting correctly used and updated by the web platform. 



### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
