### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -1,10 +1,9 @@
 package controllers
 
 import java.util.Locale
-
 import com.gu.pandomainauth.action.{AuthActions, UserRequest}
 import com.gu.pandomainauth.model.AuthenticatedUser
-import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
+import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher, S3BucketLoader}
 import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import conf.ApplicationConfiguration
 import logging.Logging
@@ -30,12 +29,10 @@ abstract class BaseFaciaControllerComponents(context: Context)
   def config: ApplicationConfiguration
 
   lazy val panDomainSettings: PanDomainAuthSettingsRefresher =
-    new PanDomainAuthSettingsRefresher(
-      config.pandomain.domain,
-      config.pandomain.service,
-      config.pandomain.bucketName,
-      config.pandomain.settingsFileKey,
-      config.aws.s3Client
+    PanDomainAuthSettingsRefresher(
+      domain = config.pandomain.domain,
+      system = config.pandomain.service,
+			S3BucketLoader.forAwsSdkV1(config.aws.s3Client, "pan-domain-auth-settings")
     )
 
   lazy val permissions = PermissionsProvider(

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -3,7 +3,11 @@ package controllers
 import java.util.Locale
 import com.gu.pandomainauth.action.{AuthActions, UserRequest}
 import com.gu.pandomainauth.model.AuthenticatedUser
-import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher, S3BucketLoader}
+import com.gu.pandomainauth.{
+  PanDomain,
+  PanDomainAuthSettingsRefresher,
+  S3BucketLoader
+}
 import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import conf.ApplicationConfiguration
 import logging.Logging
@@ -32,7 +36,10 @@ abstract class BaseFaciaControllerComponents(context: Context)
     PanDomainAuthSettingsRefresher(
       domain = config.pandomain.domain,
       system = config.pandomain.service,
-			S3BucketLoader.forAwsSdkV1(config.aws.s3Client, "pan-domain-auth-settings")
+      S3BucketLoader.forAwsSdkV1(
+        config.aws.s3Client,
+        "pan-domain-auth-settings"
+      )
     )
 
   lazy val permissions = PermissionsProvider(

--- a/app/model/ClipboardCard.scala
+++ b/app/model/ClipboardCard.scala
@@ -23,7 +23,7 @@ object ClipboardCard {
       )
   }
 
-  implicit val format = Format(reads, writes)
+  implicit val format: Format[ClipboardCard] = Format(reads, writes)
 }
 
 case class ClipboardCard(card: Either[Trail, EditionsClientCard])

--- a/app/services/AwsEndpoints.scala
+++ b/app/services/AwsEndpoints.scala
@@ -1,16 +1,14 @@
 package services
 
-import com.amazonaws.regions.ServiceAbbreviations.{S3 => S3Endpoint, _}
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.s3.AmazonS3.{ENDPOINT_PREFIX => S3Endpoint}
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch.{ENDPOINT_PREFIX => CloudWatch}
+import com.amazonaws.regions.RegionUtils
 import conf.ApplicationConfiguration
 
 class AwsEndpoints(val config: ApplicationConfiguration) {
   private lazy val region =
-    Region.getRegion(Regions.fromName(config.aws.region))
+    RegionUtils.getRegion(config.aws.region)
 
-  lazy val sns: String = region.getServiceEndpoint(SNS)
-  lazy val elb: String = region.getServiceEndpoint(ElasticLoadbalancing)
   lazy val monitoring: String = region.getServiceEndpoint(CloudWatch)
-  lazy val dynamoDb: String = region.getServiceEndpoint(Dynamodb)
   lazy val s3: String = region.getServiceEndpoint(S3Endpoint)
 }

--- a/app/services/AwsEndpoints.scala
+++ b/app/services/AwsEndpoints.scala
@@ -1,7 +1,9 @@
 package services
 
 import com.amazonaws.services.s3.AmazonS3.{ENDPOINT_PREFIX => S3Endpoint}
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch.{ENDPOINT_PREFIX => CloudWatch}
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch.{
+  ENDPOINT_PREFIX => CloudWatch
+}
 import com.amazonaws.regions.RegionUtils
 import conf.ApplicationConfiguration
 

--- a/app/services/editions/publishing/FeastPublicationTarget.scala
+++ b/app/services/editions/publishing/FeastPublicationTarget.scala
@@ -67,7 +67,7 @@ class FeastPublicationTarget(
         )
       case EditionsFeastCollection(_, _, metadata) =>
         val recipes = metadata
-          .map(_.collectionItems.map { case EditionsRecipe(id, _) =>
+          .map(_.collectionItems.collect { case EditionsRecipe(id, _) =>
             id
           })
           .getOrElse(List.empty)

--- a/app/switchboard/Switchboard.scala
+++ b/app/switchboard/Switchboard.scala
@@ -23,7 +23,7 @@ class Lifecycle(conf: SwitchboardConfiguration, scheduler: Scheduler)
   scheduler.scheduleWithFixedDelay(0.seconds, 1.minute) { () =>
     refreshSwitches()
   }
-  scheduler.scheduleOnce(0.seconds) { () => refreshSwitches() }
+  scheduler.scheduleOnce(0.seconds)(refreshSwitches())
 
   def refreshSwitches(): Unit = {
     logger.info("Refreshing switches from switchboard")

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
   "com.gu" %% "fapi-client-play30" % "13.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "3.0.0",
-  "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),
   "com.github.blemale" %% "scaffeine" % "4.1.0" % "compile",
   "com.gu" %% "thrift-serializer" % "4.0.2",


### PR DESCRIPTION
This upgrades Panda from v4 to v7, allowing us to use [key rotation](https://github.com/guardian/pan-domain-authentication/pull/150).

Follows the guidance from https://github.com/guardian/pan-domain-authentication/issues/160 and based on https://github.com/guardian/atom-workshop/pull/361

## Testing
