### PR TITLE
Cap scrollable medium visible stories to 8

### DIFF
--- a/app/slices/ScrollableContainer.scala
+++ b/app/slices/ScrollableContainer.scala
@@ -18,7 +18,7 @@ object ScrollableSmall extends ScrollableContainer {
 
 object ScrollableMedium extends ScrollableContainer {
   def storiesVisible(stories: Seq[Story]): Int = {
-    stories.size min 6
+    stories.size min 8
   }
 }
 


### PR DESCRIPTION
## What's changed?

[Part of this F+C ticket](https://trello.com/c/fot1SQkO/873-qa-scrollable-medium-and-small-should-cap-at-8?filter=member:georgeslebreton4)

This just reflects in the tooling the desired cap of 8 stories on scrollable medium containers, denoted by the dividing lines. 

## Screenshot

You can just about see there's now 8 stories above the dividing lines in a scrollable medium container:

<img width="883" alt="image" src="https://github.com/user-attachments/assets/fb32172b-640f-406f-8450-3196e7a2fea5" />



### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
