### PR TITLE
Restrict splash to one story

### DIFF
--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -114,7 +114,6 @@ interface ConnectedCollectionContextProps extends CollectionContextProps {
 	handleBlur: () => void;
 	lastDesktopArticle?: string;
 	lastMobileArticle?: string;
-	groupIds: string[];
 	updateCardMeta: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
 }
@@ -137,7 +136,6 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			removeSupportingCard,
 			lastDesktopArticle,
 			lastMobileArticle,
-			groupIds,
 			updateCardMeta,
 			addImageToCard,
 		} = this.props;
@@ -153,7 +151,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 					canPublish={browsingStage !== 'live'}
 					browsingStage={browsingStage}
 				>
-					{(group, isUneditable, showGroupName) => (
+					{(group, isUneditable, groupIds, showGroupName) => (
 						<div key={group.uuid}>
 							<GroupDisplayComponent
 								key={group.uuid}
@@ -264,10 +262,7 @@ const createMapStateToProps = () => {
 			collectionSet: props.browsingStage,
 		});
 
-		const groupIds = state.collections.data[props.id]?.draft || [];
-
 		return {
-			groupIds: groupIds,
 			lastDesktopArticle: articleVisibilityDetails.desktop,
 			lastMobileArticle: articleVisibilityDetails.mobile,
 		};

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -114,7 +114,7 @@ interface ConnectedCollectionContextProps extends CollectionContextProps {
 	handleBlur: () => void;
 	lastDesktopArticle?: string;
 	lastMobileArticle?: string;
-	groupsIds: string[];
+	groupIds: string[];
 	updateCardMeta: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
 }
@@ -137,7 +137,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			removeSupportingCard,
 			lastDesktopArticle,
 			lastMobileArticle,
-			groupsIds,
+			groupIds,
 			updateCardMeta,
 			addImageToCard,
 		} = this.props;
@@ -163,7 +163,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								isUneditable={isUneditable}
 								groupId={group.uuid}
 								groupName={group.name ? group.name : ''}
-								groupsIds={groupsIds}
+								groupIds={groupIds}
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}
@@ -198,7 +198,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 													isUneditable={isUneditable}
 													cardId={card.uuid}
 													groupName={group.name ? group.name : ''}
-													groupsIds={groupsIds}
+													groupIds={groupIds}
 													onMove={handleMove}
 													onDrop={handleInsert}
 													cardTypeAllowList={this.getPermittedCardTypes(
@@ -264,10 +264,10 @@ const createMapStateToProps = () => {
 			collectionSet: props.browsingStage,
 		});
 
-		const groupsIds = state.collections.data[props.id]?.draft || [];
+		const groupIds = state.collections.data[props.id]?.draft || [];
 
 		return {
-			groupsIds: groupsIds,
+			groupIds: groupIds,
 			lastDesktopArticle: articleVisibilityDetails.desktop,
 			lastMobileArticle: articleVisibilityDetails.mobile,
 		};

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -164,6 +164,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								isUneditable={isUneditable}
 								groupId={group.uuid}
 								groupName={group.name ? group.name : ''}
+								//todo: numberOfCards can probably just be got by the card array
 								numberOfCardsInGroup={group.cards.length}
 								groupsIds={groupsIds}
 								onMove={handleMove}

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -163,8 +163,6 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								isUneditable={isUneditable}
 								groupId={group.uuid}
 								groupName={group.name ? group.name : ''}
-								//todo: numberOfCards can probably just be got by the card array
-								numberOfCardsInGroup={group.cards.length}
 								groupsIds={groupsIds}
 								onMove={handleMove}
 								onDrop={handleInsert}
@@ -200,7 +198,6 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 													isUneditable={isUneditable}
 													cardId={card.uuid}
 													groupName={group.name ? group.name : ''}
-													numberOfCardsInGroup={group.cards.length}
 													groupsIds={groupsIds}
 													onMove={handleMove}
 													onDrop={handleInsert}

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -160,6 +160,8 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 							<GroupLevel
 								isUneditable={isUneditable}
 								groupId={group.uuid}
+								groupName={group.name ? group.name : ''}
+								numberOfCardsInGroup={group.cards.length}
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}
@@ -180,6 +182,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 												collectionId={id}
 												uuid={card.uuid}
 												parentId={group.uuid}
+
 												isUneditable={isUneditable}
 												size={size}
 												canShowPageViewData={true}

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styled, Theme } from 'constants/theme';
 import Collection from './CollectionComponents/Collection';
-import { AlsoOnDetail, CardMeta } from 'types/Collection';
+import { AlsoOnDetail, CardMeta, Group } from 'types/Collection';
 import { CardSets, Card as TCard } from 'types/Collection';
 import GroupDisplayComponent from 'components/GroupDisplay';
 import GroupLevel from 'components/clipboard/GroupLevel';
@@ -19,6 +19,7 @@ import { CardTypes } from 'constants/cardTypes';
 import { updateCardMetaWithPersist as updateCardMetaAction } from 'actions/Cards';
 import { ValidationResponse } from '../../util/validateImageSrc';
 import { bindActionCreators } from 'redux';
+import groups from 'reducers/groupsReducer';
 
 const getArticleNotifications = (
 	id: string,
@@ -114,6 +115,7 @@ interface ConnectedCollectionContextProps extends CollectionContextProps {
 	handleBlur: () => void;
 	lastDesktopArticle?: string;
 	lastMobileArticle?: string;
+	groupsIds: string[];
 	updateCardMeta: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
 }
@@ -136,9 +138,12 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			removeSupportingCard,
 			lastDesktopArticle,
 			lastMobileArticle,
+			groupsIds,
 			updateCardMeta,
 			addImageToCard,
 		} = this.props;
+
+		console.log('CollectionContextProps', this.props.groupsIds);
 
 		return (
 			<CollectionWrapper data-testid="collection">
@@ -151,94 +156,103 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 					canPublish={browsingStage !== 'live'}
 					browsingStage={browsingStage}
 				>
-					{(group, isUneditable, showGroupName) => (
-						<div key={group.uuid}>
-							<GroupDisplayComponent
-								key={group.uuid}
-								groupName={showGroupName ? group.name : null}
-							/>
-							<GroupLevel
-								isUneditable={isUneditable}
-								groupId={group.uuid}
-								groupName={group.name ? group.name : ''}
-								numberOfCardsInGroup={group.cards.length}
-								onMove={handleMove}
-								onDrop={handleInsert}
-								cardIds={group.cards}
-							>
-								{(card, getAfNodeProps) => (
-									<>
-										<FocusWrapper
-											tabIndex={0}
-											area="collection"
-											onBlur={() => handleBlur()}
-											onFocus={(e: React.FocusEvent<HTMLDivElement>) =>
-												handleArticleFocus(e, group.uuid, card, frontId)
-											}
-											uuid={card.uuid}
-										>
-											<Card
-												frontId={frontId}
-												collectionId={id}
+					{(group, isUneditable, showGroupName) => {
+						console.log('CollectionContext group', group);
+						return (
+							<div key={group.uuid}>
+								<GroupDisplayComponent
+									key={group.uuid}
+									groupName={showGroupName ? group.name : null}
+								/>
+								<GroupLevel
+									isUneditable={isUneditable}
+									groupId={group.uuid}
+									groupName={group.name ? group.name : ''}
+									numberOfCardsInGroup={group.cards.length}
+									groupsIds={groupsIds}
+									onMove={handleMove}
+									onDrop={handleInsert}
+									cardIds={group.cards}
+								>
+									{(card, getAfNodeProps) => (
+										<>
+											<FocusWrapper
+												tabIndex={0}
+												area="collection"
+												onBlur={() => handleBlur()}
+												onFocus={(e: React.FocusEvent<HTMLDivElement>) =>
+													handleArticleFocus(e, group.uuid, card, frontId)
+												}
 												uuid={card.uuid}
-												parentId={group.uuid}
-
-												isUneditable={isUneditable}
-												size={size}
-												canShowPageViewData={true}
-												getNodeProps={() => getAfNodeProps(isUneditable)}
-												onSelect={() => selectCard(card.uuid, id, false)}
-												onDelete={() => removeCard(group.uuid, card.uuid)}
-												groupSizeId={group.id ? parseInt(group.id) : 0}
-												updateCardMeta={updateCardMeta}
-												addImageToCard={addImageToCard}
 											>
-												<CardLevel
+												<Card
+													frontId={frontId}
+													collectionId={id}
+													uuid={card.uuid}
+													parentId={group.uuid}
 													isUneditable={isUneditable}
-													cardId={card.uuid}
-													onMove={handleMove}
-													onDrop={handleInsert}
-													cardTypeAllowList={this.getPermittedCardTypes(
-														card.cardType,
-													)}
-													dropMessage={this.getDropMessage(card.cardType)}
+													size={size}
+													canShowPageViewData={true}
+													getNodeProps={() => getAfNodeProps(isUneditable)}
+													onSelect={() => selectCard(card.uuid, id, false)}
+													onDelete={() => removeCard(group.uuid, card.uuid)}
+													groupSizeId={group.id ? parseInt(group.id) : 0}
+													updateCardMeta={updateCardMeta}
+													addImageToCard={addImageToCard}
 												>
-													{(supporting, getSupportingProps) => (
-														<Card
-															frontId={frontId}
-															uuid={supporting.uuid}
-															parentId={card.uuid}
-															canShowPageViewData={false}
-															onSelect={() =>
-																selectCard(supporting.uuid, id, true)
-															}
-															isUneditable={isUneditable}
-															getNodeProps={() =>
-																getSupportingProps(isUneditable)
-															}
-															onDelete={() =>
-																removeSupportingCard(card.uuid, supporting.uuid)
-															}
-															size="small"
-															updateCardMeta={updateCardMeta}
-															addImageToCard={addImageToCard}
-														/>
-													)}
-												</CardLevel>
-											</Card>
-										</FocusWrapper>
-										<VisibilityDivider
-											notifications={getArticleNotifications(
-												card.uuid,
-												lastDesktopArticle,
-												lastMobileArticle,
-											)}
-										/>
-									</>
-								)}
-							</GroupLevel>
-						</div>
-					)}
+													<CardLevel
+														isUneditable={isUneditable}
+														cardId={card.uuid}
+														groupName={group.name ? group.name : ''}
+														numberOfCardsInGroup={group.cards.length}
+														groupsIds={groupsIds}
+														onMove={handleMove}
+														onDrop={handleInsert}
+														cardTypeAllowList={this.getPermittedCardTypes(
+															card.cardType,
+														)}
+														dropMessage={this.getDropMessage(card.cardType)}
+													>
+														{(supporting, getSupportingProps) => (
+															<Card
+																frontId={frontId}
+																uuid={supporting.uuid}
+																parentId={card.uuid}
+																canShowPageViewData={false}
+																onSelect={() =>
+																	selectCard(supporting.uuid, id, true)
+																}
+																isUneditable={isUneditable}
+																getNodeProps={() =>
+																	getSupportingProps(isUneditable)
+																}
+																onDelete={() =>
+																	removeSupportingCard(
+																		card.uuid,
+																		supporting.uuid,
+																	)
+																}
+																size="small"
+																updateCardMeta={updateCardMeta}
+																addImageToCard={addImageToCard}
+															/>
+														)}
+													</CardLevel>
+												</Card>
+											</FocusWrapper>
+											<VisibilityDivider
+												notifications={getArticleNotifications(
+													card.uuid,
+													lastDesktopArticle,
+													lastMobileArticle,
+												)}
+											/>
+										</>
+									)}
+								</GroupLevel>
+							</div>
+						);
+					}}
 				</Collection>
 			</CollectionWrapper>
 		);
@@ -260,8 +274,14 @@ const createMapStateToProps = () => {
 			collectionId: props.id,
 			collectionSet: props.browsingStage,
 		});
+		// console.log('state', state);
+		console.log('collections data', state.collections.data[props.id]);
+		console.log('collections data id', props.id);
 
+		const groupsIds = state.collections.data[props.id]?.draft || [];
+		console.log({ groupsIds });
 		return {
+			groupsIds: groupsIds,
 			lastDesktopArticle: articleVisibilityDetails.desktop,
 			lastMobileArticle: articleVisibilityDetails.mobile,
 		};

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -143,8 +143,6 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			addImageToCard,
 		} = this.props;
 
-		console.log('CollectionContextProps', this.props.groupsIds);
-
 		return (
 			<CollectionWrapper data-testid="collection">
 				<Collection
@@ -156,103 +154,97 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 					canPublish={browsingStage !== 'live'}
 					browsingStage={browsingStage}
 				>
-					{(group, isUneditable, showGroupName) => {
-						console.log('CollectionContext group', group);
-						return (
-							<div key={group.uuid}>
-								<GroupDisplayComponent
-									key={group.uuid}
-									groupName={showGroupName ? group.name : null}
-								/>
-								<GroupLevel
-									isUneditable={isUneditable}
-									groupId={group.uuid}
-									groupName={group.name ? group.name : ''}
-									numberOfCardsInGroup={group.cards.length}
-									groupsIds={groupsIds}
-									onMove={handleMove}
-									onDrop={handleInsert}
-									cardIds={group.cards}
-								>
-									{(card, getAfNodeProps) => (
-										<>
-											<FocusWrapper
-												tabIndex={0}
-												area="collection"
-												onBlur={() => handleBlur()}
-												onFocus={(e: React.FocusEvent<HTMLDivElement>) =>
-													handleArticleFocus(e, group.uuid, card, frontId)
-												}
+					{(group, isUneditable, showGroupName) => (
+						<div key={group.uuid}>
+							<GroupDisplayComponent
+								key={group.uuid}
+								groupName={showGroupName ? group.name : null}
+							/>
+							<GroupLevel
+								isUneditable={isUneditable}
+								groupId={group.uuid}
+								groupName={group.name ? group.name : ''}
+								numberOfCardsInGroup={group.cards.length}
+								groupsIds={groupsIds}
+								onMove={handleMove}
+								onDrop={handleInsert}
+								cardIds={group.cards}
+							>
+								{(card, getAfNodeProps) => (
+									<>
+										<FocusWrapper
+											tabIndex={0}
+											area="collection"
+											onBlur={() => handleBlur()}
+											onFocus={(e: React.FocusEvent<HTMLDivElement>) =>
+												handleArticleFocus(e, group.uuid, card, frontId)
+											}
+											uuid={card.uuid}
+										>
+											<Card
+												frontId={frontId}
+												collectionId={id}
 												uuid={card.uuid}
+												parentId={group.uuid}
+												isUneditable={isUneditable}
+												size={size}
+												canShowPageViewData={true}
+												getNodeProps={() => getAfNodeProps(isUneditable)}
+												onSelect={() => selectCard(card.uuid, id, false)}
+												onDelete={() => removeCard(group.uuid, card.uuid)}
+												groupSizeId={group.id ? parseInt(group.id) : 0}
+												updateCardMeta={updateCardMeta}
+												addImageToCard={addImageToCard}
 											>
-												<Card
-													frontId={frontId}
-													collectionId={id}
-													uuid={card.uuid}
-													parentId={group.uuid}
+												<CardLevel
 													isUneditable={isUneditable}
-													size={size}
-													canShowPageViewData={true}
-													getNodeProps={() => getAfNodeProps(isUneditable)}
-													onSelect={() => selectCard(card.uuid, id, false)}
-													onDelete={() => removeCard(group.uuid, card.uuid)}
-													groupSizeId={group.id ? parseInt(group.id) : 0}
-													updateCardMeta={updateCardMeta}
-													addImageToCard={addImageToCard}
+													cardId={card.uuid}
+													groupName={group.name ? group.name : ''}
+													numberOfCardsInGroup={group.cards.length}
+													groupsIds={groupsIds}
+													onMove={handleMove}
+													onDrop={handleInsert}
+													cardTypeAllowList={this.getPermittedCardTypes(
+														card.cardType,
+													)}
+													dropMessage={this.getDropMessage(card.cardType)}
 												>
-													<CardLevel
-														isUneditable={isUneditable}
-														cardId={card.uuid}
-														groupName={group.name ? group.name : ''}
-														numberOfCardsInGroup={group.cards.length}
-														groupsIds={groupsIds}
-														onMove={handleMove}
-														onDrop={handleInsert}
-														cardTypeAllowList={this.getPermittedCardTypes(
-															card.cardType,
-														)}
-														dropMessage={this.getDropMessage(card.cardType)}
-													>
-														{(supporting, getSupportingProps) => (
-															<Card
-																frontId={frontId}
-																uuid={supporting.uuid}
-																parentId={card.uuid}
-																canShowPageViewData={false}
-																onSelect={() =>
-																	selectCard(supporting.uuid, id, true)
-																}
-																isUneditable={isUneditable}
-																getNodeProps={() =>
-																	getSupportingProps(isUneditable)
-																}
-																onDelete={() =>
-																	removeSupportingCard(
-																		card.uuid,
-																		supporting.uuid,
-																	)
-																}
-																size="small"
-																updateCardMeta={updateCardMeta}
-																addImageToCard={addImageToCard}
-															/>
-														)}
-													</CardLevel>
-												</Card>
-											</FocusWrapper>
-											<VisibilityDivider
-												notifications={getArticleNotifications(
-													card.uuid,
-													lastDesktopArticle,
-													lastMobileArticle,
-												)}
-											/>
-										</>
-									)}
-								</GroupLevel>
-							</div>
-						);
-					}}
+													{(supporting, getSupportingProps) => (
+														<Card
+															frontId={frontId}
+															uuid={supporting.uuid}
+															parentId={card.uuid}
+															canShowPageViewData={false}
+															onSelect={() =>
+																selectCard(supporting.uuid, id, true)
+															}
+															isUneditable={isUneditable}
+															getNodeProps={() =>
+																getSupportingProps(isUneditable)
+															}
+															onDelete={() =>
+																removeSupportingCard(card.uuid, supporting.uuid)
+															}
+															size="small"
+															updateCardMeta={updateCardMeta}
+															addImageToCard={addImageToCard}
+														/>
+													)}
+												</CardLevel>
+											</Card>
+										</FocusWrapper>
+										<VisibilityDivider
+											notifications={getArticleNotifications(
+												card.uuid,
+												lastDesktopArticle,
+												lastMobileArticle,
+											)}
+										/>
+									</>
+								)}
+							</GroupLevel>
+						</div>
+					)}
 				</Collection>
 			</CollectionWrapper>
 		);
@@ -274,12 +266,9 @@ const createMapStateToProps = () => {
 			collectionId: props.id,
 			collectionSet: props.browsingStage,
 		});
-		// console.log('state', state);
-		console.log('collections data', state.collections.data[props.id]);
-		console.log('collections data id', props.id);
 
 		const groupsIds = state.collections.data[props.id]?.draft || [];
-		console.log({ groupsIds });
+
 		return {
 			groupsIds: groupsIds,
 			lastDesktopArticle: articleVisibilityDetails.desktop,

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styled, Theme } from 'constants/theme';
 import Collection from './CollectionComponents/Collection';
-import { AlsoOnDetail, CardMeta, Group } from 'types/Collection';
+import { AlsoOnDetail, CardMeta } from 'types/Collection';
 import { CardSets, Card as TCard } from 'types/Collection';
 import GroupDisplayComponent from 'components/GroupDisplay';
 import GroupLevel from 'components/clipboard/GroupLevel';
@@ -19,7 +19,6 @@ import { CardTypes } from 'constants/cardTypes';
 import { updateCardMetaWithPersist as updateCardMetaAction } from 'actions/Cards';
 import { ValidationResponse } from '../../util/validateImageSrc';
 import { bindActionCreators } from 'redux';
-import groups from 'reducers/groupsReducer';
 
 const getArticleNotifications = (
 	id: string,

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -51,6 +51,7 @@ interface CollectionPropsBeforeState {
 	children: (
 		group: Group,
 		isUneditable: boolean,
+		groupIds: string[],
 		showGroupName?: boolean,
 	) => React.ReactNode;
 	alsoOn: { [id: string]: AlsoOnDetail };
@@ -223,6 +224,8 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 
 		const isUneditable = isCollectionLocked || browsingStage !== cardSets.draft;
 
+		const groupIds = groups.map((group) => group.uuid);
+
 		return (
 			<>
 				<CollectionDisplay
@@ -338,7 +341,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 						) : null
 					}
 				>
-					{groups.map((group) => children(group, isUneditable, true))}
+					{groups.map((group) => children(group, isUneditable, groupIds, true ))}
 					{hasContent && (
 						<EditModeVisibility visibleMode="fronts">
 							<PreviouslyCollectionContainer data-testid="previously">
@@ -357,7 +360,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											launched they will not appear here.
 										</PreviouslyCollectionInfo>
 										<PreviouslyGroupsWrapper>
-											{children(previousGroup, true, false)}
+											{children(previousGroup, true, groupIds, false)}
 										</PreviouslyGroupsWrapper>
 									</>
 								)}

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -341,7 +341,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 						) : null
 					}
 				>
-					{groups.map((group) => children(group, isUneditable, groupIds, true ))}
+					{groups.map((group) => children(group, isUneditable, groupIds, true))}
 					{hasContent && (
 						<EditModeVisibility visibleMode="fronts">
 							<PreviouslyCollectionContainer data-testid="previously">

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,13 +179,101 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
+		// events.dropArticle(this.props.id, 'collection');
+		// this.props.moveCard(move.to, move.data, move.from || null, 'collection');
 
-		events.dropArticle(this.props.id, 'collection');
-		this.props.moveCard(move.to, move.data, move.from || null, 'collection');
+		const numberOfArticlesAlreadyInGroup = move.to.numberOfCardsInGroup;
+
+		// if we are inserting an article into any group that is not the splash, then we just insert
+		if (move.to.groupName !== 'splash') {
+			events.dropArticle(this.props.id, 'collection');
+			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
+		} else {
+			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
+			if (numberOfArticlesAlreadyInGroup === 0 || undefined) {
+				console.log('moving article to splash with no other articles');
+
+				events.dropArticle(this.props.id, 'collection');
+				this.props.moveCard(
+					move.to,
+					move.data,
+					move.from || null,
+					'collection',
+					);
+				}
+				// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+				// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
+			else if (
+					!!move.to.groupsIds &&
+					!!numberOfArticlesAlreadyInGroup &&
+					numberOfArticlesAlreadyInGroup > 0 &&
+					move.to.index === 0
+				) {
+					console.log(
+						'moving article to top of splash group with another article',
+					);
+
+					// grabbing the pre-existing article is tricky. Either amend the e target or add a function to add the metadata?
+
+					const otherGroup = move.to.groupsIds.filter(
+						(groupId) => groupId !== move.to.id,
+					)[0];
+
+					// this.props.id needs to be the id of the other card
+					const amendedTo = {
+						index: 0,
+						id: otherGroup,
+						type: 'group',
+						groupsIds: move.to.groupsIds,
+					};
+
+					events.dropArticle(this.props.id, 'collection');
+
+					// the "to" needs to be index 0, groupId the id of the other group, and type group
+					this.props.moveCard(
+						amendedTo,
+						move.data,
+						move.from || null,
+						'collection',
+					);
+				}
+
+				// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+				// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
+				else if (
+					!!move.to.groupsIds &&
+					!!numberOfArticlesAlreadyInGroup &&
+					numberOfArticlesAlreadyInGroup > 0 &&
+					move.to.index > 0
+				) {
+					console.log(
+						'moving article to bottom of splash group with another article',
+					);
+					const otherGroup = move.to.groupsIds.filter(
+						(groupId) => groupId !== move.to.id,
+					)[0];
+
+					const amendedTo = {
+						index: 0,
+						id: otherGroup,
+						type: 'group',
+						groupsIds: move.to.groupsIds,
+					};
+					events.dropArticle(this.props.id, 'collection');
+
+					this.props.moveCard(
+						amendedTo,
+						move.data,
+						move.from || null,
+						'collection',
+					);
+				}
+
+		}
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-		const numberOfArticlesAlreadyInGroup = to.numberOfCardsInGroup
+		const numberOfArticlesAlreadyInGroup = to.numberOfCardsInGroup;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		if (to.groupName !== 'splash') {
@@ -203,21 +291,29 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			}
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (!!to.groupsIds && !!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index === 0) {
-				console.log('inserting article at top of splash group with another article');
-
+			else if (
+				!!to.groupsIds &&
+				!!numberOfArticlesAlreadyInGroup &&
+				numberOfArticlesAlreadyInGroup > 0 &&
+				to.index === 0
+			) {
+				console.log(
+					'inserting article at top of splash group with another article',
+				);
 
 				// grabbing the pre-existing article is tricky. Either amend the e target or add a function to add the metadata?
 
-				const otherGroup = to.groupsIds.filter((groupId) => groupId !== to.id)[0];
+				const otherGroup = to.groupsIds.filter(
+					(groupId) => groupId !== to.id,
+				)[0];
 
 				// this.props.id needs to be the id of the other card
 				const amendedTo = {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
-					groupsIds: to.groupsIds
-				}
+					groupsIds: to.groupsIds,
+				};
 
 				events.dropArticle(
 					this.props.id,
@@ -229,16 +325,25 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-			else if (!!to.groupsIds && !!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index > 0) {
-				console.log('inserting article at bottom of splash group with another article');
-				const otherGroup = to.groupsIds.filter((groupId) => groupId !== to.id)[0];
+			else if (
+				!!to.groupsIds &&
+				!!numberOfArticlesAlreadyInGroup &&
+				numberOfArticlesAlreadyInGroup > 0 &&
+				to.index > 0
+			) {
+				console.log(
+					'inserting article at bottom of splash group with another article',
+				);
+				const otherGroup = to.groupsIds.filter(
+					(groupId) => groupId !== to.id,
+				)[0];
 
 				const amendedTo = {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
-					groupsIds: to.groupsIds
-				}
+					groupsIds: to.groupsIds,
+				};
 				events.dropArticle(
 					this.props.id,
 					isDropFromCAPIFeed(e) ? 'feed' : 'url',

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -187,7 +187,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		console.log('e', e);
 		console.log('to', to);
 
-		console.log('this.props', this.props);
+		console.log('handle insert .props', this.props);
+
+		const numberOfArticlesAlreadyInGroup = to.numberOfCardsInGroup
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		if (to.groupName !== 'splash') {
@@ -195,7 +197,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			this.props.insertCardFromDropEvent(e, to, 'collection');
 		} else {
 			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
-			if (to.numberOfCardsInGroup === 0) {
+			if (numberOfArticlesAlreadyInGroup === 0 || undefined) {
 				console.log('inserting article into splash with no other articles');
 				events.dropArticle(
 					this.props.id,
@@ -205,24 +207,45 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			}
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (to.numberOfCardsInGroup > 0 && to.index === 0) {
+			else if (!!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index === 0) {
 				console.log('inserting article at top of splash group with another article');
+
+				// this.props.id needs to be the id of the other card
+				const otherCardId = "123"
+				const amendedTo = {
+					index: 0,
+					id: '1234',
+					type: 'group',
+					groupsIds: to.groupsIds
+				}
+
 				events.dropArticle(
-					this.props.id,
+					otherCardId,
 					isDropFromCAPIFeed(e) ? 'feed' : 'url',
 				);
-				this.props.insertCardFromDropEvent(e, to, 'collection');
+				// the "to" needs to be index 0, groupId the id of the other group, and type group
+				this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
 			}
 
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-			else if (to.numberOfCardsInGroup > 0 && to.index > 0) {
+			else if (!!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index > 0) {
 				console.log('inserting article at bottom of splash group with another article');
+				const otherGroup = to.groupsIds.filter((groupId) => groupId !== to.id)[0];
+				console.log('to.id', to.id);
+				console.log('otherGroup', otherGroup);
+
+				const amendedTo = {
+					index: 0,
+					id: otherGroup,
+					type: 'group',
+					groupsIds: to.groupsIds
+				}
 				events.dropArticle(
 					this.props.id,
 					isDropFromCAPIFeed(e) ? 'feed' : 'url',
 				);
-				this.props.insertCardFromDropEvent(e, to, 'collection');
+				this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
 			}
 		}
 	};
@@ -233,6 +256,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// TODO remove the false bit when we're happy to actually lock users editing
 		const isEditingLocked =
 			false && (this.state.isCollectionsStale || !!collectionsError);
+
+			console.log('front content.props', this.props);
+			console.log('col elements', this.collectionElements)
 
 		return (
 			<FrontCollectionsContainer

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,16 +179,12 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
+
 		events.dropArticle(this.props.id, 'collection');
 		this.props.moveCard(move.to, move.data, move.from || null, 'collection');
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-		console.log('e', e);
-		console.log('to', to);
-
-		console.log('handle insert .props', this.props);
-
 		const numberOfArticlesAlreadyInGroup = to.numberOfCardsInGroup
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
@@ -207,20 +203,24 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			}
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (!!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index === 0) {
+			else if (!!to.groupsIds && !!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index === 0) {
 				console.log('inserting article at top of splash group with another article');
 
+
+				// grabbing the pre-existing article is tricky. Either amend the e target or add a function to add the metadata?
+
+				const otherGroup = to.groupsIds.filter((groupId) => groupId !== to.id)[0];
+
 				// this.props.id needs to be the id of the other card
-				const otherCardId = "123"
 				const amendedTo = {
 					index: 0,
-					id: '1234',
+					id: otherGroup,
 					type: 'group',
 					groupsIds: to.groupsIds
 				}
 
 				events.dropArticle(
-					otherCardId,
+					this.props.id,
 					isDropFromCAPIFeed(e) ? 'feed' : 'url',
 				);
 				// the "to" needs to be index 0, groupId the id of the other group, and type group
@@ -229,11 +229,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-			else if (!!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index > 0) {
+			else if (!!to.groupsIds && !!numberOfArticlesAlreadyInGroup && numberOfArticlesAlreadyInGroup > 0 && to.index > 0) {
 				console.log('inserting article at bottom of splash group with another article');
 				const otherGroup = to.groupsIds.filter((groupId) => groupId !== to.id)[0];
-				console.log('to.id', to.id);
-				console.log('otherGroup', otherGroup);
 
 				const amendedTo = {
 					index: 0,
@@ -256,9 +254,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// TODO remove the false bit when we're happy to actually lock users editing
 		const isEditingLocked =
 			false && (this.state.isCollectionsStale || !!collectionsError);
-
-			console.log('front content.props', this.props);
-			console.log('col elements', this.collectionElements)
 
 		return (
 			<FrontCollectionsContainer

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -199,7 +199,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
 			else if (
-				!!move.to.groupsIds &&
+				!!move.to.groupIds &&
 				move.to.cards !== undefined &&
 				move.to.index === 0
 			) {
@@ -213,7 +213,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				);
 
 				//then we need to move the other article to the other group
-				const otherGroup = move.to.groupsIds.filter(
+				const otherGroup = move.to.groupIds.filter(
 					(groupId) => groupId !== move.to.id,
 				)[0];
 				const existingCardData = move.to.cards[0];
@@ -221,7 +221,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
-					groupsIds: move.to.groupsIds,
+					groupIds: move.to.groupIds,
 				};
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,
@@ -234,12 +234,12 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
 			else if (
-				!!move.to.groupsIds &&
+				!!move.to.groupIds &&
 				!!numberOfArticlesAlreadyInGroup &&
 				numberOfArticlesAlreadyInGroup > 0 &&
 				move.to.index > 0
 			) {
-				const otherGroup = move.to.groupsIds.filter(
+				const otherGroup = move.to.groupIds.filter(
 					(groupId) => groupId !== move.to.id,
 				)[0];
 
@@ -247,7 +247,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
-					groupsIds: move.to.groupsIds,
+					groupIds: move.to.groupIds,
 				};
 				events.dropArticle(this.props.id, 'collection');
 
@@ -279,7 +279,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			}
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (!!to.groupsIds && to.cards !== undefined && to.index === 0) {
+			else if (!!to.groupIds && to.cards !== undefined && to.index === 0) {
 				// we do the regular insert steps for the article we're inserting to splash
 				events.dropArticle(
 					this.props.id,
@@ -289,7 +289,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 				//then we need to move the other article to the other group
 
-				const otherGroup = to.groupsIds.filter(
+				const otherGroup = to.groupIds.filter(
 					(groupId) => groupId !== to.id,
 				)[0];
 				const existingCardData = to.cards[0];
@@ -297,7 +297,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
-					groupsIds: to.groupsIds,
+					groupIds: to.groupIds,
 				};
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,
@@ -310,12 +310,12 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
 			else if (
-				!!to.groupsIds &&
+				!!to.groupIds &&
 				!!numberOfArticlesAlreadyInGroup &&
 				numberOfArticlesAlreadyInGroup > 0 &&
 				to.index > 0
 			) {
-				const otherGroup = to.groupsIds.filter(
+				const otherGroup = to.groupIds.filter(
 					(groupId) => groupId !== to.id,
 				)[0];
 
@@ -323,7 +323,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
-					groupsIds: to.groupsIds,
+					groupIds: to.groupIds,
 				};
 				events.dropArticle(
 					this.props.id,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,9 +179,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
-		// events.dropArticle(this.props.id, 'collection');
-		// this.props.moveCard(move.to, move.data, move.from || null, 'collection');
-
 		const numberOfArticlesAlreadyInGroup = move.to.numberOfCardsInGroup;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
@@ -191,84 +188,76 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		} else {
 			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
 			if (numberOfArticlesAlreadyInGroup === 0 || undefined) {
-				console.log('moving article to splash with no other articles');
-
 				events.dropArticle(this.props.id, 'collection');
 				this.props.moveCard(
 					move.to,
 					move.data,
 					move.from || null,
 					'collection',
-					);
-				}
-				// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
-				// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
+				);
+			}
+			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
 			else if (
-					!!move.to.groupsIds &&
-					!!numberOfArticlesAlreadyInGroup &&
-					numberOfArticlesAlreadyInGroup > 0 &&
-					move.to.index === 0
-				) {
-					console.log(
-						'moving article to top of splash group with another article',
-					);
+				!!move.to.groupsIds &&
+				move.to.cards !== undefined &&
+				move.to.index === 0
+			) {
+				//we do the regular move steps for the article we're moving to splash
+				events.dropArticle(this.props.id, 'collection');
+				this.props.moveCard(
+					move.to,
+					move.data,
+					move.from || null,
+					'collection',
+				);
 
-					// grabbing the pre-existing article is tricky. Either amend the e target or add a function to add the metadata?
+				//then we need to move the other article to the other group
+				const otherGroup = move.to.groupsIds.filter(
+					(groupId) => groupId !== move.to.id,
+				)[0];
+				const existingCardData = move.to.cards[0];
+				const existingCardTo = {
+					index: 0,
+					id: otherGroup,
+					type: 'group',
+					groupsIds: move.to.groupsIds,
+				};
+				const existingCardMoveData: Move<TCard> = {
+					data: existingCardData,
+					from: false,
+					to: existingCardTo,
+				};
+				this.handleMove(existingCardMoveData);
+			}
 
-					const otherGroup = move.to.groupsIds.filter(
-						(groupId) => groupId !== move.to.id,
-					)[0];
+			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
+			else if (
+				!!move.to.groupsIds &&
+				!!numberOfArticlesAlreadyInGroup &&
+				numberOfArticlesAlreadyInGroup > 0 &&
+				move.to.index > 0
+			) {
+				const otherGroup = move.to.groupsIds.filter(
+					(groupId) => groupId !== move.to.id,
+				)[0];
 
-					// this.props.id needs to be the id of the other card
-					const amendedTo = {
-						index: 0,
-						id: otherGroup,
-						type: 'group',
-						groupsIds: move.to.groupsIds,
-					};
+				const amendedTo = {
+					index: 0,
+					id: otherGroup,
+					type: 'group',
+					groupsIds: move.to.groupsIds,
+				};
+				events.dropArticle(this.props.id, 'collection');
 
-					events.dropArticle(this.props.id, 'collection');
-
-					// the "to" needs to be index 0, groupId the id of the other group, and type group
-					this.props.moveCard(
-						amendedTo,
-						move.data,
-						move.from || null,
-						'collection',
-					);
-				}
-
-				// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
-				// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-				else if (
-					!!move.to.groupsIds &&
-					!!numberOfArticlesAlreadyInGroup &&
-					numberOfArticlesAlreadyInGroup > 0 &&
-					move.to.index > 0
-				) {
-					console.log(
-						'moving article to bottom of splash group with another article',
-					);
-					const otherGroup = move.to.groupsIds.filter(
-						(groupId) => groupId !== move.to.id,
-					)[0];
-
-					const amendedTo = {
-						index: 0,
-						id: otherGroup,
-						type: 'group',
-						groupsIds: move.to.groupsIds,
-					};
-					events.dropArticle(this.props.id, 'collection');
-
-					this.props.moveCard(
-						amendedTo,
-						move.data,
-						move.from || null,
-						'collection',
-					);
-				}
-
+				this.props.moveCard(
+					amendedTo,
+					move.data,
+					move.from || null,
+					'collection',
+				);
+			}
 		}
 	};
 
@@ -282,7 +271,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		} else {
 			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
 			if (numberOfArticlesAlreadyInGroup === 0 || undefined) {
-				console.log('inserting article into splash with no other articles');
 				events.dropArticle(
 					this.props.id,
 					isDropFromCAPIFeed(e) ? 'feed' : 'url',
@@ -291,36 +279,32 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			}
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (
-				!!to.groupsIds &&
-				!!numberOfArticlesAlreadyInGroup &&
-				numberOfArticlesAlreadyInGroup > 0 &&
-				to.index === 0
-			) {
-				console.log(
-					'inserting article at top of splash group with another article',
+			else if (!!to.groupsIds && to.cards !== undefined && to.index === 0) {
+				// we do the regular insert steps for the article we're inserting to splash
+				events.dropArticle(
+					this.props.id,
+					isDropFromCAPIFeed(e) ? 'feed' : 'url',
 				);
+				this.props.insertCardFromDropEvent(e, to, 'collection');
 
-				// grabbing the pre-existing article is tricky. Either amend the e target or add a function to add the metadata?
+				//then we need to move the other article to the other group
 
 				const otherGroup = to.groupsIds.filter(
 					(groupId) => groupId !== to.id,
 				)[0];
-
-				// this.props.id needs to be the id of the other card
-				const amendedTo = {
+				const existingCardData = to.cards[0];
+				const existingCardTo = {
 					index: 0,
 					id: otherGroup,
 					type: 'group',
 					groupsIds: to.groupsIds,
 				};
-
-				events.dropArticle(
-					this.props.id,
-					isDropFromCAPIFeed(e) ? 'feed' : 'url',
-				);
-				// the "to" needs to be index 0, groupId the id of the other group, and type group
-				this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
+				const existingCardMoveData: Move<TCard> = {
+					data: existingCardData,
+					from: false,
+					to: existingCardTo,
+				};
+				this.handleMove(existingCardMoveData);
 			}
 
 			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
@@ -331,9 +315,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				numberOfArticlesAlreadyInGroup > 0 &&
 				to.index > 0
 			) {
-				console.log(
-					'inserting article at bottom of splash group with another article',
-				);
 				const otherGroup = to.groupsIds.filter(
 					(groupId) => groupId !== to.id,
 				)[0];

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -257,6 +257,8 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
 		const numberOfArticlesAlreadyInGroup = to.cards?.length;
 
+		const dropSource = isDropFromCAPIFeed(e) ? 'feed' : 'url';
+
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		// we also just insert if we're in the splash and there's no other article already in the splash
 		if (
@@ -264,7 +266,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			numberOfArticlesAlreadyInGroup === 0 ||
 			undefined
 		) {
-			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
+			events.dropArticle(this.props.id, dropSource);
 			this.props.insertCardFromDropEvent(e, to, 'collection');
 			return;
 		}
@@ -273,7 +275,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
 		if (!!to.groupIds && to.cards !== undefined && to.index === 0) {
 			// we do the regular insert steps for the article we're inserting to splash
-			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
+			events.dropArticle(this.props.id, dropSource);
 			this.props.insertCardFromDropEvent(e, to, 'collection');
 
 			// then we need to move the other article to the other group
@@ -310,7 +312,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				type: 'group',
 				groupIds: to.groupIds,
 			};
-			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
+			events.dropArticle(this.props.id, dropSource);
 			this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
 			return;
 		}

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -184,8 +184,47 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-		events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
-		this.props.insertCardFromDropEvent(e, to, 'collection');
+		console.log('e', e);
+		console.log('to', to);
+
+		console.log('this.props', this.props);
+
+		// if we are inserting an article into any group that is not the splash, then we just insert
+		if (to.groupName !== 'splash') {
+			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
+			this.props.insertCardFromDropEvent(e, to, 'collection');
+		} else {
+			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
+			if (to.numberOfCardsInGroup === 0) {
+				console.log('inserting article into splash with no other articles');
+				events.dropArticle(
+					this.props.id,
+					isDropFromCAPIFeed(e) ? 'feed' : 'url',
+				);
+				this.props.insertCardFromDropEvent(e, to, 'collection');
+			}
+			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
+			else if (to.numberOfCardsInGroup > 0 && to.index === 0) {
+				console.log('inserting article at top of splash group with another article');
+				events.dropArticle(
+					this.props.id,
+					isDropFromCAPIFeed(e) ? 'feed' : 'url',
+				);
+				this.props.insertCardFromDropEvent(e, to, 'collection');
+			}
+
+			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
+			else if (to.numberOfCardsInGroup > 0 && to.index > 0) {
+				console.log('inserting article at bottom of splash group with another article');
+				events.dropArticle(
+					this.props.id,
+					isDropFromCAPIFeed(e) ? 'feed' : 'url',
+				);
+				this.props.insertCardFromDropEvent(e, to, 'collection');
+			}
+		}
 	};
 
 	public render() {

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,14 +179,13 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
-		const numberOfArticlesAlreadyInGroup = move.to.cards?.length;
+		const numberOfArticlesAlreadyInGroup = move.to.cards?.length ?? 0;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		// we also just insert if we're in the splash and there's no other article already in the splash
 		if (
 			move.to.groupName !== 'splash' ||
-			numberOfArticlesAlreadyInGroup === 0 ||
-			undefined
+			numberOfArticlesAlreadyInGroup === 0
 		) {
 			events.dropArticle(this.props.id, 'collection');
 			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
@@ -228,7 +227,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
 		if (
 			!!move.to.groupIds &&
-			!!numberOfArticlesAlreadyInGroup &&
 			numberOfArticlesAlreadyInGroup > 0 &&
 			move.to.index > 0
 		) {
@@ -255,7 +253,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-		const numberOfArticlesAlreadyInGroup = to.cards?.length;
+		const numberOfArticlesAlreadyInGroup = to.cards?.length ?? 0;
 
 		const dropSource = isDropFromCAPIFeed(e) ? 'feed' : 'url';
 
@@ -263,8 +261,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// we also just insert if we're in the splash and there's no other article already in the splash
 		if (
 			to.groupName !== 'splash' ||
-			numberOfArticlesAlreadyInGroup === 0 ||
-			undefined
+			numberOfArticlesAlreadyInGroup === 0
 		) {
 			events.dropArticle(this.props.id, dropSource);
 			this.props.insertCardFromDropEvent(e, to, 'collection');
@@ -300,7 +297,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
 		if (
 			!!to.groupIds &&
-			!!numberOfArticlesAlreadyInGroup &&
 			numberOfArticlesAlreadyInGroup > 0 &&
 			to.index > 0
 		) {

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,7 +179,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
-		const numberOfArticlesAlreadyInGroup = move.to.numberOfCardsInGroup;
+		const numberOfArticlesAlreadyInGroup = move.to.cards?.length;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		if (move.to.groupName !== 'splash') {
@@ -262,7 +262,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-		const numberOfArticlesAlreadyInGroup = to.numberOfCardsInGroup;
+		const numberOfArticlesAlreadyInGroup = to.cards?.length;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		if (to.groupName !== 'splash') {

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -182,82 +182,75 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		const numberOfArticlesAlreadyInGroup = move.to.cards?.length;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
-		if (move.to.groupName !== 'splash') {
+		// we also just insert if we're in the splash and there's no other article already in the splash
+		if (
+			move.to.groupName !== 'splash' ||
+			numberOfArticlesAlreadyInGroup === 0 ||
+			undefined
+		) {
 			events.dropArticle(this.props.id, 'collection');
 			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
-		} else {
-			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
-			if (numberOfArticlesAlreadyInGroup === 0 || undefined) {
-				events.dropArticle(this.props.id, 'collection');
-				this.props.moveCard(
-					move.to,
-					move.data,
-					move.from || null,
-					'collection',
-				);
-			}
-			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
-			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (
-				!!move.to.groupIds &&
-				move.to.cards !== undefined &&
-				move.to.index === 0
-			) {
-				//we do the regular move steps for the article we're moving to splash
-				events.dropArticle(this.props.id, 'collection');
-				this.props.moveCard(
-					move.to,
-					move.data,
-					move.from || null,
-					'collection',
-				);
+			return;
+		}
 
-				//then we need to move the other article to the other group
-				const otherGroup = move.to.groupIds.filter(
-					(groupId) => groupId !== move.to.id,
-				)[0];
-				const existingCardData = move.to.cards[0];
-				const existingCardTo = {
-					index: 0,
-					id: otherGroup,
-					type: 'group',
-					groupIds: move.to.groupIds,
-				};
-				const existingCardMoveData: Move<TCard> = {
-					data: existingCardData,
-					from: false,
-					to: existingCardTo,
-				};
-				this.handleMove(existingCardMoveData);
-			}
+		// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+		// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
+		if (
+			!!move.to.groupIds &&
+			move.to.cards !== undefined &&
+			move.to.index === 0
+		) {
+			//we do the regular move steps for the article we're moving to splash
+			events.dropArticle(this.props.id, 'collection');
+			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
 
-			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
-			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-			else if (
-				!!move.to.groupIds &&
-				!!numberOfArticlesAlreadyInGroup &&
-				numberOfArticlesAlreadyInGroup > 0 &&
-				move.to.index > 0
-			) {
-				const otherGroup = move.to.groupIds.filter(
-					(groupId) => groupId !== move.to.id,
-				)[0];
+			//then we need to move the other article to the other group
+			const otherGroup = move.to.groupIds.filter(
+				(groupId) => groupId !== move.to.id,
+			)[0];
+			const existingCardData = move.to.cards[0];
+			const existingCardTo = {
+				index: 0,
+				id: otherGroup,
+				type: 'group',
+				groupIds: move.to.groupIds,
+			};
+			const existingCardMoveData: Move<TCard> = {
+				data: existingCardData,
+				from: false,
+				to: existingCardTo,
+			};
+			this.handleMove(existingCardMoveData);
+			return;
+		}
 
-				const amendedTo = {
-					index: 0,
-					id: otherGroup,
-					type: 'group',
-					groupIds: move.to.groupIds,
-				};
-				events.dropArticle(this.props.id, 'collection');
+		// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+		// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
+		if (
+			!!move.to.groupIds &&
+			!!numberOfArticlesAlreadyInGroup &&
+			numberOfArticlesAlreadyInGroup > 0 &&
+			move.to.index > 0
+		) {
+			const otherGroup = move.to.groupIds.filter(
+				(groupId) => groupId !== move.to.id,
+			)[0];
 
-				this.props.moveCard(
-					amendedTo,
-					move.data,
-					move.from || null,
-					'collection',
-				);
-			}
+			const amendedTo = {
+				index: 0,
+				id: otherGroup,
+				type: 'group',
+				groupIds: move.to.groupIds,
+			};
+			events.dropArticle(this.props.id, 'collection');
+
+			this.props.moveCard(
+				amendedTo,
+				move.data,
+				move.from || null,
+				'collection',
+			);
+			return;
 		}
 	};
 
@@ -265,72 +258,61 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		const numberOfArticlesAlreadyInGroup = to.cards?.length;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
-		if (to.groupName !== 'splash') {
+		// we also just insert if we're in the splash and there's no other article already in the splash
+		if (
+			to.groupName !== 'splash' ||
+			numberOfArticlesAlreadyInGroup === 0 ||
+			undefined
+		) {
 			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
 			this.props.insertCardFromDropEvent(e, to, 'collection');
-		} else {
-			// if we're in the splash and we insert an article and there's no other article already in the splash, then we just insert
-			if (numberOfArticlesAlreadyInGroup === 0 || undefined) {
-				events.dropArticle(
-					this.props.id,
-					isDropFromCAPIFeed(e) ? 'feed' : 'url',
-				);
-				this.props.insertCardFromDropEvent(e, to, 'collection');
-			}
-			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
-			// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
-			else if (!!to.groupIds && to.cards !== undefined && to.index === 0) {
-				// we do the regular insert steps for the article we're inserting to splash
-				events.dropArticle(
-					this.props.id,
-					isDropFromCAPIFeed(e) ? 'feed' : 'url',
-				);
-				this.props.insertCardFromDropEvent(e, to, 'collection');
+			return;
+		}
 
-				//then we need to move the other article to the other group
+		// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+		// if we're inserting to index 0, i.e. top of the group, then we want to grab the pre-existing article and move it to the other group
+		if (!!to.groupIds && to.cards !== undefined && to.index === 0) {
+			// we do the regular insert steps for the article we're inserting to splash
+			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
+			this.props.insertCardFromDropEvent(e, to, 'collection');
 
-				const otherGroup = to.groupIds.filter(
-					(groupId) => groupId !== to.id,
-				)[0];
-				const existingCardData = to.cards[0];
-				const existingCardTo = {
-					index: 0,
-					id: otherGroup,
-					type: 'group',
-					groupIds: to.groupIds,
-				};
-				const existingCardMoveData: Move<TCard> = {
-					data: existingCardData,
-					from: false,
-					to: existingCardTo,
-				};
-				this.handleMove(existingCardMoveData);
-			}
+			// then we need to move the other article to the other group
+			const otherGroup = to.groupIds.filter((groupId) => groupId !== to.id)[0];
+			const existingCardData = to.cards[0];
+			const existingCardTo = {
+				index: 0,
+				id: otherGroup,
+				type: 'group',
+				groupIds: to.groupIds,
+			};
+			const existingCardMoveData: Move<TCard> = {
+				data: existingCardData,
+				from: false,
+				to: existingCardTo,
+			};
+			this.handleMove(existingCardMoveData);
+			return;
+		}
 
-			// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
-			// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-			else if (
-				!!to.groupIds &&
-				!!numberOfArticlesAlreadyInGroup &&
-				numberOfArticlesAlreadyInGroup > 0 &&
-				to.index > 0
-			) {
-				const otherGroup = to.groupIds.filter(
-					(groupId) => groupId !== to.id,
-				)[0];
+		// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
+		// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
+		if (
+			!!to.groupIds &&
+			!!numberOfArticlesAlreadyInGroup &&
+			numberOfArticlesAlreadyInGroup > 0 &&
+			to.index > 0
+		) {
+			const otherGroup = to.groupIds.filter((groupId) => groupId !== to.id)[0];
 
-				const amendedTo = {
-					index: 0,
-					id: otherGroup,
-					type: 'group',
-					groupIds: to.groupIds,
-				};
-				events.dropArticle(
-					this.props.id,
-					isDropFromCAPIFeed(e) ? 'feed' : 'url',
-				);
-				this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
-			}
+			const amendedTo = {
+				index: 0,
+				id: otherGroup,
+				type: 'group',
+				groupIds: to.groupIds,
+			};
+			events.dropArticle(this.props.id, isDropFromCAPIFeed(e) ? 'feed' : 'url');
+			this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
+			return;
 		}
 	};
 

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -259,10 +259,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		// we also just insert if we're in the splash and there's no other article already in the splash
-		if (
-			to.groupName !== 'splash' ||
-			numberOfArticlesAlreadyInGroup === 0
-		) {
+		if (to.groupName !== 'splash' || numberOfArticlesAlreadyInGroup === 0) {
 			events.dropArticle(this.props.id, dropSource);
 			this.props.insertCardFromDropEvent(e, to, 'collection');
 			return;
@@ -295,11 +292,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 		// if we're in the splash and we insert an article and there's already another article, then we also look at the index we're inserting to
 		// if we're inserting to index 1, i.e. bottom of the group, then we add this story to the other group
-		if (
-			!!to.groupIds &&
-			numberOfArticlesAlreadyInGroup > 0 &&
-			to.index > 0
-		) {
+		if (!!to.groupIds && numberOfArticlesAlreadyInGroup > 0 && to.index > 0) {
 			const otherGroup = to.groupIds.filter((groupId) => groupId !== to.id)[0];
 
 			const amendedTo = {

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -20,6 +20,9 @@ interface OuterProps {
 	isUneditable?: boolean;
 	dropMessage?: string;
 	cardTypeAllowList?: CardTypes[];
+	groupName: string;
+	numberOfCardsInGroup: number;
+	groupsIds: string[];
 }
 
 interface InnerProps {
@@ -49,11 +52,17 @@ const CardLevel = ({
 	isUneditable,
 	dropMessage,
 	cardTypeAllowList,
+	groupName,
+	numberOfCardsInGroup,
+	groupsIds,
 }: Props) => (
 	<CardTypeLevel
 		arr={supporting || []}
 		parentType="card"
 		parentId={cardId}
+		groupName={groupName}
+		numberOfCardsInGroup={numberOfCardsInGroup}
+		groupsIds={groupsIds}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -21,7 +21,7 @@ interface OuterProps {
 	dropMessage?: string;
 	cardTypeAllowList?: CardTypes[];
 	groupName?: string;
-	groupsIds?: string[];
+	groupIds?: string[];
 }
 
 interface InnerProps {
@@ -52,14 +52,14 @@ const CardLevel = ({
 	dropMessage,
 	cardTypeAllowList,
 	groupName,
-	groupsIds,
+	groupIds,
 }: Props) => (
 	<CardTypeLevel
 		arr={supporting || []}
 		parentType="card"
 		parentId={cardId}
 		groupName={groupName}
-		groupsIds={groupsIds}
+		groupIds={groupIds}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -21,7 +21,6 @@ interface OuterProps {
 	dropMessage?: string;
 	cardTypeAllowList?: CardTypes[];
 	groupName?: string;
-	numberOfCardsInGroup?: number;
 	groupsIds?: string[];
 }
 
@@ -53,7 +52,6 @@ const CardLevel = ({
 	dropMessage,
 	cardTypeAllowList,
 	groupName,
-	numberOfCardsInGroup,
 	groupsIds,
 }: Props) => (
 	<CardTypeLevel
@@ -61,7 +59,6 @@ const CardLevel = ({
 		parentType="card"
 		parentId={cardId}
 		groupName={groupName}
-		numberOfCardsInGroup={numberOfCardsInGroup}
 		groupsIds={groupsIds}
 		onMove={onMove}
 		onDrop={onDrop}

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -20,9 +20,9 @@ interface OuterProps {
 	isUneditable?: boolean;
 	dropMessage?: string;
 	cardTypeAllowList?: CardTypes[];
-	groupName: string;
-	numberOfCardsInGroup: number;
-	groupsIds: string[];
+	groupName?: string;
+	numberOfCardsInGroup?: number;
+	groupsIds?: string[];
 }
 
 interface InnerProps {

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -17,6 +17,7 @@ interface OuterProps {
 	isUneditable?: boolean;
 	groupName: string;
 	numberOfCardsInGroup: number;
+	groupsIds: string[];
 }
 
 interface InnerProps {
@@ -63,7 +64,8 @@ const GroupLevel = ({
 	onDrop,
 	isUneditable,
 	groupName,
-	numberOfCardsInGroup
+	numberOfCardsInGroup,
+	groupsIds
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
@@ -71,6 +73,7 @@ const GroupLevel = ({
 		parentId={groupId}
 		groupName={groupName}
 		numberOfCardsInGroup={numberOfCardsInGroup}
+		groupsIds={groupsIds}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -16,7 +16,6 @@ interface OuterProps {
 	onDrop: DropHandler;
 	isUneditable?: boolean;
 	groupName: string;
-	numberOfCardsInGroup: number;
 	groupsIds: string[];
 }
 
@@ -64,7 +63,6 @@ const GroupLevel = ({
 	onDrop,
 	isUneditable,
 	groupName,
-	numberOfCardsInGroup,
 	groupsIds,
 }: Props) => (
 	<CardTypeLevel
@@ -72,7 +70,6 @@ const GroupLevel = ({
 		parentType="group"
 		parentId={groupId}
 		groupName={groupName}
-		numberOfCardsInGroup={numberOfCardsInGroup}
 		groupsIds={groupsIds}
 		onMove={onMove}
 		onDrop={onDrop}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -15,6 +15,8 @@ interface OuterProps {
 	onMove: MoveHandler<Card>;
 	onDrop: DropHandler;
 	isUneditable?: boolean;
+	groupName: string;
+	numberOfCardsInGroup: number;
 }
 
 interface InnerProps {
@@ -60,11 +62,15 @@ const GroupLevel = ({
 	onMove,
 	onDrop,
 	isUneditable,
+	groupName,
+	numberOfCardsInGroup
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
 		parentType="group"
 		parentId={groupId}
+		groupName={groupName}
+		numberOfCardsInGroup={numberOfCardsInGroup}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -65,7 +65,7 @@ const GroupLevel = ({
 	isUneditable,
 	groupName,
 	numberOfCardsInGroup,
-	groupsIds
+	groupsIds,
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -16,7 +16,7 @@ interface OuterProps {
 	onDrop: DropHandler;
 	isUneditable?: boolean;
 	groupName: string;
-	groupsIds: string[];
+	groupIds: string[];
 }
 
 interface InnerProps {
@@ -63,14 +63,14 @@ const GroupLevel = ({
 	onDrop,
 	isUneditable,
 	groupName,
-	groupsIds,
+	groupIds,
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
 		parentType="group"
 		parentId={groupId}
 		groupName={groupName}
-		groupsIds={groupsIds}
+		groupIds={groupIds}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -11,7 +11,6 @@ interface PosSpec {
 	id: string;
 	index: number;
 	groupName?: string;
-	numberOfCardsInGroup?: number;
 	groupsIds?: string[];
 	cards?: any[];
 }
@@ -61,7 +60,6 @@ export interface LevelProps<T> {
 	parentId: string;
 	parentType: string;
 	groupName?: string;
-	numberOfCardsInGroup?: number;
 	groupsIds?: string[];
 	type: string;
 	getDropType?: (item: T) => string;
@@ -186,7 +184,6 @@ class Level<T> extends React.Component<Props<T>, State> {
 			type: this.props.parentType,
 			id: this.props.parentId,
 			groupName: this.props.groupName,
-			numberOfCardsInGroup: this.props.numberOfCardsInGroup,
 			groupsIds: this.props.groupsIds,
 			cards: this.props.arr,
 		};

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -11,7 +11,7 @@ interface PosSpec {
 	id: string;
 	index: number;
 	groupName?: string;
-	groupsIds?: string[];
+	groupIds?: string[];
 	cards?: any[];
 }
 
@@ -60,7 +60,7 @@ export interface LevelProps<T> {
 	parentId: string;
 	parentType: string;
 	groupName?: string;
-	groupsIds?: string[];
+	groupIds?: string[];
 	type: string;
 	getDropType?: (item: T) => string;
 	dragImageOffsetX?: number;
@@ -184,7 +184,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 			type: this.props.parentType,
 			id: this.props.parentId,
 			groupName: this.props.groupName,
-			groupsIds: this.props.groupsIds,
+			groupIds: this.props.groupIds,
 			cards: this.props.arr,
 		};
 

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -10,8 +10,9 @@ interface PosSpec {
 	type: string;
 	id: string;
 	index: number;
-	groupName: string;
-	numberOfCardsInGroup: number;
+	groupName?: string;
+	numberOfCardsInGroup?: number;
+	groupsIds: string[];
 
 }
 
@@ -61,6 +62,7 @@ export interface LevelProps<T> {
 	parentType: string;
 	groupName: string;
 	numberOfCardsInGroup: number;
+	groupsIds: string[];
 	type: string;
 	getDropType?: (item: T) => string;
 	dragImageOffsetX?: number;
@@ -184,7 +186,8 @@ class Level<T> extends React.Component<Props<T>, State> {
 			type: this.props.parentType,
 			id: this.props.parentId,
 			groupName: this.props.groupName,
-			numberOfCardsInGroup: this.props.numberOfCardsInGroup
+			numberOfCardsInGroup: this.props.numberOfCardsInGroup,
+			groupsIds: this.props.groupsIds
 		};
 
 		if (!af) {
@@ -192,6 +195,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 		}
 
 		const { parents, id, index, type, data, forceClone } = JSON.parse(af);
+
 
 		if (!isInside(this.props.parents, [type, id])) {
 			const [parentType, parentId] = parents[parents.length - 1];

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -13,6 +13,7 @@ interface PosSpec {
 	groupName?: string;
 	numberOfCardsInGroup?: number;
 	groupsIds?: string[];
+	cards?: any[];
 
 }
 
@@ -187,7 +188,8 @@ class Level<T> extends React.Component<Props<T>, State> {
 			id: this.props.parentId,
 			groupName: this.props.groupName,
 			numberOfCardsInGroup: this.props.numberOfCardsInGroup,
-			groupsIds: this.props.groupsIds
+			groupsIds: this.props.groupsIds,
+			cards: this.props.arr
 		};
 
 		if (!af) {

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -14,7 +14,6 @@ interface PosSpec {
 	numberOfCardsInGroup?: number;
 	groupsIds?: string[];
 	cards?: any[];
-
 }
 
 const isOnSameLevel = (from: PosSpec, to: PosSpec): boolean =>
@@ -189,7 +188,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 			groupName: this.props.groupName,
 			numberOfCardsInGroup: this.props.numberOfCardsInGroup,
 			groupsIds: this.props.groupsIds,
-			cards: this.props.arr
+			cards: this.props.arr,
 		};
 
 		if (!af) {
@@ -197,7 +196,6 @@ class Level<T> extends React.Component<Props<T>, State> {
 		}
 
 		const { parents, id, index, type, data, forceClone } = JSON.parse(af);
-
 
 		if (!isInside(this.props.parents, [type, id])) {
 			const [parentType, parentId] = parents[parents.length - 1];

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -10,6 +10,9 @@ interface PosSpec {
 	type: string;
 	id: string;
 	index: number;
+	groupName: string;
+	numberOfCardsInGroup: number;
+
 }
 
 const isOnSameLevel = (from: PosSpec, to: PosSpec): boolean =>
@@ -56,6 +59,8 @@ export interface LevelProps<T> {
 	children: LevelChild<T>;
 	parentId: string;
 	parentType: string;
+	groupName: string;
+	numberOfCardsInGroup: number;
 	type: string;
 	getDropType?: (item: T) => string;
 	dragImageOffsetX?: number;
@@ -178,6 +183,8 @@ class Level<T> extends React.Component<Props<T>, State> {
 			index: i,
 			type: this.props.parentType,
 			id: this.props.parentId,
+			groupName: this.props.groupName,
+			numberOfCardsInGroup: this.props.numberOfCardsInGroup
 		};
 
 		if (!af) {

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -12,7 +12,7 @@ interface PosSpec {
 	index: number;
 	groupName?: string;
 	numberOfCardsInGroup?: number;
-	groupsIds: string[];
+	groupsIds?: string[];
 
 }
 

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -60,9 +60,9 @@ export interface LevelProps<T> {
 	children: LevelChild<T>;
 	parentId: string;
 	parentType: string;
-	groupName: string;
-	numberOfCardsInGroup: number;
-	groupsIds: string[];
+	groupName?: string;
+	numberOfCardsInGroup?: number;
+	groupsIds?: string[];
 	type: string;
 	getDropType?: (item: T) => string;
 	dragImageOffsetX?: number;

--- a/fronts-client/src/lib/dnd/__tests__/dnd.spec.tsx
+++ b/fronts-client/src/lib/dnd/__tests__/dnd.spec.tsx
@@ -113,7 +113,7 @@ describe('Curation', () => {
 			to: {
 				cards: [{ id: '3' }, { id: '4' }],
 				groupName: undefined,
-				groupsIds: undefined,
+				groupIds: undefined,
 				id: '2',
 				index: 1,
 				type: 'a',
@@ -174,7 +174,7 @@ describe('Curation', () => {
 			to: {
 				cards: [{ id: '3' }, { id: '4' }],
 				groupName: undefined,
-				groupsIds: undefined,
+				groupIds: undefined,
 				id: '2',
 				index: 0,
 				type: 'a',
@@ -290,7 +290,7 @@ describe('Curation', () => {
 		expect(to).toEqual({
 			cards: [{ id: '1' }],
 			groupName: undefined,
-			groupsIds: undefined,
+			groupIds: undefined,
 			id: '2',
 			index: 1,
 			type: 'a',

--- a/fronts-client/src/lib/dnd/__tests__/dnd.spec.tsx
+++ b/fronts-client/src/lib/dnd/__tests__/dnd.spec.tsx
@@ -110,7 +110,15 @@ describe('Curation', () => {
 		expect(edit).toEqual({
 			data: { id: '1' },
 			from: { type: 'b', id: '0', index: 0 },
-			to: { type: 'a', id: '2', index: 1 },
+			to: {
+				cards: [{ id: '3' }, { id: '4' }],
+				groupName: undefined,
+				groupsIds: undefined,
+				id: '2',
+				index: 1,
+				numberOfCardsInGroup: undefined,
+				type: 'a',
+			},
 		});
 	});
 
@@ -164,7 +172,15 @@ describe('Curation', () => {
 		expect(edit).toEqual({
 			data: { id: '1' },
 			from: { type: 'b', id: '0', index: 0 },
-			to: { type: 'a', id: '2', index: 0 },
+			to: {
+				cards: [{ id: '3' }, { id: '4' }],
+				groupName: undefined,
+				groupsIds: undefined,
+				id: '2',
+				index: 0,
+				numberOfCardsInGroup: undefined,
+				type: 'a',
+			},
 		});
 
 		runDrag(nodeProps)(dropProps, false);
@@ -273,7 +289,15 @@ describe('Curation', () => {
 		})(dropProps);
 
 		expect(JSON.parse(event.dataTransfer.getData('text'))).toEqual(data);
-		expect(to).toEqual({ id: '2', index: 1, type: 'a' });
+		expect(to).toEqual({
+			cards: [{ id: '1' }],
+			groupName: undefined,
+			groupsIds: undefined,
+			id: '2',
+			index: 1,
+			numberOfCardsInGroup: undefined,
+			type: 'a',
+		});
 	});
 
 	it('does not allow moves of a node to a subPath of that node', () => {

--- a/fronts-client/src/lib/dnd/__tests__/dnd.spec.tsx
+++ b/fronts-client/src/lib/dnd/__tests__/dnd.spec.tsx
@@ -116,7 +116,6 @@ describe('Curation', () => {
 				groupsIds: undefined,
 				id: '2',
 				index: 1,
-				numberOfCardsInGroup: undefined,
 				type: 'a',
 			},
 		});
@@ -178,7 +177,6 @@ describe('Curation', () => {
 				groupsIds: undefined,
 				id: '2',
 				index: 0,
-				numberOfCardsInGroup: undefined,
 				type: 'a',
 			},
 		});
@@ -295,7 +293,6 @@ describe('Curation', () => {
 			groupsIds: undefined,
 			id: '2',
 			index: 1,
-			numberOfCardsInGroup: undefined,
 			type: 'a',
 		});
 	});

--- a/fronts-client/src/util/collectionUtils.ts
+++ b/fronts-client/src/util/collectionUtils.ts
@@ -64,6 +64,7 @@ export type InsertDropType = keyof typeof dropToCardMap;
 const dropToCard = (e: React.DragEvent): MappableDropType | null => {
 	for (const [type, fn] of Object.entries(dropToCardMap)) {
 		const data = e.dataTransfer.getData(type);
+
 		if (data) {
 			return fn(data);
 		}

--- a/fronts-client/src/util/collectionUtils.ts
+++ b/fronts-client/src/util/collectionUtils.ts
@@ -64,7 +64,6 @@ export type InsertDropType = keyof typeof dropToCardMap;
 const dropToCard = (e: React.DragEvent): MappableDropType | null => {
 	for (const [type, fn] of Object.entries(dropToCardMap)) {
 		const data = e.dataTransfer.getData(type);
-
 		if (data) {
 			return fn(data);
 		}


### PR DESCRIPTION
## What's changed?
Closes [this fronts+curation ticket](https://trello.com/c/HAnWsQvN/353-flexible-general-restrict-splash-to-one-story)

As per the ticket description, we want the tool to reflect how the frontend renders so that fronts editors will have clarity over what will appear to users. In this case specifically, as the splash can only contain up to a single story, we want to make sure this is limited in the tool as well. 

The approach I've taken is to update the `handleInsert` and `handleMove` functions called when a card is dragged to a collection/group, such that if we're not adding a card to a group with the name splash, nothing has changed and the pre-existing logic keeps running to insert as normal. This only concerns the new fairground containers, so it didn't feel necessary to ensure this is implemented retroactively. 

If we are adding to a splash, we check how many cards there already are in the group and which position we're inserting to:
- if there's no cards in the group already, we insert as normal
- if there's a card in the group already, and we're inserting to the bottom of it, the card we're inserting is instead moved to the top of the standard stories group
- if there's a card in the group already, and we're inserting to the top of it, the new story is inserted into the splash, and the previous story is moved to the top of the standard stories group.

Some new properties to relevant components have been added to enable checking these conditions (e.g. the ids of the groups in the collection, and the name and cards currently in the relevant group).

Manual testing would involve checking these four scenarios, for both dragging from the feed of stories and moving between groups. 

The jest tests have just been updated to pass, but not take into account these conditions yet - happy to try adding these variations though. 

The branch is currently up on code. 

## Video


https://github.com/user-attachments/assets/9c8e8c4e-c70a-49bd-b1dd-b94d29711aa7



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
