### PR TITLE
Reset heading sticky position to sticky

### DIFF
--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -139,12 +139,13 @@ const CollectionMeta = styled(CollectionMetaBase)`
 const ItemCountMeta = CollectionMetaBase;
 
 const CollectionHeadingSticky = styled.div`
-	position: relative;
+	position: sticky;
 	top: 0;
 	background-color: ${theme.collection.background};
 	box-shadow: 0 -1px 0 ${theme.base.colors.text};
 	margin: 0 -${contentContainerMargin};
 	padding: 0 ${contentContainerMargin};
+	z-index: 20;
 `;
 
 const CollectionHeadingInner = styled(ContainerHeadingPinline)`


### PR DESCRIPTION
## What's changed?

Just resetting this to the original setting on the back of CP's communication. 

Image of a container partway down the page showing the heading is still displaying
<img width="694" alt="image" src="https://github.com/user-attachments/assets/8dce2e35-8189-4ce9-b894-ab1ab18b6e79" />


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
