### PR TITLE
Adjust visual hierarchy of containers depending on primary/secondary

### DIFF
--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -176,6 +176,8 @@ const CollectionHeadingText = styled.div<{
 		css`
 			font-family: TS3TextSans;
 			font-size: 20px;
+			font-weight: normal;
+			padding-left: 4px;
 		`}
 `;
 

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -160,7 +160,7 @@ const CollectionHeadlineWithConfigContainer = styled.div`
 
 const CollectionHeadingText = styled.div<{
 	isLoading: boolean;
-	isSecondaryLevel?: boolean;
+	isSecondaryContainer: boolean;
 }>`
 	width: 100%;
 	white-space: nowrap;
@@ -171,8 +171,8 @@ const CollectionHeadingText = styled.div<{
 		`} white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	${({ isSecondaryLevel }) =>
-		isSecondaryLevel &&
+	${({ isSecondaryContainer }) =>
+		isSecondaryContainer &&
 		css`
 			font-family: TS3TextSans;
 			font-size: 20px;
@@ -308,9 +308,11 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 								<CollectionHeadingText
 									isLoading={!collection}
 									title={!!collection ? collection!.displayName : 'Loading …'}
-									isSecondaryLevel={collection?.metadata?.some(
-										(tag) => tag.type === 'Secondary',
-									)}
+									isSecondaryContainer={
+										collection?.metadata?.some(
+											(tag) => tag.type === 'Secondary',
+										) ?? false
+									}
 								>
 									{!!collection ? collection!.displayName : 'Loading …'}
 									<CollectionConfigContainer>

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -17,6 +17,7 @@ import {
 } from 'selectors/shared';
 import EditModeVisibility from 'components/util/EditModeVisibility';
 import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUI';
+import { css } from 'styled-components';
 
 interface FrontCollectionOverviewContainerProps {
 	frontId: string;
@@ -33,10 +34,12 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
 	hasOpenForms: boolean;
 };
 
-const Container = styled.div<{ isSelected: boolean }>`
+const Container = styled.div<{
+	isSelected: boolean;
+	isSecondaryContainer: boolean;
+}>`
 	align-items: center;
 	appearance: none;
-	background-color: ${theme.base.colors.backgroundColor};
 	border: solid 1px ${theme.base.colors.borderColor};
 	border-radius: 1.25em;
 	color: inherit;
@@ -50,6 +53,15 @@ const Container = styled.div<{ isSelected: boolean }>`
 	text-align: left;
 	text-decoration: none;
 	transition: background-color 0.3s;
+	${({ isSecondaryContainer }) =>
+		isSecondaryContainer
+			? css`
+					margin-left: 0.75em;
+					background-color: ${theme.base.colors.backgroundColorLight};
+				`
+			: css`
+					background-color: ${theme.base.colors.backgroundColor};
+				`};
 
 	${(props) =>
 		props.isSelected && `background-color: ${props.theme.colors.whiteDark}`}
@@ -75,10 +87,16 @@ const TextContainerRight = styled.div`
 	white-space: nowrap;
 `;
 
-const Name = styled.span`
+const Name = styled.span<{ isSecondaryContainer: boolean }>`
 	color: ${theme.base.colors.text};
 	font-weight: bold;
 	padding-right: 0.25em;
+	${({ isSecondaryContainer }) =>
+		isSecondaryContainer &&
+		css`
+			font-family: TS3TextSans;
+			font-weight: normal;
+		`}
 `;
 
 const ItemCount = styled.span`
@@ -127,9 +145,19 @@ const CollectionOverview = ({
 				openCollection(collection.id);
 			}}
 			isSelected={isSelected}
+			isSecondaryContainer={
+				collection.metadata?.some((tag) => tag.type === 'Secondary') ?? false
+			}
 		>
 			<TextContainerLeft>
-				<Name>{collection.displayName}</Name>
+				<Name
+					isSecondaryContainer={
+						collection.metadata?.some((tag) => tag.type === 'Secondary') ??
+						false
+					}
+				>
+					{collection.displayName}
+				</Name>
 				<ItemCount>({cardCount})</ItemCount>
 			</TextContainerLeft>
 			<TextContainerRight>


### PR DESCRIPTION
## What's changed?


Closes this f+c [ticket](https://trello.com/c/0rpuA4HV/932-improve-the-visual-hierarchy-of-primary-secondary-containers-in-the-fronts-tooling) to Improve the visual hierarchy of primary & secondary containers in the fronts tooling. 

We've shown this to a couple of stakeholders in editorial who've said they're happy with the look. 

![image](https://github.com/user-attachments/assets/34336118-5be3-426f-8888-339d2225c1e0)


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
