### PR TITLE
Remove switch for portrait crop

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,13 +33,6 @@ object TenImageSlideshows
       enabled = false
     )
 
-object SupportPortraitCrops
-    extends FeatureSwitch(
-      key = "support-portrait-crops",
-      title = "Support portrait crops for feature card containers",
-      enabled = false
-    )
-
 object PinboardIntegration
     extends FeatureSwitch(
       key = "pinboard",
@@ -52,7 +45,6 @@ object FeatureSwitches {
     ObscureFeed,
     PageViewDataVisualisation,
     TenImageSlideshows,
-    SupportPortraitCrops,
     PinboardIntegration
   )
 

--- a/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
+++ b/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
@@ -160,11 +160,6 @@ export const initialState = {
 			},
 			featureSwitches: [
 				{
-					key: 'support-portrait-crops',
-					title: 'Support portrait crops for feature card containers',
-					enabled: false,
-				},
-				{
 					key: 'obscure-feed',
 					title: "Obscure the feed -- it's distracting for developers!",
 					enabled: false,
@@ -664,11 +659,6 @@ export const initialState = {
 		lastFetchOrder: [],
 	},
 	featureSwitches: {
-		'support-portrait-crops': {
-			key: 'support-portrait-crops',
-			title: 'Support portrait crops for feature card containers',
-			enabled: false,
-		},
 		'obscure-feed': {
 			key: 'obscure-feed',
 			title: "Obscure the feed -- it's distracting for developers!",
@@ -909,11 +899,6 @@ export const finalStateWhenAddNewCollection = {
 				'08a80ac8-3525-48e2-af88-22e8854aa0d7': [],
 			},
 			featureSwitches: [
-				{
-					key: 'support-portrait-crops',
-					title: 'Support portrait crops for feature card containers',
-					enabled: false,
-				},
 				{
 					key: 'obscure-feed',
 					title: "Obscure the feed -- it's distracting for developers!",
@@ -1415,11 +1400,6 @@ export const finalStateWhenAddNewCollection = {
 		lastFetchOrder: [],
 	},
 	featureSwitches: {
-		'support-portrait-crops': {
-			key: 'support-portrait-crops',
-			title: 'Support portrait crops for feature card containers',
-			enabled: false,
-		},
 		'obscure-feed': {
 			key: 'obscure-feed',
 			title: "Obscure the feed -- it's distracting for developers!",
@@ -1674,11 +1654,6 @@ export const finalStateWhenRemoveACollection = {
 				'08a80ac8-3525-48e2-af88-22e8854aa0d7': [],
 			},
 			featureSwitches: [
-				{
-					key: 'support-portrait-crops',
-					title: 'Support portrait crops for feature card containers',
-					enabled: false,
-				},
 				{
 					key: 'obscure-feed',
 					title: "Obscure the feed -- it's distracting for developers!",
@@ -2179,11 +2154,6 @@ export const finalStateWhenRemoveACollection = {
 		lastFetchOrder: [],
 	},
 	featureSwitches: {
-		'support-portrait-crops': {
-			key: 'support-portrait-crops',
-			title: 'Support portrait crops for feature card containers',
-			enabled: false,
-		},
 		'obscure-feed': {
 			key: 'obscure-feed',
 			title: "Obscure the feed -- it's distracting for developers!",

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -26,7 +26,6 @@ import {
 import {
 	editionsCardImageCriteria,
 	DRAG_DATA_CARD_IMAGE_OVERRIDE,
-	SUPPORT_PORTRAIT_CROPS,
 	COLLECTIONS_USING_PORTRAIT_TRAILS,
 	landScapeCardImageCriteria,
 	portraitCardImageCriteria,
@@ -464,10 +463,6 @@ class Card extends React.Component<CardContainerProps> {
 
 		if (COLLECTIONS_USING_SQUARE_TRAILS.includes(collectionType)) {
 			return squareImageCriteria;
-		}
-
-		if (!SUPPORT_PORTRAIT_CROPS) {
-			return landScapeCardImageCriteria;
 		}
 
 		return COLLECTIONS_USING_PORTRAIT_TRAILS.includes(collectionType)

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -47,7 +47,6 @@ import {
 	editionsTabletCardImageCriteria,
 	portraitCardImageCriteria,
 	COLLECTIONS_USING_PORTRAIT_TRAILS,
-	SUPPORT_PORTRAIT_CROPS,
 	COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS,
 	landscape5To4CardImageCriteria,
 	COLLECTIONS_USING_SQUARE_TRAILS,
@@ -1013,9 +1012,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		}
 		if (COLLECTIONS_USING_SQUARE_TRAILS.includes(collectionType)) {
 			return squareImageCriteria;
-		}
-		if (!SUPPORT_PORTRAIT_CROPS) {
-			return landScapeCardImageCriteria;
 		}
 		return COLLECTIONS_USING_PORTRAIT_TRAILS.includes(collectionType)
 			? portraitCardImageCriteria

--- a/fronts-client/src/constants/image.ts
+++ b/fronts-client/src/constants/image.ts
@@ -1,13 +1,7 @@
-import pageConfig from 'util/extractConfigFromPage';
 import {
 	FLEXIBLE_GENERAL_NAME,
 	FLEXIBLE_SPECIAL_NAME,
 } from './flexibleContainers';
-
-export const SUPPORT_PORTRAIT_CROPS =
-	pageConfig?.userData?.featureSwitches.find(
-		(feature) => feature.key === 'support-portrait-crops',
-	)?.enabled || false;
 
 export const landScapeCardImageCriteria = {
 	minWidth: 400,


### PR DESCRIPTION
## What's changed?
Removes the portrait crop feature switch introduced in https://github.com/guardian/facia-tool/pull/1733. The portrait-compatible containers and now being used by editorial on the europe-beta front and we no longer want this feature behind a switch. 

## Screenshots

### Feature switchboard before and after

![Screenshot 2025-02-11 at 16 34 55](https://github.com/user-attachments/assets/6cf7f77e-118c-42bb-abe7-ca4d2b078de2)
![Screenshot 2025-02-11 at 16 56 52](https://github.com/user-attachments/assets/ccb0d2de-831f-4add-8965-880149479158)

### Portrait crop still available in tool
 
![Screenshot 2025-02-11 at 16 57 41](https://github.com/user-attachments/assets/56650b56-74aa-48d5-98a0-6b5ca60106a7)



## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
