### PR TITLE
Update ubuntu versions in CI workflows

### DIFF
--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -174,11 +174,7 @@ jobs:
                     - 4724:5432
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: "11"
-                  distribution: "corretto"
-                  cache: "sbt"
+            - uses: guardian/setup-scala@v1
             - name: Run tests
               run: sbt 'test; database-int:test'
 
@@ -186,11 +182,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: "11"
-                  distribution: "corretto"
-                  cache: "sbt"
+            - uses: guardian/setup-scala@v1
             - name: Check scala formatting
               run: sbt 'scalafmtCheck; scalafmtSbtCheck;'
 
@@ -220,11 +212,7 @@ jobs:
             - name: Set GITHUB_RUN_NUMBER environment variable
               run: |
                   echo "GITHUB_RUN_NUMBER=${{ needs.generate_build_number.outputs.BUILD_NUMBER }}" >> $GITHUB_ENV
-            - uses: actions/setup-java@v4
-              with:
-                  java-version: "11"
-                  distribution: "corretto"
-                  cache: "sbt"
+            - uses: guardian/setup-scala@v1
             - name: Bundle
               run: sbt debian:packageBin
             - uses: actions/upload-artifact@v4

--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -58,7 +58,7 @@ jobs:
                   path: public/src/jspm_packages
                   if-no-files-found: error
     test_client_v1:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         permissions:
             id-token: write
             contents: read
@@ -129,7 +129,7 @@ jobs:
               working-directory: fronts-client
 
     integrationtest_client_v2:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         permissions:
             id-token: write
             contents: read

--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     generate_build_number:
         name: Generate build number
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         outputs:
             BUILD_NUMBER: ${{ steps.create-build-number.outputs.BUILD_NUMBER }}
         steps:
@@ -19,7 +19,7 @@ jobs:
                     echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> "$GITHUB_OUTPUT"
 
     build_client_v1:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -58,7 +58,7 @@ jobs:
                   path: public/src/jspm_packages
                   if-no-files-found: error
     test_client_v1:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -89,7 +89,7 @@ jobs:
                     grunt --stack test
 
     build_client_v2:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -112,7 +112,7 @@ jobs:
                   path: public/fronts-client-v2
                   if-no-files-found: error
     test_client_v2:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -129,7 +129,7 @@ jobs:
               working-directory: fronts-client
 
     integrationtest_client_v2:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -152,7 +152,7 @@ jobs:
               working-directory: fronts-client
 
     test_backend:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -183,7 +183,7 @@ jobs:
               run: sbt 'test; database-int:test'
 
     lint_backend:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-java@v4
@@ -195,7 +195,7 @@ jobs:
               run: sbt 'scalafmtCheck; scalafmtSbtCheck;'
 
     build_backend:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read
@@ -234,7 +234,7 @@ jobs:
                   if-no-files-found: error
                   compression-level: '0' #no point, it's already compressed
     upload:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             id-token: write
             contents: read

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION
## What's changed?

Github have stated that the ubuntu-20.04 runner image is [being closed down](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) by April, so this updates the CI workflow that were using it. 

I first tried updating everything to `ubuntu-latest` (i.e. [ubuntu-24.04](https://github.com/actions/runner-images#:~:text=Latest%20Image%20Release-,Ubuntu%2024.04,-ubuntu%2Dlatest%20or)) as this is [commonly used](https://github.com/search?q=org%3Aguardian%20ubuntu-latest&type=code) in Guardian projects, but this only worked for about half of the workflows. 

For some of those failing workflows, the issue seemed related to sbt not being installed, so I've also replaced the `setup-java` action with `setup-scala` (and added the required `.tool-versions` file specifying java 11).

## As for the client CI tests...

For these (`test_client_v1` and `integration_test_client_v2`), the problem looked related to the tests trying to [run  puppeteer](https://github.com/guardian/facia-tool/actions/runs/13283371077/job/37086476245?pr=1759#step:8:19) and failing. 

From some googling, others have also had [issues](https://github.com/puppeteer/puppeteer/issues/12818) with puppeteer following the upgrade from 22 to 24, specifically due to an enhanced security feature of ubuntu-24.04(AppArmor profile). The puppeteer team have [stated they're not going](https://github.com/puppeteer/puppeteer/issues/13595#issuecomment-2640283618) to integrate a solution directly, and although there are a few suggestions from the [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/88ef09c6ccc27d024972725c728a9db50f010f36/docs/troubleshooting.md#setting-up-chrome-linux-sandbox) or [the team](https://github.com/puppeteer/puppeteer/issues/13595#issuecomment-2640309385) on how to get puppeteer working with ubuntu v23+, implementing one of them feels best left to a separate PR, and for the time being I've just pinned the ubuntu image to 22.04. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
