### PR TITLE
Adjust dropdown menu height to fix its view

### DIFF
--- a/fronts-client/src/components/FeastCollectionMenu.tsx
+++ b/fronts-client/src/components/FeastCollectionMenu.tsx
@@ -39,7 +39,8 @@ const MenuItem = styled.li`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding: 10px 15px;
+	padding: 1px;
+	height: 30px;
 	cursor: pointer;
 	border-bottom: 1px gray;
 	:hover {


### PR DESCRIPTION
## What's changed?
Fix drop down menu lauout to let it appear in the user's view and not behind the Heading component.
Before:

<img width="964" alt="image" src="https://github.com/user-attachments/assets/8459cee0-88f0-4998-98e1-4f0b8eb24534" />

After:

<img width="927" alt="image" src="https://github.com/user-attachments/assets/169f6eef-b52f-4eb4-b366-f534d5aff0ed" />



## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [X] ✅ CI checks / tests run locally
- [X] 🔍 Checked on CODE

### Client
- [X] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [X] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [X] 📷 Screenshots / GIFs of relevant UI changes included
