### PR TITLE
Allow editors to visualise container types in the Fronts Tool

### DIFF
--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -121,8 +121,8 @@ const LockedCollectionFlag = styled.span`
 	font-family: GHGuardianHeadline;
 	font-size: 22px;
 	color: ${theme.base.colors.backgroundColor};
-	height: 40px;
-	line-height: 40px;
+	height: 14px;
+	line-height: 14px;
 `;
 
 const CollectionMetaBase = styled.span`
@@ -373,11 +373,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 				<CollectionHeadingSticky tabIndex={-1}>
 					<CollectionHeadingInner>
 						<CollectionHeadlineWithConfigContainer>
-							{isLocked ? (
-								<LockedCollectionFlag>
-									<LockedPadlockIcon fill={theme.base.colors.textDark} />
-								</LockedCollectionFlag>
-							) : null}
 							{this.state.editingContainerName ? (
 								<CollectionHeaderInput
 									data-testid="rename-front-input"
@@ -407,6 +402,14 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 											{!!collection ? collection!.displayName : 'Loading …'}
 										</CollectionDisplayName>
 										<CollectionConfigContainer>
+											{isLocked ? (
+												<LockedCollectionFlag>
+													<LockedPadlockIcon
+														fill={theme.base.colors.textDark}
+														size={'s'}
+													/>
+												</LockedCollectionFlag>
+											) : null}
 											{collection?.type ? (
 												<CollectionConfigText
 													priority={'primary'}

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -208,7 +208,7 @@ const CollectionDisplayName = styled.span`
 `;
 
 const CollectionConfigContainer = styled.div`
-	display: inline-block;
+	display: flex;
 	font-family: GHGuardianHeadline;
 	font-size: 15px;
 	color: ${theme.base.colors.text};
@@ -216,18 +216,18 @@ const CollectionConfigContainer = styled.div`
 	vertical-align: bottom;
 	position: relative;
 	z-index: 2;
-	margin-bottom: 2px;
+	margin-bottom: 4px;
+	gap: 4px;
 `;
 
 const CollectionConfigText = styled.div`
 	display: inline;
 	font-weight: normal;
 	font-style: normal;
-	font-size: 14px;
-`;
-
-const CollectionConfigTextPipe = styled.span`
-	color: ${theme.base.colors.borderColor};
+	font-size: 12px;
+	background-color: ${theme.colors.white};
+	color: ${theme.colors.blackDark};
+	padding: 2px 3px;
 `;
 
 const CollectionShortVerticalPinline = styled(ShortVerticalPinline)`
@@ -236,10 +236,11 @@ const CollectionShortVerticalPinline = styled(ShortVerticalPinline)`
 `;
 
 const TargetedTerritoryBox = styled.div`
-	background-color: black;
-	color: white;
+	color: ${theme.button.color};
+	background-color: ${theme.base.colors.button};
 	font-size: 15px;
 	padding: 0 5px;
+	width: min-content;
 	span {
 		font-size: 7px;
 		vertical-align: middle;
@@ -277,7 +278,6 @@ const CollectionType = styled.div`
 	font-weight: normal;
 	line-height: normal;
 	position: absolute;
-	top: 10px;
 	right: 44px;
 	width: max-content;
 	${CollectionTypeContainer}:hover & {
@@ -391,7 +391,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 										<CollectionConfigContainer>
 											{collectionConfigLabels.map((label, index) => (
 												<CollectionConfigText>
-													{index !== 0 ? <CollectionConfigTextPipe> | </CollectionConfigTextPipe> : null}
 													{label}
 												</CollectionConfigText>
 											))}

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -321,6 +321,16 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 		const targetedTerritory = collection ? collection.targetedTerritory : null;
 		const { displayName } = this.state;
 
+
+		const getCollectionThumbnailSvgPath = (maybeCollectionType: string | undefined) => {
+			if(!maybeCollectionType) return null;
+			return /^(fixed|dynamic|flexible|scrollable|static)\//.test(maybeCollectionType)
+				? '/thumbnails/' + collection?.type + '.svg'
+				: null;
+		}
+
+		const collectionTypeThumbnail = getCollectionThumbnailSvgPath(collection?.type);
+
 		return (
 			<CollectionContainer
 				id={collection && createCollectionId(collection, frontId)}
@@ -391,8 +401,8 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 							)}
 							{collection?.type && !canPublishUnpublishedChanges ?
 								<CollectionTypeContainer>
-									<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection.type} /></CollectionType>
-									<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
+									<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection?.type} /></CollectionType>
+									{collectionTypeThumbnail ? <CollectionTypeThumbnail src={collectionTypeThumbnail}/> : null}
 								</CollectionTypeContainer>
 								: null}
 						</CollectionHeadlineWithConfigContainer>

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -38,7 +38,7 @@ import { selectors as editionsIssueSelectors } from '../bundles/editionsIssueBun
 import { removeFrontCollection } from '../actions/Editions';
 import { FeastCollectionMenu } from './FeastCollectionMenu';
 import type { CollectionUpdateMode } from '../strategies/update-collection';
-import {LockedPadlockIcon} from "./icons/Icons";
+import { LockedPadlockIcon } from './icons/Icons';
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
 	`front-${frontId}-collection-${id}`;
@@ -231,15 +231,17 @@ const CollectionConfigContainer = styled.div`
 
 const CollectionConfigText = styled.div<{
 	priority: 'primary' | 'secondary';
-	weight: 'normal' | 'bold'
+	weight: 'normal' | 'bold';
 }>`
 	display: inline;
 	height: min-content;
-	font-weight: ${({weight}) => weight === 'bold' ? 'bold' : 'normal'};
+	font-weight: ${({ weight }) => (weight === 'bold' ? 'bold' : 'normal')};
 	font-style: normal;
 	font-size: 10px;
-	background-color: ${({priority}) => priority === 'primary' ? theme.base.colors.button : theme.colors.white};
-	color: ${({priority}) => priority === 'primary' ? theme.button.color : theme.colors.blackDark};
+	background-color: ${({ priority }) =>
+		priority === 'primary' ? theme.base.colors.button : theme.colors.white};
+	color: ${({ priority }) =>
+		priority === 'primary' ? theme.button.color : theme.colors.blackDark};
 	padding: 2px 3px;
 	span {
 		font-size: 7px;
@@ -290,7 +292,6 @@ const CollectionType = styled.div`
 	}
 `;
 
-
 class CollectionDisplay extends React.Component<Props, CollectionState> {
 	public static defaultProps = {
 		isUneditable: false,
@@ -328,29 +329,37 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 			handleBlur,
 			isEditions,
 			isFeast,
-			canPublishUnpublishedChanges
+			canPublishUnpublishedChanges,
 		}: Props = this.props;
 		const itemCount = cardIds ? cardIds.length : 0;
 		const targetedTerritory = collection ? collection.targetedTerritory : null;
 		const { displayName } = this.state;
 
-
-		const getCollectionThumbnailSvgPath = (maybeCollectionType: string | undefined) => {
-			if(!maybeCollectionType) return null;
+		const getCollectionThumbnailSvgPath = (
+			maybeCollectionType: string | undefined,
+		) => {
+			if (!maybeCollectionType) return null;
 			// Fall back to (blank) thrasher thumbnail if collection type is not recognized
-			return /^(fixed|dynamic|flexible|scrollable|static)\//.test(maybeCollectionType)
+			return /^(fixed|dynamic|flexible|scrollable|static)\//.test(
+				maybeCollectionType,
+			)
 				? '/thumbnails/' + collection?.type + '.svg'
 				: '/thumbnails/fixed/thrasher.svg';
-		}
+		};
 
-		const collectionTypeThumbnail = getCollectionThumbnailSvgPath(collection?.type);
+		const collectionTypeThumbnail = getCollectionThumbnailSvgPath(
+			collection?.type,
+		);
 
-		const collectionConfigLabels =
-			[
-				oc(collection).metadata[0].type() ? oc(collection).metadata[0].type() : null,
-				collection?.suppressImages ? 'Images suppressed' : null,
-				collection?.platform && collection.platform !== 'Any' ? `${collection.platform} Only` : null
-			].filter(label => label !== null) as string[];
+		const collectionConfigLabels = [
+			oc(collection).metadata[0].type()
+				? oc(collection).metadata[0].type()
+				: null,
+			collection?.suppressImages ? 'Images suppressed' : null,
+			collection?.platform && collection.platform !== 'Any'
+				? `${collection.platform} Only`
+				: null,
+		].filter((label) => label !== null) as string[];
 
 		return (
 			<CollectionContainer
@@ -364,9 +373,11 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 				<CollectionHeadingSticky tabIndex={-1}>
 					<CollectionHeadingInner>
 						<CollectionHeadlineWithConfigContainer>
-							{isLocked ? <LockedCollectionFlag>
-								<LockedPadlockIcon fill={theme.base.colors.textDark}/>
-							</LockedCollectionFlag> :  null}
+							{isLocked ? (
+								<LockedCollectionFlag>
+									<LockedPadlockIcon fill={theme.base.colors.textDark} />
+								</LockedCollectionFlag>
+							) : null}
 							{this.state.editingContainerName ? (
 								<CollectionHeaderInput
 									data-testid="rename-front-input"
@@ -383,40 +394,50 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 									onBlur={() => this.setName()}
 								/>
 							) : (
-									<CollectionHeading
-										isLoading={!collection}
-										isSecondaryContainer={
-											collection?.metadata?.some(
-												(tag) => tag.type === 'Secondary',
-											) ?? false
-										}
-									>
-										<CollectionHeadingText>
-											<CollectionDisplayName>
-												{!!collection ? collection!.displayName : 'Loading …'}
-											</CollectionDisplayName>
-											<CollectionConfigContainer>
-												{collection?.type
-													? <CollectionConfigText priority={'primary'} weight={'normal'}>
-														{collection.type}
-													</CollectionConfigText>
-													: null
-												}
-												{targetedTerritory && (
-													<CollectionConfigText priority={'primary'} weight={'bold'}>
-														{targetedTerritory}
-														<span> &nbsp;ONLY</span>
-													</CollectionConfigText>
-												)}
-												{collectionConfigLabels.map((label, index) => (
-													<CollectionConfigText priority={'secondary'} weight={'normal'}>
-														{label}
-													</CollectionConfigText>
-												))}
-											</CollectionConfigContainer>
-										</CollectionHeadingText>
-										{collectionTypeThumbnail && !canPublishUnpublishedChanges ? <CollectionTypeThumbnail src={collectionTypeThumbnail}/> : null}
-									</CollectionHeading>
+								<CollectionHeading
+									isLoading={!collection}
+									isSecondaryContainer={
+										collection?.metadata?.some(
+											(tag) => tag.type === 'Secondary',
+										) ?? false
+									}
+								>
+									<CollectionHeadingText>
+										<CollectionDisplayName>
+											{!!collection ? collection!.displayName : 'Loading …'}
+										</CollectionDisplayName>
+										<CollectionConfigContainer>
+											{collection?.type ? (
+												<CollectionConfigText
+													priority={'primary'}
+													weight={'normal'}
+												>
+													{collection.type}
+												</CollectionConfigText>
+											) : null}
+											{targetedTerritory && (
+												<CollectionConfigText
+													priority={'primary'}
+													weight={'bold'}
+												>
+													{targetedTerritory}
+													<span> &nbsp;ONLY</span>
+												</CollectionConfigText>
+											)}
+											{collectionConfigLabels.map((label, index) => (
+												<CollectionConfigText
+													priority={'secondary'}
+													weight={'normal'}
+												>
+													{label}
+												</CollectionConfigText>
+											))}
+										</CollectionConfigContainer>
+									</CollectionHeadingText>
+									{collectionTypeThumbnail && !canPublishUnpublishedChanges ? (
+										<CollectionTypeThumbnail src={collectionTypeThumbnail} />
+									) : null}
+								</CollectionHeading>
 							)}
 						</CollectionHeadlineWithConfigContainer>
 						{isFeast && collection ? (

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -38,6 +38,7 @@ import { selectors as editionsIssueSelectors } from '../bundles/editionsIssueBun
 import { removeFrontCollection } from '../actions/Editions';
 import { FeastCollectionMenu } from './FeastCollectionMenu';
 import type { CollectionUpdateMode } from '../strategies/update-collection';
+import ToolTip from "./inputs/HoverActionToolTip";
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
 	`front-${frontId}-collection-${id}`;
@@ -163,6 +164,8 @@ const CollectionHeadingText = styled.div<{
 	isSecondaryContainer: boolean;
 }>`
 	width: 100%;
+	// allow some space for the container type thumbnail (which has absolute positioning)
+	max-width: calc(100% - 42px);
 	white-space: nowrap;
 	${({ isLoading }) =>
 		isLoading &&
@@ -235,6 +238,39 @@ const CollectionHeaderInput = styled.input`
 	font-weight: bold;
 	width: 20em;
 `;
+
+const CollectionTypeContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 4px;
+	position: absolute;
+	right: 10px;
+	z-index: 0;
+`;
+
+const CollectionTypeThumbnail = styled.img`
+	height: 30px;
+	width: 40px;
+`;
+
+const CollectionType = styled.div`
+	font-size: 10px;
+	font-family: TS3TextSans;
+	font-weight: normal;
+	line-height: normal;
+	display: none;
+	// absolute positioning to not affect Discard / Launch buttons etc.
+	position: absolute;
+	top: 5px;
+	right: 45px;
+	width: max-content;
+
+	${CollectionTypeContainer}:hover & {
+		display: unset;
+	}
+`;
+
 
 class CollectionDisplay extends React.Component<Props, CollectionState> {
 	public static defaultProps = {
@@ -377,6 +413,12 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 								)}
 							</HeadlineContentContainer>
 						) : null}
+						{collection?.type ?
+							<CollectionTypeContainer>
+								<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
+								<CollectionType><ToolTip text={collection.type}/></CollectionType>
+							</CollectionTypeContainer>
+							: null}
 					</CollectionHeadingInner>
 					{isFeast ? (
 						<DragToConvertFeastCollection sourceContainerId={id} />

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -70,6 +70,7 @@ type Props = ContainerProps & {
 	) => void;
 	isEditions: boolean;
 	removeFrontCollection: (frontId: string, collectionId: string) => void;
+	canPublishUnpublishedChanges: boolean;
 };
 
 interface CollectionState {
@@ -309,6 +310,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 			handleBlur,
 			isEditions,
 			isFeast,
+			canPublishUnpublishedChanges
 		}: Props = this.props;
 		const itemCount = cardIds ? cardIds.length : 0;
 		const targetedTerritory = collection ? collection.targetedTerritory : null;
@@ -413,7 +415,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 								)}
 							</HeadlineContentContainer>
 						) : null}
-						{collection?.type ?
+						{collection?.type && !canPublishUnpublishedChanges ?
 							<CollectionTypeContainer>
 								<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
 								<CollectionType><ToolTip text={collection.type}/></CollectionType>

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -155,6 +155,8 @@ const CollectionHeadingInner = styled(ContainerHeadingPinline)`
 `;
 
 const CollectionHeadlineWithConfigContainer = styled.div`
+	display: flex;
+	gap: 8px;
 	flex-grow: 1;
 	min-width: 0;
 	flex-basis: 100%;
@@ -171,8 +173,12 @@ const CollectionHeadingText = styled.div<{
 		css`
 			color: ${theme.base.colors.textMuted};
 		`} white-space: nowrap;
-	overflow: hidden;
+	overflow-x: scroll;
+	overflow-y: hidden;
 	text-overflow: ellipsis;
+	display: flex;
+	justify-content: flex-start;
+	gap: 8px;
 	${({ isSecondaryContainer }) =>
 		isSecondaryContainer &&
 		css`
@@ -201,7 +207,6 @@ const CollectionConfigContainer = styled.div`
 	font-size: 15px;
 	color: ${theme.base.colors.text};
 	white-space: nowrap;
-	margin-left: 8px;
 	vertical-align: bottom;
 	position: relative;
 	z-index: 2;
@@ -245,8 +250,7 @@ const CollectionTypeContainer = styled.div`
 	flex-direction: row;
 	align-items: center;
 	gap: 4px;
-	position: absolute;
-	right: 10px;
+	position: relative;
 	z-index: 0;
 
 	:hover {
@@ -265,7 +269,7 @@ const CollectionType = styled.div`
 	font-weight: normal;
 	line-height: normal;
 	position: absolute;
-	top: 6px;
+	top: 10px;
 	right: 44px;
 	width: max-content;
 	${CollectionTypeContainer}:hover & {
@@ -345,46 +349,52 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 									onBlur={() => this.setName()}
 								/>
 							) : (
-								<CollectionHeadingText
-									isLoading={!collection}
-									title={!!collection ? collection!.displayName : 'Loading …'}
-									isSecondaryContainer={
-										collection?.metadata?.some(
-											(tag) => tag.type === 'Secondary',
-										) ?? false
-									}
-								>
-									{!!collection ? collection!.displayName : 'Loading …'}
-									<CollectionConfigContainer>
-										{oc(collection).metadata[0].type() ? (
-											<CollectionConfigText>
-												<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-												{oc(collection).metadata[0].type()}
-											</CollectionConfigText>
-										) : null}
-										{collection?.suppressImages ? (
-											<CollectionConfigText>
-												<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-												Images suppressed
-											</CollectionConfigText>
-										) : null}
-										{collection &&
-										collection.platform &&
-										collection.platform !== 'Any' ? (
-											<CollectionConfigText>
-												<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-												{`${collection.platform} Only`}
-											</CollectionConfigText>
-										) : null}
-										{targetedTerritory && (
-											<TargetedTerritoryBox>
-												{targetedTerritory}
-												<span> &nbsp;ONLY</span>
-											</TargetedTerritoryBox>
-										)}
-									</CollectionConfigContainer>
-								</CollectionHeadingText>
+									<CollectionHeadingText
+										isLoading={!collection}
+										title={!!collection ? collection!.displayName : 'Loading …'}
+										isSecondaryContainer={
+											collection?.metadata?.some(
+												(tag) => tag.type === 'Secondary',
+											) ?? false
+										}
+									>
+										{!!collection ? collection!.displayName : 'Loading …'}
+										<CollectionConfigContainer>
+											{oc(collection).metadata[0].type() ? (
+												<CollectionConfigText>
+													<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+													{oc(collection).metadata[0].type()}
+												</CollectionConfigText>
+											) : null}
+											{collection?.suppressImages ? (
+												<CollectionConfigText>
+													<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+													Images suppressed
+												</CollectionConfigText>
+											) : null}
+											{collection &&
+											collection.platform &&
+											collection.platform !== 'Any' ? (
+												<CollectionConfigText>
+													<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
+													{`${collection.platform} Only`}
+												</CollectionConfigText>
+											) : null}
+											{targetedTerritory && (
+												<TargetedTerritoryBox>
+													{targetedTerritory}
+													<span> &nbsp;ONLY</span>
+												</TargetedTerritoryBox>
+											)}
+										</CollectionConfigContainer>
+									</CollectionHeadingText>
 							)}
+							{collection?.type && !canPublishUnpublishedChanges ?
+								<CollectionTypeContainer>
+									<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection.type} /></CollectionType>
+									<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
+								</CollectionTypeContainer>
+								: null}
 						</CollectionHeadlineWithConfigContainer>
 						{isFeast && collection ? (
 							<FeastCollectionMenu
@@ -417,12 +427,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 								)}
 							</HeadlineContentContainer>
 						) : null}
-						{collection?.type && !canPublishUnpublishedChanges ?
-							<CollectionTypeContainer>
-								<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection.type} /></CollectionType>
-								<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
-							</CollectionTypeContainer>
-							: null}
 					</CollectionHeadingInner>
 					{isFeast ? (
 						<DragToConvertFeastCollection sourceContainerId={id} />

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -39,6 +39,7 @@ import { removeFrontCollection } from '../actions/Editions';
 import { FeastCollectionMenu } from './FeastCollectionMenu';
 import type { CollectionUpdateMode } from '../strategies/update-collection';
 import ToolTip from "./inputs/HoverActionToolTip";
+import {LockedPadlockIcon} from "./icons/Icons";
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
 	`front-${frontId}-collection-${id}`;
@@ -121,10 +122,9 @@ const CollectionDisabledTheme = styled.div`
 const LockedCollectionFlag = styled.span`
 	font-family: GHGuardianHeadline;
 	font-size: 22px;
-	color: ${theme.base.colors.text};
+	color: ${theme.base.colors.backgroundColor};
 	height: 40px;
 	line-height: 40px;
-	border-bottom: 1px solid ${theme.base.colors.borderColor};
 `;
 
 const CollectionMetaBase = styled.span`
@@ -344,6 +344,9 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 				<CollectionHeadingSticky tabIndex={-1}>
 					<CollectionHeadingInner>
 						<CollectionHeadlineWithConfigContainer>
+							{isLocked ? <LockedCollectionFlag>
+								<LockedPadlockIcon fill={theme.base.colors.textDark}/>
+							</LockedCollectionFlag> :  null}
 							{this.state.editingContainerName ? (
 								<CollectionHeaderInput
 									data-testid="rename-front-input"
@@ -422,9 +425,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 								onDeleteClicked={this.handleDeleteClick}
 							/>
 						) : undefined}
-						{isLocked ? (
-							<LockedCollectionFlag>Locked</LockedCollectionFlag>
-						) : headlineContent ? (
+						{!isLocked && headlineContent ? (
 							<HeadlineContentContainer>
 								{headlineContent}
 								{isEditions && !isFeast && (

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -173,12 +173,13 @@ const CollectionHeadingText = styled.div<{
 		css`
 			color: ${theme.base.colors.textMuted};
 		`} white-space: nowrap;
-	overflow-x: scroll;
-	overflow-y: hidden;
+	overflow: hidden;
 	text-overflow: ellipsis;
+	min-height: 40px;
+	height: 100%;
+	justify-content: center;
 	display: flex;
-	justify-content: flex-start;
-	gap: 8px;
+	flex-direction: column;
 	${({ isSecondaryContainer }) =>
 		isSecondaryContainer &&
 		css`
@@ -201,6 +202,11 @@ const CollectionToggleContainer = styled.div`
 	}
 `;
 
+const CollectionDisplayName = styled.span`
+	text-overflow: ellipsis;
+	overflow: hidden;
+`;
+
 const CollectionConfigContainer = styled.div`
 	display: inline-block;
 	font-family: GHGuardianHeadline;
@@ -210,12 +216,14 @@ const CollectionConfigContainer = styled.div`
 	vertical-align: bottom;
 	position: relative;
 	z-index: 2;
+	margin-bottom: 2px;
 `;
 
 const CollectionConfigText = styled.div`
 	display: inline;
 	font-weight: normal;
 	font-style: normal;
+	font-size: 14px;
 `;
 
 const CollectionConfigTextPipe = styled.span`
@@ -372,7 +380,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 											) ?? false
 										}
 									>
-										{!!collection ? collection!.displayName : 'Loading …'}
+										<CollectionDisplayName>{!!collection ? collection!.displayName : 'Loading …'}</CollectionDisplayName>
 										<CollectionConfigContainer>
 											{oc(collection).metadata[0].type() ? (
 												<CollectionConfigText>

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -165,8 +165,6 @@ const CollectionHeadingText = styled.div<{
 	isSecondaryContainer: boolean;
 }>`
 	width: 100%;
-	// allow some space for the container type thumbnail (which has absolute positioning)
-	max-width: calc(100% - 42px);
 	white-space: nowrap;
 	${({ isLoading }) =>
 		isLoading &&
@@ -203,8 +201,10 @@ const CollectionConfigContainer = styled.div`
 	font-size: 15px;
 	color: ${theme.base.colors.text};
 	white-space: nowrap;
-	margin-left: 3px;
+	margin-left: 8px;
 	vertical-align: bottom;
+	position: relative;
+	z-index: 2;
 `;
 
 const CollectionConfigText = styled.div`
@@ -248,6 +248,10 @@ const CollectionTypeContainer = styled.div`
 	position: absolute;
 	right: 10px;
 	z-index: 0;
+
+	:hover {
+		z-index: 3;
+	}
 `;
 
 const CollectionTypeThumbnail = styled.img`
@@ -260,12 +264,10 @@ const CollectionType = styled.div`
 	font-family: TS3TextSans;
 	font-weight: normal;
 	line-height: normal;
-	// absolute positioning to not affect Discard / Launch buttons etc.
 	position: absolute;
-	top: 5px;
-	right: 45px;
+	top: 6px;
+	right: 44px;
 	width: max-content;
-
 	${CollectionTypeContainer}:hover & {
 		display: unset;
 	}
@@ -417,8 +419,8 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 						) : null}
 						{collection?.type && !canPublishUnpublishedChanges ?
 							<CollectionTypeContainer>
-								<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
 								<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection.type} /></CollectionType>
+								<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
 							</CollectionTypeContainer>
 							: null}
 					</CollectionHeadingInner>

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -324,9 +324,10 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 
 		const getCollectionThumbnailSvgPath = (maybeCollectionType: string | undefined) => {
 			if(!maybeCollectionType) return null;
+			// Fall back to (blank) thrasher thumbnail if collection type is not recognized
 			return /^(fixed|dynamic|flexible|scrollable|static)\//.test(maybeCollectionType)
 				? '/thumbnails/' + collection?.type + '.svg'
-				: null;
+				: '/thumbnails/fixed/thrasher.svg';
 		}
 
 		const collectionTypeThumbnail = getCollectionThumbnailSvgPath(collection?.type);

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -260,7 +260,6 @@ const CollectionType = styled.div`
 	font-family: TS3TextSans;
 	font-weight: normal;
 	line-height: normal;
-	display: none;
 	// absolute positioning to not affect Discard / Launch buttons etc.
 	position: absolute;
 	top: 5px;
@@ -323,6 +322,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 				onFocus={() => handleFocus(id)}
 				onBlur={handleBlur}
 				hasMultipleFrontsOpen={hasMultipleFrontsOpen}
+				className="collection-container"
 			>
 				<CollectionHeadingSticky tabIndex={-1}>
 					<CollectionHeadingInner>
@@ -418,7 +418,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 						{collection?.type && !canPublishUnpublishedChanges ?
 							<CollectionTypeContainer>
 								<CollectionTypeThumbnail src={`/thumbnails/${collection.type}.svg`}/>
-								<CollectionType><ToolTip text={collection.type}/></CollectionType>
+								<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection.type} /></CollectionType>
 							</CollectionTypeContainer>
 							: null}
 					</CollectionHeadingInner>

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -208,12 +208,14 @@ const CollectionHeadingText = styled.div`
 	flex-direction: column;
 	align-items: flex-start;
 	row-gap: 2px;
+	overflow: hidden;
 `;
 
 const CollectionDisplayName = styled.span`
 	text-overflow: ellipsis;
 	overflow: hidden;
 	font-size: 18px;
+	width: 100%;
 `;
 
 const CollectionConfigContainer = styled.div`
@@ -227,6 +229,7 @@ const CollectionConfigContainer = styled.div`
 	position: relative;
 	z-index: 2;
 	column-gap: 4px;
+	row-gap: 2px;
 `;
 
 const CollectionConfigText = styled.div<{

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -371,7 +371,6 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 				onFocus={() => handleFocus(id)}
 				onBlur={handleBlur}
 				hasMultipleFrontsOpen={hasMultipleFrontsOpen}
-				className="collection-container"
 			>
 				<CollectionHeadingSticky tabIndex={-1}>
 					<CollectionHeadingInner>

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -38,7 +38,6 @@ import { selectors as editionsIssueSelectors } from '../bundles/editionsIssueBun
 import { removeFrontCollection } from '../actions/Editions';
 import { FeastCollectionMenu } from './FeastCollectionMenu';
 import type { CollectionUpdateMode } from '../strategies/update-collection';
-import ToolTip from "./inputs/HoverActionToolTip";
 import {LockedPadlockIcon} from "./icons/Icons";
 
 export const createCollectionId = ({ id }: Collection, frontId: string) =>
@@ -97,7 +96,6 @@ const CollectionContainer = styled(ContentContainer)<{
 
 const HeadlineContentContainer = styled.span`
 	position: relative;
-	margin-right: -11px;
 	display: flex;
 	align-items: center;
 	gap: 2px;
@@ -162,7 +160,7 @@ const CollectionHeadlineWithConfigContainer = styled.div`
 	flex-basis: 100%;
 `;
 
-const CollectionHeadingText = styled.div<{
+const CollectionHeading = styled.div<{
 	isLoading: boolean;
 	isSecondaryContainer: boolean;
 }>`
@@ -175,11 +173,14 @@ const CollectionHeadingText = styled.div<{
 		`} white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	min-height: 40px;
+	min-height: 48px;
 	height: 100%;
-	justify-content: center;
 	display: flex;
-	flex-direction: column;
+	align-items: center;
+	column-gap: 4px;
+	flex-direction: row;
+	justify-content: space-between;
+	font-size: 18px;
 	${({ isSecondaryContainer }) =>
 		isSecondaryContainer &&
 		css`
@@ -202,13 +203,22 @@ const CollectionToggleContainer = styled.div`
 	}
 `;
 
+const CollectionHeadingText = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	row-gap: 2px;
+`;
+
 const CollectionDisplayName = styled.span`
 	text-overflow: ellipsis;
 	overflow: hidden;
+	font-size: 18px;
 `;
 
 const CollectionConfigContainer = styled.div`
 	display: flex;
+	flex-wrap: wrap;
 	font-family: GHGuardianHeadline;
 	font-size: 15px;
 	color: ${theme.base.colors.text};
@@ -216,35 +226,30 @@ const CollectionConfigContainer = styled.div`
 	vertical-align: bottom;
 	position: relative;
 	z-index: 2;
-	margin-bottom: 4px;
-	gap: 4px;
+	column-gap: 4px;
 `;
 
-const CollectionConfigText = styled.div`
+const CollectionConfigText = styled.div<{
+	priority: 'primary' | 'secondary';
+	weight: 'normal' | 'bold'
+}>`
 	display: inline;
-	font-weight: normal;
+	height: min-content;
+	font-weight: ${({weight}) => weight === 'bold' ? 'bold' : 'normal'};
 	font-style: normal;
-	font-size: 12px;
-	background-color: ${theme.colors.white};
-	color: ${theme.colors.blackDark};
+	font-size: 10px;
+	background-color: ${({priority}) => priority === 'primary' ? theme.base.colors.button : theme.colors.white};
+	color: ${({priority}) => priority === 'primary' ? theme.button.color : theme.colors.blackDark};
 	padding: 2px 3px;
+	span {
+		font-size: 7px;
+		vertical-align: middle;
+	}
 `;
 
 const CollectionShortVerticalPinline = styled(ShortVerticalPinline)`
 	right: initial;
 	left: 0;
-`;
-
-const TargetedTerritoryBox = styled.div`
-	color: ${theme.button.color};
-	background-color: ${theme.base.colors.button};
-	font-size: 15px;
-	padding: 0 5px;
-	width: min-content;
-	span {
-		font-size: 7px;
-		vertical-align: middle;
-	}
 `;
 
 const CollectionHeaderInput = styled.input`
@@ -378,37 +383,41 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 									onBlur={() => this.setName()}
 								/>
 							) : (
-									<CollectionHeadingText
+									<CollectionHeading
 										isLoading={!collection}
-										title={!!collection ? collection!.displayName : 'Loading …'}
 										isSecondaryContainer={
 											collection?.metadata?.some(
 												(tag) => tag.type === 'Secondary',
 											) ?? false
 										}
 									>
-										<CollectionDisplayName>{!!collection ? collection!.displayName : 'Loading …'}</CollectionDisplayName>
-										<CollectionConfigContainer>
-											{collectionConfigLabels.map((label, index) => (
-												<CollectionConfigText>
-													{label}
-												</CollectionConfigText>
-											))}
-											{targetedTerritory && (
-												<TargetedTerritoryBox>
-													{targetedTerritory}
-													<span> &nbsp;ONLY</span>
-												</TargetedTerritoryBox>
-											)}
-										</CollectionConfigContainer>
-									</CollectionHeadingText>
+										<CollectionHeadingText>
+											<CollectionDisplayName>
+												{!!collection ? collection!.displayName : 'Loading …'}
+											</CollectionDisplayName>
+											<CollectionConfigContainer>
+												{collection?.type
+													? <CollectionConfigText priority={'primary'} weight={'normal'}>
+														{collection.type}
+													</CollectionConfigText>
+													: null
+												}
+												{targetedTerritory && (
+													<CollectionConfigText priority={'primary'} weight={'bold'}>
+														{targetedTerritory}
+														<span> &nbsp;ONLY</span>
+													</CollectionConfigText>
+												)}
+												{collectionConfigLabels.map((label, index) => (
+													<CollectionConfigText priority={'secondary'} weight={'normal'}>
+														{label}
+													</CollectionConfigText>
+												))}
+											</CollectionConfigContainer>
+										</CollectionHeadingText>
+										{collectionTypeThumbnail && !canPublishUnpublishedChanges ? <CollectionTypeThumbnail src={collectionTypeThumbnail}/> : null}
+									</CollectionHeading>
 							)}
-							{collection?.type && !canPublishUnpublishedChanges ?
-								<CollectionTypeContainer>
-									<CollectionType className="visible-based-on-collection-container-width"><ToolTip text={collection?.type} /></CollectionType>
-									{collectionTypeThumbnail ? <CollectionTypeThumbnail src={collectionTypeThumbnail}/> : null}
-								</CollectionTypeContainer>
-								: null}
 						</CollectionHeadlineWithConfigContainer>
 						{isFeast && collection ? (
 							<FeastCollectionMenu

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -340,6 +340,13 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 
 		const collectionTypeThumbnail = getCollectionThumbnailSvgPath(collection?.type);
 
+		const collectionConfigLabels =
+			[
+				oc(collection).metadata[0].type() ? oc(collection).metadata[0].type() : null,
+				collection?.suppressImages ? 'Images suppressed' : null,
+				collection?.platform && collection.platform !== 'Any' ? `${collection.platform} Only` : null
+			].filter(label => label !== null) as string[];
+
 		return (
 			<CollectionContainer
 				id={collection && createCollectionId(collection, frontId)}
@@ -382,26 +389,12 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 									>
 										<CollectionDisplayName>{!!collection ? collection!.displayName : 'Loading …'}</CollectionDisplayName>
 										<CollectionConfigContainer>
-											{oc(collection).metadata[0].type() ? (
+											{collectionConfigLabels.map((label, index) => (
 												<CollectionConfigText>
-													<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-													{oc(collection).metadata[0].type()}
+													{index !== 0 ? <CollectionConfigTextPipe> | </CollectionConfigTextPipe> : null}
+													{label}
 												</CollectionConfigText>
-											) : null}
-											{collection?.suppressImages ? (
-												<CollectionConfigText>
-													<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-													Images suppressed
-												</CollectionConfigText>
-											) : null}
-											{collection &&
-											collection.platform &&
-											collection.platform !== 'Any' ? (
-												<CollectionConfigText>
-													<CollectionConfigTextPipe> | </CollectionConfigTextPipe>
-													{`${collection.platform} Only`}
-												</CollectionConfigText>
-											) : null}
+											))}
 											{targetedTerritory && (
 												<TargetedTerritoryBox>
 													{targetedTerritory}

--- a/fronts-client/src/components/CollectionDisplay.tsx
+++ b/fronts-client/src/components/CollectionDisplay.tsx
@@ -439,6 +439,7 @@ class CollectionDisplay extends React.Component<Props, CollectionState> {
 											))}
 										</CollectionConfigContainer>
 									</CollectionHeadingText>
+									{/*Hide when Discard / Launch buttons are visible*/}
 									{collectionTypeThumbnail && !canPublishUnpublishedChanges ? (
 										<CollectionTypeThumbnail src={collectionTypeThumbnail} />
 									) : null}

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -152,6 +152,7 @@ const OpenFormsWarningContainer = styled.div`
 
 const ActionButtonsContainer = styled.div`
 	display: flex;
+	z-index: 2;
 `;
 
 const MoveButtonsContainer = styled.div`

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -227,6 +227,8 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 
 		const groupIds = groups.map((group) => group.uuid);
 
+		const canPublishUnpublishedChanges = hasUnpublishedChanges && canPublish;
+
 		return (
 			<>
 				<CollectionDisplay
@@ -238,9 +240,9 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 					isOpen={isOpen}
 					hasMultipleFrontsOpen={hasMultipleFrontsOpen}
 					onChangeOpenState={() => onChangeOpenState(id, isOpen)}
+					canPublishUnpublishedChanges={canPublishUnpublishedChanges}
 					headlineContent={
-						hasUnpublishedChanges &&
-						canPublish && (
+						canPublishUnpublishedChanges && (
 							<Fragment>
 								<EditModeVisibility visibleMode="editions">
 									{!isFeast && (

--- a/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
+++ b/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
@@ -2,7 +2,7 @@
 	TODO: Move this logic into FrontSection.tsx when styledComponents is migrated to v6
     styledComponents v6 will support container queries, which will allow us to remove this CSS file
    */
-.front-header, .collection-container {
+.front-header {
 	container-type: inline-size;
 }
 

--- a/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
+++ b/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
@@ -2,16 +2,22 @@
 	TODO: Move this logic into FrontSection.tsx when styledComponents is migrated to v6
     styledComponents v6 will support container queries, which will allow us to remove this CSS file
    */
-.front-header {
+.front-header, .collection-container {
 	container-type: inline-size;
 }
 
-.visible-based-on-front-header-width {
+.visible-based-on-front-header-width, .visible-based-on-collection-container-width {
 	display: block;
 }
 
 @container (max-width: 600px) {
   .visible-based-on-front-header-width {
+	  display: none;
+  }
+}
+
+@container (max-width: 400px) {
+  .visible-based-on-collection-container-width {
 	  display: none;
   }
 }

--- a/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
+++ b/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
@@ -16,7 +16,7 @@
   }
 }
 
-@container (max-width: 400px) {
+@container (max-width: 600px) {
   .visible-based-on-collection-container-width {
 	  display: none;
   }

--- a/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
+++ b/fronts-client/src/components/FrontsEdit/FrontSection/front-section.css
@@ -6,18 +6,12 @@
 	container-type: inline-size;
 }
 
-.visible-based-on-front-header-width, .visible-based-on-collection-container-width {
+.visible-based-on-front-header-width {
 	display: block;
 }
 
 @container (max-width: 600px) {
   .visible-based-on-front-header-width {
-	  display: none;
-  }
-}
-
-@container (max-width: 600px) {
-  .visible-based-on-collection-container-width {
 	  display: none;
   }
 }

--- a/fronts-client/src/components/typography/ContainerHeadingPinline.ts
+++ b/fronts-client/src/components/typography/ContainerHeadingPinline.ts
@@ -2,9 +2,8 @@ import { styled } from 'constants/theme';
 import ContainerHeading from './ContainerHeading';
 
 export default styled(ContainerHeading)<{ setBack?: boolean }>`
+	min-height: 40px;
 	align-items: center;
-	height: 40px;
-	line-height: 40px;
 	vertical-align: middle;
 	justify-content: space-between;
 	border-bottom: ${({ theme, setBack }) =>


### PR DESCRIPTION
## What's changed?

Adds a container type label and image to each collection in the Fronts Tool.

Rejigs the existing config labels into a more consistent format. The container headline is slightly smaller to save space.

| Before (narrow front) | After (narrow front) | 
| --- | --- |
| <img src="https://github.com/user-attachments/assets/49302195-263e-4d0b-a186-a752439e5a29" width="400px" /> | <img src="https://github.com/user-attachments/assets/3fb60a0d-faeb-43f5-919f-8272c1a5c4b0" width="400px" /> |

| Before (wide front) | After (wide front) | 
| --- | --- |
| <img src="https://github.com/user-attachments/assets/97d54edb-6f35-46f4-a067-60e2d9135733" width="400px" /> | <img src="https://github.com/user-attachments/assets/ef2230ba-51aa-469d-b04d-426a4be644ab" width="400px" /> |

| Before (locked container) | After (locked container) | 
| --- | --- |
| <img width="367" alt="image" src="https://github.com/user-attachments/assets/5a73dcf8-4526-4f74-82e7-58334d9574cb" /> | <img width="367" alt="image" src="https://github.com/user-attachments/assets/149d076d-61d6-4c2c-9a2d-ef76ba3d3842" /> |

| Before (Discard & Launch) | After (Discard & Launch) | 
| --- | --- |
| <img width="367" alt="image" src="https://github.com/user-attachments/assets/eb1a1821-3821-4cad-ba95-ed316faced85" /> | <img width="367" alt="image" src="https://github.com/user-attachments/assets/b6cfb965-584a-4ae6-a250-126b03971ae6" /> |

When there are too many config labels this can cause a layout shift:


https://github.com/user-attachments/assets/790ab903-e0bf-4fe0-b0b2-bdc4056870fe



This is undesirable but should hopefully be quite rare. We could avoid the layout shift by not wrapping the labels, but then there will be cases where labels aren't displayed.