### PR TITLE
Add editable maxItems field in Config tool

### DIFF
--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -421,8 +421,8 @@ trait UpdateActionsTrait extends Logging {
       collectionId: String,
       collectionJson: CollectionJson
   ): CollectionJson = {
-    configAgent.getConfig(collectionId).flatMap(_.groups) match {
-      case Some(groups) if groups.groups.nonEmpty => collectionJson
+    configAgent.getConfig(collectionId).flatMap(_.groupsConfig) match {
+      case Some(groupsConfig) if groupsConfig.groups.nonEmpty => collectionJson
       case _ =>
         collectionJson.copy(
           live = collectionJson.live.map(removeGroupsFromTrail),

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "15.0.0",
+  "com.gu" %% "fapi-client-play30" % "16.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "3.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/fronts-client/src/fixtures/shared.ts
+++ b/fronts-client/src/fixtures/shared.ts
@@ -1,3 +1,5 @@
+import { CollectionConfig } from '../types/FaciaApi';
+
 const capiArticle = {
 	id: 'world/live/2018/sep/13/florence-hurricane-latest-live-news-updates-weather-path-storm-surge-north-carolina',
 	type: 'liveblog',
@@ -591,11 +593,25 @@ const normalisedCollectonWithPreviously = {
 	excludedRegions: [],
 };
 
-const collectionConfig = {
+const collectionConfig: CollectionConfig = {
 	id: 'exampleCollection',
 	displayName: 'Example Collection',
 	type: 'any',
 	groups: ['large', 'medium', 'small'],
+	groupsConfig: [
+		{
+			name: 'large',
+			maxItems: 10,
+		},
+		{
+			name: 'medium',
+			maxItems: 10,
+		},
+		{
+			name: 'small',
+			maxItems: 10,
+		},
+	],
 };
 
 const collectionWithSupportingArticles = {

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -21,6 +21,11 @@ interface Group {
 	cards: string[];
 }
 
+interface GroupConfig {
+	name: string;
+	maxItems?: number;
+}
+
 /** CardSets represent all of the lists of cards available in a collection. */
 type CardSets = 'draft' | 'live' | 'previously';
 /** Stages represent only those lists which are curated by the user.*/
@@ -160,6 +165,7 @@ interface CollectionFromResponse {
 	platform?: string;
 	displayName: string;
 	groups?: string[];
+	groupsConfig?: GroupConfig[];
 	metadata?: Array<{ type: string }>;
 	uneditable?: boolean;
 	targetedTerritory?: string;
@@ -184,6 +190,7 @@ interface Collection {
 	platform?: string;
 	displayName: string;
 	groups?: string[];
+	groupsConfig?: GroupConfig[];
 	metadata?: Array<{ type: string }>;
 	uneditable?: boolean;
 	type?: string;
@@ -213,6 +220,7 @@ export {
 	Collection,
 	CardSizes,
 	Group,
+	GroupConfig,
 	Stages,
 	CardSets,
 	ArticleTag,

--- a/fronts-client/src/types/FaciaApi.ts
+++ b/fronts-client/src/types/FaciaApi.ts
@@ -1,5 +1,9 @@
 import { $Diff } from 'utility-types';
-import { CollectionFromResponse, NestedCard } from 'types/Collection';
+import {
+	CollectionFromResponse,
+	GroupConfig,
+	NestedCard,
+} from 'types/Collection';
 import { EditionsPrefill } from './Edition';
 
 interface FrontConfigResponse {
@@ -44,6 +48,7 @@ interface CollectionConfigResponse {
 	backfill?: unknown;
 	href?: string;
 	groups?: string[];
+	groupsConfig?: GroupConfig[];
 	metadata?: unknown[];
 	uneditable?: boolean;
 	showTags?: boolean;
@@ -116,6 +121,7 @@ export interface EditionCollectionFromResponse {
 	platform?: string;
 	displayName: string;
 	groups?: string[];
+	groupsConfig?: GroupConfig[];
 	metadata?: Array<{ type: string }>;
 	uneditable?: boolean;
 	isHidden?: boolean;

--- a/fronts-client/src/util/__tests__/shared.spec.ts
+++ b/fronts-client/src/util/__tests__/shared.spec.ts
@@ -151,7 +151,7 @@ describe('Shared utilities', () => {
 			const groupId = result.normalisedCollection.live![0];
 			expect(result.groups[groupId].cards).toHaveLength(3);
 		});
-		it('should create different groups for cards belonging to different groups even if they are not specificied in the config', () => {
+		it('should create different groups for cards belonging to different groups even if they are not specified in the config', () => {
 			const result = normaliseCollectionWithNestedArticles(collection, {
 				...collectionConfig,
 				groups: undefined,

--- a/fronts-client/src/util/frontsUtils.ts
+++ b/fronts-client/src/util/frontsUtils.ts
@@ -39,6 +39,7 @@ const combineCollectionWithConfig = (
 			? collection.displayName
 			: collectionConfig.displayName,
 		groups: collectionConfig.groups,
+		groupsConfig: collectionConfig.groupsConfig,
 		type: collectionConfig.type,
 		frontsToolSettings: collectionConfig.frontsToolSettings,
 		platform: collectionConfig.platform,

--- a/public/src/css/style.css
+++ b/public/src/css/style.css
@@ -1930,6 +1930,15 @@ ol.search_list > li::before {
     height: 50px;
 }
 
+.capitalize-first-letter {
+    /*needed for :first-letter to work*/
+    display: inline-block;
+}
+
+.capitalize-first-letter:first-letter {
+    text-transform: capitalize;
+}
+
 .cnf-form .action-buttons {
     height: 40px;
 }

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -31,6 +31,20 @@ export default {
             'big',
             'very big',
             'huge'
+          ],
+          'groupsConfig': [
+            {
+              name: 'standard'
+            },
+            {
+              name: 'big'
+            },
+            {
+              name: 'very big'
+            },
+            {
+              name: 'huge'
+            }
           ]
         },
         {
@@ -40,6 +54,20 @@ export default {
             'big',
             'very big',
             'huge'
+          ],
+          'groupsConfig': [
+            {
+              name: 'standard'
+            },
+            {
+              name: 'big'
+            },
+            {
+              name: 'very big'
+            },
+            {
+              name: 'huge'
+            }
           ]
         },
         {
@@ -47,6 +75,14 @@ export default {
           'groups': [
             'standard',
             'snap'
+          ],
+          'groupsConfig': [
+            {
+              name: 'standard'
+            },
+            {
+              name: 'snap'
+            }
           ]
         },
         {
@@ -54,26 +90,76 @@ export default {
           'groups': [
             'standard',
             'big'
+          ],
+          'groupsConfig': [
+            {
+              name: 'standard'
+            },
+            {
+              name: 'big'
+            }
           ]
         },
         { 'name': 'nav/list' },
         { 'name': 'nav/media-list' },
         { 'name': 'news/most-popular' },
-        { 'name': 'breaking-news/not-for-other-fronts', groups: ['minor', 'major'] },
+        {
+          'name': 'breaking-news/not-for-other-fronts',
+          groups: [
+            'minor',
+            'major'
+          ],
+          groupsConfig: [
+            {
+              name: 'minor'
+            },
+            {
+              name: 'major'
+            }
+          ]
+        },
         { 'name': 'fixed/showcase' },
         { 'name': 'scrollable/highlights' },
         {
             'name': 'flexible/general',
             'groups': [
-                'standard',
-                'splash'
+              'splash',
+              'very big',
+              'big',
+              'standard'
+            ],
+            'groupsConfig': [
+              {
+                name: 'splash',
+                maxItems: 1
+              },
+              {
+                name: 'very big',
+                maxItems: 0
+              },
+              {
+                name: 'big',
+                maxItems: 0
+              },
+              {
+                name: 'standard',
+                maxItems: 8
+              }
             ]
         },
         {
             'name': 'flexible/special',
             'groups': [
-                'standard',
-                'snap'
+              'standard',
+              'snap'
+            ],
+            'groupsConfig': [
+              {
+                name: 'standard'
+              },
+              {
+                name: 'snap'
+              }
             ]
         },
 		{ 'name': 'scrollable/small' },

--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -58,7 +58,17 @@ export default class ConfigCollection extends DropTarget {
                 frontsToolSettings: asObservableProps([
                     'displayEditWarning'
                 ])
-            }
+            },
+      {
+          groupsConfig: ko.observableArray(
+            opts.groupsConfig !== undefined && Array.isArray(opts.groupsConfig) ?
+              opts.groupsConfig.map((groupConfig) => {
+                return {
+                  name: groupConfig.name,
+                  maxItems: observableNumeric(groupConfig.maxItems)
+                };
+              }) : []
+            )}
         );
 
         populateObservables(this.meta, opts);
@@ -82,6 +92,8 @@ export default class ConfigCollection extends DropTarget {
 
         this.subscribeOn(this.meta.type, type => {
             this.meta.groups(vars.model.typesGroups[type]);
+            const groupsConfig = vars.model.typesGroupsConfig[type];
+            this.meta.groupsConfig(groupsConfig !== undefined ? groupsConfig() : undefined);
         });
 
         this.typePicker = this._typePicker.bind(this);

--- a/public/src/js/models/config/persistence.js
+++ b/public/src/js/models/config/persistence.js
@@ -65,7 +65,8 @@ function flattenModel (model) {
     return _.reduce(model, function (accumulator, value, key) {
         var x = flattenValue(value);
 
-        if (x) {
+        // We want to drop falsy values, but not 0
+        if (x || x === 0) {
             accumulator[key] = x;
         }
 

--- a/public/src/js/models/config/persistence.js
+++ b/public/src/js/models/config/persistence.js
@@ -53,6 +53,9 @@ function flattenModel (model) {
 
     function flattenValue(value) {
         if (_.isFunction(value)) {
+            if (_.isArray(value())) {
+              return value().map(flattenValue);
+            }
             return value();
         } else if (_.isObject(value)) {
             var flattened = flattenModel(value);

--- a/public/src/js/utils/observable-numeric.js
+++ b/public/src/js/utils/observable-numeric.js
@@ -8,7 +8,7 @@ export default function(initialValue) {
         },
         write(newValue) {
             var parsedValue = parseFloat(newValue);
-            actual(isNaN(parsedValue) ? newValue : parsedValue);
+            actual(isNaN(parsedValue) ? newValue : Math.abs(parsedValue));
         }
     });
 }

--- a/public/src/js/utils/populate-observables.js
+++ b/public/src/js/utils/populate-observables.js
@@ -9,6 +9,10 @@ function populateObservables(target, opts) {
             target[key](opts[key]);
         } else if (_.isObject(target[key]) && _.isObject(opts[key])) {
             populateObservables(target[key], opts[key]);
+        } else if (_.isFunction(target[key]) && !_.isUndefined(target[key]()) && _.isArray(target[key]()) && _.isArray(opts[key])) {
+            target[key]().forEach((item) => {
+              populateObservables(item, opts[key]);
+            });
         }
     });
 }

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -261,8 +261,8 @@
 
             <!-- ko if: meta.type() === "flexible/general"-->
               <div data-bind="foreach: meta.groupsConfig">
-                <label for="flexGenSplashStoryLimit"><span data-bind="text: name" class="capitalize-first-letter"></span> stories</label>
-                <input id="flexGenSplashStoryLimit" type="number" data-bind="value: maxItems" attr: { max: 20, min: 0 } max="20" min="0">
+                <label data-bind="attr: { for: 'maxItems-' + $index() }"><span data-bind="text: name" class="capitalize-first-letter"></span> stories</label>
+                <input type="number" data-bind="value: maxItems, attr: { id: 'maxItems-' + $index(), max: 20, min: 0 }" max="20" min="0">
               </div>
             <!-- /ko -->
 

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -259,10 +259,12 @@
                 <span class="cnf-form__value" data-bind="text: meta.groups"></span>
             <!-- /ko -->
 
-			<!-- ko if: meta.type() === "flexible/general"-->
-			<label for="flexGenStoryLimit">Max stories to display</label>
-			<input id="flexGenStoryLimit" type="number" data-bind="value: meta.displayHints.maxItemsToDisplay" attr: { max: 20, min: 1 } max="20" min="1" placeholder="9">
-			<!-- /ko -->
+            <!-- ko if: meta.type() === "flexible/general"-->
+              <div data-bind="foreach: meta.groupsConfig">
+                <label for="flexGenSplashStoryLimit"><span data-bind="text: name" class="capitalize-first-letter"></span> stories</label>
+                <input id="flexGenSplashStoryLimit" type="number" data-bind="value: maxItems" attr: { max: 20, min: 0 } max="20" min="0">
+              </div>
+            <!-- /ko -->
 
             <label for="userVisibility">User visibility</label>
             <select id="userVisibility" data-bind="

--- a/public/src/js/widgets/config-card-types.js
+++ b/public/src/js/widgets/config-card-types.js
@@ -2,6 +2,7 @@ import ko from 'knockout';
 import _ from 'underscore';
 import * as vars from 'modules/vars';
 import Extension from 'models/extension';
+import observableNumeric from '../utils/observable-numeric';
 
 export default class extends Extension {
     constructor(baseModel) {
@@ -16,10 +17,21 @@ export default class extends Extension {
         }
 
         baseModel.types = ko.observableArray(_.pluck(types, 'name'));
-        var groups = {};
+        const typesGroups = {};
+        const typesGroupsConfig = {};
         _.each(types, type => {
-            groups[type.name] = type.groups;
+            typesGroups[type.name] = type.groups;
+            typesGroupsConfig[type.name] = type.groupsConfig !== undefined && Array.isArray(type.groupsConfig)
+                ? ko.observableArray(
+                    type.groupsConfig.map((groupConfig) => {
+                      return {
+                        name: groupConfig.name,
+                        maxItems: observableNumeric(groupConfig.maxItems)
+                      };
+                    })
+                ) : undefined;
         });
-        baseModel.typesGroups = groups;
+        baseModel.typesGroups = typesGroups;
+        baseModel.typesGroupsConfig = typesGroupsConfig;
     }
 }

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -10,6 +10,7 @@ import images from 'test/utils/images';
 import configRegion from 'test/utils/regions/config';
 import * as wait from 'test/utils/wait';
 import * as mockjax from 'test/utils/mockjax';
+import observableNumeric from '../../src/js/utils/observable-numeric';
 
 describe('Config Front', function () {
     beforeEach(function () {
@@ -29,6 +30,14 @@ describe('Config Front', function () {
                 types: ko.observableArray(['type-one', 'type-two']),
                 typesGroups: {
                     'type-one': ['group-a', 'group-b']
+                },
+                typesGroupsConfig: {
+                    'type-one': ko.observableArray(
+                      [
+                        {name: 'group-a', maxItems: observableNumeric(10)},
+                        {name: 'group-b', maxItems: observableNumeric(10)}
+                      ]
+                    )
                 }
             }), true);
         };

--- a/public/test/spec/config.persistence.spec.js
+++ b/public/test/spec/config.persistence.spec.js
@@ -38,6 +38,7 @@ describe('Persistence', function () {
         var collection = new Collection({
             displayName: 'red loop',
             groups: ['one', 'two'],
+            groupsConfig: [{ name: 'one'}, { name: 'two' }],
             showSections: true,
             backfill: {
                 type: 'capi',

--- a/public/test/spec/config.persistence.spec.js
+++ b/public/test/spec/config.persistence.spec.js
@@ -61,6 +61,7 @@ describe('Persistence', function () {
             initialCollection: {
                 displayName: 'red loop',
                 groups: ['one', 'two'],
+                groupsConfig: [{ name: 'one'}, { name: 'two' }],
                 showSections: true,
                 backfill: {
                     type: 'capi',
@@ -91,12 +92,14 @@ describe('Persistence', function () {
         var one = new Collection({
             displayName: 'monkeys',
             groups: ['bonobo', 'chimp'],
+            groupsConfig: [{ name: 'bonobo'}, { name: 'chimp' }],
             uneditable: true,
             id: 'monkeys-collection'
         });
         var two = new Collection({
             displayName: 'birds',
             groups: ['parrot'],
+            groupsConfig: [{ name: 'parrot'}],
             id: 'birds-collection'
         });
         front.collections.items.push(one, two);
@@ -138,6 +141,7 @@ describe('Persistence', function () {
         var collection = new Collection({
             displayName: 'green apple',
             groups: [],
+            groupsConfig: [],
             uneditable: true
         });
         collection.parents.push(front);
@@ -151,7 +155,8 @@ describe('Persistence', function () {
             collection: {
                 displayName: 'green apple',
                 uneditable: true,
-                groups: []
+                groups: [],
+                groupsConfig: []
             }
         });
         expect(this.events.before).toHaveBeenCalled();
@@ -177,6 +182,7 @@ describe('Persistence', function () {
         var collection = new Collection({
             displayName: 'green apple',
             groups: [],
+            groupsConfig: [],
             uneditable: true,
             displayHints: {
                 maxItemsToDisplay: 3
@@ -194,6 +200,7 @@ describe('Persistence', function () {
                 displayName: 'green apple',
                 uneditable: true,
                 groups: [],
+                groupsConfig: [],
                 displayHints: {
                     maxItemsToDisplay: 3
                 }
@@ -230,6 +237,7 @@ describe('Persistence', function () {
             id: 'apple-collection',
             displayName: 'green apple',
             groups: [],
+            groupsConfig: [],
             uneditable: true
         });
         collection.parents.push(one, two);
@@ -244,7 +252,8 @@ describe('Persistence', function () {
                 id: 'apple-collection',
                 displayName: 'green apple',
                 uneditable: true,
-                groups: []
+                groups: [],
+                groupsConfig: []
             }
         });
         expect(this.events.before).toHaveBeenCalled();

--- a/test/config/TransformationsSpec.scala
+++ b/test/config/TransformationsSpec.scala
@@ -1,10 +1,6 @@
 package config
 
-import com.gu.facia.client.models.{
-  CollectionConfigJson => CollectionConfig,
-  ConfigJson => Config,
-  FrontJson => Front
-}
+import com.gu.facia.client.models.{GroupConfigJson, CollectionConfigJson => CollectionConfig, ConfigJson => Config, FrontJson => Front}
 import org.scalatest._
 import updates.CreateFront
 
@@ -14,6 +10,7 @@ class TransformationsSpec extends FlatSpec with Matchers {
     `type` = Some("???"),
     href = Some("newfront"),
     groups = Some(List("1", "2")),
+    groupsConfig = Some(List(GroupConfigJson(name = "1", maxItems = Some(10)), GroupConfigJson(name = "2", maxItems = Some(10)))),
     uneditable = Some(false),
     showTags = Some(true),
     showSections = Some(false),
@@ -40,6 +37,7 @@ class TransformationsSpec extends FlatSpec with Matchers {
   )
 
   val emptyCollectionFixture = CollectionConfig(
+    None,
     None,
     None,
     None,

--- a/test/services/CollectionServiceTest.scala
+++ b/test/services/CollectionServiceTest.scala
@@ -1,12 +1,6 @@
 package services
 
-import com.gu.facia.client.models.{
-  CollectionConfigJson,
-  CollectionJson,
-  ConfigJson,
-  FrontJson,
-  Trail
-}
+import com.gu.facia.client.models.{CollectionConfigJson, CollectionJson, ConfigJson, FrontJson, GroupConfigJson, Trail}
 import conf.ApplicationConfiguration
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
@@ -90,6 +84,10 @@ class CollectionServiceTest extends FreeSpec with Matchers {
       href = None,
       description = None,
       groups = Some(List("Group 1", "Group 2")),
+      groupsConfig = Some(List(
+        GroupConfigJson(name = "Group 1", maxItems = Some(10)),
+        GroupConfigJson(name = "Group 2", maxItems = Some(10))
+      )),
       uneditable = None,
       showTags = None,
       showSections = None,


### PR DESCRIPTION
## What's changed?
Add an editable maxItems field per 'group' (e.g. splash, standard) in a given container.

This allows the new `flexible/general` container to have different card groups with variable card limits.

Intended to replace the use of the `maxItemsToDisplay` field. Note this PR does not enforce any card limits in the Fronts Tool, this will be carried out in a future PR.

Note you will need to 'reset' the container to see the `groupsConfig` defaults pull through. So if you are looking at a `flexible/general` container in the config, you will need to change the container type to something else and then back to `flexible/general`.

| Before | After | 
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a90c33ff-6fed-495c-89ac-56b40fe95db8" width="400px" /> | <img src="https://github.com/user-attachments/assets/b54ee1c7-5de4-444a-9970-c01a5842d783" width="400px" /> | 

