### PR TITLE
Reorder flexible/general groups

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -123,27 +123,27 @@ export default {
         {
             'name': 'flexible/general',
             'groups': [
-              'splash',
-              'very big',
+              'standard',
               'big',
-              'standard'
+              'very big',
+              'splash'
             ],
             'groupsConfig': [
               {
-                name: 'splash',
-                maxItems: 1
-              },
-              {
-                name: 'very big',
-                maxItems: 0
+                name: 'standard',
+                maxItems: 8
               },
               {
                 name: 'big',
                 maxItems: 0
               },
               {
-                name: 'standard',
-                maxItems: 8
+                name: 'very big',
+                maxItems: 0
+              },
+              {
+                name: 'splash',
+                maxItems: 1
               }
             ]
         },

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -256,7 +256,7 @@
             <config-collection-tags params="tags: meta.metadata" class="tags"></config-collection-tags>
             <!-- ko if: meta.groups -->
                 <label>Groups</label>
-                <span class="cnf-form__value" data-bind="text: meta.groups"></span>
+                <span class="cnf-form__value" data-bind="text: meta.groups().slice().reverse()"></span>
             <!-- /ko -->
 
             <!-- ko if: meta.type() === "flexible/general"-->

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -260,7 +260,7 @@
             <!-- /ko -->
 
             <!-- ko if: meta.type() === "flexible/general"-->
-              <div data-bind="foreach: meta.groupsConfig">
+              <div data-bind="foreach: meta.groupsConfig.slice().reverse()">
                 <label data-bind="attr: { for: 'maxItems-' + $index() }"><span data-bind="text: name" class="capitalize-first-letter"></span> stories</label>
                 <input type="number" data-bind="value: maxItems, attr: { id: 'maxItems-' + $index(), max: 20, min: 0 }" max="20" min="0">
               </div>


### PR DESCRIPTION
## What's changed?

Groups are assumed to be in ascending order of importance, so this re-orders the flexible/general groups to reflect this.

Modified config tool to render the maxItems in the more intuitive (reverse) orde