### PR TITLE
Restriction on one card in splash group should not apply to sublinks

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -259,7 +259,11 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
 		// we also just insert if we're in the splash and there's no other article already in the splash
-		if (to.groupName !== 'splash' || numberOfArticlesAlreadyInGroup === 0) {
+		if (
+			to.type !== 'group' ||
+			to.groupName !== 'splash' ||
+			numberOfArticlesAlreadyInGroup === 0
+		) {
 			events.dropArticle(this.props.id, dropSource);
 			this.props.insertCardFromDropEvent(e, to, 'collection');
 			return;


### PR DESCRIPTION
## What's changed?

https://github.com/guardian/facia-tool/pull/1753 restricted splash groups to only contain one story, but it also inadvertently limited splash cards to only have one sublink.

This PR adds an additional guard so that the singular limit on splash groups only applies if second story is being added to the group rather than to the card (as a sublink).
