### PR TITLE
Set default boost level for groups in flexible general containers when dragging from feed

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -263,7 +263,7 @@ const insertCardWithCreate =
 		);
 		if (toWithRespectToState) {
 			try {
-				const card = await dispatch(cardFactory(drop));
+				const card = await dispatch(cardFactory(drop, to));
 				if (!card) {
 					return;
 				}
@@ -433,11 +433,12 @@ const addImageToCard =
  */
 export const createArticleEntitiesFromDrop = (
 	drop: MappableDropType,
+	to: PosSpec,
 ): ThunkResult<Promise<Card | undefined>> => {
 	return async (dispatch, getState) => {
 		const isEdition = selectEditMode(getState()) === 'editions';
 		const { card, supportingCards, externalArticle } =
-			await getCardEntitiesFromDrop(drop, isEdition, dispatch, getState());
+			await getCardEntitiesFromDrop(drop, isEdition, dispatch, getState(), to);
 
 		if (externalArticle) {
 			dispatch(externalArticleActions.fetchSuccess(externalArticle));

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -433,7 +433,7 @@ const addImageToCard =
  */
 export const createArticleEntitiesFromDrop = (
 	drop: MappableDropType,
-	to: PosSpec,
+	to?: PosSpec,
 ): ThunkResult<Promise<Card | undefined>> => {
 	return async (dispatch, getState) => {
 		const isEdition = selectEditMode(getState()) === 'editions';

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -160,6 +160,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 							<GroupLevel
 								isUneditable={isUneditable}
 								groupId={group.uuid}
+								collectionId={id}
 								groupName={group.name ? group.name : ''}
 								groupIds={groupIds}
 								onMove={handleMove}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -15,6 +15,7 @@ interface OuterProps {
 	onMove: MoveHandler<Card>;
 	onDrop: DropHandler;
 	isUneditable?: boolean;
+	collectionId: string;
 	groupName: string;
 	groupIds: string[];
 }
@@ -62,6 +63,7 @@ const GroupLevel = ({
 	onMove,
 	onDrop,
 	isUneditable,
+	collectionId,
 	groupName,
 	groupIds,
 }: Props) => (
@@ -69,6 +71,7 @@ const GroupLevel = ({
 		arr={cards}
 		parentType="group"
 		parentId={groupId}
+		collectionId={collectionId}
 		groupName={groupName}
 		groupIds={groupIds}
 		onMove={onMove}

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -10,6 +10,7 @@ interface PosSpec {
 	type: string;
 	id: string;
 	index: number;
+	collectionId?: string;
 	groupName?: string;
 	groupIds?: string[];
 	cards?: any[];
@@ -59,6 +60,7 @@ export interface LevelProps<T> {
 	children: LevelChild<T>;
 	parentId: string;
 	parentType: string;
+	collectionId: string;
 	groupName?: string;
 	groupIds?: string[];
 	type: string;
@@ -183,6 +185,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 			index: i,
 			type: this.props.parentType,
 			id: this.props.parentId,
+			collectionId: this.props.collectionId,
 			groupName: this.props.groupName,
 			groupIds: this.props.groupIds,
 			cards: this.props.arr,

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -60,7 +60,7 @@ export interface LevelProps<T> {
 	children: LevelChild<T>;
 	parentId: string;
 	parentType: string;
-	collectionId: string;
+	collectionId?: string;
 	groupName?: string;
 	groupIds?: string[];
 	type: string;

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -59,7 +59,7 @@ const createCard = (
 	isEditionsApp: boolean,
 	{
 		cardType = 'article',
-		boostLevel = 'megaboost',
+		boostLevel = 'default',
 		imageHide = false,
 		imageReplace = false,
 		imageCutoutReplace = false,

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -173,9 +173,15 @@ const getCardEntitiesFromDrop = async (
 	state: State,
 	to: PosSpec,
 ): Promise<TArticleEntities> => {
-	const collectionType = to.collectionId && selectCollectionType(state, to.collectionId);
+	const collectionType =
+		to.collectionId && selectCollectionType(state, to.collectionId);
 	if (drop.type === 'CAPI') {
-		return getArticleEntitiesFromFeedDrop(drop.data, isEdition, to, collectionType);
+		return getArticleEntitiesFromFeedDrop(
+			drop.data,
+			isEdition,
+			to,
+			collectionType,
+		);
 	}
 
 	if (drop.type === 'RECIPE') {
@@ -330,19 +336,19 @@ const getArticleEntitiesFromFeedDrop = (
 	collectionType?: string,
 ): TArticleEntities => {
 	const externalArticle = transformExternalArticle(capiArticle);
-	function getGroupDefaultBoostLevel(){
+	function getGroupDefaultBoostLevel() {
 		if (collectionType === FLEXIBLE_GENERAL_NAME) {
-		switch (to.groupName) {
-			case 'very big':
-				return 'megaboost';
-			case 'big':
-				return 'boost';
-			case 'splash':
-			case 'standard':
-			default:
-				return 'default';
-		}}
-		else {
+			switch (to.groupName) {
+				case 'very big':
+					return 'megaboost';
+				case 'big':
+					return 'boost';
+				case 'splash':
+				case 'standard':
+				default:
+					return 'default';
+			}
+		} else {
 			return 'default';
 		}
 	}

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -171,10 +171,10 @@ const getCardEntitiesFromDrop = async (
 	isEdition: boolean,
 	dispatch: Dispatch,
 	state: State,
-	to: PosSpec,
+	to?: PosSpec,
 ): Promise<TArticleEntities> => {
 	const collectionType =
-		to.collectionId && selectCollectionType(state, to.collectionId);
+		to && to.collectionId && selectCollectionType(state, to.collectionId);
 	if (drop.type === 'CAPI') {
 		return getArticleEntitiesFromFeedDrop(
 			drop.data,
@@ -332,12 +332,12 @@ const getFeastCollectionFromFeedDrop = (
 const getArticleEntitiesFromFeedDrop = (
 	capiArticle: CapiArticle,
 	isEdition: boolean,
-	to: PosSpec,
+	to?: PosSpec,
 	collectionType?: string,
 ): TArticleEntities => {
 	const externalArticle = transformExternalArticle(capiArticle);
 	function getGroupDefaultBoostLevel() {
-		if (collectionType === FLEXIBLE_GENERAL_NAME) {
+		if (to && collectionType === FLEXIBLE_GENERAL_NAME) {
 			switch (to.groupName) {
 				case 'very big':
 					return 'megaboost';

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -35,9 +35,11 @@ import { CardTypesMap, type CardTypes } from '../constants/cardTypes';
 import { Chef } from '../types/Chef';
 import { State } from '../types/State';
 import { selectCard } from '../selectors/shared';
+import { PosSpec } from 'lib/dnd';
 
 interface CreateCardOptions {
 	cardType?: CardTypes;
+	boostLevel?: 'default' | 'boost' | 'megaboost' | 'gigaboost';
 	imageHide?: boolean;
 	imageReplace?: boolean;
 	imageCutoutReplace?: boolean;
@@ -55,6 +57,7 @@ const createCard = (
 	isEditionsApp: boolean,
 	{
 		cardType = 'article',
+		boostLevel = 'megaboost',
 		imageHide = false,
 		imageReplace = false,
 		imageCutoutReplace = false,
@@ -71,6 +74,7 @@ const createCard = (
 	cardType,
 	meta: {
 		...(imageHide ? { imageHide } : {}),
+		...(boostLevel ? { boostLevel } : {}),
 		...(imageReplace ? { imageReplace } : {}),
 		...(imageCutoutReplace ? { imageCutoutReplace, imageCutoutSrc } : {}),
 		...(showByline ? { showByline } : {}),
@@ -165,9 +169,10 @@ const getCardEntitiesFromDrop = async (
 	isEdition: boolean,
 	dispatch: Dispatch,
 	state: State,
+	to: PosSpec,
 ): Promise<TArticleEntities> => {
 	if (drop.type === 'CAPI') {
-		return getArticleEntitiesFromFeedDrop(drop.data, isEdition);
+		return getArticleEntitiesFromFeedDrop(drop.data, isEdition, to);
 	}
 
 	if (drop.type === 'RECIPE') {
@@ -318,10 +323,24 @@ const getFeastCollectionFromFeedDrop = (
 const getArticleEntitiesFromFeedDrop = (
 	capiArticle: CapiArticle,
 	isEdition: boolean,
+	to: PosSpec,
 ): TArticleEntities => {
 	const externalArticle = transformExternalArticle(capiArticle);
+	const groupDefaultBoostLevel = (() => {
+		switch (to.groupName) {
+			case 'very big':
+				return 'megaboost';
+			case 'big':
+				return 'boost';
+			case 'splash':
+			case 'standard':
+			default:
+				return 'default';
+		}
+	})();
 	const card = createCard(externalArticle.id, isEdition, {
 		cardType: 'article',
+		boostLevel: groupDefaultBoostLevel,
 		imageHide: externalArticle.frontsMeta.defaults.imageHide,
 		imageReplace: externalArticle.frontsMeta.defaults.imageReplace,
 		imageCutoutReplace: externalArticle.frontsMeta.defaults.imageCutoutReplace,


### PR DESCRIPTION
## What's changed?

Part of this [F+C ticket](https://trello.com/c/a16rDa8J/1012-add-group-limits-to-fronts-tool) implementing the new group config limits in the v2 client. 

This adds a defaultGroupBoostLevel applied to a card when it is dropped in a flexible general container group. A good portion of the changes is just passing props around so we can check the name of the group being added to (via the `to` prop) and access the collectionId to check the collectionType. 

This doesn't seem to work when moving a story from the clipboard or between groups, but those points will be addressed in a subsequent PR. 

## Testing

Check out the branch, set up a flexible general container which should then have the 4 groups, splash, very big, big and standard. When dragging from the feed (not using the clipboard or moving from one group to another), you should observe the following behaviour:
- going into a splash or standard group, there should be no boostlevel applied
- going into a very big, it should be megaboost
- going into a big it should be boost. 


## Screenshot

Shows the settings were applied correctly (just on dragging and dropping) and are coming through on DCR. 

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/8199e938-83ec-409a-803a-d49e231efcf3" />


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
