### PR TITLE
Handle inserting and moving in groups depending on max items

### DIFF
--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -265,6 +265,7 @@ const createMapStateToProps = () => {
 			collectionId: props.id,
 			collectionSet: props.browsingStage,
 		});
+		// const CardsData =
 
 		return {
 			lastDesktopArticle: articleVisibilityDetails.desktop,

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -265,7 +265,6 @@ const createMapStateToProps = () => {
 			collectionId: props.id,
 			collectionSet: props.browsingStage,
 		});
-		// const CardsData =
 
 		return {
 			lastDesktopArticle: articleVisibilityDetails.desktop,

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -151,7 +151,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 					canPublish={browsingStage !== 'live'}
 					browsingStage={browsingStage}
 				>
-					{(group, isUneditable, groupIds, groupsData, showGroupName) => (
+					{(group, isUneditable, groupIds, groups, showGroupName) => (
 						<div key={group.uuid}>
 							<GroupDisplayComponent
 								key={group.uuid}
@@ -164,7 +164,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								groupName={group.name ? group.name : ''}
 								groupIds={groupIds}
 								groupMaxItems={group.maxItems}
-								groupsData={groupsData}
+								groups={groups}
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}
@@ -200,7 +200,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 													cardId={card.uuid}
 													groupName={group.name ? group.name : ''}
 													groupIds={groupIds}
-													groupsData={groupsData}
+													groups={groups}
 													onMove={handleMove}
 													onDrop={handleInsert}
 													cardTypeAllowList={this.getPermittedCardTypes(

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -163,6 +163,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								collectionId={id}
 								groupName={group.name ? group.name : ''}
 								groupIds={groupIds}
+								groupMaxItems={group.maxItems}
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -151,7 +151,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 					canPublish={browsingStage !== 'live'}
 					browsingStage={browsingStage}
 				>
-					{(group, isUneditable, groupIds, showGroupName) => (
+					{(group, isUneditable, groupIds, groupsData, showGroupName) => (
 						<div key={group.uuid}>
 							<GroupDisplayComponent
 								key={group.uuid}
@@ -164,6 +164,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								groupName={group.name ? group.name : ''}
 								groupIds={groupIds}
 								groupMaxItems={group.maxItems}
+								groupsData={groupsData}
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}
@@ -199,6 +200,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 													cardId={card.uuid}
 													groupName={group.name ? group.name : ''}
 													groupIds={groupIds}
+													groupsData={groupsData}
 													onMove={handleMove}
 													onDrop={handleInsert}
 													cardTypeAllowList={this.getPermittedCardTypes(

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -226,7 +226,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 		const isUneditable = isCollectionLocked || browsingStage !== cardSets.draft;
 
 		const groupIds = groups.map((group) => group.uuid);
-		const groupsData = groups
+		const groupsData = groups;
 
 		return (
 			<>
@@ -343,7 +343,9 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 						) : null
 					}
 				>
-					{groups.map((group) => children(group, isUneditable, groupIds, groupsData, true))}
+					{groups.map((group) =>
+						children(group, isUneditable, groupIds, groupsData, true),
+					)}
 					{hasContent && (
 						<EditModeVisibility visibleMode="fronts">
 							<PreviouslyCollectionContainer data-testid="previously">
@@ -362,7 +364,13 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											launched they will not appear here.
 										</PreviouslyCollectionInfo>
 										<PreviouslyGroupsWrapper>
-											{children(previousGroup, true, groupIds, groupsData, false)}
+											{children(
+												previousGroup,
+												true,
+												groupIds,
+												groupsData,
+												false,
+											)}
 										</PreviouslyGroupsWrapper>
 									</>
 								)}

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -226,7 +226,6 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 		const isUneditable = isCollectionLocked || browsingStage !== cardSets.draft;
 
 		const groupIds = groups.map((group) => group.uuid);
-		const groupsData = groups;
 
 		return (
 			<>
@@ -344,7 +343,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 					}
 				>
 					{groups.map((group) =>
-						children(group, isUneditable, groupIds, groupsData, true),
+						children(group, isUneditable, groupIds, groups, true),
 					)}
 					{hasContent && (
 						<EditModeVisibility visibleMode="fronts">
@@ -368,7 +367,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 												previousGroup,
 												true,
 												groupIds,
-												groupsData,
+												groups,
 												false,
 											)}
 										</PreviouslyGroupsWrapper>

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -52,6 +52,7 @@ interface CollectionPropsBeforeState {
 		group: Group,
 		isUneditable: boolean,
 		groupIds: string[],
+		groupsData: Group[],
 		showGroupName?: boolean,
 	) => React.ReactNode;
 	alsoOn: { [id: string]: AlsoOnDetail };
@@ -225,6 +226,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 		const isUneditable = isCollectionLocked || browsingStage !== cardSets.draft;
 
 		const groupIds = groups.map((group) => group.uuid);
+		const groupsData = groups
 
 		return (
 			<>
@@ -341,7 +343,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 						) : null
 					}
 				>
-					{groups.map((group) => children(group, isUneditable, groupIds, true))}
+					{groups.map((group) => children(group, isUneditable, groupIds, groupsData, true))}
 					{hasContent && (
 						<EditModeVisibility visibleMode="fronts">
 							<PreviouslyCollectionContainer data-testid="previously">
@@ -360,7 +362,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											launched they will not appear here.
 										</PreviouslyCollectionInfo>
 										<PreviouslyGroupsWrapper>
-											{children(previousGroup, true, groupIds, false)}
+											{children(previousGroup, true, groupIds, groupsData, false)}
 										</PreviouslyGroupsWrapper>
 									</>
 								)}

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -363,13 +363,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											launched they will not appear here.
 										</PreviouslyCollectionInfo>
 										<PreviouslyGroupsWrapper>
-											{children(
-												previousGroup,
-												true,
-												groupIds,
-												groups,
-												false,
-											)}
+											{children(previousGroup, true, groupIds, groups, false)}
 										</PreviouslyGroupsWrapper>
 									</>
 								)}

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -183,7 +183,8 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		const hasMaxItemsAlready =
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
 
-		// if we are moving an article into any group that is either empty or doesn't have the max items already,
+		// if we are moving an article into the standard group,
+		// or any group that is either empty or doesn't have the max items already,
 		// or if we're moving the article within the same group,
 		// then we just move the article to the location
 		if (

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -296,6 +296,10 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				(groupId) => groupId === to.id,
 			);
 			const nextGroup = to.groupIds[currentGroupIndex + 1];
+			const nextGroupData = to.groupsData && to.groupsData.find(
+				(group) =>
+					group.uuid === nextGroup,
+			);
 			const isAddingCardToLastPlaceInGroup = to.index === to.cards.length;
 
 			// if we're not adding the card to the last place in the group, then we need to move the last article to the next group
@@ -307,11 +311,20 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 				// then we need to move the other article to the other group
 				const existingCardData = to.cards[to.cards.length - 1];
+				// const existingCardTo = {
+				// 	index: 0,
+				// 	id: nextGroup,
+				// 	type: 'group',
+				// 	groupIds: to.groupIds,
+				// };
 				const existingCardTo = {
 					index: 0,
 					id: nextGroup,
 					type: 'group',
 					groupIds: to.groupIds,
+					groupMaxItems: nextGroupData?.maxItems,
+					groupsData: to.groupsData,
+					cards: nextGroupData?.cardsData //not the complete data which I think is messing it up
 				};
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -182,10 +182,16 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		const numberOfArticlesAlreadyInGroup = move.to.cards?.length ?? 0;
 		const hasMaxItemsAlready =
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
+		console.log('move', move);
 
 		// if we are moving an article into any group either has no cards or doesn't have the max items already,
+		// or if we're moving the article within the same group,
 		// then we just move the article to the location
-		if (numberOfArticlesAlreadyInGroup === 0 || !hasMaxItemsAlready) {
+		if (
+			numberOfArticlesAlreadyInGroup === 0 ||
+			!hasMaxItemsAlready ||
+			(move.from && move.to.id === move.from.id)
+		) {
 			events.dropArticle(this.props.id, 'collection');
 			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
 			return;

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -184,7 +184,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
 		console.log('move', move);
 
-		// if we are moving an article into any group either has no cards or doesn't have the max items already,
+		// if we are moving an article into any group that is either empty or doesn't have the max items already,
 		// or if we're moving the article within the same group,
 		// then we just move the article to the location
 		if (
@@ -197,7 +197,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			return;
 		}
 
-		// if we're in a group with max items and already has the max number of stories,
+		// if we're in a group with max items that already has the max number of stories,
 		// and we move an article, then depending on where we're inserting the story
 		// we need to either move the last article to the next group
 		// or move the article into the next group

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -220,10 +220,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 				//then we need to move the other article to the other group
 				const existingCardData = move.to.cards[move.to.cards.length - 1];
-				const nextGroupData = move.to.groupsData && move.to.groupsData.find(
-					(group) =>
-						group.uuid === nextGroup,
-				);
+				const nextGroupData =
+					move.to.groupsData &&
+					move.to.groupsData.find((group) => group.uuid === nextGroup);
 				const existingCardTo = {
 					index: 0,
 					id: nextGroup,
@@ -231,7 +230,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					groupIds: move.to.groupIds,
 					groupMaxItems: nextGroupData?.maxItems,
 					groupsData: move.to.groupsData,
-					cards: nextGroupData?.cardsData
+					cards: nextGroupData?.cardsData,
 				};
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,
@@ -292,10 +291,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				(groupId) => groupId === to.id,
 			);
 			const nextGroup = to.groupIds[currentGroupIndex + 1];
-			const nextGroupData = to.groupsData && to.groupsData.find(
-				(group) =>
-					group.uuid === nextGroup,
-			);
+			const nextGroupData =
+				to.groupsData &&
+				to.groupsData.find((group) => group.uuid === nextGroup);
 			const isAddingCardToLastPlaceInGroup = to.index === to.cards.length;
 
 			// if we're not adding the card to the last place in the group, then we need to move the last article to the next group
@@ -314,7 +312,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					groupIds: to.groupIds,
 					groupMaxItems: nextGroupData?.maxItems,
 					groupsData: to.groupsData,
-					cards: nextGroupData?.cardsData
+					cards: nextGroupData?.cardsData,
 				};
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,17 +179,14 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
-		console.log('move', move.to.groupMaxItems);
+		console.log("move card id", move.data.id);
 		const numberOfArticlesAlreadyInGroup = move.to.cards?.length ?? 0;
 		const hasMaxItemsAlready =
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
 
-		// if we are inserting an article into any group that is not the splash, then we just insert
-		// we also just insert if we're in the splash and there's no other article already in the splash
-		if (
-			numberOfArticlesAlreadyInGroup === 0 ||
-			!hasMaxItemsAlready
-		) {
+		// if we are inserting an article into any group either has no cards or doesn't have the max items already,
+		// then we just insert
+		if (numberOfArticlesAlreadyInGroup === 0 || !hasMaxItemsAlready) {
 			events.dropArticle(this.props.id, 'collection');
 			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
 			return;
@@ -223,20 +220,32 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				);
 
 				//then we need to move the other article to the other group
+				console.log("move.to.cards", move.to.cards);
 				const existingCardData = move.to.cards[move.to.cards.length - 1];
+				console.log("existingCardData id", existingCardData.id);
+				console.log("groupsData", move.to.groupsData);
+				console.log("next group", nextGroup);
+				const nextGroupData = move.to.groupsData && move.to.groupsData.find(
+					(group) =>
+						group.uuid === nextGroup,
+				);
+				console.log("groupMovingToData", nextGroupData);
 				const existingCardTo = {
 					index: 0,
 					id: nextGroup,
 					type: 'group',
 					groupIds: move.to.groupIds,
+					groupMaxItems: nextGroupData?.maxItems,
+					groupsData: move.to.groupsData,
+					cards: nextGroupData?.cards //not the complete data which I think is messing it up
 				};
+				console.log("existingCardTo", existingCardTo);
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,
 					from: false,
 					to: existingCardTo,
 				};
 				this.handleMove(existingCardMoveData);
-				return;
 			}
 			// If we're adding to the last place in the group, then we move the article into the next group
 			else {
@@ -254,13 +263,12 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					move.from || null,
 					'collection',
 				);
-				return;
 			}
+			return;
 		}
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
-		console.log('to', to);
 		const numberOfArticlesAlreadyInGroup = to.cards?.length ?? 0;
 		const hasMaxItemsAlready =
 			to.groupMaxItems === numberOfArticlesAlreadyInGroup;

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -328,6 +328,8 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				this.handleMove(existingCardMoveData);
 			}
 			// If we're adding to the last place in the group, then we insert the article into the next group
+			// we need to check if the next group already has the max number of items,
+			// if it does, then we need to move the last article to the next group
 			else {
 				const amendedTo = {
 					index: 0,
@@ -337,6 +339,31 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				};
 				events.dropArticle(this.props.id, dropSource);
 				this.props.insertCardFromDropEvent(e, amendedTo, 'collection');
+
+				const nextGroupNumberOfArticles = nextGroupData?.cardsData?.length ?? 0;
+				const nextGroupHasMaxItems =
+					nextGroupData?.maxItems === nextGroupNumberOfArticles;
+				if (nextGroupHasMaxItems) {
+					if (!nextGroupData.cardsData) {
+						return;
+					}
+					const existingCardData = nextGroupData.cardsData[to.cards.length - 1];
+					const existingCardTo = {
+						index: 0,
+						id: nextGroup,
+						type: 'group',
+						groupIds: to.groupIds,
+						groupMaxItems: nextGroupData?.maxItems,
+						groupsData: to.groupsData,
+						cards: nextGroupData?.cardsData,
+					};
+					const existingCardMoveData: Move<TCard> = {
+						data: existingCardData,
+						from: false,
+						to: existingCardTo,
+					};
+					this.handleMove(existingCardMoveData);
+				}
 			}
 			return;
 		}

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -246,7 +246,10 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				this.handleMove(existingCardMoveData);
 			}
 			// If we're adding to the last place in the group, then we move the article into the next group
+			// we need to check if the next group already has the max number of items,
+			// if it does, then we need to move the last article to the next group
 			else {
+				// we do the move step for the article we're now moving to the next group
 				const amendedTo = {
 					index: 0,
 					id: nextGroup,
@@ -261,6 +264,37 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					move.from || null,
 					'collection',
 				);
+
+				// then we check if the next group already has the max number of items,
+				// if it does, then we need to move the last article to the next group
+				const nextGroupData =
+					move.to.groupsData &&
+					move.to.groupsData.find((group) => group.uuid === nextGroup);
+				const nextGroupNumberOfArticles = nextGroupData?.cardsData?.length ?? 0;
+				const nextGroupHasMaxItems =
+					nextGroupData?.maxItems === nextGroupNumberOfArticles;
+				if (nextGroupHasMaxItems) {
+					if (!nextGroupData.cardsData) {
+						return;
+					}
+					const existingCardData =
+						nextGroupData.cardsData[nextGroupNumberOfArticles - 1];
+					const existingCardTo = {
+						index: 0,
+						id: nextGroup,
+						type: 'group',
+						groupIds: move.to.groupIds,
+						groupMaxItems: nextGroupData?.maxItems,
+						groupsData: move.to.groupsData,
+						cards: nextGroupData?.cardsData,
+					};
+					const existingCardMoveData: Move<TCard> = {
+						data: existingCardData,
+						from: false,
+						to: existingCardTo,
+					};
+					this.handleMove(existingCardMoveData);
+				}
 			}
 			return;
 		}

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -183,8 +183,8 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		const hasMaxItemsAlready =
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
 
-		// if we are inserting an article into any group either has no cards or doesn't have the max items already,
-		// then we just insert
+		// if we are moving an article into any group either has no cards or doesn't have the max items already,
+		// then we just move the article to the location
 		if (numberOfArticlesAlreadyInGroup === 0 || !hasMaxItemsAlready) {
 			events.dropArticle(this.props.id, 'collection');
 			this.props.moveCard(move.to, move.data, move.from || null, 'collection');
@@ -192,9 +192,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		}
 
 		// if we're in a group with max items and already has the max number of stories,
-		// and we move an article, then we need to either move the last article to the next group
-		// or insert the article into the next group depending on where were inserting the story
-
+		// and we move an article, then depending on where we're inserting the story
+		// we need to either move the last article to the next group
+		// or move the article into the next group
 		if (
 			!!move.to.groupIds &&
 			move.to.cards !== undefined &&
@@ -268,8 +268,10 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 		const dropSource = isDropFromCAPIFeed(e) ? 'feed' : 'url';
 
-		// if we are inserting an article into any group that doesn't have a max items (e.g. legacy containers), then we just insert
-		// we also just insert if we're in a group that doesn't have any articles in it yet
+		// if we are inserting an article into any group that doesn't have a max items (e.g. legacy containers),
+		// or a group that doesn't have any articles in it yet
+		// or a group that doesn't have the max items already,
+		// then we just insert
 		if (
 			to.type !== 'group' ||
 			to.groupMaxItems === undefined ||
@@ -282,8 +284,9 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		}
 
 		// if we're in a group with max items and already has the max number of stories,
-		// and we insert an article, then we need to either move the last article to the next group
-		// or insert the article into the next group depending on where were inserting the story
+		// then depending on where we're inserting the story
+		// we need to either move the last article to the next group
+		// or insert the article into the next group
 		if (!!to.groupIds && to.cards !== undefined && hasMaxItemsAlready) {
 			const currentGroupIndex = to.groupIds.findIndex(
 				(groupId) => groupId === to.id,
@@ -302,7 +305,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				events.dropArticle(this.props.id, dropSource);
 				this.props.insertCardFromDropEvent(e, to, 'collection');
 
-				// then we need to move the other article to the other group
+				// then we move the other article to the other group
 				const existingCardData = to.cards[to.cards.length - 1];
 				const existingCardTo = {
 					index: 0,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,7 +179,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
-		console.log("move card id", move.data.id);
 		const numberOfArticlesAlreadyInGroup = move.to.cards?.length ?? 0;
 		const hasMaxItemsAlready =
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
@@ -220,16 +219,11 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 				);
 
 				//then we need to move the other article to the other group
-				console.log("move.to.cards", move.to.cards);
 				const existingCardData = move.to.cards[move.to.cards.length - 1];
-				console.log("existingCardData id", existingCardData.id);
-				console.log("groupsData", move.to.groupsData);
-				console.log("next group", nextGroup);
 				const nextGroupData = move.to.groupsData && move.to.groupsData.find(
 					(group) =>
 						group.uuid === nextGroup,
 				);
-				console.log("groupMovingToData", nextGroupData);
 				const existingCardTo = {
 					index: 0,
 					id: nextGroup,
@@ -237,9 +231,8 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					groupIds: move.to.groupIds,
 					groupMaxItems: nextGroupData?.maxItems,
 					groupsData: move.to.groupsData,
-					cards: nextGroupData?.cardsData //not the complete data which I think is messing it up
+					cards: nextGroupData?.cardsData
 				};
-				console.log("existingCardTo", existingCardTo);
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,
 					from: false,
@@ -311,12 +304,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 
 				// then we need to move the other article to the other group
 				const existingCardData = to.cards[to.cards.length - 1];
-				// const existingCardTo = {
-				// 	index: 0,
-				// 	id: nextGroup,
-				// 	type: 'group',
-				// 	groupIds: to.groupIds,
-				// };
 				const existingCardTo = {
 					index: 0,
 					id: nextGroup,
@@ -324,7 +311,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					groupIds: to.groupIds,
 					groupMaxItems: nextGroupData?.maxItems,
 					groupsData: to.groupsData,
-					cards: nextGroupData?.cardsData //not the complete data which I think is messing it up
+					cards: nextGroupData?.cardsData
 				};
 				const existingCardMoveData: Move<TCard> = {
 					data: existingCardData,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -187,6 +187,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// or if we're moving the article within the same group,
 		// then we just move the article to the location
 		if (
+			move.to.groupName === "standard" ||
 			numberOfArticlesAlreadyInGroup === 0 ||
 			!hasMaxItemsAlready ||
 			(move.from && move.to.id === move.from.id)

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -182,7 +182,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		const numberOfArticlesAlreadyInGroup = move.to.cards?.length ?? 0;
 		const hasMaxItemsAlready =
 			move.to.groupMaxItems === numberOfArticlesAlreadyInGroup;
-		console.log('move', move);
 
 		// if we are moving an article into any group that is either empty or doesn't have the max items already,
 		// or if we're moving the article within the same group,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -237,7 +237,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 					groupIds: move.to.groupIds,
 					groupMaxItems: nextGroupData?.maxItems,
 					groupsData: move.to.groupsData,
-					cards: nextGroupData?.cards //not the complete data which I think is messing it up
+					cards: nextGroupData?.cardsData //not the complete data which I think is messing it up
 				};
 				console.log("existingCardTo", existingCardTo);
 				const existingCardMoveData: Move<TCard> = {

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -179,6 +179,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	}
 
 	public handleMove = (move: Move<TCard>) => {
+		console.log('move', move.to.groupMaxItems);
 		const numberOfArticlesAlreadyInGroup = move.to.cards?.length ?? 0;
 
 		// if we are inserting an article into any group that is not the splash, then we just insert
@@ -253,6 +254,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	};
 
 	public handleInsert = (e: React.DragEvent, to: PosSpec) => {
+		console.log("to", to.groupMaxItems);
 		const numberOfArticlesAlreadyInGroup = to.cards?.length ?? 0;
 
 		const dropSource = isDropFromCAPIFeed(e) ? 'feed' : 'url';

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -188,7 +188,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// or if we're moving the article within the same group,
 		// then we just move the article to the location
 		if (
-			move.to.groupName === "standard" ||
+			move.to.groupName === 'standard' ||
 			numberOfArticlesAlreadyInGroup === 0 ||
 			!hasMaxItemsAlready ||
 			(move.from && move.to.id === move.from.id)

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { connect } from 'react-redux';
-import { Card } from 'types/Collection';
+import { Card, Group } from 'types/Collection';
 import DropZone, {
 	DefaultDropContainer,
 	DefaultDropIndicator,
@@ -22,6 +22,7 @@ interface OuterProps {
 	cardTypeAllowList?: CardTypes[];
 	groupName?: string;
 	groupIds?: string[];
+	groupsData?: Group[]
 }
 
 interface InnerProps {
@@ -53,6 +54,7 @@ const CardLevel = ({
 	cardTypeAllowList,
 	groupName,
 	groupIds,
+	groupsData,
 }: Props) => (
 	<CardTypeLevel
 		arr={supporting || []}
@@ -60,6 +62,7 @@ const CardLevel = ({
 		parentId={cardId}
 		groupName={groupName}
 		groupIds={groupIds}
+		groupsData={groupsData}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -22,7 +22,7 @@ interface OuterProps {
 	cardTypeAllowList?: CardTypes[];
 	groupName?: string;
 	groupIds?: string[];
-	groupsData?: Group[]
+	groupsData?: Group[];
 }
 
 interface InnerProps {

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -22,7 +22,7 @@ interface OuterProps {
 	cardTypeAllowList?: CardTypes[];
 	groupName?: string;
 	groupIds?: string[];
-	groupsData?: Group[];
+	groups?: Group[];
 }
 
 interface InnerProps {
@@ -54,7 +54,7 @@ const CardLevel = ({
 	cardTypeAllowList,
 	groupName,
 	groupIds,
-	groupsData,
+	groups,
 }: Props) => (
 	<CardTypeLevel
 		arr={supporting || []}
@@ -62,7 +62,7 @@ const CardLevel = ({
 		parentId={cardId}
 		groupName={groupName}
 		groupIds={groupIds}
-		groupsData={groupsData}
+		groupsData={groups}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -73,9 +73,6 @@ const GroupLevel = ({
 	groupsData,
 	groupsWithCardsData,
 }: Props) => {
-	// console.log("cards", cards)
-	// console.log('cardsFromOtherGroups', groupsWithCardsData);
-	// console.log("groupsData here", groupsData);
 	return (
 	<CardTypeLevel
 		arr={cards}
@@ -109,18 +106,15 @@ const GroupLevel = ({
 const createMapStateToProps = () => {
 	const selectArticlesFromIds = createSelectArticlesFromIds();
 
-	const getCardsFromOtherGroups = () => {
+	const getCardsForOtherGroups = () => {
 		return (state: State, groupsData: Group[] | undefined) => {
 		  if (!groupsData) {
 			return [];
 		  }
 
-		//   console.log("groupsData here", groupsData);
-
 		  return groupsData.map((group) => {
 			const groupCardIds = group.cards
 			const cardsData = selectArticlesFromIds(state, {cardIds: groupCardIds});
-			// console.log("articles here", cardsData);
 			return {
 			  ...group,
 			  cardsData,
@@ -132,7 +126,7 @@ const createMapStateToProps = () => {
 		cards: selectArticlesFromIds(state, {
 			cardIds,
 		}),
-		groupsWithCardsData: getCardsFromOtherGroups()(state, groupsData),
+		groupsWithCardsData: getCardsForOtherGroups()(state, groupsData),
 	});
 };
 

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -24,6 +24,7 @@ interface OuterProps {
 
 interface InnerProps {
 	cards: Card[];
+	groupsWithCardsData: any[];
 }
 
 type Props = OuterProps & InnerProps;
@@ -70,7 +71,12 @@ const GroupLevel = ({
 	groupIds,
 	groupMaxItems,
 	groupsData,
-}: Props) => (
+	groupsWithCardsData,
+}: Props) => {
+	// console.log("cards", cards)
+	// console.log('cardsFromOtherGroups', groupsWithCardsData);
+	// console.log("groupsData here", groupsData);
+	return (
 	<CardTypeLevel
 		arr={cards}
 		parentType="group"
@@ -79,7 +85,7 @@ const GroupLevel = ({
 		groupName={groupName}
 		groupIds={groupIds}
 		groupMaxItems={groupMaxItems}
-		groupsData={groupsData}
+		groupsData={groupsWithCardsData}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}
@@ -98,14 +104,35 @@ const GroupLevel = ({
 	>
 		{children}
 	</CardTypeLevel>
-);
+)};
 
 const createMapStateToProps = () => {
 	const selectArticlesFromIds = createSelectArticlesFromIds();
-	return (state: State, { cardIds }: OuterProps) => ({
+
+	const getCardsFromOtherGroups = () => {
+		return (state: State, groupsData: Group[] | undefined) => {
+		  if (!groupsData) {
+			return [];
+		  }
+
+		//   console.log("groupsData here", groupsData);
+
+		  return groupsData.map((group) => {
+			const groupCardIds = group.cards
+			const cardsData = selectArticlesFromIds(state, {cardIds: groupCardIds});
+			// console.log("articles here", cardsData);
+			return {
+			  ...group,
+			  cardsData,
+			};
+		  });
+		};
+	  };
+	return (state: State, { cardIds, groupsData }: OuterProps) => ({
 		cards: selectArticlesFromIds(state, {
 			cardIds,
 		}),
+		groupsWithCardsData: getCardsFromOtherGroups()(state, groupsData),
 	});
 };
 

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -19,7 +19,7 @@ interface OuterProps {
 	groupName: string;
 	groupIds: string[];
 	groupMaxItems?: number;
-	groupsData?: Group[];
+	groups?: Group[];
 }
 
 interface InnerProps {
@@ -105,15 +105,14 @@ const createMapStateToProps = () => {
 	const selectArticlesFromIds = createSelectArticlesFromIds();
 
 	const getCardsForOtherGroups = () => {
-		return (state: State, groupsData: Group[] | undefined) => {
-			if (!groupsData) {
+		return (state: State, groups: Group[] | undefined) => {
+			if (!groups) {
 				return [];
 			}
 
-			return groupsData.map((group) => {
-				const groupCardIds = group.cards;
+			return groups.map((group) => {
 				const cardsData = selectArticlesFromIds(state, {
-					cardIds: groupCardIds,
+					cardIds: group.cards,
 				});
 				return {
 					...group,
@@ -122,11 +121,11 @@ const createMapStateToProps = () => {
 			});
 		};
 	};
-	return (state: State, { cardIds, groupsData }: OuterProps) => ({
+	return (state: State, { cardIds, groups }: OuterProps) => ({
 		cards: selectArticlesFromIds(state, {
 			cardIds,
 		}),
-		groupsWithCardsData: getCardsForOtherGroups()(state, groupsData),
+		groupsWithCardsData: getCardsForOtherGroups()(state, groups),
 	});
 };
 

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -19,7 +19,7 @@ interface OuterProps {
 	groupName: string;
 	groupIds: string[];
 	groupMaxItems?: number;
-	groupsData?: Group[]
+	groupsData?: Group[];
 }
 
 interface InnerProps {
@@ -106,20 +106,22 @@ const createMapStateToProps = () => {
 
 	const getCardsForOtherGroups = () => {
 		return (state: State, groupsData: Group[] | undefined) => {
-		  if (!groupsData) {
-			return [];
-		  }
+			if (!groupsData) {
+				return [];
+			}
 
-		  return groupsData.map((group) => {
-			const groupCardIds = group.cards
-			const cardsData = selectArticlesFromIds(state, {cardIds: groupCardIds});
-			return {
-			  ...group,
-			  cardsData,
-			};
-		  });
+			return groupsData.map((group) => {
+				const groupCardIds = group.cards;
+				const cardsData = selectArticlesFromIds(state, {
+					cardIds: groupCardIds,
+				});
+				return {
+					...group,
+					cardsData,
+				};
+			});
 		};
-	  };
+	};
 	return (state: State, { cardIds, groupsData }: OuterProps) => ({
 		cards: selectArticlesFromIds(state, {
 			cardIds,

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -18,6 +18,7 @@ interface OuterProps {
 	collectionId: string;
 	groupName: string;
 	groupIds: string[];
+	groupMaxItems?: number;
 }
 
 interface InnerProps {
@@ -66,6 +67,7 @@ const GroupLevel = ({
 	collectionId,
 	groupName,
 	groupIds,
+	groupMaxItems,
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
@@ -74,6 +76,7 @@ const GroupLevel = ({
 		collectionId={collectionId}
 		groupName={groupName}
 		groupIds={groupIds}
+		groupMaxItems={groupMaxItems}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LevelChild, MoveHandler, DropHandler } from 'lib/dnd';
 import type { State } from 'types/State';
 import { connect } from 'react-redux';
-import { Card } from 'types/Collection';
+import { Card, Group } from 'types/Collection';
 import DropZone, { DefaultDropContainer } from 'components/DropZone';
 import { createSelectArticlesFromIds } from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
@@ -19,6 +19,7 @@ interface OuterProps {
 	groupName: string;
 	groupIds: string[];
 	groupMaxItems?: number;
+	groupsData?: Group[]
 }
 
 interface InnerProps {
@@ -68,6 +69,7 @@ const GroupLevel = ({
 	groupName,
 	groupIds,
 	groupMaxItems,
+	groupsData,
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
@@ -77,6 +79,7 @@ const GroupLevel = ({
 		groupName={groupName}
 		groupIds={groupIds}
 		groupMaxItems={groupMaxItems}
+		groupsData={groupsData}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -24,7 +24,7 @@ interface OuterProps {
 
 interface InnerProps {
 	cards: Card[];
-	groupsWithCardsData: any[];
+	groupsWithCardsData: Group[];
 }
 
 type Props = OuterProps & InnerProps;
@@ -70,10 +70,8 @@ const GroupLevel = ({
 	groupName,
 	groupIds,
 	groupMaxItems,
-	groupsData,
 	groupsWithCardsData,
-}: Props) => {
-	return (
+}: Props) => (
 	<CardTypeLevel
 		arr={cards}
 		parentType="group"
@@ -101,7 +99,7 @@ const GroupLevel = ({
 	>
 		{children}
 	</CardTypeLevel>
-)};
+);
 
 const createMapStateToProps = () => {
 	const selectArticlesFromIds = createSelectArticlesFromIds();

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -13,6 +13,7 @@ interface PosSpec {
 	collectionId?: string;
 	groupName?: string;
 	groupIds?: string[];
+	groupMaxItems?: number;
 	cards?: any[];
 }
 
@@ -63,6 +64,7 @@ export interface LevelProps<T> {
 	collectionId?: string;
 	groupName?: string;
 	groupIds?: string[];
+	groupMaxItems?: number;
 	type: string;
 	getDropType?: (item: T) => string;
 	dragImageOffsetX?: number;
@@ -188,6 +190,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 			collectionId: this.props.collectionId,
 			groupName: this.props.groupName,
 			groupIds: this.props.groupIds,
+			groupMaxItems: this.props.groupMaxItems,
 			cards: this.props.arr,
 		};
 

--- a/fronts-client/src/lib/dnd/Level.tsx
+++ b/fronts-client/src/lib/dnd/Level.tsx
@@ -5,6 +5,7 @@ import { Store } from './store';
 import AddParentInfo, { PathConsumer, Parent } from './AddParentInfo';
 import { TRANSFER_TYPE, NO_STORE_ERROR } from './constants';
 import DropZone from './DropZone';
+import { Group } from 'types/Collection';
 
 interface PosSpec {
 	type: string;
@@ -14,6 +15,7 @@ interface PosSpec {
 	groupName?: string;
 	groupIds?: string[];
 	groupMaxItems?: number;
+	groupsData?: Group[];
 	cards?: any[];
 }
 
@@ -65,6 +67,7 @@ export interface LevelProps<T> {
 	groupName?: string;
 	groupIds?: string[];
 	groupMaxItems?: number;
+	groupsData?: Group[];
 	type: string;
 	getDropType?: (item: T) => string;
 	dragImageOffsetX?: number;
@@ -191,6 +194,7 @@ class Level<T> extends React.Component<Props<T>, State> {
 			groupName: this.props.groupName,
 			groupIds: this.props.groupIds,
 			groupMaxItems: this.props.groupMaxItems,
+			groupsData: this.props.groupsData,
 			cards: this.props.arr,
 		};
 

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -19,6 +19,7 @@ interface Group {
 	name: string | null;
 	uuid: string;
 	cards: string[];
+	maxItems?: number;
 }
 
 interface GroupConfig {

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -20,6 +20,7 @@ interface Group {
 	uuid: string;
 	cards: string[];
 	maxItems?: number;
+	cardsData?: Card[];
 }
 
 interface GroupConfig {

--- a/fronts-client/src/util/shared.ts
+++ b/fronts-client/src/util/shared.ts
@@ -58,15 +58,7 @@ const addGroupsForStage = (
 		) {
 			name = collectionConfig.groups[groupNumberAsInt];
 		}
-		//todo: check correct name
-		if (collectionConfig.groupsConfig) {
-			const groupConfig = collectionConfig.groupsConfig[groupNumberAsInt];
-			if (name = groupConfig.name) {
-				group.maxItems = groupConfig.maxItems;
 
-			}
-
-		}
 		return { ...group, name };
 	});
 
@@ -76,6 +68,20 @@ const addGroupsForStage = (
 		collectionConfig.groups.forEach((group, configGroupIndex) => {
 			if (!configGroupIndexExistsInGroups(groupsWithNames, configGroupIndex)) {
 				groupsWithNames.push(createGroup(`${configGroupIndex}`, group));
+			}
+		});
+	}
+
+	// Once we have all the groups, we can look at the config and set the maxItems value.
+	if (collectionConfig.groupsConfig) {
+		groupsWithNames.forEach((group) => {
+			const groupConfig =
+				collectionConfig.groupsConfig &&
+				collectionConfig.groupsConfig.find(
+					(config) => config.name === group.name,
+				);
+			if (groupConfig) {
+				group.maxItems = groupConfig.maxItems;
 			}
 		});
 	}
@@ -107,7 +113,6 @@ const addGroupsForStage = (
 		addedGroups: keyBy(sortedNamedGroupsWithoutMaxItemSetToZero, getUUID),
 		groupIds: sortedNamedGroupsWithoutMaxItemSetToZero.map(getUUID),
 	};
-
 };
 
 interface ReduceResult {

--- a/fronts-client/src/util/shared.ts
+++ b/fronts-client/src/util/shared.ts
@@ -74,10 +74,9 @@ const addGroupsForStage = (
 	// Once we have all the groups, we can look at the config and set the maxItems value.
 	if (collectionConfig.groupsConfig) {
 		groupsWithNames.forEach((group) => {
-			const groupConfig =
-				collectionConfig.groupsConfig?.find(
-					(config) => config.name === group.name,
-				);
+			const groupConfig = collectionConfig.groupsConfig?.find(
+				(config) => config.name === group.name,
+			);
 			if (groupConfig) {
 				group.maxItems = groupConfig.maxItems;
 			}

--- a/fronts-client/src/util/shared.ts
+++ b/fronts-client/src/util/shared.ts
@@ -75,8 +75,7 @@ const addGroupsForStage = (
 	if (collectionConfig.groupsConfig) {
 		groupsWithNames.forEach((group) => {
 			const groupConfig =
-				collectionConfig.groupsConfig &&
-				collectionConfig.groupsConfig.find(
+				collectionConfig.groupsConfig?.find(
 					(config) => config.name === group.name,
 				);
 			if (groupConfig) {

--- a/fronts-client/src/util/shared.ts
+++ b/fronts-client/src/util/shared.ts
@@ -58,7 +58,6 @@ const addGroupsForStage = (
 		) {
 			name = collectionConfig.groups[groupNumberAsInt];
 		}
-
 		return { ...group, name };
 	});
 

--- a/fronts-client/src/util/shared.ts
+++ b/fronts-client/src/util/shared.ts
@@ -58,6 +58,15 @@ const addGroupsForStage = (
 		) {
 			name = collectionConfig.groups[groupNumberAsInt];
 		}
+		//todo: check correct name
+		if (collectionConfig.groupsConfig) {
+			const groupConfig = collectionConfig.groupsConfig[groupNumberAsInt];
+			if (name = groupConfig.name) {
+				group.maxItems = groupConfig.maxItems;
+
+			}
+
+		}
 		return { ...group, name };
 	});
 
@@ -98,6 +107,7 @@ const addGroupsForStage = (
 		addedGroups: keyBy(sortedNamedGroupsWithoutMaxItemSetToZero, getUUID),
 		groupIds: sortedNamedGroupsWithoutMaxItemSetToZero.map(getUUID),
 	};
+
 };
 
 interface ReduceResult {


### PR DESCRIPTION
## What's changed?

Part of [this F+C ticket](https://trello.com/c/a16rDa8J/1012-add-group-limits-to-fronts-tool)

This PR does a couple of things:

- it surfaces the maxItems set in the groupsConfig to the group itself, which allows us to access the property in other areas of the client
- makes use of the maxItems value to adjust the logic handling inserting and moving cards into and between groups. 

This supersedes the work done for the [splash card](https://github.com/guardian/facia-tool/pull/1753).

Rather than just checking if we're in the splash or if we're adding to indexes 0 or 1 in the group (which we could do previously since there could only be a single card in the splash), now we check if we're adding to a group that already has the maximum number of items, and which place in the group we're adding the story to. If we're adding the story to the bottom of a maxed out group, we want to instead insert that story to the next group; if it's anywhere else, we want to grab the last story in the group, and move that one to the next group. 

That logic should trickle down: 
- adding a card to the top of the splash should push the original splash card down to very big
- if very big already has two stories, the second should get moved to big
- if big already has three stories, the third should get moved to standard

This should happen immediately and automatically in the UI, which can feel surprising, but improving this experience (e.g. via an animation) is something for another PR. 

## Recording

In the example below, the splash was limited to one item, the very big group to 2, and big to 3

https://github.com/user-attachments/assets/7672c2e2-4a4a-427c-aa34-97e33168f762



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
