### PR TITLE
Update logic to set boost level when moving cards

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -225,11 +225,12 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 		const { collection } = selectGroupCollection(state, groupId);
 		const group = selectGroups(state)[groupId];
 		if (collection?.type === FLEXIBLE_GENERAL_NAME) {
-			if (!group || group.id === null) {
-				return;
-			}
 			// if we move a gigaboosted card to a standard group, we set megaboost
-			if (parseInt(group.id) === 0 && card.meta.boostLevel === 'gigaboost') {
+			if (
+				group &&
+				(!group.id || parseInt(group.id) === 0) &&
+				card.meta.boostLevel === 'gigaboost'
+			) {
 				return updateCardMeta(
 					card.uuid,
 					{
@@ -237,6 +238,9 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 					},
 					{ merge: true },
 				);
+			}
+			if (!group || group.id === null) {
+				return;
 			}
 			// if we move any card to a very big group, we set megaboost
 			if (parseInt(group.id) === 2) {

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -225,12 +225,11 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 		const { collection } = selectGroupCollection(state, groupId);
 		const group = selectGroups(state)[groupId];
 		if (collection?.type === FLEXIBLE_GENERAL_NAME) {
+			if (!group || group.id === null) {
+				return;
+			}
 			// if we move a gigaboosted card to a standard group, we set megaboost
-			if (
-				group &&
-				(!group.id || parseInt(group.id) === 0) &&
-				card.meta.boostLevel === 'gigaboost'
-			) {
+			if (parseInt(group.id) === 0 && card.meta.boostLevel === 'gigaboost') {
 				return updateCardMeta(
 					card.uuid,
 					{
@@ -239,26 +238,26 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 					{ merge: true },
 				);
 			}
-		}
-		// if we move any card to a very big group, we set megaboost
-		if (group && group.id !== null && parseInt(group.id) === 2) {
-			return updateCardMeta(
-				card.uuid,
-				{
-					boostLevel: 'megaboost',
-				},
-				{ merge: true },
-			);
-		}
-		// if we move any card to a big group, we set boost
-		if (group && group.id !== null && parseInt(group.id) === 1) {
-			return updateCardMeta(
-				card.uuid,
-				{
-					boostLevel: 'boost',
-				},
-				{ merge: true },
-			);
+			// if we move any card to a very big group, we set megaboost
+			if (parseInt(group.id) === 2) {
+				return updateCardMeta(
+					card.uuid,
+					{
+						boostLevel: 'megaboost',
+					},
+					{ merge: true },
+				);
+			}
+			// if we move any card to a big group, we set boost
+			if (parseInt(group.id) === 1) {
+				return updateCardMeta(
+					card.uuid,
+					{
+						boostLevel: 'boost',
+					},
+					{ merge: true },
+				);
+			}
 		}
 	}
 };

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -206,9 +206,12 @@ const updateCardMetaWithPersist = (persistTo: PersistTo) =>
 		persistTo,
 	});
 
-/** Cards in the standard group of a flexible general container should not be gigaboosted.
- * When moving a card from the splash group to the standard group, this function checks if the card should be modified.
- * If so, it will automatically adjust the boost level from gigaboost to megaboost.
+/** Groups in a flexible general container allow different boostlevel options.
+ * When moving a card from the one group to another, this function checks if the card should be modified.
+ * If so, it will automatically adjust the boost level to what is possible or the default in the group.
+ * Very Big defaults to mega, big defaults to boost
+ * Splash allows all levels, and standard does not allow gigaboost.
+ * Group ids remain consistent, even if the group is hidden (when maxItems is set to 0), so we can use the id to determine the group.
  */
 
 const mayLowerCardBoostLevelForDestinationGroup = (
@@ -222,6 +225,7 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 		const { collection } = selectGroupCollection(state, groupId);
 		const group = selectGroups(state)[groupId];
 		if (collection?.type === FLEXIBLE_GENERAL_NAME) {
+			// if we move a gigaboosted card to a standard group, we set megaboost
 			if (
 				group &&
 				(!group.id || parseInt(group.id) === 0) &&
@@ -235,6 +239,26 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 					{ merge: true },
 				);
 			}
+		}
+		// if we move any card to a very big group, we set megaboost
+		if (group && group.id !== null && parseInt(group.id) === 2) {
+			return updateCardMeta(
+				card.uuid,
+				{
+					boostLevel: 'megaboost',
+				},
+				{ merge: true },
+			);
+		}
+		// if we move any card to a big group, we set boost
+		if (group && group.id !== null && parseInt(group.id) === 1) {
+			return updateCardMeta(
+				card.uuid,
+				{
+					boostLevel: 'boost',
+				},
+				{ merge: true },
+			);
 		}
 	}
 };


### PR DESCRIPTION
## What's changed?

When we only had the splash and standard groups in flexible general containers, we had some logic that triggered when moving a card from the splash to the standard group and set the boostlevel to megaboost if it had previously been set to gigaboost. 

That logic stays in place and we've now introduced the very big and big groups, which have similar requirements - when moving a card to the very big, they need to be set to megaboost; similarly, cards going to the big group need to be set to boosted.

Standard and splash groups both allow megaboost and boost levels, so we don't make any changes when moving a card with those properties to either group.

## Recording


https://github.com/user-attachments/assets/3ea3b169-8f58-4322-a22b-d164bf4489cb



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
