### PR TITLE
Adjust boost levels when moving between groups

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -251,7 +251,7 @@ const getBoostLevel = (groupId: number, boostIndex: number) => {
 	return boostLevels[boostIndex - 1];
 };
 
-const mayLowerCardBoostLevelForDestinationGroup = (
+const mayAdjustCardBoostLevelForDestinationGroup = (
 	state: State,
 	to: PosSpec,
 	card: Card,
@@ -261,7 +261,6 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 		const groupId = to.id;
 		const { collection } = selectGroupCollection(state, groupId);
 		const group = selectGroups(state)[groupId];
-		console.log(card.meta.group);
 
 		if (collection?.type === FLEXIBLE_GENERAL_NAME) {
 			if (!group) {
@@ -313,7 +312,7 @@ const insertCardWithCreate =
 				if (!card) {
 					return;
 				}
-				const modifyCardAction = mayLowerCardBoostLevelForDestinationGroup(
+				const modifyCardAction = mayAdjustCardBoostLevelForDestinationGroup(
 					state,
 					to,
 					card,
@@ -422,7 +421,7 @@ const moveCard = (
 					dispatch(cardsReceived([parent, ...supporting]));
 				}
 
-				const modifyCardAction = mayLowerCardBoostLevelForDestinationGroup(
+				const modifyCardAction = mayAdjustCardBoostLevelForDestinationGroup(
 					state,
 					to,
 					parent,

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -230,17 +230,24 @@ const minimumGroupBoostLevel = (groupId: number) => {
  * we don't want to go any lower.
  * Otherwise, we decrease the boost level by 1.
  */
-const getBoostLevel = (
-	groupId: number,
-	boostIndex: number,
-	hasMinimumBoostLevel: boolean,
-) => {
+const getBoostLevel = (groupId: number, boostIndex: number) => {
 	if (groupId === 3) {
 		return 'default';
 	}
-	if (hasMinimumBoostLevel) {
+	const minBoostLevel = minimumGroupBoostLevel(groupId);
+	const minBoostIndex = boostLevels.indexOf(minBoostLevel);
+
+	// If the current boost level is below the minimum required, set it to the minimum
+	if (boostIndex < minBoostIndex) {
+		return minBoostLevel;
+	}
+
+	// If the current boost level is the minimum required, don't change it
+	if (boostIndex === minBoostIndex) {
 		return boostLevels[boostIndex];
 	}
+
+	// Otherwise reduce the boost level by 1
 	return boostLevels[boostIndex - 1];
 };
 
@@ -262,18 +269,11 @@ const mayLowerCardBoostLevelForDestinationGroup = (
 			}
 			const groupId = parseInt(group.id ?? '0');
 
-			const hasMinimumBoostLevel =
-				card.meta?.boostLevel === minimumGroupBoostLevel(groupId);
-
 			const currentBoostLevel = boostLevels.indexOf(
 				card.meta.boostLevel ?? 'default',
 			);
 
-			const boostLevel = getBoostLevel(
-				groupId,
-				currentBoostLevel,
-				hasMinimumBoostLevel,
-			);
+			const boostLevel = getBoostLevel(groupId, currentBoostLevel);
 			return updateCardMeta(
 				card.uuid,
 				{


### PR DESCRIPTION
## What's changed?
Refactors boost levels when a card is moved between groups. It implements the following rules:

- If the card is moved to a splash (group 3) group, we always set the boost level to default
- If the card's boost level is lower than the minimum required for the group, set it to the minimum group boost level
- If the card already has the minimum group boost level, we don't want to go any lower, so we use the existing boost level
- Otherwise, we decrease the boost level by 1. 
   This results in the follow flow of levels:
   **Gigaboost -> MegaBoost -> Boost -> Default**
 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
