### PR TITLE
Update code owner to Fronts and Curation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 ## code changes will send PR to following users. See https://help.github.com/articles/about-codeowners/
-* @guardian/digital-cms
+* @guardian/fronts-and-curation


### PR DESCRIPTION
## What's changed?

The [Fronts and Curation team](https://github.com/orgs/guardian/teams/fronts-and-curation) are now responsible for this repository, and I think they should be listed as the code owner for it. This PR makes it so.

(digital-cms is a parent of that team which includes a lot of people, who I think don’t necessarily need to get emails about reviewing PRs on this repository.)