### PR TITLE
Fix kitchen-ipsum

### DIFF
--- a/scripts/recipes/recipe-front-generator.mjs
+++ b/scripts/recipes/recipe-front-generator.mjs
@@ -193,9 +193,28 @@ const frontsHeaders = {
  */
 async function findRecipes(searchString, count, meatFree) {
     console.debug(`search term is '${searchString}'`);
-		const baseUrl = `${recipeBase}/search?q=${encodeURIComponent(searchString)}&format=Full&limit=${count}`;
-		const url = meatFree ? baseUrl + '&dietFilter=vegetarian' : baseUrl;
-    const response = await fetch(url);
+		// const baseUrl = `${recipeBase}/search?q=${encodeURIComponent(searchString)}&format=Full&limit=${count}`;
+		// const url = meatFree ? baseUrl + '&dietFilter=vegetarian' : baseUrl;
+		const searchReq = {
+			queryText: searchString,
+			format: "Full",
+			limit: count,
+			searchType: "Embedded"
+		}
+		if(meatFree) {
+			searchReq.filters = {
+				diets: ["vegetarian"],
+				filterType: "Post"
+			}
+		}
+    const response = await fetch(`${recipeBase}/search`, {
+			method: "POST",
+			body: JSON.stringify(searchReq),
+			headers: {
+				...frontsHeaders,
+				"Content-Type": 'application/json'
+			},
+		});
     if(response.status !== 200) {
         const content = await response.text();
         console.error(`Server error ${response.status}: ${content}`);


### PR DESCRIPTION

## What's changed?

Forces the recipe front generator to use embedded search as it gives better results for the looser queries

Since we changed the default search implementation to give fewer, more accurate results to user queries the recipe front generator is having trouble getting enough results.  This switches back to using the pure embeddings implementation which gives results over a greater range for the non-standard queries used

## Implementation notes

n/a

## Checklist

### General
- [x] 🔍 Checked on LOCAL

Other checks n/a

### Client

n/a
