### PR TITLE
use max items from groups to show visible stories marker

### DIFF
--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -9,14 +9,16 @@ trait FlexibleContainer {
 }
 
 object FlexibleGeneral extends FlexibleContainer {
-	def storiesVisible(
-											stories: Seq[Story],
-											collectionConfigJson: Option[CollectionConfigJson]
-										): Int = {
-		val totalMaxItems = collectionConfigJson.get.groupsConfig
-			.getOrElse(Nil).flatMap(_.maxItems).sum
-		totalMaxItems
-	}
+  def storiesVisible(
+      stories: Seq[Story],
+      collectionConfigJson: Option[CollectionConfigJson]
+  ): Int = {
+    val totalMaxItems = collectionConfigJson.get.groupsConfig
+      .getOrElse(Nil)
+      .flatMap(_.maxItems)
+      .sum
+    totalMaxItems
+  }
 }
 
 object FlexibleSpecial extends FlexibleContainer {

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -9,15 +9,14 @@ trait FlexibleContainer {
 }
 
 object FlexibleGeneral extends FlexibleContainer {
-  def storiesVisible(
-      stories: Seq[Story],
-      collectionConfigJson: Option[CollectionConfigJson]
-  ): Int = {
-    collectionConfigJson
-      .flatMap(_.displayHints)
-      .flatMap(_.maxItemsToDisplay)
-      .getOrElse(9)
-  }
+	def storiesVisible(
+											stories: Seq[Story],
+											collectionConfigJson: Option[CollectionConfigJson]
+										): Int = {
+		val totalMaxItems = collectionConfigJson.get.groupsConfig
+			.getOrElse(Nil).flatMap(_.maxItems).sum
+		totalMaxItems
+	}
 }
 
 object FlexibleSpecial extends FlexibleContainer {


### PR DESCRIPTION
## What's changed?

Part of [this ticket ](https://trello.com/c/28pd97nL/1062-update-visible-stories-marker-considering-the-maxitems-value-for-each-group)

Makes use of the new groups config for flexible general containers to correctly position the visible markers. This is just a UI change in the fronts tool, but will be helpful to editors to indicate what they can expect to be rendered (the same work was done in frontend and mapi). 

There is a limitation that this assumes every group is filled up with its maximum number of cards, but this is in line with expectations.

## Screenshots

With up to 3 standard stories:
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/02dce0ed-23bd-4024-8943-d3a2594a0b4a" />

With up to 4:
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/d6dce546-d416-4192-8bbb-46ef4479d4ef" />



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
