### PR TITLE
Add radio buttons to select media

### DIFF
--- a/fronts-client/src/components/Explainer.tsx
+++ b/fronts-client/src/components/Explainer.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export default styled.div`
+	font-style: italic;
+	font-size: 12px;
+	margin-top: -6px;
+	color: #707070;
+`;

--- a/fronts-client/src/components/Row.tsx
+++ b/fronts-client/src/components/Row.tsx
@@ -1,11 +1,16 @@
 import { styled } from 'constants/theme';
 
-const Row = styled.div<{ flexDirection?: string; gutter?: number, rowGap?: number }>`
+const Row = styled.div<{
+	flexDirection?: string;
+	gutter?: number;
+	rowGap?: number;
+}>`
 	display: flex;
 	margin: 0 ${({ gutter = 10 }: { gutter?: number }) => `${-(gutter / 2)}px`};
 	flex-wrap: wrap;
 	// row-gap used when wrapped
-	row-gap: ${({ rowGap }: { rowGap?: number }) => rowGap ? `${rowGap}px` : '0'};
+	row-gap: ${({ rowGap }: { rowGap?: number }) =>
+		rowGap ? `${rowGap}px` : '0'};
 	flex-direction: ${({ flexDirection }) =>
 		flexDirection ? flexDirection : ''};
 `;

--- a/fronts-client/src/components/Row.tsx
+++ b/fronts-client/src/components/Row.tsx
@@ -1,8 +1,11 @@
 import { styled } from 'constants/theme';
 
-const Row = styled.div<{ flexDirection?: string; gutter?: number }>`
+const Row = styled.div<{ flexDirection?: string; gutter?: number, rowGap?: number }>`
 	display: flex;
 	margin: 0 ${({ gutter = 10 }: { gutter?: number }) => `${-(gutter / 2)}px`};
+	flex-wrap: wrap;
+	// row-gap used when wrapped
+	row-gap: ${({ rowGap }: { rowGap?: number }) => rowGap ? `${rowGap}px` : '0'};
 	flex-direction: ${({ flexDirection }) =>
 		flexDirection ? flexDirection : ''};
 `;

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -810,19 +810,21 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
+											disabled={editableFields.indexOf(this.getImageFieldName()) === -1}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
 											label="Trail Image"
 											id={getInputId(cardId, "select-trail-image")}
 											value="select-trail-image"
-											onClick={() => this.changeImageField('imageReplace')}
+											onClick={() => this.changeImageField('')}
 										/>
 									</InputGroup>
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
-											icon={<SlideshowIcon/>}
+											disabled={editableFields.indexOf("showMainVideo") === -1}
+											icon={<SelectVideoIcon/>}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
@@ -835,7 +837,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
-											icon={<SelectVideoIcon/>}
+											disabled={editableFields.indexOf("imageSlideshowReplace") === -1}
+											icon={<SlideshowIcon/>}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -817,7 +817,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											label="Trail Image"
 											id={getInputId(cardId, "select-trail-image")}
 											value="select-trail-image"
+											initialValues="select-trail-image"
 											onClick={() => this.changeImageField(this.getImageFieldName())}
+											checked={this.props.primaryImage || this.props.imageCutoutReplace}
 										/>
 									</InputGroup>
 									<InputGroup>
@@ -832,6 +834,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											id={getInputId(cardId, "select-video")}
 											value="select-video"
 											onClick={() => this.changeImageField('showMainVideo')}
+											checked={this.props.showMainVideo}
 										/>
 									</InputGroup>
 									<InputGroup>
@@ -846,6 +849,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											id={getInputId(cardId, "select-slideshow")}
 											value="select-slideshow"
 											onClick={() => this.changeImageField('imageSlideshowReplace')}
+											checked={this.props.imageSlideshowReplace}
 										/>
 									</InputGroup>
 								</Col>
@@ -1060,6 +1064,7 @@ interface ContainerProps {
 	getLastUpdatedBy: (collectionId: string) => string | null;
 	slideshow: Array<ImageData | undefined | null> | undefined;
 	imageSlideshowReplace: boolean;
+	showMainVideo: boolean;
 	imageCutoutReplace: boolean;
 	imageHide: boolean;
 	kickerOptions: ArticleTag;
@@ -1127,6 +1132,7 @@ const createMapStateToProps = () => {
 				article && selectFormFields(state, article.uuid, isSupporting),
 			kickerOptions: article ? selectArticleTag(state, cardId) : defaultObject,
 			imageSlideshowReplace: valueSelector(state, 'imageSlideshowReplace'),
+			showMainVideo: valueSelector(state, 'showMainVideo'),
 			slideshow: valueSelector(state, 'slideshow'),
 			imageHide: valueSelector(state, 'imageHide'),
 			imageReplace: valueSelector(state, 'imageReplace'),

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -76,6 +76,7 @@ import { ImageRowContainer } from './ImageRowContainer';
 import { ImageCol } from './ImageCol';
 import { renderBoostToggles } from './BoostToggles';
 import { memoize } from 'lodash';
+import InputRadio from "../inputs/InputRadio";
 
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
@@ -689,7 +690,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 					</TextOptionsInputGroup>
 					<ImageOptionsInputGroup size={this.props.size}>
 						<ImageRowContainer size={this.props.size}>
-							<Row>
+							<Row rowGap={4}>
 								<ImageCol faded={imageHide || !!coverCardImageReplace}>
 									{shouldRenderField(
 										this.getImageFieldName(),
@@ -802,6 +803,44 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 										</InputGroup>
 									)}
 								</ToggleCol>
+								<Col flex={2}>
+									<InputLabel htmlFor="media-select">
+										Select Media
+									</InputLabel>
+									<InputGroup>
+										<ConditionalField
+											component={InputRadio}
+											name="media-select"
+											type="radio"
+											label="Trail Image Only"
+											id={getInputId(cardId, "select-trail-image")}
+											value="select-trail-image"
+											onClick={() => this.changeImageField('imageReplace')}
+										/>
+									</InputGroup>
+									<InputGroup>
+										<ConditionalField
+											component={InputRadio}
+											name="media-select"
+											type="radio"
+											label="Video"
+											id={getInputId(cardId, "select-video")}
+											value="select-video"
+											onClick={() => this.changeImageField('showMainVideo')}
+										/>
+									</InputGroup>
+									<InputGroup>
+										<ConditionalField
+											component={InputRadio}
+											name="media-select"
+											type="radio"
+											label="Slideshow"
+											id={getInputId(cardId, "select-slideshow")}
+											value="select-slideshow"
+											onClick={() => this.changeImageField('imageSlideshowReplace')}
+										/>
+									</InputGroup>
+								</Col>
 							</Row>
 							<ConditionalComponent
 								permittedNames={editableFields}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -77,6 +77,7 @@ import { ImageCol } from './ImageCol';
 import { renderBoostToggles } from './BoostToggles';
 import { memoize } from 'lodash';
 import InputRadio from '../inputs/InputRadio';
+import Explainer from '../Explainer';
 
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
@@ -825,6 +826,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											}
 										/>
 									</InputGroup>
+									{!hasMainVideo && (
+										<Explainer>Main media video required</Explainer>
+									)}
 									<InputGroup>
 										<Field
 											component={InputRadio}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -63,7 +63,7 @@ import { RichTextInput } from 'components/inputs/RichTextInput';
 import InputBase from '../inputs/InputBase';
 import ButtonCircularCaret from '../inputs/ButtonCircularCaret';
 import { error } from '../../styleConstants';
-import {SelectVideoIcon, SlideshowIcon, WarningIcon} from '../icons/Icons';
+import { SelectVideoIcon, SlideshowIcon, WarningIcon } from '../icons/Icons';
 import { FormContainer } from 'components/form/FormContainer';
 import { FormContent } from 'components/form/FormContent';
 import { TextOptionsInputGroup } from 'components/form/TextOptionsInputGroup';
@@ -76,7 +76,7 @@ import { ImageRowContainer } from './ImageRowContainer';
 import { ImageCol } from './ImageCol';
 import { renderBoostToggles } from './BoostToggles';
 import { memoize } from 'lodash';
-import InputRadio from "../inputs/InputRadio";
+import InputRadio from '../inputs/InputRadio';
 
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
@@ -804,34 +804,38 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									)}
 								</ToggleCol>
 								<Col flex={2}>
-									<InputLabel htmlFor="media-select">
-										Select Media
-									</InputLabel>
+									<InputLabel htmlFor="media-select">Select Media</InputLabel>
 									<InputGroup>
 										<Field
 											component={InputRadio}
-											disabled={editableFields.indexOf(this.getImageFieldName()) === -1}
+											disabled={
+												editableFields.indexOf(this.getImageFieldName()) === -1
+											}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
 											label="Trail Image"
-											id={getInputId(cardId, "select-trail-image")}
+											id={getInputId(cardId, 'select-trail-image')}
 											value="select-trail-image"
 											initialValues="select-trail-image"
-											onClick={() => this.changeImageField(this.getImageFieldName())}
-											checked={this.props.primaryImage || this.props.imageCutoutReplace}
+											onClick={() =>
+												this.changeImageField(this.getImageFieldName())
+											}
+											checked={
+												this.props.primaryImage || this.props.imageCutoutReplace
+											}
 										/>
 									</InputGroup>
 									<InputGroup>
 										<Field
 											component={InputRadio}
-											disabled={editableFields.indexOf("showMainVideo") === -1}
-											icon={<SelectVideoIcon/>}
+											disabled={editableFields.indexOf('showMainVideo') === -1}
+											icon={<SelectVideoIcon />}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
 											label="Video"
-											id={getInputId(cardId, "select-video")}
+											id={getInputId(cardId, 'select-video')}
 											value="select-video"
 											onClick={() => this.changeImageField('showMainVideo')}
 											checked={this.props.showMainVideo}
@@ -840,15 +844,19 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<Field
 											component={InputRadio}
-											disabled={editableFields.indexOf("imageSlideshowReplace") === -1}
-											icon={<SlideshowIcon/>}
+											disabled={
+												editableFields.indexOf('imageSlideshowReplace') === -1
+											}
+											icon={<SlideshowIcon />}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
 											label="Slideshow"
-											id={getInputId(cardId, "select-slideshow")}
+											id={getInputId(cardId, 'select-slideshow')}
 											value="select-slideshow"
-											onClick={() => this.changeImageField('imageSlideshowReplace')}
+											onClick={() =>
+												this.changeImageField('imageSlideshowReplace')
+											}
 											checked={this.props.imageSlideshowReplace}
 										/>
 									</InputGroup>

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -810,9 +810,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
+											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
-											label="Trail Image Only"
+											label="Trail Image"
 											id={getInputId(cardId, "select-trail-image")}
 											value="select-trail-image"
 											onClick={() => this.changeImageField('imageReplace')}
@@ -821,6 +822,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
+											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
 											label="Video"
@@ -832,6 +834,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
+											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
 											label="Slideshow"

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -63,7 +63,7 @@ import { RichTextInput } from 'components/inputs/RichTextInput';
 import InputBase from '../inputs/InputBase';
 import ButtonCircularCaret from '../inputs/ButtonCircularCaret';
 import { error } from '../../styleConstants';
-import { WarningIcon } from '../icons/Icons';
+import {SelectVideoIcon, SlideshowIcon, WarningIcon} from '../icons/Icons';
 import { FormContainer } from 'components/form/FormContainer';
 import { FormContent } from 'components/form/FormContent';
 import { TextOptionsInputGroup } from 'components/form/TextOptionsInputGroup';
@@ -822,6 +822,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
+											icon={<SlideshowIcon/>}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"
@@ -834,6 +835,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 									<InputGroup>
 										<ConditionalField
 											component={InputRadio}
+											icon={<SelectVideoIcon/>}
 											usesBlockStyling={true}
 											name="media-select"
 											type="radio"

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -818,7 +818,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											id={getInputId(cardId, 'select-video')}
 											value="select-video"
 											onClick={() => this.changeImageField('showMainVideo')}
-											checked={this.props.showMainVideo !== undefined ? this.props.showMainVideo : false}
+											checked={
+												this.props.showMainVideo !== undefined
+													? this.props.showMainVideo
+													: false
+											}
 										/>
 									</InputGroup>
 									<InputGroup>
@@ -837,7 +841,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											onClick={() =>
 												this.changeImageField('imageSlideshowReplace')
 											}
-											checked={this.props.imageSlideshowReplace !== undefined ? this.props.imageSlideshowReplace : false}
+											checked={
+												this.props.imageSlideshowReplace !== undefined
+													? this.props.imageSlideshowReplace
+													: false
+											}
 										/>
 									</InputGroup>
 								</Col>

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -764,30 +764,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											}
 										/>
 									</InputGroup>
-									<InputGroup>
-										<ConditionalField
-											permittedFields={editableFields}
-											name="showMainVideo"
-											component={InputCheckboxToggleInline}
-											label="Show video"
-											id={getInputId(cardId, 'show-video')}
-											type="checkbox"
-											onChange={() => this.changeImageField('showMainVideo')}
-										/>
-									</InputGroup>
-									<InputGroup>
-										<ConditionalField
-											permittedFields={editableFields}
-											name="imageSlideshowReplace"
-											component={InputCheckboxToggleInline}
-											label="Slideshow"
-											id={getInputId(cardId, 'slideshow')}
-											type="checkbox"
-											onChange={() =>
-												this.changeImageField('imageSlideshowReplace')
-											}
-										/>
-									</InputGroup>
 									{primaryImage &&
 										!!primaryImage.src &&
 										!this.props.showMainVideo &&

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -788,20 +788,23 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											}
 										/>
 									</InputGroup>
-									{primaryImage && !!primaryImage.src && (
-										<InputGroup>
-											<ConditionalField
-												permittedFields={editableFields}
-												name="imageReplace"
-												component={InputCheckboxToggleInline}
-												label="Use replacement image"
-												id={getInputId(cardId, 'image-replace')}
-												type="checkbox"
-												default={false}
-												onChange={() => this.changeImageField('imageReplace')}
-											/>
-										</InputGroup>
-									)}
+									{primaryImage &&
+										!!primaryImage.src &&
+										!this.props.showMainVideo &&
+										!this.props.imageSlideshowReplace && (
+											<InputGroup>
+												<ConditionalField
+													permittedFields={editableFields}
+													name="imageReplace"
+													component={InputCheckboxToggleInline}
+													label="Use replacement image"
+													id={getInputId(cardId, 'image-replace')}
+													type="checkbox"
+													default={false}
+													onChange={() => this.changeImageField('imageReplace')}
+												/>
+											</InputGroup>
+										)}
 								</ToggleCol>
 								<Col flex={2}>
 									<InputLabel htmlFor="media-select">Select Media</InputLabel>
@@ -822,7 +825,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 												this.changeImageField(this.getImageFieldName())
 											}
 											checked={
-												this.props.primaryImage || this.props.imageCutoutReplace
+												!this.props.showMainVideo &&
+												!this.props.imageSlideshowReplace
 											}
 										/>
 									</InputGroup>

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -818,7 +818,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											id={getInputId(cardId, 'select-video')}
 											value="select-video"
 											onClick={() => this.changeImageField('showMainVideo')}
-											checked={this.props.showMainVideo}
+											checked={this.props.showMainVideo !== undefined ? this.props.showMainVideo : false}
 										/>
 									</InputGroup>
 									<InputGroup>
@@ -837,7 +837,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											onClick={() =>
 												this.changeImageField('imageSlideshowReplace')
 											}
-											checked={this.props.imageSlideshowReplace}
+											checked={this.props.imageSlideshowReplace !== undefined ? this.props.imageSlideshowReplace : false}
 										/>
 									</InputGroup>
 								</Col>

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -808,7 +808,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 										Select Media
 									</InputLabel>
 									<InputGroup>
-										<ConditionalField
+										<Field
 											component={InputRadio}
 											disabled={editableFields.indexOf(this.getImageFieldName()) === -1}
 											usesBlockStyling={true}
@@ -821,7 +821,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 										/>
 									</InputGroup>
 									<InputGroup>
-										<ConditionalField
+										<Field
 											component={InputRadio}
 											disabled={editableFields.indexOf("showMainVideo") === -1}
 											icon={<SelectVideoIcon/>}
@@ -835,7 +835,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 										/>
 									</InputGroup>
 									<InputGroup>
-										<ConditionalField
+										<Field
 											component={InputRadio}
 											disabled={editableFields.indexOf("imageSlideshowReplace") === -1}
 											icon={<SlideshowIcon/>}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -817,7 +817,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											label="Trail Image"
 											id={getInputId(cardId, "select-trail-image")}
 											value="select-trail-image"
-											onClick={() => this.changeImageField('')}
+											onClick={() => this.changeImageField(this.getImageFieldName())}
 										/>
 									</InputGroup>
 									<InputGroup>

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -311,58 +311,17 @@ const VideoIcon = ({}) => (
 );
 
 const SlideshowIcon = ({}) => (
-	<svg
-		width="20"
-		height="18"
-		viewBox="0 0 20 18"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<rect
-			x="6.5"
-			y="0.5"
-			width="13"
-			height="11"
-			fill="white"
-			stroke="#898983"
-		/>
-		<rect
-			x="3.5"
-			y="3.5"
-			width="13"
-			height="11"
-			fill="white"
-			stroke="#898983"
-		/>
-		<rect
-			x="0.5"
-			y="6.5"
-			width="13"
-			height="11"
-			fill="white"
-			stroke="#898983"
-		/>
-		<path d="M5 15V12V9L9.5 12L5 15Z" fill="#898983" stroke="#898983" />
+	<svg width="18" height="16" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect x="6.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<rect x="3.5" y="3.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<rect x="0.5" y="6.5" width="13" height="11" fill="white" stroke="#898983"/>
 	</svg>
 );
 
 const SelectVideoIcon = () => (
-	<svg
-		width="20"
-		height="20"
-		viewBox="-2 0 20 12"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<rect
-			x="0.5"
-			y="0.5"
-			width="13"
-			height="11"
-			fill="white"
-			stroke="#898983"
-		/>
-		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983" />
+	<svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect x="0.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983"/>
 	</svg>
 );
 

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -311,17 +311,57 @@ const VideoIcon = ({}) => (
 );
 
 const SlideshowIcon = ({}) => (
-	<svg width="18" height="16" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect x="6.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<rect x="3.5" y="3.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<rect x="0.5" y="6.5" width="13" height="11" fill="white" stroke="#898983"/>
+	<svg
+		width="18"
+		height="16"
+		viewBox="0 0 20 18"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect
+			x="6.5"
+			y="0.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<rect
+			x="3.5"
+			y="3.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<rect
+			x="0.5"
+			y="6.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
 	</svg>
 );
 
 const SelectVideoIcon = () => (
-	<svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect x="0.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983"/>
+	<svg
+		width="14"
+		height="12"
+		viewBox="0 0 14 12"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect
+			x="0.5"
+			y="0.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983" />
 	</svg>
 );
 

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -311,18 +311,58 @@ const VideoIcon = ({}) => (
 );
 
 const SlideshowIcon = ({}) => (
-	<svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect x="6.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<rect x="3.5" y="3.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<rect x="0.5" y="6.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<path d="M5 15V12V9L9.5 12L5 15Z" fill="#898983" stroke="#898983"/>
+	<svg
+		width="20"
+		height="18"
+		viewBox="0 0 20 18"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect
+			x="6.5"
+			y="0.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<rect
+			x="3.5"
+			y="3.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<rect
+			x="0.5"
+			y="6.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<path d="M5 15V12V9L9.5 12L5 15Z" fill="#898983" stroke="#898983" />
 	</svg>
 );
 
 const SelectVideoIcon = () => (
-	<svg width="20" height="20" viewBox="-2 0 20 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect x="0.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
-		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983"/>
+	<svg
+		width="20"
+		height="20"
+		viewBox="-2 0 20 12"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect
+			x="0.5"
+			y="0.5"
+			width="13"
+			height="11"
+			fill="white"
+			stroke="#898983"
+		/>
+		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983" />
 	</svg>
 );
 

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -310,6 +310,22 @@ const VideoIcon = ({}) => (
 	</svg>
 );
 
+const SlideshowIcon = ({}) => (
+	<svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect x="6.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<rect x="3.5" y="3.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<rect x="0.5" y="6.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<path d="M5 15V12V9L9.5 12L5 15Z" fill="#898983" stroke="#898983"/>
+	</svg>
+);
+
+const SelectVideoIcon = () => (
+	<svg width="20" height="20" viewBox="-2 0 20 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect x="0.5" y="0.5" width="13" height="11" fill="white" stroke="#898983"/>
+		<path d="M5 9V6V3L9.5 6L5 9Z" fill="#898983" stroke="#898983"/>
+	</svg>
+);
+
 const DragHandleIcon = ({ fill = theme.colors.greyDark }) => (
 	<svg
 		xmlns="http://www.w3.org/2000/svg"
@@ -378,6 +394,8 @@ export {
 	PreviewEyeIcon,
 	GuardianRoundel,
 	VideoIcon,
+	SelectVideoIcon,
+	SlideshowIcon,
 	DragHandleIcon as DragIcon,
 	WarningIcon,
 	CropIcon,

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -14,12 +14,16 @@ const RadioButtonContainer = styled.div<{usesBlockStyling?: boolean}>`
 	align-items: center;
 	padding: ${(props) => props.usesBlockStyling ? "8px 6px" : "0"};
 	background-color: ${(props) => props.usesBlockStyling ? "#CCCCCC" : "none"};
-	height:  ${(props) => props.usesBlockStyling ? `${radioButtonHeight * 2}px` : "auto"}
+	height: ${(props) => props.usesBlockStyling ? `${radioButtonHeight * 2}px` : "auto"};
+	color: ${(props) => props.theme.input.colorLabel};
+	&:has(input:checked) {
+		color: ${(props) => props.usesBlockStyling ? "white" : "auto"};
+		background-color: ${(props) => props.usesBlockStyling ? "#A9A9A9" : "none"};
+	}
 `;
 
 const Label = styled(InputLabel)`
 	padding-left: 5px;
-	color: ${(props) => props.theme.input.colorLabel};
 	line-height: 15px;
 	flex: 1;
 	cursor: pointer;

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -9,14 +9,13 @@ import { theme } from 'constants/theme';
 const radioButtonHeight = 17;
 const radioButtonWidth = 17;
 
-
 const BlockStylingMixin = () => css`
 	padding: 8px 6px;
-	background-color: #CCCCCC;
+	background-color: #cccccc;
 	height: ${radioButtonHeight * 2}px;
 	&:has(input:checked) {
 		color: white;
-		background-color: #A9A9A9;
+		background-color: #a9a9a9;
 	}
 	&:has(input:disabled) {
 		opacity: 0.8;
@@ -109,9 +108,9 @@ type Props = {
 	label?: string;
 	id: string;
 	dataTestId?: string;
-	usesBlockStyling?: boolean;
 	checked?: boolean;
 	icon?: ReactElement;
+	usesBlockStyling?: boolean;
 } & {
 	input: Pick<WrappedFieldInputProps, 'onChange'> &
 		Partial<WrappedFieldInputProps>;

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -16,9 +16,14 @@ const RadioButtonContainer = styled.div<{usesBlockStyling?: boolean}>`
 	background-color: ${(props) => props.usesBlockStyling ? "#CCCCCC" : "none"};
 	height: ${(props) => props.usesBlockStyling ? `${radioButtonHeight * 2}px` : "auto"};
 	color: ${(props) => props.theme.input.colorLabel};
+	cursor: pointer;
 	&:has(input:checked) {
 		color: ${(props) => props.usesBlockStyling ? "white" : "auto"};
 		background-color: ${(props) => props.usesBlockStyling ? "#A9A9A9" : "none"};
+	}
+	&:has(input:disabled) {
+		opacity: 0.8;
+		cursor: not-allowed;
 	}
 `;
 
@@ -26,7 +31,7 @@ const Label = styled(InputLabel)`
 	padding-left: 5px;
 	line-height: 15px;
 	flex: 1;
-	cursor: pointer;
+	cursor: inherit;
 `;
 
 const Switch = styled.div`

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'constants/theme';
-import React, {ReactElement} from 'react';
-import {WrappedFieldMetaProps, WrappedFieldInputProps} from 'redux-form';
+import React, { ReactElement } from 'react';
+import { WrappedFieldMetaProps, WrappedFieldInputProps } from 'redux-form';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
@@ -9,17 +9,19 @@ import { theme } from 'constants/theme';
 const radioButtonHeight = 17;
 const radioButtonWidth = 17;
 
-const RadioButtonContainer = styled.div<{usesBlockStyling?: boolean}>`
+const RadioButtonContainer = styled.div<{ usesBlockStyling?: boolean }>`
 	display: flex;
 	align-items: center;
-	padding: ${(props) => props.usesBlockStyling ? "8px 6px" : "0"};
-	background-color: ${(props) => props.usesBlockStyling ? "#CCCCCC" : "none"};
-	height: ${(props) => props.usesBlockStyling ? `${radioButtonHeight * 2}px` : "auto"};
+	padding: ${(props) => (props.usesBlockStyling ? '8px 6px' : '0')};
+	background-color: ${(props) => (props.usesBlockStyling ? '#CCCCCC' : 'none')};
+	height: ${(props) =>
+		props.usesBlockStyling ? `${radioButtonHeight * 2}px` : 'auto'};
 	color: ${(props) => props.theme.input.colorLabel};
 	cursor: pointer;
 	&:has(input:checked) {
-		color: ${(props) => props.usesBlockStyling ? "white" : "auto"};
-		background-color: ${(props) => props.usesBlockStyling ? "#A9A9A9" : "none"};
+		color: ${(props) => (props.usesBlockStyling ? 'white' : 'auto')};
+		background-color: ${(props) =>
+			props.usesBlockStyling ? '#A9A9A9' : 'none'};
 	}
 	&:has(input:disabled) {
 		opacity: 0.8;
@@ -119,7 +121,13 @@ export default ({
 		<InputContainer data-testid={dataTestId}>
 			<RadioButtonContainer usesBlockStyling={usesBlockStyling}>
 				<Switch>
-					<RadioButton type="radio" {...inputRest} checked={checked} {...rest} id={id} />
+					<RadioButton
+						type="radio"
+						{...inputRest}
+						checked={checked}
+						{...rest}
+						id={id}
+					/>
 					<RadioButtonLabel htmlFor={id} />
 				</Switch>
 				<Label htmlFor={id} size="sm">

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -9,9 +9,11 @@ import { theme } from 'constants/theme';
 const radioButtonHeight = 17;
 const radioButtonWidth = 17;
 
-const RadioButtonContainer = styled.div`
+const RadioButtonContainer = styled.div<{usesBlockStyling?: boolean}>`
 	display: flex;
 	align-items: flex-start;
+	padding: ${(props) => props.usesBlockStyling ? "8px 6px" : "0"};
+	background-color: ${(props) => props.usesBlockStyling ? "#CCCCCC" : "none"};
 `;
 
 const Label = styled(InputLabel)`
@@ -84,6 +86,7 @@ type Props = {
 	label?: string;
 	id: string;
 	dataTestId?: string;
+	usesBlockStyling?: boolean;
 } & {
 	input: Pick<WrappedFieldInputProps, 'onChange'> &
 		Partial<WrappedFieldInputProps>;
@@ -95,11 +98,12 @@ export default ({
 	id,
 	dataTestId,
 	input: { ...inputRest },
+	usesBlockStyling = false,
 	...rest
 }: Props) => (
 	<>
 		<InputContainer data-testid={dataTestId}>
-			<RadioButtonContainer>
+			<RadioButtonContainer usesBlockStyling={usesBlockStyling}>
 				<Switch>
 					<RadioButton type="radio" {...inputRest} {...rest} id={id} />
 					<RadioButtonLabel htmlFor={id} />

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -1,4 +1,4 @@
-import { styled } from 'constants/theme';
+import { styled, css } from 'constants/theme';
 import React, { ReactElement } from 'react';
 import { WrappedFieldMetaProps, WrappedFieldInputProps } from 'redux-form';
 
@@ -9,24 +9,27 @@ import { theme } from 'constants/theme';
 const radioButtonHeight = 17;
 const radioButtonWidth = 17;
 
-const RadioButtonContainer = styled.div<{ usesBlockStyling?: boolean }>`
-	display: flex;
-	align-items: center;
-	padding: ${(props) => (props.usesBlockStyling ? '8px 6px' : '0')};
-	background-color: ${(props) => (props.usesBlockStyling ? '#CCCCCC' : 'none')};
-	height: ${(props) =>
-		props.usesBlockStyling ? `${radioButtonHeight * 2}px` : 'auto'};
-	color: ${(props) => props.theme.input.colorLabel};
-	cursor: pointer;
+
+const BlockStylingMixin = () => css`
+	padding: 8px 6px;
+	background-color: #CCCCCC;
+	height: ${radioButtonHeight * 2}px;
 	&:has(input:checked) {
-		color: ${(props) => (props.usesBlockStyling ? 'white' : 'auto')};
-		background-color: ${(props) =>
-			props.usesBlockStyling ? '#A9A9A9' : 'none'};
+		color: white;
+		background-color: #A9A9A9;
 	}
 	&:has(input:disabled) {
 		opacity: 0.8;
 		cursor: not-allowed;
 	}
+`;
+
+const RadioButtonContainer = styled.div<{ usesBlockStyling?: boolean }>`
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	color: ${(props) => props.theme.input.colorLabel};
+	${(props) => props.usesBlockStyling && BlockStylingMixin}
 `;
 
 const Label = styled(InputLabel)`

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -94,6 +94,14 @@ const RadioButton = styled.input`
 	}
 `;
 
+const IconContainer = styled.div`
+	width: 20px;
+	margin-left: 8px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
 type Props = {
 	label?: string;
 	id: string;
@@ -133,7 +141,7 @@ export default ({
 				<Label htmlFor={id} size="sm">
 					{label}
 				</Label>
-				{icon}
+				{icon !== undefined ? <IconContainer>{icon}</IconContainer> : null}
 			</RadioButtonContainer>
 		</InputContainer>
 	</>

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'constants/theme';
-import React from 'react';
-import { WrappedFieldMetaProps, WrappedFieldInputProps } from 'redux-form';
+import React, {ReactElement} from 'react';
+import {WrappedFieldMetaProps, WrappedFieldInputProps} from 'redux-form';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
@@ -11,9 +11,10 @@ const radioButtonWidth = 17;
 
 const RadioButtonContainer = styled.div<{usesBlockStyling?: boolean}>`
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	padding: ${(props) => props.usesBlockStyling ? "8px 6px" : "0"};
 	background-color: ${(props) => props.usesBlockStyling ? "#CCCCCC" : "none"};
+	height:  ${(props) => props.usesBlockStyling ? `${radioButtonHeight * 2}px` : "auto"}
 `;
 
 const Label = styled(InputLabel)`
@@ -87,6 +88,7 @@ type Props = {
 	id: string;
 	dataTestId?: string;
 	usesBlockStyling?: boolean;
+	icon?: ReactElement;
 } & {
 	input: Pick<WrappedFieldInputProps, 'onChange'> &
 		Partial<WrappedFieldInputProps>;
@@ -98,6 +100,7 @@ export default ({
 	id,
 	dataTestId,
 	input: { ...inputRest },
+	icon = undefined,
 	usesBlockStyling = false,
 	...rest
 }: Props) => (
@@ -111,6 +114,7 @@ export default ({
 				<Label htmlFor={id} size="sm">
 					{label}
 				</Label>
+				{icon}
 			</RadioButtonContainer>
 		</InputContainer>
 	</>

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -97,6 +97,7 @@ type Props = {
 	id: string;
 	dataTestId?: string;
 	usesBlockStyling?: boolean;
+	checked?: boolean;
 	icon?: ReactElement;
 } & {
 	input: Pick<WrappedFieldInputProps, 'onChange'> &
@@ -109,6 +110,7 @@ export default ({
 	id,
 	dataTestId,
 	input: { ...inputRest },
+	checked,
 	icon = undefined,
 	usesBlockStyling = false,
 	...rest
@@ -117,7 +119,7 @@ export default ({
 		<InputContainer data-testid={dataTestId}>
 			<RadioButtonContainer usesBlockStyling={usesBlockStyling}>
 				<Switch>
-					<RadioButton type="radio" {...inputRest} {...rest} id={id} />
+					<RadioButton type="radio" {...inputRest} checked={checked} {...rest} id={id} />
 					<RadioButtonLabel htmlFor={id} />
 				</Switch>
 				<Label htmlFor={id} size="sm">


### PR DESCRIPTION
## What's changed?

Replaces various toggle switches for media selection (Show video, Slideshow) with a group of radio buttons.

The new `Video` radio button will have more features in future. Currently it can only be selected if the main media of a given article is a video.

| Before | After | 
| --- | --- |
| <img src="https://github.com/user-attachments/assets/921f1cd8-ddc9-488a-8f44-ae3729ac1741" width="400px" /> | <img src="https://github.com/user-attachments/assets/d350a5a4-d67c-4425-94d1-779f614aa735" width="400px" /> | 

### Testing
Do the toggle switches work? Are their changes reflected in the pressed Front?

There is an existing issue where Video articles cannot become Slideshows when rendered as Splash cards in Flexible General containers. This PR does not address this bug.

I have also seen a new intermittent issue where Slideshows are being rendered with empty fields, and so the slideshow cannot be edited. I am not clear of the cause, and I have not seen it for a while. It may have been caused by a broken front rather than any changes from this PR. Let me know if you see it - we wouldn't want to release this PR if it causes slideshows to intermittently break.

### Demo
<video src="https://github.com/user-attachments/assets/7a1116a7-3ecd-419f-b706-2f64da138ba0" width="400px"/>