### PR TITLE
Force search backend to show sponsored recipes

### DIFF
--- a/fronts-client/src/components/feed/RecipeSearchContainer.tsx
+++ b/fronts-client/src/components/feed/RecipeSearchContainer.tsx
@@ -172,6 +172,7 @@ export const RecipeSearchContainer = ({ rightHandContainer }: Props) => {
 						filters: filters,
 						uprateConfig: getUpdateConfig(),
 						limit: !!filters ? 300 : 100,
+						allSponsors: true,
 					});
 					break;
 			}

--- a/fronts-client/src/services/recipeQuery.ts
+++ b/fronts-client/src/services/recipeQuery.ts
@@ -49,6 +49,7 @@ export interface RecipeSearchParams {
 		decay?: number;
 	};
 	format?: 'Full' | 'Titles';
+	allSponsors?: boolean;
 }
 
 export interface ChefSearchHit {


### PR DESCRIPTION
## What's changed?

Since we started filtering out the sponsored recipes from search results, they are gone from the fronts tool too!

## Implementation notes

n/a

## Checklist

### General
- [ ] 🤖 ~~Relevant tests added~~ n/a
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ ~~No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)~~ n/a
- [ ] 📷 ~~Screenshots / GIFs of relevant UI changes included~~ n/a
