### PR TITLE
Immersive toggle

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,6 +33,13 @@ object TenImageSlideshows
       enabled = false
     )
 
+object SupportImmersiveToggle
+    extends FeatureSwitch(
+      key = "support-immersive-toggle",
+      title = "Allow users to set a card as an immersive display card",
+      enabled = false
+    )
+
 object FeatureSwitches {
   val all: List[FeatureSwitch] = List(
     ObscureFeed,

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "17.0.0",
+  "com.gu" %% "fapi-client-play30" % "18.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "3.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -27,6 +27,7 @@ const formValues = {
 	imageSlideshowReplace: false,
 	isBoosted: false,
 	boostLevel: 'default',
+	isImmersive: false,
 	isBreaking: false,
 	showLivePlayable: false,
 	primaryImage: {
@@ -243,7 +244,6 @@ describe('CardForm transform functions', () => {
 		it('should remove customKicker and showKickerCustom if the kicker is empty', () => {
 			const values = {
 				customKicker: '',
-				showKickerCustom: true,
 			};
 			const state = createStateWithChangedFormFields(
 				initialState,

--- a/fronts-client/src/components/card/CardSettingsDisplay.tsx
+++ b/fronts-client/src/components/card/CardSettingsDisplay.tsx
@@ -47,6 +47,7 @@ export default ({
 	showLargeHeadline,
 	isBoosted,
 	boostLevel,
+	isImmersive,
 }: {
 	collectionType?: string;
 	isBreaking?: boolean;
@@ -55,6 +56,7 @@ export default ({
 	showLargeHeadline?: boolean;
 	isBoosted?: boolean;
 	boostLevel?: string;
+	isImmersive?: boolean;
 }) =>
 	shouldShowBoostLevel(collectionType, boostLevel) ||
 	shouldShowLegacyBoost(collectionType, isBoosted) ||
@@ -62,7 +64,8 @@ export default ({
 	showByline ||
 	showQuotedHeadline ||
 	showLargeHeadline ||
-	isBoosted ? (
+	isBoosted ||
+	isImmersive ? (
 		<ArticleMetadataProperties>
 			{isBreaking && (
 				<ArticleMetadataProperty data-testid="breaking-news">
@@ -74,6 +77,9 @@ export default ({
 			)}
 			{showQuotedHeadline && (
 				<ArticleMetadataProperty>Quote headline</ArticleMetadataProperty>
+			)}
+			{isImmersive && (
+				<ArticleMetadataProperty>Immersive</ArticleMetadataProperty>
 			)}
 			{showLargeHeadline && (
 				<ArticleMetadataProperty>Large headline</ArticleMetadataProperty>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -131,6 +131,7 @@ interface ArticleBodyProps {
 	isDraggingImageOver: boolean;
 	isBoosted?: boolean;
 	boostLevel?: string;
+	isImmersive?: boolean;
 	hasMainVideo?: boolean;
 	showMainVideo?: boolean;
 	tone?: string | undefined;
@@ -179,6 +180,7 @@ const articleBodyDefault = React.memo(
 		isDraggingImageOver,
 		isBoosted,
 		boostLevel,
+		isImmersive,
 		tone,
 		featureFlagPageViewData,
 		canShowPageViewData,
@@ -286,6 +288,7 @@ const articleBodyDefault = React.memo(
 						showLargeHeadline={showLargeHeadline}
 						isBoosted={isBoosted}
 						boostLevel={boostLevel}
+						isImmersive={isImmersive}
 					/>
 					<CardHeadingContainer size={size}>
 						{displayPlaceholders && (

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -629,8 +629,12 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								label="Immersive"
 								id={getInputId(cardId, 'immersive')}
 								type="checkbox"
-								onChange={() =>
-									this.toggleCardStyleField('isImmersive', groupSizeId)
+								onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+									this.toggleCardStyleField(
+										'isImmersive',
+										event.target.checked,
+										groupSizeId,
+									)
 								}
 							/>
 
@@ -1026,16 +1030,24 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	// immersive card styling and boost levels are mutually exclusive.
 	// A card cannot be both immersive and boosted, so we need to toggle the other field when one is set.
 	// This function is called when one of the fields is toggled, and sets the other field to false.
-	// If the field to set is `isImmersive`, we also need to reset the boost level to default.
+	// If the field to set is `isImmersive` to true, we need to set the boost level to lowest boost level (default).
+	// If the fiels to set is `isImmersive` to false, we need to set the boost level to the default setting for that group.
 	// If the field to set is `isBoosted`, we need to reset the immersive flag to false.
 	// */
-	private toggleCardStyleField = (fieldToSet: string, group: number = 0) => {
+	private toggleCardStyleField = (
+		fieldToSet: string,
+		value?: boolean,
+		group: number = 0,
+	) => {
 		if (fieldToSet === 'isImmersive') {
-			const defaultBoostLevel =
-				CollectionToggles['flexible/general'][group][0].value;
-			this.props.change('boostLevel', defaultBoostLevel);
-		} else {
-			this.props.change('isImmersive', false);
+			if (this.props.isImmersive) {
+				const defaultBoostLevel = !value
+					? CollectionToggles['flexible/general'][group][0].value
+					: 'default';
+				this.props.change('boostLevel', defaultBoostLevel);
+			} else {
+				this.props.change('isImmersive', false);
+			}
 		}
 	};
 
@@ -1113,6 +1125,7 @@ interface ContainerProps {
 	editMode: EditMode;
 	primaryImage: ValidationResponse | null;
 	hasMainVideo: boolean;
+	isImmersive: boolean;
 }
 
 interface InterfaceProps {

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -613,10 +613,18 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						>
 							{this.getBoostToggles(groupSizeId, cardId, collectionType)}
 						</CheckboxFieldsContainer>
+
 						<CheckboxFieldsContainer
 							editableFields={editableFields}
 							size={this.props.size}
 						>
+							<Field
+								name="isImmersive"
+								component={InputCheckboxToggleInline}
+								label="Immersive"
+								id={getInputId(cardId, 'immersive')}
+								type="radio"
+							/>
 							<Field
 								name="isBoosted"
 								component={InputCheckboxToggleInline}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -623,7 +623,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								component={InputCheckboxToggleInline}
 								label="Immersive"
 								id={getInputId(cardId, 'immersive')}
-								type="radio"
+								type="checkbox"
 							/>
 							<Field
 								name="isBoosted"

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -438,7 +438,12 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			cardId: string,
 			collectionType?: string,
 		) => {
-			return renderBoostToggles(groupSizeId, cardId, collectionType);
+			return renderBoostToggles(
+				groupSizeId,
+				cardId,
+				this.toggleCardStyleField,
+				collectionType,
+			);
 		},
 	);
 
@@ -624,6 +629,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								label="Immersive"
 								id={getInputId(cardId, 'immersive')}
 								type="checkbox"
+								onChange={() => this.toggleCardStyleField('isImmersive')}
 							/>
 							<Field
 								name="isBoosted"
@@ -1011,6 +1017,21 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 				this.props.change(field, false);
 			}
 		});
+	};
+
+	//*
+	// immersive card styling and boost levels are mutually exclusive.
+	// A card cannot be both immersive and boosted, so we need to toggle the other field when one is set.
+	// This function is called when one of the fields is toggled, and sets the other field to false.
+	// If the field to set is `isImmersive`, we also need to reset the boost level to default.
+	// If the field to set is `isBoosted`, we need to reset the immersive flag to false.
+	// */
+	private toggleCardStyleField = (fieldToSet: string) => {
+		if (fieldToSet === 'isImmersive') {
+			this.props.change('boostLevel', 'default');
+		} else {
+			this.props.change('isImmersive', false);
+		}
 	};
 
 	/**

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -74,7 +74,7 @@ import { ImageOptionsInputGroup } from './ImageOptionsInputGroup';
 import { RowContainer } from './RowContainer';
 import { ImageRowContainer } from './ImageRowContainer';
 import { ImageCol } from './ImageCol';
-import { renderBoostToggles } from './BoostToggles';
+import { CollectionToggles, renderBoostToggles } from './BoostToggles';
 import { memoize } from 'lodash';
 import InputRadio from '../inputs/InputRadio';
 import Explainer from '../Explainer';
@@ -629,8 +629,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								label="Immersive"
 								id={getInputId(cardId, 'immersive')}
 								type="checkbox"
-								onChange={() => this.toggleCardStyleField('isImmersive')}
+								onChange={() =>
+									this.toggleCardStyleField('isImmersive', groupSizeId)
+								}
 							/>
+
 							<Field
 								name="isBoosted"
 								component={InputCheckboxToggleInline}
@@ -1026,9 +1029,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	// If the field to set is `isImmersive`, we also need to reset the boost level to default.
 	// If the field to set is `isBoosted`, we need to reset the immersive flag to false.
 	// */
-	private toggleCardStyleField = (fieldToSet: string) => {
+	private toggleCardStyleField = (fieldToSet: string, group: number = 0) => {
 		if (fieldToSet === 'isImmersive') {
-			this.props.change('boostLevel', 'default');
+			const defaultBoostLevel =
+				CollectionToggles['flexible/general'][group][0].value;
+			this.props.change('boostLevel', defaultBoostLevel);
 		} else {
 			this.props.change('isImmersive', false);
 		}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -629,10 +629,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								label="Immersive"
 								id={getInputId(cardId, 'immersive')}
 								type="checkbox"
-								onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+								onChange={(event: any) =>
 									this.toggleCardStyleField(
 										'isImmersive',
-										event.target.checked,
+										event as boolean,
 										groupSizeId,
 									)
 								}
@@ -1040,14 +1040,12 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		group: number = 0,
 	) => {
 		if (fieldToSet === 'isImmersive') {
-			if (this.props.isImmersive) {
-				const defaultBoostLevel = !value
-					? CollectionToggles['flexible/general'][group][0].value
-					: 'default';
-				this.props.change('boostLevel', defaultBoostLevel);
-			} else {
-				this.props.change('isImmersive', false);
-			}
+			const defaultBoostLevel = !value
+				? CollectionToggles['flexible/general'][group][0].value
+				: 'default';
+			this.props.change('boostLevel', defaultBoostLevel);
+		} else {
+			this.props.change('isImmersive', false);
 		}
 	};
 
@@ -1125,7 +1123,6 @@ interface ContainerProps {
 	editMode: EditMode;
 	primaryImage: ValidationResponse | null;
 	hasMainVideo: boolean;
-	isImmersive: boolean;
 }
 
 interface InterfaceProps {

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -78,7 +78,7 @@ import { CollectionToggles, renderBoostToggles } from './BoostToggles';
 import { memoize } from 'lodash';
 import InputRadio from '../inputs/InputRadio';
 import Explainer from '../Explainer';
-
+import pageConfig from 'util/extractConfigFromPage';
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
 	collectionId: string | null;
@@ -546,7 +546,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		};
 
 		const cardCriteria = this.determineCardCriteria();
-
+		const supportImmersiveToggle = pageConfig?.userData?.featureSwitches.find(
+			(feature) => feature.key === 'support-immersive-toggle',
+		);
 		return (
 			<FormContainer
 				data-testid="edit-form"
@@ -623,20 +625,22 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 							editableFields={editableFields}
 							size={this.props.size}
 						>
-							<Field
-								name="isImmersive"
-								component={InputCheckboxToggleInline}
-								label="Immersive"
-								id={getInputId(cardId, 'immersive')}
-								type="checkbox"
-								onChange={(event: any) =>
-									this.toggleCardStyleField(
-										'isImmersive',
-										event as boolean,
-										groupSizeId,
-									)
-								}
-							/>
+							{supportImmersiveToggle ? (
+								<Field
+									name="isImmersive"
+									component={InputCheckboxToggleInline}
+									label="Immersive"
+									id={getInputId(cardId, 'immersive')}
+									type="checkbox"
+									onChange={(event: any) =>
+										this.toggleCardStyleField(
+											'isImmersive',
+											event as boolean,
+											groupSizeId,
+										)
+									}
+								/>
+							) : null}
 
 							<Field
 								name="isBoosted"

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -548,7 +548,8 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		const cardCriteria = this.determineCardCriteria();
 		const supportImmersiveToggle = pageConfig?.userData?.featureSwitches.find(
 			(feature) => feature.key === 'support-immersive-toggle',
-		);
+		)?.enabled;
+
 		return (
 			<FormContainer
 				data-testid="edit-form"
@@ -618,30 +619,31 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 							size={this.props.size}
 							extraBottomMargin="8px"
 						>
-							{this.getBoostToggles(groupSizeId, cardId, collectionType)}
+							{[
+								...this.getBoostToggles(groupSizeId, cardId, collectionType),
+								supportImmersiveToggle ? (
+									<Field
+										name="isImmersive"
+										component={InputCheckboxToggleInline}
+										label="Immersive"
+										id={getInputId(cardId, 'immersive')}
+										type="checkbox"
+										onChange={(event: any) =>
+											this.toggleCardStyleField(
+												'isImmersive',
+												event as boolean,
+												groupSizeId,
+											)
+										}
+									/>
+								) : null,
+							]}
 						</CheckboxFieldsContainer>
 
 						<CheckboxFieldsContainer
 							editableFields={editableFields}
 							size={this.props.size}
 						>
-							{supportImmersiveToggle ? (
-								<Field
-									name="isImmersive"
-									component={InputCheckboxToggleInline}
-									label="Immersive"
-									id={getInputId(cardId, 'immersive')}
-									type="checkbox"
-									onChange={(event: any) =>
-										this.toggleCardStyleField(
-											'isImmersive',
-											event as boolean,
-											groupSizeId,
-										)
-									}
-								/>
-							) : null}
-
 							<Field
 								name="isBoosted"
 								component={InputCheckboxToggleInline}

--- a/fronts-client/src/components/form/BoostToggles.tsx
+++ b/fronts-client/src/components/form/BoostToggles.tsx
@@ -83,6 +83,7 @@ const getInputId = (cardId: string, label: string) => `${cardId}-${label}`;
 export const renderBoostToggles = (
 	groupIndex: number = 0,
 	cardId: string,
+	onChange: (value: string) => void,
 	collectionType?: string,
 ) => {
 	// Only render boost toggles for flexible collections
@@ -104,6 +105,7 @@ export const renderBoostToggles = (
 			id={getInputId(cardId, id)}
 			value={value}
 			type="radio"
+			onChange={() => onChange('boostLevel')}
 		/>
 	));
 };

--- a/fronts-client/src/components/form/BoostToggles.tsx
+++ b/fronts-client/src/components/form/BoostToggles.tsx
@@ -57,7 +57,7 @@ const TOGGLES: Record<BoostLevels, Toggle> = {
  * - **Group 1 (Splash)**: Default, Boost, MegaBoost, GigaBoost
  *
  * */
-const CollectionToggles: Record<string, Record<number, Toggle[]>> = {
+export const CollectionToggles: Record<string, Record<number, Toggle[]>> = {
 	'flexible/general': {
 		0: [TOGGLES.default, TOGGLES.boost, TOGGLES.megaboost],
 		1: [

--- a/fronts-client/src/components/form/__tests__/BoostToggles.spec.tsx
+++ b/fronts-client/src/components/form/__tests__/BoostToggles.spec.tsx
@@ -44,7 +44,12 @@ describe('renderBoostToggles', () => {
 	groupToggles.forEach(({ group, collectionType, expectedLabels }) => {
 		it(`returns the correct toggles for ${collectionType} group ${group}`, () => {
 			// ✅ Get the raw output instead of rendering in a form
-			const toggles = renderBoostToggles(group, mockCardId, collectionType);
+			const toggles = renderBoostToggles(
+				group,
+				mockCardId,
+				() => {},
+				collectionType,
+			);
 
 			// ✅ Render only the toggles, skipping redux-form & form
 			const tree = renderer.create(<>{toggles}</>).toJSON();
@@ -58,7 +63,7 @@ describe('renderBoostToggles', () => {
 	});
 
 	it('returns an empty fragment if collectionType is invalid', () => {
-		const toggles = renderBoostToggles(0, mockCardId, 'invalid/type');
+		const toggles = renderBoostToggles(0, mockCardId, () => {}, 'invalid/type');
 		const tree = renderer.create(<>{toggles}</>).toJSON();
 
 		expect(tree).toMatchSnapshot();
@@ -66,7 +71,7 @@ describe('renderBoostToggles', () => {
 	});
 
 	it('returns an empty fragment if collectionType is missing', () => {
-		const toggles = renderBoostToggles(0, mockCardId);
+		const toggles = renderBoostToggles(0, mockCardId, () => {});
 		const tree = renderer.create(<>{toggles}</>).toJSON();
 
 		expect(tree).toMatchSnapshot();

--- a/fronts-client/src/components/form/__tests__/BoostToggles.spec.tsx
+++ b/fronts-client/src/components/form/__tests__/BoostToggles.spec.tsx
@@ -43,7 +43,6 @@ const groupToggles = [
 describe('renderBoostToggles', () => {
 	groupToggles.forEach(({ group, collectionType, expectedLabels }) => {
 		it(`returns the correct toggles for ${collectionType} group ${group}`, () => {
-			// ✅ Get the raw output instead of rendering in a form
 			const toggles = renderBoostToggles(
 				group,
 				mockCardId,
@@ -51,11 +50,9 @@ describe('renderBoostToggles', () => {
 				collectionType,
 			);
 
-			// ✅ Render only the toggles, skipping redux-form & form
 			const tree = renderer.create(<>{toggles}</>).toJSON();
 			expect(tree).toMatchSnapshot();
 
-			// Ensure expected labels exist
 			const nodes = Array.isArray(tree) ? tree : [tree];
 			const labels = nodes.map((node) => node?.props.label);
 			expect(labels).toEqual(expectedLabels);

--- a/fronts-client/src/components/form/__tests__/__snapshots__/BoostToggles.spec.tsx.snap
+++ b/fronts-client/src/components/form/__tests__/__snapshots__/BoostToggles.spec.tsx.snap
@@ -12,6 +12,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-0"
     label="Default"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="default"
   />,
@@ -21,6 +22,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-1"
     label="Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="boost"
   />,
@@ -30,6 +32,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-2"
     label="Mega Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="megaboost"
   />,
@@ -44,6 +47,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-1"
     label="Default"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="boost"
   />,
@@ -53,6 +57,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-2"
     label="Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="megaboost"
   />,
@@ -66,6 +71,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
   id="test-card-boostlevel-2"
   label="Default"
   name="boostLevel"
+  onChange={[Function]}
   type="radio"
   value="megaboost"
 />
@@ -79,6 +85,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-0"
     label="Default"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="default"
   />,
@@ -88,6 +95,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-1"
     label="Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="boost"
   />,
@@ -97,6 +105,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-2"
     label="Mega Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="megaboost"
   />,
@@ -106,6 +115,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/general gro
     id="test-card-boostlevel-3"
     label="Giga Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="gigaboost"
   />,
@@ -120,6 +130,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-0"
     label="Default"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="default"
   />,
@@ -129,6 +140,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-1"
     label="Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="boost"
   />,
@@ -138,6 +150,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-2"
     label="Mega Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="megaboost"
   />,
@@ -147,6 +160,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-3"
     label="Giga Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="gigaboost"
   />,
@@ -161,6 +175,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-0"
     label="Default"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="default"
   />,
@@ -170,6 +185,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-1"
     label="Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="boost"
   />,
@@ -179,6 +195,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-2"
     label="Mega Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="megaboost"
   />,
@@ -188,6 +205,7 @@ exports[`renderBoostToggles returns the correct toggles for flexible/special gro
     id="test-card-boostlevel-3"
     label="Giga Boost"
     name="boostLevel"
+    onChange={[Function]}
     type="radio"
     value="gigaboost"
   />,

--- a/fronts-client/src/selectors/__tests__/formSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/formSelectors.spec.ts
@@ -39,7 +39,7 @@ describe('Form utils', () => {
 				),
 			).toEqual([...defaultFields, 'isBoosted']);
 		});
-		it('should add boostLevel and remove large headline for flexible collection configs', () => {
+		it('should add boostLevel and isImmersive and remove large headline for flexible collection configs', () => {
 			const localState = cloneDeep(state);
 			localState.fronts.frontsConfig.data.collections.exampleCollection.type =
 				'flexible/general';
@@ -51,7 +51,7 @@ describe('Form utils', () => {
 					false,
 				),
 			).toEqual(
-				[...defaultFields, 'boostLevel'].filter(
+				[...defaultFields, 'boostLevel', 'isImmersive'].filter(
 					(t) => t !== 'showLargeHeadline',
 				),
 			);

--- a/fronts-client/src/selectors/formSelectors.ts
+++ b/fronts-client/src/selectors/formSelectors.ts
@@ -5,6 +5,7 @@ import { hasMainVideo } from 'util/externalArticle';
 import {
 	isCollectionConfigDynamic,
 	isCollectionConfigFlexible,
+	isCollectionConfigFlexibleGeneral,
 } from '../util/frontsUtils';
 import { createSelector } from 'reselect';
 import type { State } from 'types/State';
@@ -102,6 +103,9 @@ export const createSelectFormFieldsForCard = () => {
 			}
 			if (isCollectionConfigFlexible(parentCollectionConfig)) {
 				fields = without(fields, 'showLargeHeadline');
+			}
+			if (isCollectionConfigFlexibleGeneral(parentCollectionConfig)) {
+				fields.push('isImmersive');
 			}
 			if (isCollectionConfigDynamic(parentCollectionConfig)) {
 				fields.push('isBoosted');

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -101,6 +101,7 @@ type CardRootMeta = ChefCardMeta &
 		coverCardImageReplace?: boolean;
 		coverCardMobileImage?: ImageData;
 		coverCardTabletImage?: ImageData;
+		isImmersive?: boolean;
 	};
 
 type CardRootFields = NestedCardRootFields & {

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -74,6 +74,7 @@ type CardRootMeta = ChefCardMeta &
 		isBoosted?: boolean;
 		/** For flexible collections only */
 		boostLevel?: BoostLevels;
+		isImmersive?: boolean;
 		showLivePlayable?: boolean;
 		showMainVideo?: boolean;
 		showLargeHeadline?: boolean;
@@ -101,7 +102,6 @@ type CardRootMeta = ChefCardMeta &
 		coverCardImageReplace?: boolean;
 		coverCardMobileImage?: ImageData;
 		coverCardTabletImage?: ImageData;
-		isImmersive?: boolean;
 	};
 
 type CardRootFields = NestedCardRootFields & {

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -50,6 +50,7 @@ interface CreateCardOptions {
 	showQuotedHeadline?: boolean;
 	showKickerCustom?: boolean;
 	customKicker?: string;
+	isImmersive?: boolean;
 }
 
 // Ideally we will convert this to a type. See
@@ -68,6 +69,7 @@ const createCard = (
 		showKickerCustom = false,
 		customKicker = '',
 		imageCutoutSrc,
+		isImmersive = false,
 	}: CreateCardOptions = {},
 ): Card => ({
 	uuid: v4(),
@@ -75,6 +77,7 @@ const createCard = (
 	frontPublicationDate: Date.now(),
 	cardType,
 	meta: {
+		...(isImmersive ? { isImmersive } : {}),
 		...(imageHide ? { imageHide } : {}),
 		...(boostLevel ? { boostLevel } : {}),
 		...(imageReplace ? { imageReplace } : {}),
@@ -364,6 +367,7 @@ const getArticleEntitiesFromFeedDrop = (
 		showQuotedHeadline: externalArticle.frontsMeta.defaults.showQuotedHeadline,
 		showKickerCustom: externalArticle.frontsMeta.defaults.showKickerCustom,
 		customKicker: externalArticle.frontsMeta.pickedKicker,
+		isImmersive: false,
 	});
 	return { card, externalArticle };
 };

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -40,6 +40,7 @@ export interface CardFormData {
 	coverCardImageReplace: boolean;
 	coverCardMobileImage: ImageData;
 	coverCardTabletImage: ImageData;
+	isImmersive: boolean;
 }
 
 export type FormFields = keyof CardFormData;
@@ -146,6 +147,7 @@ export const getInitialValuesForCardForm = (
 				coverCardImageReplace: article.coverCardImageReplace || false,
 				coverCardMobileImage: article.coverCardMobileImage || {},
 				coverCardTabletImage: article.coverCardTabletImage || {},
+				isImmersive: false, // TODO - Set this value
 			}
 		: undefined;
 };

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -147,7 +147,7 @@ export const getInitialValuesForCardForm = (
 				coverCardImageReplace: article.coverCardImageReplace || false,
 				coverCardMobileImage: article.coverCardMobileImage || {},
 				coverCardTabletImage: article.coverCardTabletImage || {},
-				isImmersive: false, // TODO - Set this value
+				isImmersive: article.isImmersive || false,
 			}
 		: undefined;
 };

--- a/fronts-client/src/util/frontsUtils.ts
+++ b/fronts-client/src/util/frontsUtils.ts
@@ -5,7 +5,10 @@ import { ArticleDetails } from 'types/FaciaApi';
 import { Stages, Collection } from 'types/Collection';
 import { frontStages } from 'constants/fronts';
 import { DYNAMIC_CONTAINER_SET } from 'constants/dynamicContainers';
-import { FLEXIBLE_CONTAINER_SET } from 'constants/flexibleContainers';
+import {
+	FLEXIBLE_CONTAINER_SET,
+	FLEXIBLE_GENERAL_NAME,
+} from 'constants/flexibleContainers';
 
 const getFrontCollections = (
 	frontId: string | void,
@@ -84,6 +87,10 @@ const isCollectionConfigFlexible = (
 	config: CollectionConfig | undefined,
 ): boolean => FLEXIBLE_CONTAINER_SET.includes(config?.type);
 
+const isCollectionConfigFlexibleGeneral = (
+	config: CollectionConfig | undefined,
+): boolean => FLEXIBLE_GENERAL_NAME === config?.type;
+
 export {
 	getFrontCollections,
 	combineCollectionWithConfig,
@@ -93,4 +100,5 @@ export {
 	getGroupsByStage,
 	isCollectionConfigDynamic,
 	isCollectionConfigFlexible,
+	isCollectionConfigFlexibleGeneral,
 };

--- a/public/src/js/constants/article-meta-fields.js
+++ b/public/src/js/constants/article-meta-fields.js
@@ -155,6 +155,14 @@ export default Object.freeze([
         type: 'string'
     },
     {
+        key: 'isImmersive',
+        editable: true,
+        omitForSupporting: true,
+        ifState: 'inFlexibleGeneralCollection',
+        label: 'immersive',
+        type: 'boolean'
+    },
+    {
         key: 'showLivePlayable',
         editable: true,
         omitForSupporting: true,

--- a/public/src/js/models/collections/article.js
+++ b/public/src/js/models/collections/article.js
@@ -87,6 +87,7 @@ export default class Article extends DropTarget {
             'visited',
             'inDynamicCollection',
             'inFlexibleCollection',
+			'inFlexibleGeneralCollection',
             'tone',
             'primaryTag',
             'sectionName',
@@ -103,6 +104,7 @@ export default class Article extends DropTarget {
         this.state.enableContentOverrides(this.meta.snapType() !== 'latest');
         this.state.inDynamicCollection(deepGet(opts, '.group.parent.isDynamic'));
         this.state.inFlexibleCollection(deepGet(opts, '.group.parent.isFlexible'));
+		this.state.inFlexibleGeneralCollection(deepGet(opts, '.group.parent.isFlexibleGeneral'));
         this.state.visited(opts.visited);
         this.frontPublicationDate = opts.frontPublicationDate;
         this.publishedBy = opts.publishedBy;

--- a/test/fixtures/FakeCapiAndOphan.scala
+++ b/test/fixtures/FakeCapiAndOphan.scala
@@ -16,6 +16,7 @@ trait FakeCapiAndOphan {
     false,
     false,
     "boostLevel.default",
+		false,
     false,
     false,
     false,

--- a/test/services/editions/EditionsTemplatingTest.scala
+++ b/test/services/editions/EditionsTemplatingTest.scala
@@ -537,6 +537,7 @@ class EditionsTemplatingTest
       false,
       false,
       "boostLevel.default",
+			false,
       false,
       false,
       false,

--- a/test/util/ContentUpgradeTest.scala
+++ b/test/util/ContentUpgradeTest.scala
@@ -69,6 +69,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |  }
           |}""".stripMargin
       val newBody = ContentUpgrade.rewriteBody(body)
+
       newBody shouldBe
         """
           |{"response":
@@ -84,6 +85,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |      "isHosted":true,
           |      "frontsMeta":{
           |        "defaults":{
+					|          "isImmersive":false,
           |          "boostLevel.gigaBoost":false,
           |          "isBreaking":false,
           |          "isBoosted":false,
@@ -180,6 +182,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |      "isHosted":true,
           |      "frontsMeta":{
           |        "defaults":{
+					|          "isImmersive":false,
           |          "boostLevel.gigaBoost":false,
           |          "isBreaking":false,
           |          "isBoosted":false,
@@ -274,6 +277,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |      "isHosted":true,
           |      "frontsMeta":{
           |        "defaults":{
+					|          "isImmersive":false,
           |          "boostLevel.gigaBoost":false,
           |          "isBreaking":false,
           |          "isBoosted":false,
@@ -351,6 +355,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |      "isHosted":true,
           |      "frontsMeta":{
           |        "defaults":{
+					|          "isImmersive":false,
           |          "boostLevel.gigaBoost":false,
           |          "isBreaking":false,
           |          "isBoosted":false,
@@ -428,6 +433,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |      "isHosted":true,
           |      "frontsMeta":{
           |        "defaults":{
+					|          "isImmersive":false,
           |          "boostLevel.gigaBoost":false,
           |          "isBreaking":false,
           |          "isBoosted":false,
@@ -505,6 +511,7 @@ class ContentUpgradeTest extends FreeSpec with Matchers {
           |      "isHosted":true,
           |      "frontsMeta":{
           |        "defaults":{
+					|          "isImmersive":false,
           |          "boostLevel.gigaBoost":false,
           |          "isBreaking":false,
           |          "isBoosted":false,


### PR DESCRIPTION
## What's changed?
Adds an Immersive toggle to the fronts client. This toggle is accessible only on cards in a flexible general container. It is available on any card within a flexible container. 

Immersive styling and boost levels are mutually exclusive. To ensure this, a change handler has been added which adjusts the setting of immersive or boosts to default when the other is set. 

This PR also adds an `immersive` label to a card when the immersive toggle has been set so that it is clear to the editor what display settings the card has. This follows existing patterns. 

**This PR also bumps FAPI to v18.0.0**


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
