### PR TITLE
Bump FAPI to v17.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "16.0.0",
+  "com.gu" %% "fapi-client-play30" % "17.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "3.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),


### PR DESCRIPTION
## What's changed?
Bumps the FAPI version to **17.0.0**

This version bump incorporates the following changes 
- Make common properties available on FaciaContent by @davidfurey in https://github.com/guardian/facia-scala-client/pull/352
- Filter empty groupsConfig field from collection json to fallback to groups field by @abeddow91 in https://github.com/guardian/facia-scala-client/pull/353

The update to filter empty groupsConfig fields will fix a bug reported by Central Production, detailed in trello here https://trello.com/c/7H89M6b7/1100-stories-not-staying-in-correct-configuration-when-save-launch-hit

## Checklist

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
