### PR TITLE
Drop checked property when undefined

### DIFF
--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -126,25 +126,37 @@ export default ({
 	icon = undefined,
 	usesBlockStyling = false,
 	...rest
-}: Props) => (
-	<>
-		<InputContainer data-testid={dataTestId}>
-			<RadioButtonContainer usesBlockStyling={usesBlockStyling}>
-				<Switch>
-					<RadioButton
-						type="radio"
-						{...inputRest}
-						checked={checked}
-						{...rest}
-						id={id}
-					/>
-					<RadioButtonLabel htmlFor={id} />
-				</Switch>
-				<Label htmlFor={id} size="sm">
-					{label}
-				</Label>
-				{icon !== undefined ? <IconContainer>{icon}</IconContainer> : null}
-			</RadioButtonContainer>
-		</InputContainer>
-	</>
-);
+}: Props) => {
+	const checkedProps: Record<string, boolean> = {};
+	/**
+	 * We use the checked property when we want to manually control the state of the radio button.
+	 * If checked is undefined, it will not be passed to the input element, and the button will
+	 * fall back to its default behaviour.
+	 */
+	if (checked !== undefined) {
+		checkedProps['checked'] = checked;
+	}
+
+	return (
+		<>
+			<InputContainer data-testid={dataTestId}>
+				<RadioButtonContainer usesBlockStyling={usesBlockStyling}>
+					<Switch>
+						<RadioButton
+							type="radio"
+							{...inputRest}
+							{...checkedProps}
+							{...rest}
+							id={id}
+						/>
+						<RadioButtonLabel htmlFor={id} />
+					</Switch>
+					<Label htmlFor={id} size="sm">
+						{label}
+					</Label>
+					{icon !== undefined ? <IconContainer>{icon}</IconContainer> : null}
+				</RadioButtonContainer>
+			</InputContainer>
+		</>
+	);
+};


### PR DESCRIPTION
## What's changed?

In #1761 we added a new type of radio button which didn't play well with Redux Form. We had to manually control the checked state of these new buttons and bind them to the form state ourselves, however this accidentally affected the pre-existing toggle buttons for Boost.

The Boost buttons, as radio buttons with no checked property, were accidentally set as unchecked. If the checked property is undefined we should drop it from being passed to the input altogether, which will cause it to revert to the default radio input behaviour.

### To test

Both types of radio buttons (Boost and Select Media) should work and preserve state.