### PR TITLE
Move pinboard container

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -724,7 +724,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 										collectionType={this.props.collectionType}
 									/>
 								</ImageCol>
-								<ToggleCol flex={2}>
+								<ToggleCol flex={1}>
 									<InputGroup>
 										<ConditionalField
 											permittedFields={editableFields}
@@ -782,6 +782,15 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 												/>
 											</InputGroup>
 										)}
+									{articleCapiFieldValues.urlPath && (
+										// the below tag is empty and meaningless to the fronts tool itself, but serves as a handle for
+										// Pinboard to attach itself via, identified/distinguished by the urlPath data attribute
+										// @ts-ignore
+										<pinboard-article-button
+											data-url-path={articleCapiFieldValues.urlPath}
+											data-with-draggable-thumbs-of-ratio={`${cardCriteria.widthAspectRatio}:${cardCriteria.heightAspectRatio}`}
+										/>
+									)}
 								</ToggleCol>
 								<Col flex={2}>
 									<InputLabel htmlFor="media-select">Select Media</InputLabel>
@@ -923,15 +932,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						</RowContainer>
 					)}
 				</FormContent>
-				{articleCapiFieldValues.urlPath && (
-					// the below tag is empty and meaningless to the fronts tool itself, but serves as a handle for
-					// Pinboard to attach itself via, identified/distinguished by the urlPath data attribute
-					// @ts-ignore
-					<pinboard-article-button
-						data-url-path={articleCapiFieldValues.urlPath}
-						data-with-draggable-thumbs-of-ratio={`${cardCriteria.widthAspectRatio}:${cardCriteria.heightAspectRatio}`}
-					/>
-				)}
 				<FormButtonContainer>
 					<Button onClick={this.handleCancel} type="button" size="l">
 						Cancel


### PR DESCRIPTION
## What's changed?
#1780 moved the Pinboard position to after the Select Media buttons. This restores them to their original position. Some of the flex shrink / grow patterns still don't seem ideal but this would probably require a deeper rethink to address.

## To test
_This is a little cumbersome to do. Feel free not to test._

Run Fronts Tool locally, connected to _CODE_ CAPI, with Pinboard running locally. Opt in to the Pinboard feature switch: https://fronts.local.dev-gutools.co.uk/v2?pinboardFeatureFlag_alternateCropSuggesting=true.

Find / create an article which is tracked in CODE Workflow. Create a pinboard associated with the article. You should see the Pinboard button appear next to the Trail Image.

To see the crop suggestions, you will need to add the relevant size crops to that Pinboard. This uses the logic found in the `determineCardCriteria` method. For example if the card is in a collection using 5:4 trails, and the article has 5:4 crops associated with it in Pinboard, then it will 'suggest' those crops.

### Screenshots

Without crops:
<img width="349" alt="image" src="https://github.com/user-attachments/assets/a0912f0d-4862-463c-b1e1-f16b91f8c80f" />

With crops (different viewports shown):
<img width="440" alt="image" src="https://github.com/user-attachments/assets/cf5c4634-13e1-444b-bc00-17f63e6efb42" />
<img width="339" alt="image" src="https://github.com/user-attachments/assets/95ec9d9d-af99-4e7a-a7b8-743fe47453cf" />
<img width="817" alt="image" src="https://github.com/user-attachments/assets/84e3a24c-153b-487d-9836-8aa5c7baec7e" />
<img width="672" alt="image" src="https://github.com/user-attachments/assets/ef1b1319-957c-4354-bfe9-42f2631ca6b6" />
