### PR TITLE
Limit scrollable small visible stories to 4

### DIFF
--- a/app/slices/ScrollableContainer.scala
+++ b/app/slices/ScrollableContainer.scala
@@ -12,7 +12,7 @@ object ScrollableHighlights extends ScrollableContainer {
 
 object ScrollableSmall extends ScrollableContainer {
   def storiesVisible(stories: Seq[Story]): Int = {
-    stories.size min 8
+    stories.size min 4
   }
 }
 


### PR DESCRIPTION
## What's changed?

Updates the indicator that only 4 stories will be shown on platforms. Part of this F&C [ticket](https://trello.com/c/7rvtUFuh/1115-limit-small-and-medium-carousels-to-4-stories)

Corresponding PRs to actually restrict the number of stories that are shown on platforms are being raised in frontend and mapi.

## Screenshot
<img width="699" alt="image" src="https://github.com/user-attachments/assets/8920ac15-0928-48e9-b666-70e06d379680" />

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
