### PR TITLE
Limit visible stories in scrollable medium to 4

### DIFF
--- a/app/slices/ScrollableContainer.scala
+++ b/app/slices/ScrollableContainer.scala
@@ -18,7 +18,7 @@ object ScrollableSmall extends ScrollableContainer {
 
 object ScrollableMedium extends ScrollableContainer {
   def storiesVisible(stories: Seq[Story]): Int = {
-    stories.size min 8
+    stories.size min 4
   }
 }
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

Resolves [this ticket](https://trello.com/c/7rvtUFuh/1115-limit-small-and-medium-carousels-to-4-stories). This was missed in the corresponding scrollable small PR. 

## Screenshot

<img width="689" alt="image" src="https://github.com/user-attachments/assets/a6cb2c36-ba30-4bcc-aed1-f445b4842a57" />


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
