### PR TITLE
Add check for opinion section and hide image if there's no cutout

### DIFF
--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -235,7 +235,7 @@ jobs:
             - test_client_v2
             - test_backend
             - build_backend
-            - integrationtest_client_v2
+            # - integrationtest_client_v2
         steps:
             - uses: actions/checkout@v4
             - uses: actions/download-artifact@v4

--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -235,7 +235,7 @@ jobs:
             - test_client_v2
             - test_backend
             - build_backend
-            # - integrationtest_client_v2
+            - integrationtest_client_v2
         steps:
             - uses: actions/checkout@v4
             - uses: actions/download-artifact@v4

--- a/app/logic/CapiPrefiller.scala
+++ b/app/logic/CapiPrefiller.scala
@@ -49,8 +49,22 @@ object CapiPrefiller {
         // finally if a cutout is desired but nothing appropriate was found then explicitly set to use article trail
         case (true, None) => (Some(MediaType.UseArticleTrail), None)
       }
+
+    // We want the default for tone/opinion to choose the cutout photo
+    // If there's no cutout, default to hide image rather than show the trail image.
+    val hideImageIfNotCutout = {
+      if (content.sectionName == Some("Opinion")) {
+        !mediaType.contains(MediaType.Cutout)
+      } else {
+        metadata.imageHide
+      }
+    }
+
     val newMetadata =
-      metadata.copy(imageCutoutReplace = mediaType.contains(MediaType.Cutout))
+      metadata.copy(
+        imageCutoutReplace = mediaType.contains(MediaType.Cutout),
+        imageHide = hideImageIfNotCutout
+      )
 
     val pickedKicker = pickKicker(content)
 


### PR DESCRIPTION
## What's changed?

Closes this [ticket](https://trello.com/c/pZUNi59j/1140-opinion-toggle-change)

This updates some logic when the content is being pulled in to the tool: for opinion articles, the default is to choose the cutout photo - but if there's no cutout, we default to hide image rather than fall back to a trail image. 

## Video

https://github.com/user-attachments/assets/4ec1da8b-f275-43ae-aeec-2fb4436e8bec


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
