### PR TITLE
Retain boost level if moving to the same group type

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -243,16 +243,6 @@ const getBoostLevel = (
 	const minBoostLevel = minimumGroupBoostLevel(toGroupId);
 	const minBoostIndex = boostLevels.indexOf(minBoostLevel);
 
-	// If we are moving within the same group type (e.g. standard -> standard), don't change the boost level
-	if (toGroupId === maybeFromGroupId) {
-		return boostLevels[boostIndex];
-	}
-
-	// If the destination group is a splash group, set the boost level to default
-	if (toGroupId === 3) {
-		return 'default';
-	}
-
 	// If the current boost level is below the minimum required, set it to the minimum
 	if (boostIndex < minBoostIndex) {
 		return minBoostLevel;
@@ -263,8 +253,24 @@ const getBoostLevel = (
 		return boostLevels[boostIndex];
 	}
 
-	// Otherwise reduce the boost level by 1
-	return boostLevels[boostIndex - 1];
+	// If we're not moving from a group (i.e. we are moving from a clipboard), retain the boost level
+	if (maybeFromGroupId === null) {
+		return boostLevels[boostIndex];
+	}
+
+	// If we're moving down a group, reduce the boost level by 1
+	if (toGroupId < maybeFromGroupId) {
+		return boostLevels[boostIndex - 1];
+	}
+
+	// If we're moving up a group, and the destination group is a splash group, set the boost level to default
+	// (Splash groups allow all types of boosting, but we want to reserve these boost types for special occasions)
+	if (toGroupId > maybeFromGroupId && toGroupId === 3) {
+		return 'default';
+	}
+
+	// Retain the boost level if none of the other cases are met
+	return boostLevels[boostIndex];
 };
 
 const mayAdjustCardBoostLevelForDestinationGroup = (

--- a/fronts-client/src/actions/__tests__/Cards.spec.ts
+++ b/fronts-client/src/actions/__tests__/Cards.spec.ts
@@ -16,6 +16,7 @@ import {
 	insertCardWithCreate,
 	addImageToCard,
 	cloneCardToTarget,
+	getBoostLevel,
 } from 'actions/Cards';
 import {
 	reducer as collectionsReducer,
@@ -371,6 +372,49 @@ describe('Cards actions', () => {
 				imageSlideshowReplace: false,
 				imageCutoutReplace: false,
 			});
+		});
+	});
+
+	describe('gets the correct boost level when moving cards (in relevant container types)', () => {
+		it('retains the boost level if we are moving to the same group type', () => {
+			expect(getBoostLevel(2, 2, 0)).toEqual('default');
+			expect(getBoostLevel(2, 2, 1)).toEqual('boost');
+			expect(getBoostLevel(2, 2, 2)).toEqual('megaboost');
+			expect(getBoostLevel(2, 2, 3)).toEqual('gigaboost');
+
+			expect(getBoostLevel(0, 0, 0)).toEqual('default');
+			expect(getBoostLevel(0, 0, 1)).toEqual('boost');
+			expect(getBoostLevel(0, 0, 2)).toEqual('megaboost');
+			expect(getBoostLevel(0, 0, 3)).toEqual('gigaboost');
+		});
+
+		it('sets the boost level to default if we are moving to a splash', () => {
+			expect(getBoostLevel(null, 3, 0)).toEqual('default');
+			expect(getBoostLevel(null, 3, 1)).toEqual('default');
+			expect(getBoostLevel(null, 3, 2)).toEqual('default');
+			expect(getBoostLevel(null, 3, 3)).toEqual('default');
+		});
+
+		it('sets the boost level to the minimum if the current boost level is below the minimum required', () => {
+			// megaboost is the smallest boost level for `Very Big`
+			expect(getBoostLevel(null, 2, 0)).toEqual('megaboost');
+			// boost is the smallest boost level for `Big`
+			expect(getBoostLevel(null, 1, 0)).toEqual('boost');
+			// otherwise the minimum boost level is default
+			expect(getBoostLevel(null, 0, 0)).toEqual('default');
+		});
+
+		it('retains the boost level if the current boost level is the minimum required', () => {
+			expect(getBoostLevel(null, 2, 2)).toEqual('megaboost');
+			expect(getBoostLevel(null, 1, 1)).toEqual('boost');
+			expect(getBoostLevel(null, 0, 0)).toEqual('default');
+		});
+
+		it('reduces the boost level if the current boost level is above the minimum required', () => {
+			expect(getBoostLevel(null, 2, 3)).toEqual('megaboost');
+			expect(getBoostLevel(null, 1, 2)).toEqual('boost');
+			expect(getBoostLevel(null, 0, 1)).toEqual('default');
+			expect(getBoostLevel(null, 0, 0)).toEqual('default');
 		});
 	});
 });

--- a/fronts-client/src/actions/__tests__/Cards.spec.ts
+++ b/fronts-client/src/actions/__tests__/Cards.spec.ts
@@ -376,25 +376,6 @@ describe('Cards actions', () => {
 	});
 
 	describe('gets the correct boost level when moving cards (in relevant container types)', () => {
-		it('retains the boost level if we are moving to the same group type', () => {
-			expect(getBoostLevel(2, 2, 0)).toEqual('default');
-			expect(getBoostLevel(2, 2, 1)).toEqual('boost');
-			expect(getBoostLevel(2, 2, 2)).toEqual('megaboost');
-			expect(getBoostLevel(2, 2, 3)).toEqual('gigaboost');
-
-			expect(getBoostLevel(0, 0, 0)).toEqual('default');
-			expect(getBoostLevel(0, 0, 1)).toEqual('boost');
-			expect(getBoostLevel(0, 0, 2)).toEqual('megaboost');
-			expect(getBoostLevel(0, 0, 3)).toEqual('gigaboost');
-		});
-
-		it('sets the boost level to default if we are moving to a splash', () => {
-			expect(getBoostLevel(null, 3, 0)).toEqual('default');
-			expect(getBoostLevel(null, 3, 1)).toEqual('default');
-			expect(getBoostLevel(null, 3, 2)).toEqual('default');
-			expect(getBoostLevel(null, 3, 3)).toEqual('default');
-		});
-
 		it('sets the boost level to the minimum if the current boost level is below the minimum required', () => {
 			// megaboost is the smallest boost level for `Very Big`
 			expect(getBoostLevel(null, 2, 0)).toEqual('megaboost');
@@ -410,11 +391,60 @@ describe('Cards actions', () => {
 			expect(getBoostLevel(null, 0, 0)).toEqual('default');
 		});
 
-		it('reduces the boost level if the current boost level is above the minimum required', () => {
-			expect(getBoostLevel(null, 2, 3)).toEqual('megaboost');
-			expect(getBoostLevel(null, 1, 2)).toEqual('boost');
-			expect(getBoostLevel(null, 0, 1)).toEqual('default');
+		it("retains the boost level if we're not moving from a group (i.e. a clipboard)", () => {
+			expect(getBoostLevel(null, 3, 0)).toEqual('default');
+			expect(getBoostLevel(null, 3, 1)).toEqual('boost');
+			expect(getBoostLevel(null, 3, 2)).toEqual('megaboost');
+			expect(getBoostLevel(null, 3, 3)).toEqual('gigaboost');
+
+			expect(getBoostLevel(null, 2, 2)).toEqual('megaboost');
+			expect(getBoostLevel(null, 2, 3)).toEqual('gigaboost');
+
+			expect(getBoostLevel(null, 1, 1)).toEqual('boost');
+			expect(getBoostLevel(null, 1, 2)).toEqual('megaboost');
+
 			expect(getBoostLevel(null, 0, 0)).toEqual('default');
+			expect(getBoostLevel(null, 0, 1)).toEqual('boost');
+			expect(getBoostLevel(null, 0, 2)).toEqual('megaboost');
+		});
+
+		it('reduces the boost level if the current boost level if we are moving down a group', () => {
+			expect(getBoostLevel(3, 2, 3)).toEqual('megaboost');
+			expect(getBoostLevel(3, 1, 2)).toEqual('boost');
+			expect(getBoostLevel(2, 0, 1)).toEqual('default');
+		});
+
+		it('sets the boost level to default if we are moving up a group, and the destination group is a splash group', () => {
+			expect(getBoostLevel(2, 3, 2)).toEqual('default');
+
+			expect(getBoostLevel(1, 3, 1)).toEqual('default');
+			expect(getBoostLevel(1, 3, 2)).toEqual('default');
+
+			expect(getBoostLevel(0, 3, 0)).toEqual('default');
+			expect(getBoostLevel(0, 3, 1)).toEqual('default');
+			expect(getBoostLevel(0, 3, 2)).toEqual('default');
+		});
+
+		it('retains the boost level if none of the other cases are met', () => {
+			// moving within the same group
+			expect(getBoostLevel(3, 3, 3)).toEqual('gigaboost');
+			expect(getBoostLevel(3, 3, 2)).toEqual('megaboost');
+			expect(getBoostLevel(3, 3, 1)).toEqual('boost');
+			expect(getBoostLevel(3, 3, 0)).toEqual('default');
+
+			expect(getBoostLevel(2, 2, 2)).toEqual('megaboost');
+
+			expect(getBoostLevel(1, 1, 1)).toEqual('boost');
+			expect(getBoostLevel(1, 1, 2)).toEqual('megaboost');
+
+			expect(getBoostLevel(0, 0, 0)).toEqual('default');
+			expect(getBoostLevel(0, 0, 1)).toEqual('boost');
+			expect(getBoostLevel(0, 0, 2)).toEqual('megaboost');
+
+			// moving up to a non-splash group
+			expect(getBoostLevel(0, 1, 1)).toEqual('boost');
+			expect(getBoostLevel(0, 1, 2)).toEqual('megaboost');
+			expect(getBoostLevel(1, 2, 2)).toEqual('megaboost');
 		});
 	});
 });

--- a/fronts-client/src/types/Cards.ts
+++ b/fronts-client/src/types/Cards.ts
@@ -26,3 +26,5 @@ export type InsertThunkActionCreator = (
 	cardId: string,
 	removeAction?: Action,
 ) => ThunkResult<void>;
+
+export type BoostLevel = 'default' | 'boost' | 'megaboost' | 'gigaboost';


### PR DESCRIPTION
## What's changed?
We had the following report from Editorial: 
> Currently in News when you move a story with a boost on it in a standard slot to a new slot by dragging it it loses it's boost and you need to manually tick boost again. It should be retaining

We realised this was a reproducible issue. In our logic for changing boost when moving cards, the default case is to reduce the boost level. This PR adds a new case - when we are moving between groups of the same type (e.g. standard -> standard, very big -> very big), we retain the boost level.

I have added some unit tests to give us increased confidence.

### How to test
In a `flexible/general` or `flexible/special` container, move a card with a boost from a Standard group to another Standard group, or the same Standard group. The boost level should remain the same.

Other boost level adjustments should be unaffected.
