### PR TITLE
Switch immersive toggle on

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,7 +33,6 @@ object TenImageSlideshows
       enabled = false
     )
 
-
 object FeatureSwitches {
   val all: List[FeatureSwitch] = List(
     ObscureFeed,

--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,19 +33,12 @@ object TenImageSlideshows
       enabled = false
     )
 
-object SupportImmersiveToggle
-    extends FeatureSwitch(
-      key = "support-immersive-toggle",
-      title = "Allow users to set a card as an immersive display card",
-      enabled = false
-    )
 
 object FeatureSwitches {
   val all: List[FeatureSwitch] = List(
     ObscureFeed,
     PageViewDataVisualisation,
-    TenImageSlideshows,
-    SupportImmersiveToggle
+    TenImageSlideshows
   )
 
   def updateFeatureSwitchesForUser(

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -78,7 +78,6 @@ import { CollectionToggles, renderBoostToggles } from './BoostToggles';
 import { memoize } from 'lodash';
 import InputRadio from '../inputs/InputRadio';
 import Explainer from '../Explainer';
-import pageConfig from 'util/extractConfigFromPage';
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
 	collectionId: string | null;
@@ -546,9 +545,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		};
 
 		const cardCriteria = this.determineCardCriteria();
-		const supportImmersiveToggle = pageConfig?.userData?.featureSwitches.find(
-			(feature) => feature.key === 'support-immersive-toggle',
-		)?.enabled;
 
 		return (
 			<FormContainer
@@ -621,22 +617,20 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						>
 							{[
 								...this.getBoostToggles(groupSizeId, cardId, collectionType),
-								supportImmersiveToggle ? (
-									<Field
-										name="isImmersive"
-										component={InputCheckboxToggleInline}
-										label="Immersive"
-										id={getInputId(cardId, 'immersive')}
-										type="checkbox"
-										onChange={(event: any) =>
-											this.toggleCardStyleField(
-												'isImmersive',
-												event as boolean,
-												groupSizeId,
-											)
-										}
-									/>
-								) : null,
+								<Field
+									name="isImmersive"
+									component={InputCheckboxToggleInline}
+									label="Immersive"
+									id={getInputId(cardId, 'immersive')}
+									type="checkbox"
+									onChange={(event: any) =>
+										this.toggleCardStyleField(
+											'isImmersive',
+											event as boolean,
+											groupSizeId,
+										)
+									}
+								/>,
 							]}
 						</CheckboxFieldsContainer>
 


### PR DESCRIPTION
## What's changed?
Switches immersive on for all fronts tool users.

Changing `enabled` to true won't overwrite users with values already set to false. Instead, we remove the check for the switch altogether.
