### PR TITLE
Display the boost level label rather than boost level on the minimised cards

### DIFF
--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -195,6 +195,7 @@ class Card extends React.Component<CardContainerProps> {
 							canShowPageViewData={canShowPageViewData}
 							imageCriteria={this.determineCardCriteria()}
 							collectionType={collectionType}
+							groupIndex={groupSizeId}
 						>
 							<EditModeVisibility visibleMode="fronts">
 								{getSublinks}

--- a/fronts-client/src/components/card/CardSettingsDisplay.tsx
+++ b/fronts-client/src/components/card/CardSettingsDisplay.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
-import { styled, theme } from 'constants/theme';
 import { FLEXIBLE_CONTAINER_SET } from 'constants/flexibleContainers';
+import { styled, theme } from 'constants/theme';
+import React from 'react';
+import type { BoostLevels } from 'types/Collection';
+import { CollectionToggles as BoostToggles } from '../form/BoostToggles';
 
 const ArticleMetadataProperties = styled.div`
 	padding: 0 4px 3px 0;
@@ -21,22 +23,31 @@ const shouldShowLegacyBoost = (collectionType?: string, isBoosted?: boolean) =>
 	/* don't show old Boost option in flexible containers */
 	isBoosted && !FLEXIBLE_CONTAINER_SET.includes(collectionType);
 
-const shouldShowBoostLevel = (collectionType?: string, boostLevel?: string) =>
+const shouldShowBoostLevel = (
+	collectionType?: string,
+	boostLevel?: BoostLevels,
+) =>
 	boostLevel !== 'default' &&
 	/* show new Boost level in flexible containers or clipboard */
 	(FLEXIBLE_CONTAINER_SET.includes(collectionType) || !collectionType);
 
-const getBoostLevelLabel = (boostLevel?: string): string | undefined => {
-	switch (boostLevel) {
-		case 'gigaboost':
-			return 'Giga boost';
-		case 'megaboost':
-			return 'Mega boost';
-		case 'boost':
-			return 'Boost';
-		default:
-			return undefined;
-	}
+export const getBoostLevelLabel = (
+	boostLevel?: BoostLevels,
+	groupIndex?: number,
+	collectionType?: string,
+): string | undefined => {
+	if (
+		!boostLevel ||
+		groupIndex === undefined ||
+		!collectionType ||
+		!['flexible/general', 'flexible/special'].includes(collectionType)
+	)
+		return undefined;
+
+	const toggles = BoostToggles[collectionType]?.[groupIndex];
+	const label = toggles?.find((toggle) => toggle.value === boostLevel)?.label;
+	// If the label is 'Default', return undefined so that it doesn't appear in the UI
+	return label === 'Default' ? undefined : label;
 };
 
 export default ({
@@ -48,6 +59,7 @@ export default ({
 	isBoosted,
 	boostLevel,
 	isImmersive,
+	groupIndex,
 }: {
 	collectionType?: string;
 	isBreaking?: boolean;
@@ -55,8 +67,9 @@ export default ({
 	showQuotedHeadline?: boolean;
 	showLargeHeadline?: boolean;
 	isBoosted?: boolean;
-	boostLevel?: string;
+	boostLevel?: BoostLevels;
 	isImmersive?: boolean;
+	groupIndex?: number;
 }) =>
 	shouldShowBoostLevel(collectionType, boostLevel) ||
 	shouldShowLegacyBoost(collectionType, isBoosted) ||
@@ -86,7 +99,7 @@ export default ({
 			)}
 			{shouldShowBoostLevel(collectionType, boostLevel) && (
 				<ArticleMetadataProperty>
-					{getBoostLevelLabel(boostLevel)}
+					{getBoostLevelLabel(boostLevel, groupIndex, collectionType)}
 				</ArticleMetadataProperty>
 			)}
 			{shouldShowLegacyBoost(collectionType, isBoosted) && (

--- a/fronts-client/src/components/card/__tests__/CardSettingsDisplay.spec.tsx
+++ b/fronts-client/src/components/card/__tests__/CardSettingsDisplay.spec.tsx
@@ -1,0 +1,50 @@
+import { getBoostLevelLabel } from '../CardSettingsDisplay';
+
+describe('getBoostLevelLabel', () => {
+	it('returns the correct label for a boosted card in the standard group (0) of a flexible/general container)', () => {
+		expect(getBoostLevelLabel('boost', 0, 'flexible/general')).toBe('Boost');
+	});
+
+	it('returns undefined if the card has a default boost level', () => {
+		expect(
+			getBoostLevelLabel('default', 0, 'flexible/general'),
+		).toBeUndefined();
+	});
+
+	it('returns a remapped label if a card in a big group is boosted', () => {
+		expect(getBoostLevelLabel('megaboost', 1, 'flexible/general')).toBe(
+			'Boost',
+		);
+		expect(getBoostLevelLabel('boost', 1, 'flexible/general')).toBeUndefined();
+	});
+
+	it('returns correct label for flexible/special group', () => {
+		expect(getBoostLevelLabel('gigaboost', 0, 'flexible/special')).toBe(
+			'Giga Boost',
+		);
+	});
+
+	it('returns undefined for invalid boost level', () => {
+		expect(
+			getBoostLevelLabel(undefined, 0, 'flexible/general'),
+		).toBeUndefined();
+	});
+
+	it('returns undefined for undefined group index', () => {
+		expect(
+			getBoostLevelLabel('boost', undefined, 'flexible/general'),
+		).toBeUndefined();
+	});
+
+	it('returns undefined for invalid collection type', () => {
+		expect(
+			getBoostLevelLabel('boost', 0, 'unknown/collection'),
+		).toBeUndefined();
+	});
+
+	it('returns undefined if boost level not found in toggles', () => {
+		expect(
+			getBoostLevelLabel('gigaboost', 2, 'flexible/general'),
+		).toBeUndefined();
+	});
+});

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -19,7 +19,7 @@ import {
 	HoverAddToClipboardButton,
 } from '../../inputs/HoverActionButtons';
 import { HoverActionsAreaOverlay } from '../../CollectionHoverItems';
-import { CardSizes } from 'types/Collection';
+import { BoostLevels, CardSizes } from 'types/Collection';
 import CardMetaContent from '../CardMetaContent';
 import CardDraftMetaContent from '../CardDraftMetaContent';
 import DraggableArticleImageContainer from './DraggableArticleImageContainer';
@@ -130,7 +130,7 @@ interface ArticleBodyProps {
 	canDragImage?: boolean;
 	isDraggingImageOver: boolean;
 	isBoosted?: boolean;
-	boostLevel?: string;
+	boostLevel?: BoostLevels;
 	isImmersive?: boolean;
 	hasMainVideo?: boolean;
 	showMainVideo?: boolean;
@@ -143,6 +143,7 @@ interface ArticleBodyProps {
 	imageSrcHeight?: string;
 	imageCriteria?: Criteria;
 	collectionType?: string;
+	groupIndex?: number;
 }
 
 const articleBodyDefault = React.memo(
@@ -194,6 +195,7 @@ const articleBodyDefault = React.memo(
 		imageSrcHeight,
 		imageCriteria,
 		collectionType,
+		groupIndex,
 	}: ArticleBodyProps) => {
 		const displayByline = size === 'default' && showByline && byline;
 		const now = Date.now();
@@ -289,6 +291,7 @@ const articleBodyDefault = React.memo(
 						isBoosted={isBoosted}
 						boostLevel={boostLevel}
 						isImmersive={isImmersive}
+						groupIndex={groupIndex}
 					/>
 					<CardHeadingContainer size={size}>
 						{displayPlaceholders && (

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -60,6 +60,7 @@ interface ArticleComponentProps {
 	collectionId?: string;
 	imageCriteria?: Criteria;
 	collectionType?: string;
+	groupIndex?: number;
 }
 
 interface ComponentProps extends ArticleComponentProps {
@@ -109,6 +110,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 			collectionId,
 			imageCriteria,
 			collectionType,
+			groupIndex,
 		} = this.props;
 
 		const getArticleData = () =>
@@ -167,6 +169,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 								canShowPageViewData={canShowPageViewData}
 								imageCriteria={imageCriteria}
 								collectionType={collectionType}
+								groupIndex={groupIndex}
 							/>
 						</ArticleBodyContainer>
 					</DragIntentContainer>


### PR DESCRIPTION
## What's changed?
This update refines the logic for displaying the boost label on minimised cards. Instead of showing the raw boost value, the label now reflects the descriptive text (label) associated with the toggle.

## Why?
We use syntactic sugar in the boost toggle labels to create a more intuitive progression—from the default state to the maximum boost level—within each group. This change brings that same clarity to the minimised card view, ensuring consistency in how boost levels are represented.

The update ensures that both the toggle control labels and their corresponding card labels use the same source of truth (the Toggle map). This alignment will make future updates to boost levels automatically reflected in both UI elements.

It also ignores "default" toggles to avoid the labels becoming too noisy; we should only display an active boost level.


## Screenshots

### Boost toggle view 
![Screenshot 2025-05-06 at 12 56 15](https://github.com/user-attachments/assets/82e386f8-7e64-4ad8-a6d7-55dbdb9bd8a2)

### Before
![Screenshot 2025-05-06 at 12 56 33](https://github.com/user-attachments/assets/7fac7624-c3cb-4417-97f5-f2034cf6bed9)

### After
![Screenshot 2025-05-06 at 12 56 05](https://github.com/user-attachments/assets/5714efc4-abb9-460a-8d0b-2cd9bc36d5d1)



## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
