### PR TITLE
set hideShowMore to true for all new containers

### DIFF
--- a/public/src/js/models/config/collection.js
+++ b/public/src/js/models/config/collection.js
@@ -103,6 +103,16 @@ export default class ConfigCollection extends DropTarget {
         this.thisIsBetaCollection = ko.pureComputed(() => {
             return isBetaCollection(this.meta.type());
         });
+
+		this._hideShowMore = this.meta.hideShowMore;
+
+		this.meta.hideShowMore = ko.pureComputed({
+			read: () => {
+				return this.thisIsBetaCollection
+					? true
+					: this._hideShowMore();
+			},
+		});
     }
 
 

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -316,7 +316,10 @@
 			 meta.type() === 'static/medium/4')
 			-->
             <label for="hideShowMore">Hide show more</label>
-            <input id="hideShowMore" type="checkbox" data-bind="checked: meta.hideShowMore" />
+            <input id="hideShowMore" type="checkbox" data-bind="checked: (
+			 meta.type() === 'scrollable/small' ||
+			 meta.type() === 'scrollable/medium' ||
+			 meta.type() === 'static/medium/4') ? true : meta.hideShowMore," />
             <!-- /ko -->
 
             <label>No curation</label>

--- a/public/src/js/widgets/columns/fronts-config.html
+++ b/public/src/js/widgets/columns/fronts-config.html
@@ -310,17 +310,11 @@
             <label for="excludeFromRss">Exclude from RSS</label>
             <input id="excludeFromRss" type="checkbox" data-bind="checked: meta.excludeFromRss" />
 
-            <!-- ko if: !(
-			 meta.type() === 'scrollable/small' ||
-			 meta.type() === 'scrollable/medium' ||
-			 meta.type() === 'static/medium/4')
-			-->
+			<!-- ko if: thisIsBetaCollection -->
             <label for="hideShowMore">Hide show more</label>
-            <input id="hideShowMore" type="checkbox" data-bind="checked: (
-			 meta.type() === 'scrollable/small' ||
-			 meta.type() === 'scrollable/medium' ||
-			 meta.type() === 'static/medium/4') ? true : meta.hideShowMore," />
-            <!-- /ko -->
+            <input id="hideShowMore" type="checkbox" data-bind="checked: meta.hideShowMore" />
+			<!-- /ko -->
+
 
             <label>No curation</label>
             <input type="checkbox" data-bind="


### PR DESCRIPTION
## What's changed?
Previously, the toggle to hideShowMore was hidden for `scrollable/small` `scrollable/medium` and `static/medium/4` but this is set to false by default which is the wrong behaviour. 

This PR achieves two things
1. it hides the toggle for all beta containers (not just the three listed above)
2. it reads the toggle as true for all beta containers so that the clients never render a show more button on modern containers.

Once we have achieved a 100% rollout of beta containers, this toggle (and corresponding code) can be deleted. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
