### PR TITLE
Fix issue moving sublinks out of flex general cards

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -281,7 +281,8 @@ const mayAdjustCardBoostLevelForDestinationGroup = (
 	persistTo: 'collection' | 'clipboard',
 ) => {
 	if (to.type === 'group' && persistTo === 'collection') {
-		const maybeFromGroupId = maybeFrom !== null ? maybeFrom.id : null;
+		const maybeFromGroupId =
+			maybeFrom !== null && maybeFrom.type === 'group' ? maybeFrom.id : null;
 		const maybeFromGroup =
 			maybeFromGroupId !== null ? selectGroups(state)[maybeFromGroupId] : null;
 


### PR DESCRIPTION
## What's changed?

ID is only a group id if the type of the entity is a group.

Adding a check for `type === 'group'` before extracting the id fixes a console error "Cannot read properties of undefined (reading 'id') cause by `selectGroups(state)[maybeFromGroupId]` returning undefined (not null) when you try to index the map of groups using an item id