### PR TITLE
update cropType definitions, regular landscape is now 5:4, so 5:3 com…

### DIFF
--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -653,8 +653,7 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 			this.compareAspectRatio(landscape5To4CardImageCriteria, criteria)
 		) {
 			return {
-				cropType: 'Landscape',
-				customRatio: 'Landscape,5,4',
+				cropType: 'landscape',
 			};
 		} else if (this.compareAspectRatio(squareImageCriteria, criteria)) {
 			return {
@@ -662,7 +661,8 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 			};
 		} else {
 			return {
-				cropType: 'landscape',
+				cropType: 'Landscape',
+				customRatio: 'Landscape,5,3',
 			};
 		}
 	};


### PR DESCRIPTION
…es from custom ratio

## What's changed?

A bug report shows a consequence of updating the crop type names in Grid; old containers now ask for 5:3 crops _by name_ (landscape). But grid now knows landscape as 5:4, and 5:3 is not an option. So facia-tool asks for a landscape crop, Grid returns a 5:4, and facia-tool validation fails because it was expecting a 5:3. Update the ratio names for the new reality - landscape means 5:4, so use customRatio option to get a 5:3 for 5:3 containers.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
