### PR TITLE
Vite now requires cors after a vulnerability was discovered

### DIFF
--- a/fronts-client/vite.config.mts
+++ b/fronts-client/vite.config.mts
@@ -25,5 +25,8 @@ export default defineConfig({
     fs: {
       allow: ['../public/fonts', './'],
     },
-  },
+    cors: {
+        origin: /https:\/\/fronts\.((code|local)\.){0,1}(dev-){0,1}gutools\.co\.uk/
+    },
+  }
 });


### PR DESCRIPTION
See https://dev.to/mandrasch/vite-is-suddenly-not-working-anymore-due-to-cors-error-ddev-3673, https://dev.to/mandrasch/vite-is-suddenly-not-working-anymore-due-to-cors-error-ddev-3673.

We could set cors origin to blanket 'true' but this is more secure.

## What's changed?
On fresh install of `fronts-client` you will need this value set to run the Fronts Tool - otherwise it will give you a blank page with CORS errors in Console.
