### PR TITLE
Log breaking news payload for better debugging

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -282,23 +282,23 @@ class BreakingNewsClientImpl(ws: WSClient, host: String, apiKey: String)
       .post(body)
       .map { response =>
         if (response.status >= 200 && response.status < 300) {
-          logger.info("Breaking news notification sent correctly")
+          logger.info(s"Successfully sent breaking news notification: $body")
           response.body[JsValue] \ "id" match {
             case JsDefined(JsString(id)) => Right(UUID.fromString(id))
             case _ =>
               Left(
                 ApiClientError(
-                  s"Notification sent successfully but unable to parse response. Status: ${response.status}, Body: ${response.body}"
+                  s"Succssfully sent breaking news notification ($body) but unable to parse response. Status: ${response.status}, Body: ${response.body}"
                 )
               )
           }
         } else {
           logger.error(
-            s"Unable to send breaking news notification, Status ${response.status}: ${response.statusText}, Body: ${response.body}"
+            s"Unable to send breaking news notification ($body), Status ${response.status}: ${response.statusText}, Body: ${response.body}"
           )
           Left(
             ApiClientError(
-              "Unable to send breaking news notification, status ${response.status}: ${response.statusText}"
+              s"Unable to send breaking news notification ($body), status ${response.status}: ${response.statusText}"
             )
           )
         }

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -288,7 +288,7 @@ class BreakingNewsClientImpl(ws: WSClient, host: String, apiKey: String)
             case _ =>
               Left(
                 ApiClientError(
-                  s"Succssfully sent breaking news notification ($body) but unable to parse response. Status: ${response.status}, Body: ${response.body}"
+                  s"Successfully sent breaking news notification ($body) but unable to parse response. Status: ${response.status}, Body: ${response.body}"
                 )
               )
           }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
At the moment when facia sends a breaking news, it does not log any information about the content.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/8c5927ff-dbc7-4c07-80fa-fac7cb861d03" />


This makes it difficult for us track which notifications were sent and debug if any of them were not correctly processed by the downstream services e.g. mobile notifications. 

This PR therefore updates the logging messages to include the notification payload so that we can use the information to debug any breaking news alert issues in the future.

## I sent the following test notification on facia code.
<img width="662" alt="image" src="https://github.com/user-attachments/assets/91a53815-0c56-4514-bdd5-c876fb628afc" />

### Facia logs
Now the Facia logs show information about the notification id, headline and capi id.
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/e05c10a8-ab0b-4404-82cc-16f8b797535a" />

### Mobile logs 
We can check if the corresponding notification was correctly processed in our mobile services (for instance by querying the id).
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/cfbda7b6-54d4-4945-9444-dc1cbc988779" />
## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
