### PR TITLE
Improve styling of media select component

### DIFF
--- a/fronts-client/src/components/Explainer.tsx
+++ b/fronts-client/src/components/Explainer.tsx
@@ -3,6 +3,6 @@ import styled from 'styled-components';
 export default styled.div`
 	font-style: italic;
 	font-size: 12px;
-	margin-top: -6px;
+	margin-top: 4px;
 	color: #707070;
 `;

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -138,7 +138,6 @@ const SlideshowCol = styled(Col)`
 const SlideshowLabel = styled.div`
 	font-size: 12px;
 	color: ${theme.colors.greyMedium};
-	margin-bottom: 12px;
 `;
 
 const CollectionEditedError = styled.div`
@@ -181,7 +180,7 @@ const CaptionLabel = styled(InputLabel)`
 `;
 
 const CaptionInput = styled(InputBase)`
-	margin-bottom: 60px;
+	margin-bottom: 10px;
 	color: ${(props: { invalid: boolean }) =>
 		props.invalid ? error.primary : 'default'};
 	border-color: ${(props: { invalid: boolean }) =>
@@ -194,7 +193,10 @@ const CaptionInput = styled(InputBase)`
 
 const FlexContainer = styled.div`
 	display: flex;
+	justify-content: flex-end;
 	align-items: center;
+	margin-top: 6px;
+	margin-bottom: 10px;
 `;
 
 const InvalidSlideshowWarning = styled(FlexContainer)`
@@ -385,10 +387,6 @@ const FieldContainer = styled(Col)`
 		props.size === 'wide' ? '0 0 auto' : 1};
 	margin-bottom: 8px;
 	white-space: nowrap;
-	& label {
-		padding-left: 3px;
-		padding-right: 5px;
-	}
 `;
 
 const KickerSuggestionsContainer = styled.div`

--- a/fronts-client/src/components/form/FormButtonContainer.tsx
+++ b/fronts-client/src/components/form/FormButtonContainer.tsx
@@ -1,7 +1,5 @@
 import { styled } from 'constants/theme';
 
 export const FormButtonContainer = styled.div`
-	margin-left: auto;
-	margin-right: -10px;
-	margin-bottom: -10px;
+	margin: 10px -10px -10px auto;
 `;

--- a/fronts-client/src/components/form/ImageOptionsInputGroup.tsx
+++ b/fronts-client/src/components/form/ImageOptionsInputGroup.tsx
@@ -6,7 +6,6 @@ export const ImageOptionsInputGroup = styled.div`
 	flex-wrap: wrap;
 	flex: 1;
 	flex-direction: column;
-	min-width: 300px;
 	margin-top: ${(props: { size?: string }) =>
 		props.size !== 'wide' ? 0 : '6px'};
 `;

--- a/fronts-client/src/components/form/ImageRowContainer.tsx
+++ b/fronts-client/src/components/form/ImageRowContainer.tsx
@@ -5,4 +5,5 @@ export const ImageRowContainer = styled(RowContainer)`
 	flex: 1 1 auto;
 	margin-left: ${(props: { size?: string }) =>
 		props.size !== 'wide' ? 0 : '10px'};
+	overflow: visible;
 `;

--- a/fronts-client/src/components/inputs/InputCheckboxToggleInline.tsx
+++ b/fronts-client/src/components/inputs/InputCheckboxToggleInline.tsx
@@ -12,6 +12,10 @@ const checkboxWidth = 28;
 const CheckboxContainer = styled.div`
 	display: flex;
 	align-items: flex-start;
+
+	&:has(input:disabled) label {
+		cursor: not-allowed;
+	}
 `;
 
 const Label = styled(InputLabel)`
@@ -67,6 +71,16 @@ const Checkbox = styled.input`
 	&:checked + ${CheckboxLabel}, &:checked + ${CheckboxLabel}:before {
 		border-color: ${theme.input.checkboxColorActive};
 		right: 0px;
+	}
+	:disabled,
+	:disabled + ${CheckboxLabel}, :disabled + ${CheckboxLabel}:before {
+		cursor: not-allowed;
+	}
+	:disabled + ${CheckboxLabel}:before {
+		background-color: ${theme.input.checkboxButtonBackgroundDisabled};
+	}
+	:disabled + ${Label} {
+		cursor: not-allowed;
 	}
 `;
 

--- a/fronts-client/src/components/inputs/InputRadio.tsx
+++ b/fronts-client/src/components/inputs/InputRadio.tsx
@@ -9,39 +9,53 @@ import { theme } from 'constants/theme';
 const radioButtonHeight = 17;
 const radioButtonWidth = 17;
 
+const InnerContainer = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+const Row = styled.div`
+	display: flex;
+	width: 100%;
+	gap: 4px;
+	align-items: center;
+`;
 const BlockStylingMixin = () => css`
-	padding: 8px 6px;
+	width: 170px;
+	display: flex;
+	flex-direction: column;
+	padding: 8px 5px;
 	background-color: #cccccc;
-	height: ${radioButtonHeight * 2}px;
 	&:has(input:checked) {
 		color: white;
 		background-color: #a9a9a9;
+		box-shadow: 0px 0px 0 2px ${theme.colors.orangeLight};
 	}
 	&:has(input:disabled) {
 		opacity: 0.8;
 		cursor: not-allowed;
 	}
+	&:has(input:disabled):hover {
+		box-shadow: none;
+	}
+	&:hover {
+		box-shadow: 0px 0px 0 2px ${theme.colors.orangeLight};
+	}
 `;
 
-const RadioButtonContainer = styled.div<{ usesBlockStyling?: boolean }>`
-	display: flex;
-	align-items: center;
-	cursor: pointer;
-	color: ${(props) => props.theme.input.colorLabel};
-	${(props) => props.usesBlockStyling && BlockStylingMixin}
-`;
-
-const Label = styled(InputLabel)`
-	padding-left: 5px;
+const Label = styled(InputLabel)<{ usesBlockStyling?: boolean }>`
 	line-height: 15px;
 	flex: 1;
-	cursor: inherit;
+	cursor: pointer;
+	width: min-content;
+	padding: 0;
+	color: ${(props) => props.theme.input.colorLabel};
+	${(props) => props.usesBlockStyling && BlockStylingMixin}
 `;
 
 const Switch = styled.div`
 	position: relative;
 	width: ${radioButtonWidth}px;
-	margin-left: auto;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
@@ -51,6 +65,7 @@ const RadioButtonLabel = styled.label`
 	display: block;
 	overflow: hidden;
 	cursor: pointer;
+	width: ${radioButtonWidth}px;
 	height: ${radioButtonHeight}px;
 	padding: 0;
 	line-height: ${radioButtonHeight}px;
@@ -98,7 +113,6 @@ const RadioButton = styled.input`
 
 const IconContainer = styled.div`
 	width: 20px;
-	margin-left: 8px;
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -110,6 +124,7 @@ type Props = {
 	dataTestId?: string;
 	checked?: boolean;
 	icon?: ReactElement;
+	contents?: ReactElement;
 	usesBlockStyling?: boolean;
 } & {
 	input: Pick<WrappedFieldInputProps, 'onChange'> &
@@ -124,6 +139,7 @@ export default ({
 	input: { ...inputRest },
 	checked,
 	icon = undefined,
+	contents = undefined,
 	usesBlockStyling = false,
 	...rest
 }: Props) => {
@@ -140,22 +156,25 @@ export default ({
 	return (
 		<>
 			<InputContainer data-testid={dataTestId}>
-				<RadioButtonContainer usesBlockStyling={usesBlockStyling}>
-					<Switch>
-						<RadioButton
-							type="radio"
-							{...inputRest}
-							{...checkedProps}
-							{...rest}
-							id={id}
-						/>
-						<RadioButtonLabel htmlFor={id} />
-					</Switch>
-					<Label htmlFor={id} size="sm">
-						{label}
-					</Label>
-					{icon !== undefined ? <IconContainer>{icon}</IconContainer> : null}
-				</RadioButtonContainer>
+				<Label htmlFor={id} size="sm" usesBlockStyling={usesBlockStyling}>
+					<InnerContainer>
+						<Row>
+							<Switch>
+								<RadioButton
+									type="radio"
+									{...inputRest}
+									{...checkedProps}
+									{...rest}
+									id={id}
+								/>
+								<RadioButtonLabel htmlFor={id} />
+							</Switch>
+							{label}
+						</Row>
+						{icon !== undefined ? <IconContainer>{icon}</IconContainer> : null}
+					</InnerContainer>
+					{contents !== undefined ? contents : null}
+				</Label>
 			</InputContainer>
 		</>
 	);

--- a/fronts-client/src/components/inputs/SelectMediaInput.ts
+++ b/fronts-client/src/components/inputs/SelectMediaInput.ts
@@ -1,0 +1,11 @@
+import { styled } from 'constants/theme';
+import InputContainer from './InputContainer';
+
+export default styled.div`
+	& > ${InputContainer} {
+		margin: 5px 0;
+	}
+	flex-wrap: wrap;
+	display: flex;
+	column-gap: 10px;
+`;

--- a/fronts-client/src/components/inputs/SelectMediaLabelContainer.ts
+++ b/fronts-client/src/components/inputs/SelectMediaLabelContainer.ts
@@ -1,0 +1,7 @@
+import { styled } from 'constants/theme';
+
+export default styled.div`
+	display: flex;
+	align-items: center;
+	gap: 4px;
+`;

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -129,6 +129,7 @@ const input = {
 	checkboxColorActive: base.colors.highlightColor,
 	placeholderText: base.colors.placeholderDark,
 	radioButtonBackgroundDisabled: '#E6E6E6',
+	checkboxButtonBackgroundDisabled: '#E6E6E6',
 };
 
 const collection = {


### PR DESCRIPTION
While working on the new video tooling I cleaned up some of the styling.



| Before | After |
|--------|--------|
| <img width="679" alt="Screenshot 2025-05-21 at 14 57 01" src="https://github.com/user-attachments/assets/cd9e61c6-57e8-4678-a897-8bbe64f9126d" /> | <img width="679" alt="Screenshot 2025-05-21 at 14 57 35" src="https://github.com/user-attachments/assets/8740dded-eba3-495a-ac53-ebad4f804e79" /> |

### Changelist
* Increase the bounding box for block-style radio buttons (now any part can be clicked)
* Change the styling around the Media Select area (better padding and flex behaviour, improved hover / focus)