### PR TITLE
Allow users to replace videos using Media Atom Maker modal

### DIFF
--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -418,6 +418,25 @@ const CropIcon = ({
 	</svg>
 );
 
+const ReplaceVideoIcon = ({ fill = theme.colors.white }) => (
+	<svg
+		width="22"
+		height="21"
+		viewBox="0 0 18 17"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			d="M18 2.47267H15.5008V0H13.9055V2.47267H11.4062V4.01477H13.9055V6.59379H15.5008V4.01477H18V2.47267Z"
+			fill={fill}
+		/>
+		<path
+			d="M12.9217 8.42835V5.92909H10.4224V3.45642H0V16.2884H15.421V8.42835H12.9217ZM3.6 6.38838L11.7 9.98838L3.6 13.5884V6.38838Z"
+			fill={fill}
+		/>
+	</svg>
+);
+
 export {
 	DownCaretIcon,
 	RubbishBinIcon,
@@ -438,4 +457,5 @@ export {
 	DragHandleIcon as DragIcon,
 	WarningIcon,
 	CropIcon,
+	ReplaceVideoIcon,
 };

--- a/fronts-client/src/components/inputs/InputImage.tsx
+++ b/fronts-client/src/components/inputs/InputImage.tsx
@@ -9,7 +9,6 @@ import InputContainer from './InputContainer';
 import InputBase from './InputBase';
 import InputLabel from './InputLabel';
 import DragIntentContainer from '../DragIntentContainer';
-import { GridModal } from 'components/modals/GridModal';
 import {
 	validateImageEvent,
 	validateMediaItem,
@@ -40,6 +39,7 @@ import { selectEditMode } from '../../selectors/pathSelectors';
 import CircularIconContainer from '../icons/CircularIconContainer';
 import { error } from '../../styleConstants';
 import ValidatingSpinnerOverlay from '../image/ValidatingSpinnerOverlay';
+import { OverlayModal } from '../modals/OverlayModal';
 
 const AddImageButton = styled(ButtonDefault)<{ small?: boolean }>`
 	background-color: ${({ small }) =>
@@ -140,7 +140,7 @@ const Label = styled(InputLabel)`
 	vertical-align: super;
 `;
 
-const ButtonDelete = styled(ButtonDefault)<{
+export const ButtonDelete = styled(ButtonDefault)<{
 	confirmDelete?: boolean;
 }>`
 	position: absolute;
@@ -167,7 +167,7 @@ const ButtonDelete = styled(ButtonDefault)<{
 	}
 `;
 
-const DeleteIconOptions = styled.div`
+export const DeleteIconOptions = styled.div`
 	display: block;
 	position: absolute;
 	height: 14px;
@@ -374,11 +374,10 @@ class InputImage extends React.Component<ComponentProps, ComponentState> {
 				isInvalid={isInvalid}
 				confirmDelete={this.state.confirmDelete}
 			>
-				<GridModal
+				<OverlayModal
 					url={gridModalUrl}
 					isOpen={this.state.modalOpen}
 					onClose={this.closeModal}
-					onMessage={this.onMessage}
 				/>
 				<DragIntentContainer
 					active

--- a/fronts-client/src/components/modals/OverlayModal.tsx
+++ b/fronts-client/src/components/modals/OverlayModal.tsx
@@ -1,17 +1,10 @@
-import React from 'react';
+import { styled } from '../../constants/theme';
 import Modal from 'react-modal';
-import { styled } from 'constants/theme';
-import ButtonDefault from 'components/inputs/ButtonDefault';
-import { CloseIcon } from 'components/icons/Icons';
+import ButtonDefault from '../inputs/ButtonDefault';
+import React from 'react';
+import { CloseIcon } from '../icons/Icons';
 
-interface ModalProps {
-	isOpen: boolean;
-	url: string;
-	onClose: () => void;
-	onMessage: (message: any) => void;
-}
-
-const StyledModal = styled(Modal)`
+export const StyledModal = styled(Modal)`
 	position: absolute;
 	font-size: 14px;
 	overflow: auto;
@@ -23,7 +16,7 @@ const StyledModal = styled(Modal)`
 	background: rgba(0, 0, 0, 0.8);
 `;
 
-const ModalButton = styled(ButtonDefault)`
+export const ModalButton = styled(ButtonDefault)`
 	position: absolute;
 	right: 17px;
 	top: 15px;
@@ -32,20 +25,26 @@ const ModalButton = styled(ButtonDefault)`
 	width: 27px;
 `;
 
-const GridIFrame = styled.iframe`
+export const ImageContainer = styled.div`
+	position: absolute;
+	top: 5px;
+	left: 6px;
+`;
+
+interface ModalProps {
+	isOpen: boolean;
+	url: string;
+	onClose: () => void;
+}
+
+const IFrame = styled.iframe`
 	height: 100%;
 	width: 96%;
 	margin-left: 2%;
 	border: 0;
 `;
 
-const ImageContainer = styled.div`
-	position: absolute;
-	top: 5px;
-	left: 6px;
-`;
-
-export const GridModal = ({ isOpen, url, onMessage, onClose }: ModalProps) => (
+export const OverlayModal = ({ isOpen, url, onClose }: ModalProps) => (
 	<React.Fragment>
 		<StyledModal
 			isOpen={isOpen}
@@ -61,7 +60,7 @@ export const GridModal = ({ isOpen, url, onMessage, onClose }: ModalProps) => (
 				</ImageContainer>
 			</ModalButton>
 
-			<GridIFrame src={url} />
+			<IFrame src={url} />
 		</StyledModal>
 	</React.Fragment>
 );

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -1,12 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import ButtonDefault from '../inputs/ButtonDefault';
 import { createPortal } from 'react-dom';
+import { ReplaceVideoIcon } from '../icons/Icons';
 import InputCheckboxToggleInline from '../inputs/InputCheckboxToggleInline';
-import { Field } from 'redux-form';
-import { extractAtomId, stripQueryParams } from '../../util/extractAtomId';
+import { change, Field } from 'redux-form';
+import {
+	AtomProperties,
+	extractAtomId,
+	extractAtomProperties,
+	stripQueryParams,
+} from '../../util/extractAtomId';
 import { VideoUriInput } from '../inputs/VideoUriInput';
+import { useDispatch } from 'react-redux';
 import Explainer from '../Explainer';
+import { OverlayModal } from '../modals/OverlayModal';
 import type { Atom } from '../../types/Capi';
+import urlConstants from '../../constants/url';
 
 interface VideoControlsProps {
 	videoBaseUrl: string | null;
@@ -26,20 +36,122 @@ const VideoControlsOuterContainer = styled.div`
 	position: relative;
 `;
 
+const VideoAction = styled(ButtonDefault)<{ small?: boolean }>`
+	background-color: #5e5e5e50;
+	&:hover,
+	&:active,
+	&:hover:enabled,
+	&:active:enabled {
+		background-color: #5e5e5e99;
+	}
+	height: 50%;
+	width: 100%;
+	font-size: 12px;
+	flex-grow: 1;
+	padding: 0;
+	text-shadow: 0 0 2px black;
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	gap: 4px;
+`;
+
+const VideoControlsInnerContainer = styled.div<{ url?: string }>`
+	background-image: url(${(props) => props.url});
+	height: 100%;
+	position: relative;
+	aspect-ratio: 5 / 4;
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: center center;
+	-webkit-box-flex: 1;
+	flex-grow: 1;
+	margin-bottom: 5px;
+`;
+
 const MarginWrapper = styled.div`
 	margin-bottom: 8px;
 	margin-top: 8px;
 `;
 
 export const VideoControls = ({
+	videoBaseUrl,
 	mainMediaVideoAtom,
 	replacementVideoAtom,
 	showMainVideo,
 	showReplacementVideo,
 	changeField,
 	changeMediaField,
+	form,
 	replacementVideoControlsId,
 }: VideoControlsProps) => {
+	const [mainMediaVideoAtomProperties, setMainMediaVideoAtomProperties] =
+		React.useState<AtomProperties>();
+	const [replacementVideoAtomProperties, setReplacementVideoAtomProperties] =
+		React.useState<AtomProperties>();
+
+	const [showMediaAtomMakerModal, setShowMediaAtomMakerModal] =
+		React.useState<boolean>(false);
+	const dispatch = useDispatch();
+
+	type AtomData = {
+		atomId: string;
+	};
+
+	const onMessage = (event: MessageEvent) => {
+		if (videoBaseUrl === null || event.origin !== videoBaseUrl) {
+			return;
+		}
+
+		const data: AtomData = event.data;
+
+		if (!data || !data.atomId) {
+			return;
+		}
+
+		dispatch(
+			change(
+				form,
+				'atomId',
+				`${urlConstants.video.capiAtomPath}${data.atomId}`,
+			),
+		);
+		/**
+		 * Even if we can't fetch the replacement atom, it's worth setting the videoReplace and replaceVideoUri fields
+		 * to give some feedback to the user.
+		 *
+		 * Invalid atoms can't be saved, so there should be no risk in setting these fields.
+		 */
+		dispatch(
+			change(form, 'replaceVideoUri', `${videoBaseUrl}/videos/${data.atomId}`),
+		);
+		changeMediaField('videoReplace');
+		handleCloseMediaAtomMakerModal();
+	};
+
+	const handleOpenMediaAtomMakerModal = () => {
+		setShowMediaAtomMakerModal(true);
+		window.addEventListener('message', onMessage, false);
+	};
+	const handleCloseMediaAtomMakerModal = () => {
+		setShowMediaAtomMakerModal(false);
+		window.removeEventListener('message', onMessage, false);
+	};
+
+	useEffect(() => {
+		if (replacementVideoAtom !== undefined) {
+			const atomProperties = extractAtomProperties(replacementVideoAtom);
+			setReplacementVideoAtomProperties(atomProperties);
+		}
+	}, [replacementVideoAtom]);
+
+	useEffect(() => {
+		if (mainMediaVideoAtom !== undefined) {
+			const atomProperties = extractAtomProperties(mainMediaVideoAtom);
+			setMainMediaVideoAtomProperties(atomProperties);
+		}
+	}, [mainMediaVideoAtom]);
+
 	if (!showMainVideo && !showReplacementVideo) {
 		return null;
 	}
@@ -84,7 +196,35 @@ export const VideoControls = ({
 						replacementVideoControls,
 					)
 				: null}
+			{showMediaAtomMakerModal && videoBaseUrl !== null
+				? createPortal(
+						<OverlayModal
+							onClose={handleCloseMediaAtomMakerModal}
+							isOpen={showMediaAtomMakerModal}
+							url={`${videoBaseUrl}/videos?embeddedMode=live`}
+						/>,
+						document.body,
+					)
+				: null}
 			<VideoControlsOuterContainer>
+				<VideoControlsInnerContainer
+					url={
+						showReplacementVideo
+							? replacementVideoAtomProperties?.trailImage
+							: mainMediaVideoAtomProperties?.trailImage
+					}
+				>
+					<VideoAction
+						onClick={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							handleOpenMediaAtomMakerModal();
+						}}
+					>
+						<ReplaceVideoIcon />
+						Replace video
+					</VideoAction>
+				</VideoControlsInnerContainer>
 				<Field
 					name="replaceVideoUri"
 					component={VideoUriInput}


### PR DESCRIPTION
### Changelist

* Implement an 'Replace video' button which opens a Media Atom Maker modal - similar to Grid for images[^1]
	* This is an alternative way of providing a video
	* If a video is provided by this modal the 'video url' field is kept in sync

[^1]: For Panda / rights reasons, in CODE and local Fronts Tool we need to open CODE MAM, which provides atoms from CODE CAPI. Unfortunately Fronts Tool reads from PROD CAPI (following the departmental principle to connect CODE services to PROD services where possible). This leads to errors locally and in CODE.