### PR TITLE
Allow users to preview a card's video in the Fronts Tool

### DIFF
--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -437,6 +437,21 @@ const ReplaceVideoIcon = ({ fill = theme.colors.white }) => (
 	</svg>
 );
 
+const PreviewVideoIcon = ({ fill = theme.colors.white }) => (
+	<svg
+		width="20"
+		height="18"
+		viewBox="0 0 16 14"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			d="M15.421 0.456543H0V13.2885H15.421V0.456543ZM3.6 3.3885L11.7 6.9885L3.6 10.5885V3.3885Z"
+			fill={fill}
+		/>
+	</svg>
+);
+
 export {
 	DownCaretIcon,
 	RubbishBinIcon,
@@ -458,4 +473,5 @@ export {
 	WarningIcon,
 	CropIcon,
 	ReplaceVideoIcon,
+	PreviewVideoIcon,
 };

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -2,13 +2,14 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import ButtonDefault from '../inputs/ButtonDefault';
 import { createPortal } from 'react-dom';
-import { ReplaceVideoIcon } from '../icons/Icons';
+import { PreviewVideoIcon, ReplaceVideoIcon } from '../icons/Icons';
 import InputCheckboxToggleInline from '../inputs/InputCheckboxToggleInline';
 import { change, Field } from 'redux-form';
 import {
 	AtomProperties,
 	extractAtomId,
 	extractAtomProperties,
+	getVideoUri,
 	stripQueryParams,
 } from '../../util/extractAtomId';
 import { VideoUriInput } from '../inputs/VideoUriInput';
@@ -90,6 +91,11 @@ export const VideoControls = ({
 	const [replacementVideoAtomProperties, setReplacementVideoAtomProperties] =
 		React.useState<AtomProperties>();
 
+	const [currentVideoUri, setCurrentVideoUri] = React.useState<
+		string | undefined
+	>(undefined);
+	const [showVideoPreviewModal, setShowVideoPreviewModal] =
+		React.useState<boolean>(false);
 	const [showMediaAtomMakerModal, setShowMediaAtomMakerModal] =
 		React.useState<boolean>(false);
 	const dispatch = useDispatch();
@@ -152,6 +158,18 @@ export const VideoControls = ({
 		}
 	}, [mainMediaVideoAtom]);
 
+	useEffect(() => {
+		const videoUri = showReplacementVideo
+			? getVideoUri(replacementVideoAtomProperties)
+			: getVideoUri(mainMediaVideoAtomProperties);
+
+		setCurrentVideoUri(videoUri);
+	}, [
+		showReplacementVideo,
+		mainMediaVideoAtomProperties,
+		replacementVideoAtomProperties,
+	]);
+
 	if (!showMainVideo && !showReplacementVideo) {
 		return null;
 	}
@@ -196,6 +214,16 @@ export const VideoControls = ({
 						replacementVideoControls,
 					)
 				: null}
+			{currentVideoUri !== undefined && showVideoPreviewModal
+				? createPortal(
+						<OverlayModal
+							onClose={() => setShowVideoPreviewModal(false)}
+							isOpen={showVideoPreviewModal}
+							url={currentVideoUri}
+						/>,
+						document.body,
+					)
+				: null}
 			{showMediaAtomMakerModal && videoBaseUrl !== null
 				? createPortal(
 						<OverlayModal
@@ -223,6 +251,17 @@ export const VideoControls = ({
 					>
 						<ReplaceVideoIcon />
 						Replace video
+					</VideoAction>
+					<VideoAction
+						onClick={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							setShowVideoPreviewModal(true);
+						}}
+						disabled={currentVideoUri === undefined}
+					>
+						<PreviewVideoIcon />
+						Preview video
 					</VideoAction>
 				</VideoControlsInnerContainer>
 				<Field


### PR DESCRIPTION
### Changelist
* Implement a 'Preview video' button which opens a Preview modal for the current video. The current video is either the main media video or the 'replacement' video, depending on which videos are set and the value of the 'Use replacement video' toggle, if present.