### PR TITLE
Allow replacement videos to be removed from a card

### DIFF
--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -2,9 +2,14 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import ButtonDefault from '../inputs/ButtonDefault';
 import { createPortal } from 'react-dom';
-import { PreviewVideoIcon, ReplaceVideoIcon } from '../icons/Icons';
+import {
+	ConfirmDeleteIcon,
+	PreviewVideoIcon,
+	ReplaceVideoIcon,
+	RubbishBinIcon,
+} from '../icons/Icons';
 import InputCheckboxToggleInline from '../inputs/InputCheckboxToggleInline';
-import { change, Field } from 'redux-form';
+import { autofill, change, Field } from 'redux-form';
 import {
 	AtomProperties,
 	extractAtomId,
@@ -12,6 +17,7 @@ import {
 	getVideoUri,
 	stripQueryParams,
 } from '../../util/extractAtomId';
+import { ButtonDelete, DeleteIconOptions } from '../inputs/InputImage';
 import { VideoUriInput } from '../inputs/VideoUriInput';
 import { useDispatch } from 'react-redux';
 import Explainer from '../Explainer';
@@ -99,7 +105,25 @@ export const VideoControls = ({
 		React.useState<boolean>(false);
 	const [showMediaAtomMakerModal, setShowMediaAtomMakerModal] =
 		React.useState<boolean>(false);
+	const [confirmDelete, setConfirmDelete] = React.useState<boolean>(false);
 	const dispatch = useDispatch();
+
+	const handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
+		e.stopPropagation();
+
+		if (!confirmDelete) {
+			setConfirmDelete(true);
+			setTimeout(() => setConfirmDelete(false), 3000);
+			return;
+		}
+
+		// This exact incantation is needed to clear the form fields...
+		dispatch(autofill(form, 'replaceVideoUri', undefined));
+		dispatch(autofill(form, 'atomId', undefined));
+		dispatch(change(form, 'replacementVideoAtom', undefined));
+		changeMediaField('showMainVideo');
+		setConfirmDelete(false);
+	};
 
 	type AtomData = {
 		atomId: string;
@@ -264,6 +288,22 @@ export const VideoControls = ({
 						<PreviewVideoIcon />
 						Preview video
 					</VideoAction>
+					{showReplacementVideo && replacementVideoAtom && (
+						<ButtonDelete
+							type="button"
+							priority="primary"
+							onClick={handleDelete}
+							confirmDelete={confirmDelete}
+						>
+							<DeleteIconOptions>
+								{confirmDelete ? (
+									<ConfirmDeleteIcon size="s" />
+								) : (
+									<RubbishBinIcon size="s" />
+								)}
+							</DeleteIconOptions>
+						</ButtonDelete>
+					)}
 				</VideoControlsInnerContainer>
 				<Field
 					name="replaceVideoUri"


### PR DESCRIPTION
Follows #1819.

We want to allow editors to remove replacement videos at the click (or two) of a button.

| Before | After (stage one) | After (stage two)
|--------|--------|--------|
| <img width="675" alt="Screenshot 2025-05-21 at 15 01 10" src="https://github.com/user-attachments/assets/368b29b9-e476-4912-a12b-d97b7be93568" /> | <img width="675" alt="Screenshot 2025-05-21 at 15 02 22" src="https://github.com/user-attachments/assets/09cd5e2e-48c5-4db7-b8a1-ed2b681e4f15" /> | <img width="675" alt="Screenshot 2025-05-21 at 15 02 25" src="https://github.com/user-attachments/assets/205bba6f-d44d-45c6-87f0-634716b8078e" /> |


### Testing
Note the replacement video feature is hidden behind a feature switch marked 'Enable replacement video'. The CODE feature switch dashboard can be found [here](https://fronts.code.dev-gutools.co.uk/v2/features).

You will also need to pull the video config values using the `setup.sh` script, if you haven't done so already.

### Changelist
* Allow the 'replacement' video to be removed from the card
	* This uses the two-stage delete button (the same button used to disassociate images)

Note you can also remove the video by clearing the video uri field.