### PR TITLE
Add a tooltip and warning for videos

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -84,6 +84,7 @@ import SelectMediaInput from '../inputs/SelectMediaInput';
 import SelectMediaLabelContainer from '../inputs/SelectMediaLabelContainer';
 import pageConfig from '../../util/extractConfigFromPage';
 import type { Atom, AtomResponse } from '../../types/Capi';
+import Tooltip from '../modals/Tooltip';
 
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
@@ -892,6 +893,9 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											<InputLabel htmlFor="media-select">
 												Select Media
 											</InputLabel>
+											{enableReplacementVideoFeatureSwitch?.enabled ? (
+												<Tooltip />
+											) : null}
 										</SelectMediaLabelContainer>
 										<SelectMediaInput>
 											<Field

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -292,7 +292,7 @@ const GuardianRoundel = ({ size = 'm' }: IconProps) => (
 	</svg>
 );
 
-const VideoIcon = ({}) => (
+const VideoIcon = ({ fill = '#333' }) => (
 	<svg
 		xmlns="http://www.w3.org/2000/svg"
 		xmlnsXlink="http://www.w3.org/1999/xlink"
@@ -306,7 +306,7 @@ const VideoIcon = ({}) => (
 				d="M1.2 0L0 1.2v6l1.2 1.2h6.9V0H1.2zM12 .5l-3 3v1.8l3 3h.9V.5H12z"
 			/>
 		</defs>
-		<use fill="#333" fillRule="evenodd" xlinkHref="#a" />
+		<use fill={fill} fillRule="evenodd" xlinkHref="#a" />
 	</svg>
 );
 
@@ -452,6 +452,26 @@ const PreviewVideoIcon = ({ fill = theme.colors.white }) => (
 	</svg>
 );
 
+const InfoIcon = ({ fill = theme.colors.white, size = 'm' }: IconProps) => (
+	<svg
+		width={`${mapSize(size)}px`}
+		height={`${mapSize(size)}px`}
+		viewBox="0 0 416.979 416.979"
+		fill={fill}
+	>
+		<g
+			id="SVGRepo_tracerCarrier"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		></g>
+		<g>
+			<g>
+				<path d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85 c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786 c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576 c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765 c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z"></path>
+			</g>
+		</g>
+	</svg>
+);
+
 export {
 	DownCaretIcon,
 	RubbishBinIcon,
@@ -474,4 +494,5 @@ export {
 	CropIcon,
 	ReplaceVideoIcon,
 	PreviewVideoIcon,
+	InfoIcon,
 };

--- a/fronts-client/src/components/modals/Tooltip.tsx
+++ b/fronts-client/src/components/modals/Tooltip.tsx
@@ -52,8 +52,8 @@ export default () => {
 					<div>
 						<VideoIcon fill={'white'} />
 					</div>
-					If a Video can't play, it falls back to the Trail Image. If no Trail
-					Image exists, it falls back to the Video's Poster Image.
+					Before the Video is played, we show its Trail Image. If no Trail Image
+					exists, we show its Poster Image.
 				</TooltipModal>
 			) : null}
 		</Container>

--- a/fronts-client/src/components/modals/Tooltip.tsx
+++ b/fronts-client/src/components/modals/Tooltip.tsx
@@ -1,0 +1,61 @@
+import { styled } from '../../constants/theme';
+import { InfoIcon, VideoIcon } from '../icons/Icons';
+import React from 'react';
+
+const TooltipModal = styled.div`
+	position: absolute;
+	width: 200px;
+	bottom: 20px;
+	transform: translateX(calc(-50% + 7px));
+	background-color: black;
+	color: white;
+	border-radius: 4px;
+	z-index: 2;
+	font-size: 10px;
+	font-family: TS3TextSans, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	padding: 6px;
+	line-height: 14px;
+`;
+
+const InfoIconContainer = styled.div`
+	cursor: pointer;
+`;
+
+const Container = styled.div`
+	position: relative;
+	line-height: 14px;
+`;
+
+export default () => {
+	const [showModal, setShowModal] = React.useState(false);
+
+	const handleMouseEnter = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		setShowModal(true);
+	};
+
+	const handleMouseLeave = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		setShowModal(false);
+	};
+
+	return (
+		<Container>
+			<InfoIconContainer
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+			>
+				<InfoIcon fill={'black'} size={'s'} />
+			</InfoIconContainer>
+			{showModal ? (
+				<TooltipModal>
+					<div>
+						<VideoIcon fill={'white'} />
+					</div>
+					If a Video can't play, it falls back to the Trail Image. If no Trail
+					Image exists, it falls back to the Video's Poster Image.
+				</TooltipModal>
+			) : null}
+		</Container>
+	);
+};

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -22,6 +22,7 @@ import { VideoUriInput } from '../inputs/VideoUriInput';
 import { useDispatch } from 'react-redux';
 import Explainer from '../Explainer';
 import { OverlayModal } from '../modals/OverlayModal';
+import { InvalidWarning } from '../form/ArticleMetaForm';
 import type { Atom } from '../../types/Capi';
 import urlConstants from '../../constants/url';
 
@@ -203,6 +204,18 @@ export const VideoControls = ({
 		replacementVideoControlsId,
 	);
 
+	const warningsContainer = document.getElementById(warningsContainerId);
+
+	const mainMediaIsSelfHosted =
+		showMainVideo &&
+		mainMediaVideoAtom !== null &&
+		mainMediaVideoAtomProperties?.platform === 'url';
+
+	const replacementVideoIsSelfHosted =
+		showReplacementVideo &&
+		replacementVideoAtom !== null &&
+		replacementVideoAtomProperties?.platform === 'url';
+
 	return (
 		<>
 			{/*
@@ -324,6 +337,13 @@ export const VideoControls = ({
 					normalize={stripQueryParams}
 				></Field>
 			</VideoControlsOuterContainer>
+			{warningsContainer !== null &&
+			(mainMediaIsSelfHosted || replacementVideoIsSelfHosted)
+				? createPortal(
+						<InvalidWarning warning="Self-hosted videos are not supported" />,
+						warningsContainer,
+					)
+				: null}
 		</>
 	);
 };


### PR DESCRIPTION
Follows #1820. 

We want to provide the editor with more information about what happens when a video can't be played, and a warning for when they use self-host video.

| Before | After (tooltip - on hover) | After (warning - for self-hosted) |
|--------|--------|--------|
| <img width="661" alt="Screenshot 2025-05-21 at 15 02 22" src="https://github.com/user-attachments/assets/4626fc7f-9c01-4553-9507-f2bd2816b563" /> | <img width="661" alt="Screenshot 2025-05-21 at 15 03 09" src="https://github.com/user-attachments/assets/6dc937d2-9cb5-48cb-8057-0eb2d2bfb117" /> | <img width="661" alt="Screenshot 2025-05-21 at 15 03 23" src="https://github.com/user-attachments/assets/cc9b5970-a128-4c44-bd7c-ca17c476c09b" /> |

### Testing
Note the replacement video feature is hidden behind a feature switch marked 'Enable replacement video'. The CODE feature switch dashboard can be found [here](https://fronts.code.dev-gutools.co.uk/v2/features).

You will also need to pull the video config values using the `setup.sh` script, if you haven't done so already.

### Changelist

* Add a tooltip to explain what happens if the selected video cannot be played
* Warn users not to upload self-hosted video (as it is currently not supported)