### PR TITLE
Update feed item aspect ratio and height

### DIFF
--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -219,6 +219,9 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 					<ArticleThumbnail
 						style={{
 							backgroundImage: `url('${thumbnail}')`,
+							aspectRatio: '5/4',
+							backgroundPosition: 'center center',
+							backgroundSize: 'cover',
 						}}
 					>
 						{hasVideo && (

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -152,7 +152,7 @@ const card = {
 
 const thumbnailImage = {
 	width: '83px',
-	height: '50px',
+	height: '66.39px',
 };
 
 const thumbnailImageSquare = {


### PR DESCRIPTION
## What's changed?
Closes this [ticket](https://trello.com/c/egMFY70V/1225-amend-clipboard-to-default-to-54), sets the default aspect ratio (with required height adjustment) to 5:4 for feed items (which includes the clipboard). This brings it in line with the thumbnails in the 5/4 collections, and for consistency, we also apply the same background image properties as [thumbnails](https://github.com/guardian/facia-tool/blob/fd9b1d59186e780b169247865fc026fad4fc0aaf/fronts-client/src/components/image/Thumbnail.tsx#L37) (size and position).


## Screenshots


| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f0cb5631-b897-4153-b471-22a1690b5003" width="400px" /> | <img src="https://github.com/user-attachments/assets/2c05e067-502f-441c-b391-96661edaab7f" width="400px" /> |





### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
