### PR TITLE
Add a shortcut to close the Overlay modal

### DIFF
--- a/fronts-client/src/components/modals/OverlayModal.tsx
+++ b/fronts-client/src/components/modals/OverlayModal.tsx
@@ -1,7 +1,7 @@
 import { styled } from '../../constants/theme';
 import Modal from 'react-modal';
 import ButtonDefault from '../inputs/ButtonDefault';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { CloseIcon } from '../icons/Icons';
 
 export const StyledModal = styled(Modal)`
@@ -44,23 +44,39 @@ const IFrame = styled.iframe`
 	border: 0;
 `;
 
-export const OverlayModal = ({ isOpen, url, onClose }: ModalProps) => (
-	<React.Fragment>
-		<StyledModal
-			isOpen={isOpen}
-			style={{
-				overlay: {
-					zIndex: 900,
-				},
-			}}
-		>
-			<ModalButton type="button" priority="primary" onClick={onClose}>
-				<ImageContainer>
-					<CloseIcon />
-				</ImageContainer>
-			</ModalButton>
+export const OverlayModal = ({ isOpen, url, onClose }: ModalProps) => {
+	useEffect(() => {
+		const handleKeyUp = (e: KeyboardEvent) => {
+			if (e.key === 'Escape' && isOpen) {
+				onClose();
+			}
+		};
+		// For some reason, the keydown event does not always capture the Escape key
+		// Instead, we use keyup event to close the modal
+		window.addEventListener('keyup', handleKeyUp);
+		return () => {
+			window.removeEventListener('keyup', handleKeyUp);
+		};
+	}, [isOpen, onClose]);
 
-			<IFrame src={url} />
-		</StyledModal>
-	</React.Fragment>
-);
+	return (
+		<React.Fragment>
+			<StyledModal
+				isOpen={isOpen}
+				style={{
+					overlay: {
+						zIndex: 900,
+					},
+				}}
+			>
+				<ModalButton type="button" priority="primary" onClick={onClose}>
+					<ImageContainer>
+						<CloseIcon />
+					</ImageContainer>
+				</ModalButton>
+
+				<IFrame src={url} />
+			</StyledModal>
+		</React.Fragment>
+	);
+};


### PR DESCRIPTION
## What's changed?
Adds a shortcut to close the Overlay modal - press the Escape key.

iFrames steal keypress events when focussed - so we need to post events up from the iFrame in these contexts: https://github.com/guardian/media-atom-maker/pull/1204

### To test
Toggle the 'Enable replacement video' feature switch on (e.g. https://fronts.local.dev-gutools.co.uk/v2/features).

Find / create a card with a video. Open the Video Preview modal. You should be able to exit using the Escape key.

This will also work with the Video Replace modal (which opens Media Atom Maker) and the Image Replace modal (which opens Grid), so long as the iFrame does not have focus.

https://github.com/guardian/media-atom-maker/pull/1204 fixes this for Media Atom Maker by passing the keypress event up. Grid fix pending.
