### PR TITLE
Remove video/vertical container 

### DIFF
--- a/app/slices/FixedContainers.scala
+++ b/app/slices/FixedContainers.scala
@@ -40,7 +40,6 @@ class FixedContainers(val config: ApplicationConfiguration) {
       slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)
     ),
     ("fixed/video", video),
-    ("fixed/video/vertical", video),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcase),
     ("static/medium/4", staticMedium4),

--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -19,7 +19,6 @@ export default {
         { 'name': 'fixed/medium/slow-XII-mpu' },
         { 'name': 'fixed/thrasher' },
         { 'name': 'fixed/video' },
-        { 'name': 'fixed/video/vertical' },
         { 'name': 'fixed/medium/slow-VII' },
         { 'name': 'fixed/small/fast-VIII' },
         { 'name': 'fixed/small/slow-V-mpu' },


### PR DESCRIPTION

## What's changed?
Removes the video/vertical container. It is not used and no longer required. There are 0 instances of this container type in use in  production.

This is part of the work to deprecate and remove old containers. 

Other relevant PRs for this are

Frontend : 
DCR : 

This container type was never implemented on Apps. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
