### PR TITLE
Set card criteria to landscape54 image if no collection type

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -1193,7 +1193,10 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		heightAspectRatio: number;
 	} => {
 		const { collectionType } = this.props;
-		if (!collectionType || COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
+		if (
+			!collectionType ||
+			COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)
+		) {
 			return landscape5To4CardImageCriteria;
 		}
 		if (COLLECTIONS_USING_SQUARE_TRAILS.includes(collectionType)) {

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -1193,10 +1193,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		heightAspectRatio: number;
 	} => {
 		const { collectionType } = this.props;
-		if (!collectionType) {
-			return landScapeCardImageCriteria;
-		}
-		if (COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
+		if (!collectionType || COLLECTIONS_USING_LANDSCAPE_5_TO_4_TRAILS.includes(collectionType)) {
 			return landscape5To4CardImageCriteria;
 		}
 		if (COLLECTIONS_USING_SQUARE_TRAILS.includes(collectionType)) {


### PR DESCRIPTION
## What's changed?

Sets the image criteria to 5:4 if there's no collection type, e.g. if we're in the clipboard section of the tool. 

Closes this [ticket](https://trello.com/c/gIvQuc2p/1297-update-clipboard-crop-tool-to-require-54-images)

## Videos
Before with 5:3 images

https://github.com/user-attachments/assets/3da14956-5a65-49d0-bd9f-d33a3ee11055

After with 5:4 required

https://github.com/user-attachments/assets/fb35282d-6353-4a9d-b2a6-30148959024a



### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
