### PR TITLE
Fp/ab/fix video bug

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -426,19 +426,14 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			await this.fetchAndSetReplacementVideoAtom(this.props.atomId);
 		}, 500);
 	}
-	componentDidMount() {
-		this.fetchAndSetReplacementVideoAtom(this.props.atomId);
-	}
 
-	componentDidUpdate(
-		prevProps: Readonly<Props>,
-		prevState: Readonly<FormComponentState>,
-		snapshot?: any,
-	) {
-		if (prevProps.atomId === this.props.atomId) {
-			return;
+	componentDidUpdate(prevProps: Readonly<Props>) {
+		const atomIsAlreadyDefined = this.props.replacementVideoAtom !== undefined;
+		const atomIdChanged = prevProps.atomId !== this.props.atomId;
+
+		if (atomIsAlreadyDefined && atomIdChanged) {
+			this.debouncedFetchAndSetReplacementVideoAtom();
 		}
-		this.debouncedFetchAndSetReplacementVideoAtom();
 	}
 
 	private fetchAndSetReplacementVideoAtom = async (

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -440,7 +440,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		atomId: string | undefined,
 	) => {
 		if (atomId === undefined || atomId === '') {
-			this.props.change('replacementVideoAtom', undefined);
+			this.props.change('replacementVideoAtom', '');
 			return;
 		}
 		this.fetchAtom(atomId)
@@ -450,7 +450,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			)
 			.catch((error) => {
 				console.error(error);
-				this.props.change('replacementVideoAtom', undefined);
+				this.props.change('replacementVideoAtom', '');
 			});
 	};
 

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -118,10 +118,9 @@ export const VideoControls = ({
 			return;
 		}
 
-		// This exact incantation is needed to clear the form fields...
-		dispatch(autofill(form, 'replaceVideoUri', undefined));
-		dispatch(autofill(form, 'atomId', undefined));
-		dispatch(change(form, 'replacementVideoAtom', undefined));
+		// Redux Form needs empty strings to clear fields, not null or undefined.
+		dispatch(autofill(form, 'replaceVideoUri', ''));
+		dispatch(autofill(form, 'atomId', ''));
 		changeMediaField('showMainVideo');
 		setConfirmDelete(false);
 	};
@@ -191,6 +190,12 @@ export const VideoControls = ({
 		if (replacementVideoAtom !== undefined) {
 			const atomProperties = extractAtomProperties(replacementVideoAtom);
 			setReplacementVideoAtomProperties(atomProperties);
+		} else {
+			setReplacementVideoAtomProperties({
+				assetId: undefined,
+				videoImage: undefined,
+				platform: undefined,
+			});
 		}
 	}, [replacementVideoAtom]);
 
@@ -198,6 +203,12 @@ export const VideoControls = ({
 		if (mainMediaVideoAtom !== undefined) {
 			const atomProperties = extractAtomProperties(mainMediaVideoAtom);
 			setMainMediaVideoAtomProperties(atomProperties);
+		} else {
+			setMainMediaVideoAtomProperties({
+				assetId: undefined,
+				videoImage: undefined,
+				platform: undefined,
+			});
 		}
 	}, [mainMediaVideoAtom]);
 

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -7,7 +7,7 @@ import { isDirty } from 'redux-form';
 import pageConfig from 'util/extractConfigFromPage';
 import { CardMeta, ImageData } from 'types/Collection';
 import { DerivedArticle } from 'types/Article';
-import { CapiArticle } from 'types/Capi';
+import { Atom, CapiArticle } from 'types/Capi';
 import type { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
 
@@ -44,6 +44,7 @@ export interface CardFormData {
 	videoReplace: boolean;
 	replaceVideoUri: string;
 	atomId: string;
+	replacementVideoAtom: Atom | undefined;
 }
 
 export type FormFields = keyof CardFormData;
@@ -154,6 +155,7 @@ export const getInitialValuesForCardForm = (
 				coverCardTabletImage: article.coverCardTabletImage || {},
 				isImmersive: article.isImmersive || false,
 				atomId: article.atomId || '',
+				replacementVideoAtom: article.replacementVideoAtom || undefined,
 			}
 		: undefined;
 };


### PR DESCRIPTION
## What's changed?
Fixes an issue where replacement videos would appear unsaved due to atom hydration making the form 'dirty'. We now reinitialise the form with the hydrated atom, which clears the save state.

Atom hydration is important as the lifecycle of the atom is independent to the lifecycle of the content. If the atom is updated to a different video asset, hydration allows this update to propagate to the Fronts Tool. Without this users might assume the video is not updating, delete and re-insert the video.

This PR also fixes some other bugs around clearing the replacement atom state.