### PR TITLE
Enable replacement video feature for all users

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,19 +33,11 @@ object TenImageSlideshows
       enabled = false
     )
 
-object EnableReplacementVideo
-    extends FeatureSwitch(
-      key = "enable-replacement-video",
-      title = "Enable replacement video",
-      enabled = false
-    )
-
 object FeatureSwitches {
   val all: List[FeatureSwitch] = List(
     ObscureFeed,
     PageViewDataVisualisation,
-    TenImageSlideshows,
-    EnableReplacementVideo
+    TenImageSlideshows
   )
 
   def updateFeatureSwitchesForUser(

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -82,7 +82,6 @@ import { getMainMediaVideoAtom } from '../../util/externalArticle';
 import { selectVideoBaseUrl } from '../../selectors/configSelectors';
 import SelectMediaInput from '../inputs/SelectMediaInput';
 import SelectMediaLabelContainer from '../inputs/SelectMediaLabelContainer';
-import pageConfig from '../../util/extractConfigFromPage';
 import type { Atom, AtomResponse } from '../../types/Capi';
 import Tooltip from '../modals/Tooltip';
 
@@ -564,11 +563,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		const slideshowHasAtLeastTwoImages =
 			(slideshow ?? []).filter((field) => !!field).length >= 2;
 
-		const enableReplacementVideoFeatureSwitch =
-			pageConfig?.userData?.featureSwitches.find(
-				(feature) => feature.key === 'enable-replacement-video',
-			);
-
 		const invalidCardReplacement = coverCardImageReplace
 			? !imageDefined(coverCardMobileImage) ||
 				!imageDefined(coverCardTabletImage)
@@ -916,9 +910,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											<InputLabel htmlFor="media-select">
 												Select Media
 											</InputLabel>
-											{enableReplacementVideoFeatureSwitch?.enabled ? (
-												<Tooltip />
-											) : null}
+											<Tooltip />
 										</SelectMediaLabelContainer>
 										<SelectMediaInput>
 											<Field
@@ -947,27 +939,21 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 											<Field
 												component={InputRadio}
 												icon={<SelectVideoIcon />}
-												disabled={
-													!hasMainVideo &&
-													enableReplacementVideoFeatureSwitch?.enabled !== true
-												}
 												contents={
-													enableReplacementVideoFeatureSwitch?.enabled ? (
-														<VideoControls
-															videoBaseUrl={videoBaseUrl}
-															mainMediaVideoAtom={mainMediaVideoAtom}
-															replacementVideoAtom={replacementVideoAtom}
-															showMainVideo={showMainVideo}
-															showReplacementVideo={videoReplace}
-															changeField={change}
-															changeMediaField={this.changeMediaField}
-															form={form}
-															replacementVideoControlsId={
-																replacementVideoControlsId
-															}
-															warningsContainerId={warningsContainerId}
-														/>
-													) : null
+													<VideoControls
+														videoBaseUrl={videoBaseUrl}
+														mainMediaVideoAtom={mainMediaVideoAtom}
+														replacementVideoAtom={replacementVideoAtom}
+														showMainVideo={showMainVideo}
+														showReplacementVideo={videoReplace}
+														changeField={change}
+														changeMediaField={this.changeMediaField}
+														form={form}
+														replacementVideoControlsId={
+															replacementVideoControlsId
+														}
+														warningsContainerId={warningsContainerId}
+													/>
 												}
 												usesBlockStyling={true}
 												name="media-select"
@@ -982,9 +968,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 													this.props.showMainVideo || this.props.videoReplace
 												}
 											/>
-											{enableReplacementVideoFeatureSwitch?.enabled ? (
-												<div id={replacementVideoControlsId} />
-											) : null}
+											<div id={replacementVideoControlsId} />
 										</SelectMediaInput>
 										<SelectMediaInput>
 											<Field


### PR DESCRIPTION
Removes the replacement video feature switch and enables the feature for all users.

The replacement video work has been in production (behind a switch) and not caused any major issues so this gives us confidence to release. We can roll back this PR if necessary.