### PR TITLE
Redux form prefers empty strings as undefined state

### DIFF
--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -54,7 +54,7 @@ const formValues = {
 	videoReplace: false,
 	replaceVideoUri: '',
 	atomId: '',
-	replacementVideoAtom: undefined,
+	replacementVideoAtom: '',
 };
 
 const createStateWithChangedFormFields = (

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -439,7 +439,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
 			const reinitialisedValues = {
 				...initialValues,
-				replacementVideoAtom: atom,
+				replacementVideoAtom: atom !== undefined ? atom : '',
 			};
 
 			// Hydrate the form with the latest atom, and reinitialise the form

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -44,7 +44,7 @@ export interface CardFormData {
 	videoReplace: boolean;
 	replaceVideoUri: string;
 	atomId: string;
-	replacementVideoAtom: Atom | undefined;
+	replacementVideoAtom: Atom | string;
 }
 
 export type FormFields = keyof CardFormData;
@@ -155,7 +155,7 @@ export const getInitialValuesForCardForm = (
 				coverCardTabletImage: article.coverCardTabletImage || {},
 				isImmersive: article.isImmersive || false,
 				atomId: article.atomId || '',
-				replacementVideoAtom: article.replacementVideoAtom || undefined,
+				replacementVideoAtom: article.replacementVideoAtom || '',
 			}
 		: undefined;
 };


### PR DESCRIPTION
## What's changed?
With #1828 we introduced a new bug where replacement videos could only be added to a card if there was a replacement video already set. This is because if replacement atom hydration failed (i.e. whenever the `atomId` field was empty), we would initialise the atom with a state of undefined, rather than empty string - which is what Redux form needs to work.

Falling back to an empty string allows videos to fail hydration gracefully, and the form doesn't get into a broken state.