### PR TITLE
Improve wording of tooltip

### DIFF
--- a/fronts-client/src/components/modals/Tooltip.tsx
+++ b/fronts-client/src/components/modals/Tooltip.tsx
@@ -52,8 +52,8 @@ export default () => {
 					<div>
 						<VideoIcon fill={'white'} />
 					</div>
-					Before the Video is played, we show its Trail Image. If no Trail Image
-					exists, we show its Poster Image.
+					Before a Youtube video is played, we show the card's Trail Image. If
+					no Trail Image exists, we show the Poster Image.
 				</TooltipModal>
 			) : null}
 		</Container>


### PR DESCRIPTION
## What's changed?
After some production testing on a Training Front I realised we definitely pull the Card's trail image through rather than the Video's trail image. I've amended the wording here to reflect that.

Also specified 'Youtube' video as self-hosted videos may have a different logic (when implemented).
