### PR TITLE
Remove `getBoostLevel` and replace boost adjustment logic with simple…

### DIFF
--- a/fronts-client/src/actions/__tests__/Cards.spec.ts
+++ b/fronts-client/src/actions/__tests__/Cards.spec.ts
@@ -16,7 +16,6 @@ import {
 	insertCardWithCreate,
 	addImageToCard,
 	cloneCardToTarget,
-	getBoostLevel,
 } from 'actions/Cards';
 import {
 	reducer as collectionsReducer,
@@ -372,79 +371,6 @@ describe('Cards actions', () => {
 				imageSlideshowReplace: false,
 				imageCutoutReplace: false,
 			});
-		});
-	});
-
-	describe('gets the correct boost level when moving cards (in relevant container types)', () => {
-		it('sets the boost level to the minimum if the current boost level is below the minimum required', () => {
-			// megaboost is the smallest boost level for `Very Big`
-			expect(getBoostLevel(null, 2, 0)).toEqual('megaboost');
-			// boost is the smallest boost level for `Big`
-			expect(getBoostLevel(null, 1, 0)).toEqual('boost');
-			// otherwise the minimum boost level is default
-			expect(getBoostLevel(null, 0, 0)).toEqual('default');
-		});
-
-		it('retains the boost level if the current boost level is the minimum required', () => {
-			expect(getBoostLevel(null, 2, 2)).toEqual('megaboost');
-			expect(getBoostLevel(null, 1, 1)).toEqual('boost');
-			expect(getBoostLevel(null, 0, 0)).toEqual('default');
-		});
-
-		it("retains the boost level if we're not moving from a group (i.e. a clipboard)", () => {
-			expect(getBoostLevel(null, 3, 0)).toEqual('default');
-			expect(getBoostLevel(null, 3, 1)).toEqual('boost');
-			expect(getBoostLevel(null, 3, 2)).toEqual('megaboost');
-			expect(getBoostLevel(null, 3, 3)).toEqual('gigaboost');
-
-			expect(getBoostLevel(null, 2, 2)).toEqual('megaboost');
-			expect(getBoostLevel(null, 2, 3)).toEqual('gigaboost');
-
-			expect(getBoostLevel(null, 1, 1)).toEqual('boost');
-			expect(getBoostLevel(null, 1, 2)).toEqual('megaboost');
-
-			expect(getBoostLevel(null, 0, 0)).toEqual('default');
-			expect(getBoostLevel(null, 0, 1)).toEqual('boost');
-			expect(getBoostLevel(null, 0, 2)).toEqual('megaboost');
-		});
-
-		it('reduces the boost level if the current boost level if we are moving down a group', () => {
-			expect(getBoostLevel(3, 2, 3)).toEqual('megaboost');
-			expect(getBoostLevel(3, 1, 2)).toEqual('boost');
-			expect(getBoostLevel(2, 0, 1)).toEqual('default');
-		});
-
-		it('sets the boost level to default if we are moving up a group, and the destination group is a splash group', () => {
-			expect(getBoostLevel(2, 3, 2)).toEqual('default');
-
-			expect(getBoostLevel(1, 3, 1)).toEqual('default');
-			expect(getBoostLevel(1, 3, 2)).toEqual('default');
-
-			expect(getBoostLevel(0, 3, 0)).toEqual('default');
-			expect(getBoostLevel(0, 3, 1)).toEqual('default');
-			expect(getBoostLevel(0, 3, 2)).toEqual('default');
-		});
-
-		it('retains the boost level if none of the other cases are met', () => {
-			// moving within the same group
-			expect(getBoostLevel(3, 3, 3)).toEqual('gigaboost');
-			expect(getBoostLevel(3, 3, 2)).toEqual('megaboost');
-			expect(getBoostLevel(3, 3, 1)).toEqual('boost');
-			expect(getBoostLevel(3, 3, 0)).toEqual('default');
-
-			expect(getBoostLevel(2, 2, 2)).toEqual('megaboost');
-
-			expect(getBoostLevel(1, 1, 1)).toEqual('boost');
-			expect(getBoostLevel(1, 1, 2)).toEqual('megaboost');
-
-			expect(getBoostLevel(0, 0, 0)).toEqual('default');
-			expect(getBoostLevel(0, 0, 1)).toEqual('boost');
-			expect(getBoostLevel(0, 0, 2)).toEqual('megaboost');
-
-			// moving up to a non-splash group
-			expect(getBoostLevel(0, 1, 1)).toEqual('boost');
-			expect(getBoostLevel(0, 1, 2)).toEqual('megaboost');
-			expect(getBoostLevel(1, 2, 2)).toEqual('megaboost');
 		});
 	});
 });


### PR DESCRIPTION
…r `mayResetBoostLevel` implementation.
## What's changed?
We no longer adjust the boost level up/down when moving between groups. Instead, when a card moves up or down one or more groups, or is added to a group from the clipboard or feed, it should adopt the minimum boost level of the group it moves into, regardless of its previous boost level. 

This change has been requested by Editorial to make the boost logic easier to predict when moving cards between fronts, groups, and containers. 
