### PR TITLE
Fix replacement video issues

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -84,6 +84,7 @@ import SelectMediaInput from '../inputs/SelectMediaInput';
 import SelectMediaLabelContainer from '../inputs/SelectMediaLabelContainer';
 import type { Atom, AtomResponse } from '../../types/Capi';
 import Tooltip from '../modals/Tooltip';
+import { isAtom } from '../../util/atom';
 
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
@@ -113,15 +114,6 @@ type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
 	change: (field: string, value: any) => void;
 	slideshowHasAtLeastTwoImages: boolean;
 	criteria: Criteria;
-};
-
-export const isAtom = (value: unknown): value is Atom => {
-	return (
-		typeof value === 'object' &&
-		typeof (value as Atom).id === 'string' &&
-		typeof (value as Atom).atomType === 'string' &&
-		typeof (value as Atom).data === 'object'
-	);
 };
 
 const SlideshowRowContainer = styled(RowContainer)`

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -115,6 +115,15 @@ type RenderSlideshowProps = WrappedFieldArrayProps<ImageData> & {
 	criteria: Criteria;
 };
 
+export const isAtom = (value: unknown): value is Atom => {
+	return (
+		typeof value === 'object' &&
+		typeof (value as Atom).id === 'string' &&
+		typeof (value as Atom).atomType === 'string' &&
+		typeof (value as Atom).data === 'object'
+	);
+};
+
 const SlideshowRowContainer = styled(RowContainer)`
 	flex: 1 1 auto;
 	overflow: visible;
@@ -442,7 +451,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			const reinitialisedValues = {
 				...initialValues,
 				// Redux form prefers empty strings to undefined values
-				replacementVideoAtom: atom !== undefined ? atom : '',
+				replacementVideoAtom: isAtom(atom) ? atom : '',
 			};
 
 			// Hydrate the form with the latest atom, and reinitialise the form
@@ -1069,7 +1078,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						<InvalidWarning warning="You need at least two images to make a slideshow" />
 					) : null}
 					{(showMainVideo && !hasMainVideo) ||
-					(videoReplace && !replacementVideoAtom) ? (
+					(videoReplace && !isAtom(replacementVideoAtom)) ? (
 						<InvalidWarning warning="You need to provide a valid video" />
 					) : null}
 				</div>
@@ -1087,7 +1096,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 							!valid ||
 							(imageSlideshowReplace && !slideshowHasAtLeastTwoImages) ||
 							(showMainVideo && !hasMainVideo) ||
-							(videoReplace && !replacementVideoAtom)
+							(videoReplace && !isAtom(replacementVideoAtom))
 						}
 						size="l"
 						data-testid="edit-form-save-button"

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -441,6 +441,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
 			const reinitialisedValues = {
 				...initialValues,
+				// Redux form prefers empty strings to undefined values
 				replacementVideoAtom: atom !== undefined ? atom : '',
 			};
 
@@ -1260,7 +1261,7 @@ interface ContainerProps {
 	videoReplace: boolean;
 	replaceVideoUri: string;
 	atomId: string;
-	replacementVideoAtom: Atom | undefined;
+	replacementVideoAtom: Atom | undefined | string;
 	videoBaseUrl: string | null;
 }
 

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -428,7 +428,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	}
 
 	async componentDidUpdate(prevProps: Readonly<Props>) {
-		const atomIsAlreadyDefined = this.props.replacementVideoAtom !== undefined;
 		const atomIdChanged = prevProps.atomId !== this.props.atomId;
 
 		if (this.isFirstLoad) {
@@ -447,7 +446,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			return;
 		}
 
-		if (atomIsAlreadyDefined && atomIdChanged) {
+		if (atomIdChanged) {
 			this.debouncedFetchAndSetReplacementVideoAtom();
 		}
 	}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -428,11 +428,15 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	}
 
 	async componentDidUpdate(prevProps: Readonly<Props>) {
-		const atomIdChanged = prevProps.atomId !== this.props.atomId;
+		const { atomId } = this.props;
+		const atomIdChanged = prevProps.atomId !== atomId;
 
 		if (this.isFirstLoad) {
 			this.isFirstLoad = false;
-			const atom = await this.getAtom(this.props.atomId);
+			if (atomId === '' || atomId === undefined) {
+				return;
+			}
+			const atom = await this.getAtom(atomId);
 			const initialValues = this.props.initialValues;
 
 			const reinitialisedValues = {
@@ -479,12 +483,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 		}
 	};
 
-	private getAtom = async (
-		atomId: string | undefined,
-	): Promise<Atom | undefined> => {
-		if (atomId === undefined) {
-			return undefined;
-		}
+	private getAtom = async (atomId: string): Promise<Atom | undefined> => {
 		return this.fetchAtom(atomId)
 			.then((response) => response.media)
 			.catch(() => undefined);

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -22,9 +22,10 @@ import { VideoUriInput } from '../inputs/VideoUriInput';
 import { useDispatch } from 'react-redux';
 import Explainer from '../Explainer';
 import { OverlayModal } from '../modals/OverlayModal';
-import { InvalidWarning, isAtom } from '../form/ArticleMetaForm';
+import { InvalidWarning } from '../form/ArticleMetaForm';
 import type { Atom } from '../../types/Capi';
 import urlConstants from '../../constants/url';
+import { isAtom } from '../../util/atom';
 
 interface VideoControlsProps {
 	videoBaseUrl: string | null;

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -29,7 +29,7 @@ import urlConstants from '../../constants/url';
 interface VideoControlsProps {
 	videoBaseUrl: string | null;
 	mainMediaVideoAtom: Atom | undefined;
-	replacementVideoAtom: Atom | undefined;
+	replacementVideoAtom: Atom | undefined | string;
 	showMainVideo: boolean;
 	showReplacementVideo: boolean;
 	changeField: (field: string, value: any) => void;
@@ -187,7 +187,10 @@ export const VideoControls = ({
 	};
 
 	useEffect(() => {
-		if (replacementVideoAtom !== undefined) {
+		if (
+			typeof replacementVideoAtom !== 'string' &&
+			replacementVideoAtom !== undefined
+		) {
 			const atomProperties = extractAtomProperties(replacementVideoAtom);
 			setReplacementVideoAtomProperties(atomProperties);
 		} else {
@@ -241,7 +244,8 @@ export const VideoControls = ({
 
 	const replacementVideoIsSelfHosted =
 		showReplacementVideo &&
-		replacementVideoAtom !== null &&
+		replacementVideoAtom !== undefined &&
+		typeof replacementVideoAtom !== 'string' &&
 		replacementVideoAtomProperties?.platform === 'url';
 
 	return (
@@ -258,12 +262,17 @@ export const VideoControls = ({
 								name="useReplacementVideo"
 								component={InputCheckboxToggleInline}
 								label="Use replacement video"
-								disabled={!replacementVideoAtom}
+								disabled={
+									replacementVideoAtom === undefined ||
+									typeof replacementVideoAtom === 'string'
+								}
 								id={`${replacementVideoControlsId}-useReplacementVideo`}
 								type="checkbox"
 								dataTestId="use-replacement-video"
 								checked={
-									showReplacementVideo && replacementVideoAtom !== undefined
+									showReplacementVideo &&
+									typeof replacementVideoAtom !== 'string' &&
+									replacementVideoAtom !== undefined
 								}
 								onChange={() => {
 									if (showReplacementVideo) {
@@ -273,7 +282,8 @@ export const VideoControls = ({
 									}
 								}}
 							/>
-							{!replacementVideoAtom && (
+							{(replacementVideoAtom === undefined ||
+								typeof replacementVideoAtom === 'string') && (
 								<Explainer>Replacement video required</Explainer>
 							)}
 						</MarginWrapper>,
@@ -329,22 +339,24 @@ export const VideoControls = ({
 						<PreviewVideoIcon />
 						Preview video
 					</VideoAction>
-					{showReplacementVideo && replacementVideoAtom && (
-						<ButtonDelete
-							type="button"
-							priority="primary"
-							onClick={handleDelete}
-							confirmDelete={confirmDelete}
-						>
-							<DeleteIconOptions>
-								{confirmDelete ? (
-									<ConfirmDeleteIcon size="s" />
-								) : (
-									<RubbishBinIcon size="s" />
-								)}
-							</DeleteIconOptions>
-						</ButtonDelete>
-					)}
+					{showReplacementVideo &&
+						replacementVideoAtom !== undefined &&
+						typeof replacementVideoAtom !== 'string' && (
+							<ButtonDelete
+								type="button"
+								priority="primary"
+								onClick={handleDelete}
+								confirmDelete={confirmDelete}
+							>
+								<DeleteIconOptions>
+									{confirmDelete ? (
+										<ConfirmDeleteIcon size="s" />
+									) : (
+										<RubbishBinIcon size="s" />
+									)}
+								</DeleteIconOptions>
+							</ButtonDelete>
+						)}
 				</VideoControlsInnerContainer>
 				<Field
 					name="replaceVideoUri"

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -22,7 +22,7 @@ import { VideoUriInput } from '../inputs/VideoUriInput';
 import { useDispatch } from 'react-redux';
 import Explainer from '../Explainer';
 import { OverlayModal } from '../modals/OverlayModal';
-import { InvalidWarning } from '../form/ArticleMetaForm';
+import { InvalidWarning, isAtom } from '../form/ArticleMetaForm';
 import type { Atom } from '../../types/Capi';
 import urlConstants from '../../constants/url';
 
@@ -187,10 +187,7 @@ export const VideoControls = ({
 	};
 
 	useEffect(() => {
-		if (
-			typeof replacementVideoAtom !== 'string' &&
-			replacementVideoAtom !== undefined
-		) {
+		if (isAtom(replacementVideoAtom)) {
 			const atomProperties = extractAtomProperties(replacementVideoAtom);
 			setReplacementVideoAtomProperties(atomProperties);
 		} else {
@@ -239,13 +236,12 @@ export const VideoControls = ({
 
 	const mainMediaIsSelfHosted =
 		showMainVideo &&
-		mainMediaVideoAtom !== null &&
+		isAtom(mainMediaVideoAtom) &&
 		mainMediaVideoAtomProperties?.platform === 'url';
 
 	const replacementVideoIsSelfHosted =
 		showReplacementVideo &&
-		replacementVideoAtom !== undefined &&
-		typeof replacementVideoAtom !== 'string' &&
+		isAtom(replacementVideoAtom) &&
 		replacementVideoAtomProperties?.platform === 'url';
 
 	return (
@@ -262,18 +258,11 @@ export const VideoControls = ({
 								name="useReplacementVideo"
 								component={InputCheckboxToggleInline}
 								label="Use replacement video"
-								disabled={
-									replacementVideoAtom === undefined ||
-									typeof replacementVideoAtom === 'string'
-								}
+								disabled={!isAtom(replacementVideoAtom)}
 								id={`${replacementVideoControlsId}-useReplacementVideo`}
 								type="checkbox"
 								dataTestId="use-replacement-video"
-								checked={
-									showReplacementVideo &&
-									typeof replacementVideoAtom !== 'string' &&
-									replacementVideoAtom !== undefined
-								}
+								checked={showReplacementVideo && isAtom(replacementVideoAtom)}
 								onChange={() => {
 									if (showReplacementVideo) {
 										changeMediaField('showMainVideo');
@@ -282,8 +271,7 @@ export const VideoControls = ({
 									}
 								}}
 							/>
-							{(replacementVideoAtom === undefined ||
-								typeof replacementVideoAtom === 'string') && (
+							{!isAtom(replacementVideoAtom) && (
 								<Explainer>Replacement video required</Explainer>
 							)}
 						</MarginWrapper>,
@@ -339,24 +327,22 @@ export const VideoControls = ({
 						<PreviewVideoIcon />
 						Preview video
 					</VideoAction>
-					{showReplacementVideo &&
-						replacementVideoAtom !== undefined &&
-						typeof replacementVideoAtom !== 'string' && (
-							<ButtonDelete
-								type="button"
-								priority="primary"
-								onClick={handleDelete}
-								confirmDelete={confirmDelete}
-							>
-								<DeleteIconOptions>
-									{confirmDelete ? (
-										<ConfirmDeleteIcon size="s" />
-									) : (
-										<RubbishBinIcon size="s" />
-									)}
-								</DeleteIconOptions>
-							</ButtonDelete>
-						)}
+					{showReplacementVideo && isAtom(replacementVideoAtom) && (
+						<ButtonDelete
+							type="button"
+							priority="primary"
+							onClick={handleDelete}
+							confirmDelete={confirmDelete}
+						>
+							<DeleteIconOptions>
+								{confirmDelete ? (
+									<ConfirmDeleteIcon size="s" />
+								) : (
+									<RubbishBinIcon size="s" />
+								)}
+							</DeleteIconOptions>
+						</ButtonDelete>
+					)}
 				</VideoControlsInnerContainer>
 				<Field
 					name="replaceVideoUri"

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -93,7 +93,7 @@ type CardRootMeta = ChefCardMeta &
 		snapCss?: string;
 		atomId?: string;
 		imageSlideshowReplace?: boolean;
-		replacementVideoAtom?: Atom;
+		replacementVideoAtom?: Atom | string;
 		slideshow?: Array<{
 			src?: string;
 			thumb?: string;

--- a/fronts-client/src/util/CAPIUtils.ts
+++ b/fronts-client/src/util/CAPIUtils.ts
@@ -83,6 +83,12 @@ function getThumbnail(
 	) {
 		return meta.slideshow[0].src;
 	} else if (meta.videoReplace) {
+		if (
+			typeof meta.replacementVideoAtom === 'string' ||
+			meta.replacementVideoAtom === undefined
+		) {
+			return undefined;
+		}
 		const atomProperties = extractAtomProperties(meta.replacementVideoAtom);
 		if (
 			atomProperties !== undefined &&

--- a/fronts-client/src/util/CAPIUtils.ts
+++ b/fronts-client/src/util/CAPIUtils.ts
@@ -4,6 +4,7 @@ import { CardMeta } from '../types/Collection';
 import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import startCase from 'lodash/startCase';
 import { extractAtomProperties } from './extractAtomId';
+import { isAtom } from '../components/form/ArticleMetaForm';
 
 const getIdFromURL = (url: string): string | undefined => {
 	const [, id = null] =
@@ -83,10 +84,7 @@ function getThumbnail(
 	) {
 		return meta.slideshow[0].src;
 	} else if (meta.videoReplace) {
-		if (
-			typeof meta.replacementVideoAtom === 'string' ||
-			meta.replacementVideoAtom === undefined
-		) {
+		if (!isAtom(meta.replacementVideoAtom)) {
 			return undefined;
 		}
 		const atomProperties = extractAtomProperties(meta.replacementVideoAtom);

--- a/fronts-client/src/util/CAPIUtils.ts
+++ b/fronts-client/src/util/CAPIUtils.ts
@@ -4,7 +4,7 @@ import { CardMeta } from '../types/Collection';
 import { notLiveLabels, liveBlogTones } from 'constants/fronts';
 import startCase from 'lodash/startCase';
 import { extractAtomProperties } from './extractAtomId';
-import { isAtom } from '../components/form/ArticleMetaForm';
+import { isAtom } from './atom';
 
 const getIdFromURL = (url: string): string | undefined => {
 	const [, id = null] =

--- a/fronts-client/src/util/atom.ts
+++ b/fronts-client/src/util/atom.ts
@@ -1,0 +1,10 @@
+import type { Atom } from '../types/Capi';
+
+export const isAtom = (value: unknown): value is Atom => {
+	return (
+		typeof value === 'object' &&
+		typeof (value as Atom).id === 'string' &&
+		typeof (value as Atom).atomType === 'string' &&
+		typeof (value as Atom).data === 'object'
+	);
+};

--- a/fronts-client/src/util/extractAtomId.ts
+++ b/fronts-client/src/util/extractAtomId.ts
@@ -99,15 +99,7 @@ const getVideoUri = (atomProperties: AtomProperties | undefined) => {
 		: atomProperties?.assetId;
 };
 
-const extractAtomProperties = (atom?: Atom): AtomProperties => {
-	if (atom === undefined) {
-		return {
-			assetId: undefined,
-			videoImage: undefined,
-			platform: undefined,
-		};
-	}
-
+const extractAtomProperties = (atom: Atom): AtomProperties => {
 	const assetId = extractAssetId(atom);
 	const videoImage = extractVideoImage(atom);
 	const platform = extractPlatform(atom);


### PR DESCRIPTION
## What's changed?
This PR cleans up some issues around the video replacement feature released in #1829. 

Stricter type checking should handle when the atom is undefined as well as when as it is an empty string (Redux form's preferred way of storing empty fields). 

We no longer try to fetch an atom if the atomId is undefined. 