### PR TITLE
Ab/fix boost bugs

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -98,7 +98,8 @@ function getNextGroupTarget(
 	currentGroupId: string,
 	groupIds?: string[],
 	groupsData?: Group[],
-) {
+	collectionId?: string,
+): PosSpec | undefined {
 	if (!groupIds || !groupsData) {
 		return;
 	}
@@ -119,6 +120,7 @@ function getNextGroupTarget(
 		groupMaxItems: nextGroup?.maxItems,
 		groupsData: groupsData,
 		cards: nextGroup?.cardsData,
+		collectionId,
 	};
 }
 type CollectionMove<T> = {
@@ -142,7 +144,7 @@ export const buildMoveQueue = (move: Move<TCard>) => {
 
 	// If inserting at the bottom of a full group, move the card to the next group instead.
 	const target = isBottomInsert
-		? getNextGroupTarget(to.id, to.groupIds, to.groupsData)
+		? getNextGroupTarget(to.id, to.groupIds, to.groupsData, to.collectionId)
 		: to;
 
 	if (!target) return queue;
@@ -189,6 +191,7 @@ export const buildMoveQueue = (move: Move<TCard>) => {
 			currentGroup.uuid,
 			move.to.groupIds,
 			move.to.groupsData,
+			move.to.collectionId,
 		);
 
 		if (lastCard && nextTarget) {


### PR DESCRIPTION
## What's changed?
There were multiple bugs in the automated boost logic that were causing the boost levels to be removed or set incorrecly. This PR removed fixes the following bugs: 

**- Boost level being reset when a card is moved within a group**
fix :  passes `from` context to the automated boost function. This is to check if the card is moving within the same group. If it is, we dont want to reset the boost level of that card. 
**- Boost level not being reset when a card is moved as a consequence of another card being moved** (eg when a group is full so a card is pushed down to the next group)
fix : make sure we pass the collection id when constructing a `to` target. This is required in the automated boost function to determine its a flex/gen collection. Without this, the function returns without reseting the boost level. 
**- Cards getting the wrong boost level attached to them** 
fix: rely on the group name rather than the group id for determining the default boost setting for a group. This is because the group id is not stable or reliable. 




## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
- [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 