### PR TITLE
Add tests for resetting boost levels

### DIFF
--- a/fronts-client/src/components/FrontsEdit/__tests__/mayResetBoostLevel.spec.tsx
+++ b/fronts-client/src/components/FrontsEdit/__tests__/mayResetBoostLevel.spec.tsx
@@ -1,0 +1,78 @@
+import type { Card } from 'types/Collection';
+
+import { mayResetBoostLevel } from '../../../actions/Cards';
+import { baseTo, baseFrom } from './fixtures/groups.fixture';
+
+describe('mayResetBoostLevel', () => {
+	it('should early exit if to is not a group', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			baseFrom,
+			{ ...baseTo, type: 'not-a-group' },
+			card,
+			'collection',
+		);
+		expect(result).toBe(undefined);
+	});
+	it('should early exit if the card is being persisted to the clipboard', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			baseFrom,
+			{ ...baseTo, type: 'not-a-group' },
+			card,
+			'clipboard',
+		);
+		expect(result).toBe(undefined);
+	});
+
+	it('should not reset the boost level if the card is moving inside the same group', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			{ ...baseFrom, id: 'group-1' },
+			{ ...baseTo, id: 'group-1' },
+			card,
+			'collection',
+		);
+		expect(result).toBe(undefined);
+	});
+	it('should reset the boost level to `default` if the card is moving to a standard group', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			baseFrom,
+			{ ...baseTo, groupName: 'standard' },
+			card,
+			'collection',
+		);
+		expect(result?.payload.meta.boostLevel).toBe('default');
+	});
+	it('should reset the boost level to `default` if the card is moving to a splash group', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			baseFrom,
+			{ ...baseTo, groupName: 'splash' },
+			card,
+			'collection',
+		);
+		expect(result?.payload.meta.boostLevel).toBe('default');
+	});
+	it('should reset the boost level to `boost` if the card is moving to a big group', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			baseFrom,
+			{ ...baseTo, groupName: 'big' },
+			card,
+			'collection',
+		);
+		expect(result?.payload.meta.boostLevel).toBe('boost');
+	});
+	it('should reset the boost level to `megaboost` if the card is moving to a very big group', () => {
+		const card = {} as Card;
+		const result = mayResetBoostLevel(
+			baseFrom,
+			{ ...baseTo, groupName: 'very big' },
+			card,
+			'collection',
+		);
+		expect(result?.payload.meta.boostLevel).toBe('megaboost');
+	});
+});


### PR DESCRIPTION
## What's changed?
@Georges-GNM quite rightly pointed out that there are no tests for the logic that determines if a cards boost level should be reset - this PR adds test coverage for this logic.

As part of writing these tests, there has been a small refactor to lift the check to ensure the card is in a flexible general collection check outside of the mayResetBoostlevel function. This helps simplify the function and also ensure we are in a flexible general container before attempting to reset the card's boost level.

### General
- [x] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
