### PR TITLE
Fix race condition where form reinitialisation clears user edits

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -435,33 +435,47 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	}
 
 	async componentDidUpdate(prevProps: Readonly<Props>) {
-		const { atomId } = this.props;
-		const atomIdChanged = prevProps.atomId !== atomId;
-
 		if (this.isFirstLoad) {
 			this.isFirstLoad = false;
-			if (atomId === '' || atomId === undefined) {
-				return;
-			}
-			const atom = await this.getAtom(atomId);
-			const initialValues = this.props.initialValues;
-
-			const reinitialisedValues = {
-				...initialValues,
-				// Redux form prefers empty strings to undefined values
-				replacementVideoAtom: isAtom(atom) ? atom : '',
-			};
-
-			// Hydrate the form with the latest atom, and reinitialise the form
-			// so that the form state is 'pristine' and doesn't appear unsaved.
-			this.props.initialize(reinitialisedValues);
+			await this.handleFirstLoad();
 			return;
 		}
 
-		if (atomIdChanged) {
+		if (prevProps.atomId !== this.props.atomId) {
 			this.debouncedFetchAndSetReplacementVideoAtom();
 		}
 	}
+
+	private reinitialiseWithAtom = (replacementAtom: Atom | '') => {
+		const reinitialisedValues = {
+			...this.props.initialValues,
+			replacementVideoAtom: replacementAtom,
+		};
+
+		this.props.initialize(reinitialisedValues);
+		return;
+	};
+
+	private handleFirstLoad = async () => {
+		if (this.props.atomId === '' || this.props.atomId === undefined) {
+			return;
+		}
+		const replacementAtomResponse = await this.getAtom(this.props.atomId);
+
+		// Redux form prefers empty strings to undefined values
+		const replacementAtom = isAtom(replacementAtomResponse)
+			? replacementAtomResponse
+			: '';
+
+		if (this.props.pristine) {
+			// If the form has not changed since the initial values, reinitialise the form with the hydrated atom
+			// so that the form state remains 'pristine' and doesn't appear unsaved.
+			this.reinitialiseWithAtom(replacementAtom);
+		} else {
+			// The form is already "dirty" with changes, so we can hydrate the atom without reinitialising.
+			this.props.change('replacementVideoAtom', replacementAtom);
+		}
+	};
 
 	private fetchAndSetReplacementVideoAtom = async (
 		atomId: string | undefined,


### PR DESCRIPTION
Paired on with @abeddow91 
___

## What's changed?
In https://github.com/guardian/facia-tool/pull/1828 we reinitialised the form with the hydrated atom to avoid displaying unsaved changes. When reinitialising we used the initial values of the form, rather than the current values, which led to a race condition where user edits could be erased if they were completed before the atom had finished hydration.

To fix this, we only reinitialise the form if no user edits have taken place. If they have, there's no need to reinitialise as the form is legitimately dirty - and we want to preserve that fact to show there are unsaved changes.


