### PR TITLE
Only fetch replacement video atom if videoReplace field is set

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -441,7 +441,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			return;
 		}
 
-		if (prevProps.atomId !== this.props.atomId) {
+		if (this.props.videoReplace && prevProps.atomId !== this.props.atomId) {
 			this.debouncedFetchAndSetReplacementVideoAtom();
 		}
 	}
@@ -457,7 +457,11 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 	};
 
 	private handleFirstLoad = async () => {
-		if (this.props.atomId === '' || this.props.atomId === undefined) {
+		if (
+			!this.props.videoReplace ||
+			this.props.atomId === '' ||
+			this.props.atomId === undefined
+		) {
 			return;
 		}
 		const replacementAtomResponse = await this.getAtom(this.props.atomId);


### PR DESCRIPTION
## What's changed?

Currently, for snap links, we are fetching interactive atoms and storing them as replacement video atoms. This is because snap links also use the `atomId` field and we were only checking for this field. 

This PR tightens the check. We only want to fetch for a replacement video atom if the atomId field is set _and_ the `videoReplace` field is true