### PR TITLE
New card boost bug 

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -42,9 +42,7 @@ import {
 	InsertActionCreator,
 	InsertThunkActionCreator,
 } from 'types/Cards';
-import { FLEXIBLE_GENERAL_NAME } from 'constants/flexibleContainers';
 import { PersistTo } from '../types/Middleware';
-import { selectors as collectionSelectors } from '../bundles/collectionsBundle';
 
 // Creates a thunk action creator from a plain action creator that also allows
 // passing a persistence location
@@ -214,11 +212,6 @@ const minimumGroupBoostLevel = (groupName: string) => {
 	}
 };
 
-const isFlexibleGeneralContainer = (state: State, collectionId?: string) => {
-	if (!collectionId) return false;
-	const collection = collectionSelectors.selectById(state, collectionId);
-	return collection?.type === FLEXIBLE_GENERAL_NAME;
-};
 /**
  * When a card moves up or down one or more groups,
  * it should adopt the minimum boost level
@@ -271,16 +264,10 @@ const insertCardWithCreate =
 					return;
 				}
 
-				if (isFlexibleGeneralContainer(state, to.collectionId)) {
-					const modifyCardAction = mayResetBoostLevel(
-						null,
-						to,
-						card,
-						persistTo,
-					);
+				const modifyCardAction = mayResetBoostLevel(null, to, card, persistTo);
 
-					if (modifyCardAction) dispatch(modifyCardAction);
-				}
+				if (modifyCardAction) dispatch(modifyCardAction);
+
 				dispatch(
 					insertActionCreator(
 						toWithRespectToState.id,
@@ -381,15 +368,13 @@ const moveCard = (
 					dispatch(cardsReceived([parent, ...supporting]));
 				}
 
-				if (isFlexibleGeneralContainer(state, to.collectionId)) {
-					const modifyCardAction = mayResetBoostLevel(
-						from,
-						to,
-						parent,
-						persistTo,
-					);
-					if (modifyCardAction) dispatch(modifyCardAction);
-				}
+				const modifyCardAction = mayResetBoostLevel(
+					from,
+					to,
+					parent,
+					persistTo,
+				);
+				if (modifyCardAction) dispatch(modifyCardAction);
 
 				dispatch(
 					insertActionCreator(


### PR DESCRIPTION
## What's changed?
Remove the flexible general check as we do not reliably have access to the collection id which was causing the following  bug:

when a new card is dropped in from the feed and pushes a card from one group to another, the boost level is not reset. This is becuase we validate the container type is flexible/general via the collection id before resetting the boost level. 

All cards have a boost level set on them by default anyway so we can run this function in any container and have the boost level set to default. We would like to optimise again this as it is unefficient, but the priority is resolving the production boost bug. 

**before** 
https://github.com/user-attachments/assets/57900891-de16-4077-b4f0-03cf30b39748


**after**
https://github.com/user-attachments/assets/636c031c-8cb0-4f3f-9b7d-be01ca7fbe28


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
