### PR TITLE
Enable ASG migration in progress option

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,6 +4,8 @@ stacks: [cms-fronts]
 deployments:
   facia-tool:
     type: autoscaling
+    parameters:
+      asgMigrationInProgress: true
     dependencies:
         - facia-tool-ami-update
   facia-tool-ami-update:


### PR DESCRIPTION
## What does this change?

Enables a riff-raff option to deploy the app to multiple ASGs.  We are currently migration from one VPC to another so expect there to be 2 ASGs.
