### PR TITLE
quickfix: Remove a space to ensure there's no possible crash on iOS

### DIFF
--- a/fronts-client/src/constants/feastPalettes.ts
+++ b/fronts-client/src/constants/feastPalettes.ts
@@ -154,7 +154,7 @@ export const feastCollectionPalettes: PaletteOption[] = [
 				backgroundHex: '#363632',
 			},
 		},
-		imageURL: ' https://uploads.guim.co.uk/2024/11/18/Berries.png',
+		imageURL: 'https://uploads.guim.co.uk/2024/11/18/Berries.png',
 	},
 	{
 		id: 'blackberries_blueberries',


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Removed a prefixing space character that unfortunately lead to an iOS crash. We'll take extra measures to ensure this is mitigated downstream as well, but this should be fixed here too.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
