### PR TITLE
Remove self-hosted video warning

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -648,7 +648,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 
 		const cardCriteria = this.determineCardCriteria();
 		const extraVideoControlsId = getInputId(cardId, 'extra-video-controls');
-		const warningsContainerId = getInputId(cardId, 'warnings-container');
 
 		return (
 			<FormContainer
@@ -972,7 +971,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 														changeMediaField={this.changeMediaField}
 														form={form}
 														extraVideoControlsId={extraVideoControlsId}
-														warningsContainerId={warningsContainerId}
 													/>
 												}
 												usesBlockStyling={true}
@@ -1085,7 +1083,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						</RowContainer>
 					)}
 				</FormContent>
-				<div id={warningsContainerId}>
+				<div>
 					{imageSlideshowReplace && !slideshowHasAtLeastTwoImages ? (
 						<InvalidWarning warning="You need at least two images to make a slideshow" />
 					) : null}

--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -23,7 +23,6 @@ import { VideoUriInput } from '../inputs/VideoUriInput';
 import { useDispatch } from 'react-redux';
 import Explainer from '../Explainer';
 import { OverlayModal } from '../modals/OverlayModal';
-import { InvalidWarning } from '../form/ArticleMetaForm';
 import type { Atom } from '../../types/Capi';
 import urlConstants from '../../constants/url';
 import { isAtom } from '../../util/atom';
@@ -38,7 +37,6 @@ interface VideoControlsProps {
 	changeMediaField: (fieldToSet: string) => void;
 	form: any;
 	extraVideoControlsId: string;
-	warningsContainerId: string;
 }
 
 const VideoControlsOuterContainer = styled.div`
@@ -94,7 +92,6 @@ export const VideoControls = ({
 	changeMediaField,
 	form,
 	extraVideoControlsId,
-	warningsContainerId,
 }: VideoControlsProps) => {
 	const [mainMediaVideoAtomProperties, setMainMediaVideoAtomProperties] =
 		React.useState<AtomProperties>();
@@ -256,8 +253,6 @@ export const VideoControls = ({
 
 	const extraVideoControls = document.getElementById(extraVideoControlsId);
 
-	const warningsContainer = document.getElementById(warningsContainerId);
-
 	return (
 		<>
 			{extraVideoControls !== null &&
@@ -387,13 +382,6 @@ export const VideoControls = ({
 					normalize={stripQueryParams}
 				></Field>
 			</VideoControlsOuterContainer>
-			{warningsContainer !== null &&
-			(isMainVideoSelfHosted || isReplacementVideoSelfHosted)
-				? createPortal(
-						<InvalidWarning warning="Self-hosted videos are not supported" />,
-						warningsContainer,
-					)
-				: null}
 		</>
 	);
 };


### PR DESCRIPTION
<img width="994" height="710" alt="image" src="https://github.com/user-attachments/assets/c2a910c0-4469-4fc3-aaca-1783d8b0c791" />

We released loops to all users in #1837, but missed that we no longer need to render the warning over self-hosted videos. This PR fixes that.

While we're here we can remove the portal to the warnings container, and all the associated scaffolding.