### PR TITLE
Fix replace video bug

### DIFF
--- a/fronts-client/src/components/video/VideoControls.tsx
+++ b/fronts-client/src/components/video/VideoControls.tsx
@@ -145,6 +145,7 @@ export const VideoControls = ({
 		}
 
 		if (data.atomId) {
+			changeMediaField('videoReplace');
 			dispatch(
 				change(
 					form,
@@ -165,7 +166,6 @@ export const VideoControls = ({
 					`${videoBaseUrl}/videos/${data.atomId}`,
 				),
 			);
-			changeMediaField('videoReplace');
 			handleCloseMediaAtomMakerModal();
 		}
 


### PR DESCRIPTION
## What's changed?
Currently the MAM integration (Replace video button) is not working in PROD. 

<img width="206" height="269" alt="image" src="https://github.com/user-attachments/assets/33cb821a-ee9e-429c-b760-0ffdbc208367" />

The `atomId` and `replaceVideoUri` fields are being updated by the modal; but this is not triggering a fetch for the `replacementVideoAtom`. 

I think this is because the `videoReplace` field needs to be set to true _before_ the atomId is updated - otherwise the `componentDidUpdate` method in `ArticleMetaForm` ignores the `atomId` change.

Note this is hard to test on local / CODE because of the MAM environment mixing; but I have tested locally by forcing the modal to return a PROD video and it seems to fix the issue.