### PR TITLE
Fixes runtime error when groupsConfig is not defined

### DIFF
--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -11,13 +11,16 @@ trait FlexibleContainer {
 object FlexibleGeneral extends FlexibleContainer {
   def storiesVisible(
       stories: Seq[Story],
-      collectionConfigJson: Option[CollectionConfigJson]
+	  maybeCollectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
-    val totalMaxItems = collectionConfigJson.get.groupsConfig
-      .getOrElse(Nil)
-      .flatMap(_.maxItems)
-      .sum
-    totalMaxItems
+  	maybeCollectionConfigJson match {
+		case Some(collectionConfigJson) =>
+			collectionConfigJson.groupsConfig.getOrElse(Nil)
+				.flatMap(_.maxItems)
+				.sum
+		case None =>
+			stories.size
+  	}
   }
 }
 

--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -11,16 +11,17 @@ trait FlexibleContainer {
 object FlexibleGeneral extends FlexibleContainer {
   def storiesVisible(
       stories: Seq[Story],
-	  maybeCollectionConfigJson: Option[CollectionConfigJson]
+      maybeCollectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
-  	maybeCollectionConfigJson match {
-		case Some(collectionConfigJson) =>
-			collectionConfigJson.groupsConfig.getOrElse(Nil)
-				.flatMap(_.maxItems)
-				.sum
-		case None =>
-			stories.size
-  	}
+    maybeCollectionConfigJson match {
+      case Some(collectionConfigJson) =>
+        collectionConfigJson.groupsConfig
+          .getOrElse(Nil)
+          .flatMap(_.maxItems)
+          .sum
+      case None =>
+        stories.size
+    }
   }
 }
 


### PR DESCRIPTION
From @jacobwinch in DevX:
> It looks like [a lot of 500 errors are being served for POSTs to `/stories-visible/flexible/general`](https://logs.gutools.co.uk/s/editorial-tools/app/r/s/T8tfD). I think this is happening because we are setting collectionConfigJson to None [here](https://github.com/guardian/facia-tool/blob/293e63d9531f5974f69109348f1c958942dc08c6/app/controllers/StoriesVisibleController.scala#L28) and then calling get on it [here](https://github.com/guardian/facia-tool/blob/293e63d9531f5974f69109348f1c958942dc08c6/app/slices/FlexibleContainer.scala#L16).

This PR fixes the runtime error; and defaults to the max number of stories when no groupsConfig provided.