### PR TITLE
Revert "Fixes runtime error when groupsConfig is not defined"

### DIFF
--- a/app/slices/FlexibleContainer.scala
+++ b/app/slices/FlexibleContainer.scala
@@ -11,17 +11,13 @@ trait FlexibleContainer {
 object FlexibleGeneral extends FlexibleContainer {
   def storiesVisible(
       stories: Seq[Story],
-      maybeCollectionConfigJson: Option[CollectionConfigJson]
+      collectionConfigJson: Option[CollectionConfigJson]
   ): Int = {
-    maybeCollectionConfigJson match {
-      case Some(collectionConfigJson) =>
-        collectionConfigJson.groupsConfig
-          .getOrElse(Nil)
-          .flatMap(_.maxItems)
-          .sum
-      case None =>
-        stories.size
-    }
+    val totalMaxItems = collectionConfigJson.get.groupsConfig
+      .getOrElse(Nil)
+      .flatMap(_.maxItems)
+      .sum
+    totalMaxItems
   }
 }
 


### PR DESCRIPTION
Reverts guardian/facia-tool#1848 while we investigate an ongoing issue