### PR TITLE
Update SNS topic ARN for GuCDK facia-press

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,7 +119,7 @@ PROD {
   publish_events.queue_url="https://sqs.eu-west-1.amazonaws.com/163592447864/publish-events-PROD"
 }
 
-faciatool.sns.tool_topic_arn="arn:aws:sns:eu-west-1:163592447864:facia-CODE-FrontsUpdateSNSTopic-RepwK3g95V3w"
+faciatool.sns.tool_topic_arn="arn:aws:sns:eu-west-1:642631414762:frontend-CODE-facia-press-FrontsUpdateSNSTopic280DF790-s8MaUUSSF1vP"
 PROD {
     faciatool.sns.tool_topic_arn="arn:aws:sns:eu-west-1:163592447864:facia-PROD-FrontsUpdateSNSTopic-kWN6oX2kvOmI"
 }


### PR DESCRIPTION
## What's changed?
This change updates the `faciatool.sns.tool_topic_arn` to point to the new SNS topic created by the facia-press GuCDK stack. This ensures facia-tool can correctly publish press requests to the new infrastructure.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
