### PR TITLE
remove asg migration flag to stop riff-raff from deploying to old infra

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,8 +4,6 @@ stacks: [cms-fronts]
 deployments:
   facia-tool:
     type: autoscaling
-    parameters:
-      asgMigrationInProgress: true
     dependencies:
         - facia-tool-ami-update
   facia-tool-ami-update:


### PR DESCRIPTION
## What's changed?
Riff-raff has been configured to deploy both old and new autoscaling groups during VPC migration.  In order to be able to delete the old infra in https://github.com/guardian/editorial-tools-platform/pull/949, we need to stop the parallel deployment and only deploy to the new infra.

We discovered this requirement because https://github.com/guardian/editorial-tools-platform/pull/949 was deployed to Editorial Tools::Fronts::Cloudformation CODE and subsequent deployments of facia-tool failed.

To check in CODE, I will re-apply https://github.com/guardian/editorial-tools-platform/pull/949 to CODE, then deploy this change.  We should see the facia-tool deployment succeed.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
