### PR TITLE
restore asg migration flag pending investigation of deployment issue

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,6 +4,8 @@ stacks: [cms-fronts]
 deployments:
   facia-tool:
     type: autoscaling
+    parameters:
+      asgMigrationInProgress: true
     dependencies:
         - facia-tool-ami-update
   facia-tool-ami-update:


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Reverts https://github.com/guardian/facia-tool/pull/1854 which caused a deployment issue (along with https://github.com/guardian/editorial-tools-platform/pull/949). New instances seemed to hang during ASG deployment and didn't pass ELB healthcheck: https://riffraff.gutools.co.uk/deployment/view/5a4c0572-5c25-4bd5-94a4-f8d5ef4ddb62

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
