### PR TITLE
Use npm ci to ensure lockfile is respected

### DIFF
--- a/.github/workflows/improvedci.yml
+++ b/.github/workflows/improvedci.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Set up grunt
               run: npm i -g grunt-cli
             - name: Install NPM dependencies
-              run: npm install
+              run: npm ci
             - name: Set up JSPM
               env:
                   JSPM_GITHUB_AUTH_SECRET: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
             -   name: Set up grunt
                 run: npm i -g grunt-cli
             -   name: Install NPM dependencies
-                run: npm install
+                run: npm ci
             -   name: Set up JSPM
                 env:
                     JSPM_GITHUB_AUTH_SECRET: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

This installs `node_modules` using `npm ci` instead of `npm install`, so if there is a discrepancy between the two the installation will fail.

This is motivated by the possibility of supply chain attacks, we do not want to be silently pulling in newer versions of packages.

Looks like `yarn install --frozen-lockfile` is already used for the `fronts-client` dependencies so no changes needed there.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

I think deploying to CODE and doing a smoke test of sorts would make sense here.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
