### PR TITLE
Support mise version manager

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -55,6 +55,34 @@ checkJavaVersion() {
     fi
 }
 
+set_node_version() {
+	## Check which Node version manager is available and use it
+	if command -v mise >/dev/null 2>&1; then
+		echo "Using mise"
+		eval "$(mise activate bash)"
+	elif command -v nvm >/dev/null 2>&1; then
+		echo "Using nvm"
+		nvm use
+	elif command -v fnm >/dev/null 2>&1; then
+		echo "Using fnm"
+		fnm use
+	else
+		echo -e "${RED}No Node version manager (mise, nvm, fnm) found.${NOCOLOUR}"
+		exit 1
+	fi
+
+  runningNodeVersion=$(node -v)
+  requiredNodeVersion=$(cat .nvmrc)
+
+  echo "Running ${runningNodeVersion}"
+  echo "Required ${requiredNodeVersion}"
+
+  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
+    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}."
+    exit 1
+  fi
+}
+
 main() {
     checkJavaVersion
     runNginx
@@ -63,8 +91,10 @@ main() {
     printf "\n\rStarting Yarn... \n\r\n\r"
 
     cd fronts-client
+    set_node_version
     yarn watch &
     cd ..
+    set_node_version
 
     printf "\n\rStarting Postgres... \n\r\n\r"
     docker compose up -d
@@ -82,3 +112,5 @@ main() {
 
 main
 
+
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,11 +30,26 @@ check_yarn_installed() {
 }
 
 set_node_version() {
-  echo "Attempting to set node version."
-  echo "Trying nvm" && nvm use || echo "Couldn't find nvm. Trying fnm" && fnm use
+	## Check which Node version manager is available and use it
+	if command -v mise >/dev/null 2>&1; then
+		echo "Using mise"
+		eval "$(mise activate bash)"
+	elif command -v nvm >/dev/null 2>&1; then
+		echo "Using nvm"
+		nvm use
+	elif command -v fnm >/dev/null 2>&1; then
+		echo "Using fnm"
+		fnm use
+	else
+		echo -e "${RED}No Node version manager (mise, nvm, fnm) found.${NOCOLOUR}"
+		exit 1
+	fi
 
   runningNodeVersion=$(node -v)
   requiredNodeVersion=$(cat .nvmrc)
+
+  echo "Running ${runningNodeVersion}"
+  echo "Required ${requiredNodeVersion}"
 
   if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
     echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}."


### PR DESCRIPTION
## What's changed?
Support mise version manager (https://mise.jdx.dev/), which can handle Node and Java (amongst others).