### PR TITLE
Fixes dev start when using `fnm`

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -93,6 +93,7 @@ main() {
     cd fronts-client
     set_node_version
     yarn watch &
+    sleep 1
     cd ..
     set_node_version
 


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
Fixes a small issue when using `fnm` and running `./scripts/dev-start`: 

```shell
error when starting dev server:
TypeError: crypto$2.getRandomValues is not a function      
```
## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

The issue appeared to be a result of switching node version more quickly than Yarn could run `watch`.
