### PR TITLE
Ten slideshow feature switch cleanup

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -26,18 +26,10 @@ object PageViewDataVisualisation
       enabled = true
     )
 
-object TenImageSlideshows
-    extends FeatureSwitch(
-      key = "ten-image-slideshows",
-      title = "Allow slideshows to contain 10 images rather than 5",
-      enabled = false
-    )
-
 object FeatureSwitches {
   val all: List[FeatureSwitch] = List(
     ObscureFeed,
-    PageViewDataVisualisation,
-    TenImageSlideshows
+    PageViewDataVisualisation
   )
 
   def updateFeatureSwitchesForUser(

--- a/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
+++ b/fronts-client/src/actions/__tests__/fixtures/Editions.fixture.ts
@@ -173,11 +173,6 @@ export const initialState = {
 					enabled: true,
 				},
 				{
-					key: 'ten-image-slideshows',
-					title: 'Allow slideshows to contain 10 images rather than 5',
-					enabled: false,
-				},
-				{
 					key: 'show-firefox-prompt',
 					title: 'Show the prompt to use Firefox if applicable',
 					enabled: false,
@@ -672,11 +667,6 @@ export const initialState = {
 			title: 'Show page view data visualisation (aka spark lines)',
 			enabled: true,
 		},
-		'ten-image-slideshows': {
-			key: 'ten-image-slideshows',
-			title: 'Allow slideshows to contain 10 images rather than 5',
-			enabled: false,
-		},
 		'show-firefox-prompt': {
 			key: 'show-firefox-prompt',
 			title: 'Show the prompt to use Firefox if applicable',
@@ -914,11 +904,6 @@ export const finalStateWhenAddNewCollection = {
 					key: 'page-view-data-visualisation',
 					title: 'Show page view data visualisation (aka spark lines)',
 					enabled: true,
-				},
-				{
-					key: 'ten-image-slideshows',
-					title: 'Allow slideshows to contain 10 images rather than 5',
-					enabled: false,
 				},
 				{
 					key: 'show-firefox-prompt',
@@ -1416,11 +1401,6 @@ export const finalStateWhenAddNewCollection = {
 			title: 'Show page view data visualisation (aka spark lines)',
 			enabled: true,
 		},
-		'ten-image-slideshows': {
-			key: 'ten-image-slideshows',
-			title: 'Allow slideshows to contain 10 images rather than 5',
-			enabled: false,
-		},
 		'show-firefox-prompt': {
 			key: 'show-firefox-prompt',
 			title: 'Show the prompt to use Firefox if applicable',
@@ -1672,11 +1652,6 @@ export const finalStateWhenRemoveACollection = {
 					key: 'page-view-data-visualisation',
 					title: 'Show page view data visualisation (aka spark lines)',
 					enabled: true,
-				},
-				{
-					key: 'ten-image-slideshows',
-					title: 'Allow slideshows to contain 10 images rather than 5',
-					enabled: false,
 				},
 				{
 					key: 'show-firefox-prompt',
@@ -2172,11 +2147,6 @@ export const finalStateWhenRemoveACollection = {
 			key: 'page-view-data-visualisation',
 			title: 'Show page view data visualisation (aka spark lines)',
 			enabled: true,
-		},
-		'ten-image-slideshows': {
-			key: 'ten-image-slideshows',
-			title: 'Allow slideshows to contain 10 images rather than 5',
-			enabled: false,
 		},
 		'show-firefox-prompt': {
 			key: 'show-firefox-prompt',

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -83,13 +83,6 @@ export const getCapiValuesForArticleFields = (
 	};
 };
 
-// const tenImagesFeatureSwitch = pageConfig?.userData?.featureSwitches.find(
-// 	(feature) => feature.key === 'ten-image-slideshows',
-// );
-//
-// export const maxSlideshowImages = tenImagesFeatureSwitch?.enabled ? 10 : 5;
-
-//bypasses the feature switch to temporarily ensure anyone can add 10 images to a slideshow
 export const maxSlideshowImages = 10;
 
 export const getInitialValuesForCardForm = (


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

@abeddow91 recently hard coded the slideshow limit to 10 instead of five and disabled the feature switch.  This is now being made permanent and the switch removed

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
