### PR TITLE
reduce polling duration from 30s to 5s

### DIFF
--- a/public/src/js/constants/defaults.js
+++ b/public/src/js/constants/defaults.js
@@ -278,7 +278,7 @@ export default {
     maxSlideshowImages:    5,
 
     collectionsPollMs:     10000,
-    latestArticlesPollMs:  30000,
+    latestArticlesPollMs:  5000,
     configSettingsPollMs:  30000,
     cacheExpiryMs:         60000,
     sparksRefreshMs:      300000,


### PR DESCRIPTION
## What's changed?

It's been reported that the breaking news tool takes up to 40 seconds to load newly published article into the "latest" feed, which is frustrating to users.

The polling function that checks for new latest stories runs every 30 seconds, which is likely the main reason for this delay. Reducing this time to 5 seconds should (assuming the 40 seconds max wait was accurate and there are 10 seconds of latency elsewhere in the pipeline) reduce the maximum delay to 15 seconds.

see [#1872](https://github.com/guardian/facia-tool/issues/1872)

## Implementation notes

Is should be safe to make this change, but there may be a reason why the previous period was so long. Given the v1 tool is only used for breaking news, it seems unlikely the more frequent polling will overload any services.

It would be good to inform frequent users and ask them to report any changes (for better or worse).

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
