### PR TITLE
Update Breaking News and Sports push notification titles

### DIFF
--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -71,7 +71,7 @@ object BreakingNewsUpdate {
           if (BreakingNewsTopics.map(_.name) :+ BreakingNewsGlobalTopicName)
             .contains(topic) =>
         Some("Breaking news")
-      case Some(topic) if (BreakingNewsSportUs == topic) =>
+      case Some(topic) if (BreakingNewsSportUs.name == topic) =>
         Some("Sports news")
       case Some(topic)
           if (SportBreakingNewsTopics.map(_.name) :+ SportGlobalTopicName)

--- a/app/updates/BreakingNewsUpdate.scala
+++ b/app/updates/BreakingNewsUpdate.scala
@@ -68,9 +68,15 @@ object BreakingNewsUpdate {
     val title = trail.topic match {
       case Some("uk-general-election") => Some("UK general election")
       case Some(topic)
+          if (BreakingNewsTopics.map(_.name) :+ BreakingNewsGlobalTopicName)
+            .contains(topic) =>
+        Some("Breaking news")
+      case Some(topic) if (BreakingNewsSportUs == topic) =>
+        Some("Sports news")
+      case Some(topic)
           if (SportBreakingNewsTopics.map(_.name) :+ SportGlobalTopicName)
             .contains(topic) =>
-        Some("Sport breaking news")
+        Some("Sport news")
       case Some(topic)
           if (EditorsPicksTopics.map(
             _.name

--- a/test/updates/BreakingNewsUpdateTest.scala
+++ b/test/updates/BreakingNewsUpdateTest.scala
@@ -23,9 +23,9 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
   "createPayload" - {
     "should not add titles for topics that don't need them" in {
-      val ukTrail = createTrail("FAKE TOPIC")
+      val trail = createTrail("FAKE TOPIC")
       BreakingNewsUpdate
-        .createPayload(ukTrail, exampleEmail)
+        .createPayload(trail, exampleEmail)
         .title shouldBe None
     }
 

--- a/test/updates/BreakingNewsUpdateTest.scala
+++ b/test/updates/BreakingNewsUpdateTest.scala
@@ -23,10 +23,83 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
   "createPayload" - {
     "should not add titles for topics that don't need them" in {
-      val ukTrail = createTrail(BreakingNewsUk.name)
+      val ukTrail = createTrail("FAKE TOPIC")
       BreakingNewsUpdate
         .createPayload(ukTrail, exampleEmail)
         .title shouldBe None
+    }
+
+    "should set title to 'UK general election' for uk-general-election topic" in {
+      BreakingNewsUpdate
+        .createPayload(createTrail("uk-general-election"), exampleEmail)
+        .title shouldBe Some("UK general election")
+    }
+
+    "should set title to 'Breaking news' for global breaking news topic" in {
+      BreakingNewsUpdate
+        .createPayload(createTrail(BreakingNewsUpdate.BreakingNewsGlobalTopicName), exampleEmail)
+        .title shouldBe Some("Breaking news")
+    }
+
+    "should set title to 'Breaking news' for regional breaking news topics" in {
+      val breakingNewsTopicNames = BreakingNewsUpdate.BreakingNewsTopics.map(_.name)
+      breakingNewsTopicNames.foreach { topicName =>
+        BreakingNewsUpdate
+          .createPayload(createTrail(topicName), exampleEmail)
+          .title shouldBe Some("Breaking news")
+      }
+    }
+
+    "should set title to 'Sports news' for US sport breaking news topic" in {
+      BreakingNewsUpdate
+        .createPayload(createTrail(BreakingNewsSportUs.name), exampleEmail)
+        .title shouldBe Some("Sports news")
+    }
+
+    "should set title to 'Sport news' for global sport topic" in {
+      BreakingNewsUpdate
+        .createPayload(createTrail(BreakingNewsUpdate.SportGlobalTopicName), exampleEmail)
+        .title shouldBe Some("Sport news")
+    }
+
+    "should set title to 'Sport news' for regional sport topics" in {
+      val sportTopicNames = BreakingNewsUpdate.SportBreakingNewsTopics.map(_.name)
+        .filterNot(_ == BreakingNewsSportUs.name) // US sport is handled separately as "Sports news"
+      sportTopicNames.foreach { topicName =>
+        BreakingNewsUpdate
+          .createPayload(createTrail(topicName), exampleEmail)
+          .title shouldBe Some("Sport news")
+      }
+    }
+
+    "should set title to 'Editors' pick' for global editors picks topic" in {
+      BreakingNewsUpdate
+        .createPayload(createTrail(BreakingNewsUpdate.EditorsPicksGlobalTopicName), exampleEmail)
+        .title shouldBe Some("Editors' pick")
+    }
+
+    "should set title to 'Editors' pick' for regional editors picks topics" in {
+      val editorsPicksTopicNames = BreakingNewsUpdate.EditorsPicksTopics.map(_.name)
+      editorsPicksTopicNames.foreach { topicName =>
+        BreakingNewsUpdate
+          .createPayload(createTrail(topicName), exampleEmail)
+          .title shouldBe Some("Editors' pick")
+      }
+    }
+
+    "should set title to 'One not to miss' for global one-not-to-miss topic" in {
+      BreakingNewsUpdate
+        .createPayload(createTrail(BreakingNewsUpdate.OneNotToMissGlobalTopicName), exampleEmail)
+        .title shouldBe Some("One not to miss")
+    }
+
+    "should set title to 'One not to miss' for regional one-not-to-miss topics" in {
+      val oneNotToMissTopicNames = BreakingNewsUpdate.OneNotToMissTopics.map(_.name)
+      oneNotToMissTopicNames.foreach { topicName =>
+        BreakingNewsUpdate
+          .createPayload(createTrail(topicName), exampleEmail)
+          .title shouldBe Some("One not to miss")
+      }
     }
   }
 }

--- a/test/updates/BreakingNewsUpdateTest.scala
+++ b/test/updates/BreakingNewsUpdateTest.scala
@@ -72,18 +72,18 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
       }
     }
 
-    "should set title to 'Editors' pick' for global editors picks topic" in {
+    "should set title to 'Editors' picks' for global editors picks topic" in {
       BreakingNewsUpdate
         .createPayload(createTrail(BreakingNewsUpdate.EditorsPicksGlobalTopicName), exampleEmail)
-        .title shouldBe Some("Editors' pick")
+        .title shouldBe Some("Editors' picks")
     }
 
-    "should set title to 'Editors' pick' for regional editors picks topics" in {
+    "should set title to 'Editors' picks' for regional editors picks topics" in {
       val editorsPicksTopicNames = BreakingNewsUpdate.EditorsPicksTopics.map(_.name)
       editorsPicksTopicNames.foreach { topicName =>
         BreakingNewsUpdate
           .createPayload(createTrail(topicName), exampleEmail)
-          .title shouldBe Some("Editors' pick")
+          .title shouldBe Some("Editors' picks")
       }
     }
 


### PR DESCRIPTION
Tests were asserting `"Editors' pick"` while the implementation returns `"Editors' picks"`, causing CI failures.

## Changes

- Updated test assertions in `BreakingNewsUpdateTest` from `"Editors' pick"` → `"Editors' picks"` to align with the value returned by `createPayload`
- Updated test description strings to consistently reflect the plural form