### PR TITLE
Reduce re-renders

### DIFF
--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -18,11 +18,7 @@ import { editorSelectCard } from 'bundles/frontsUI';
 import { initialiseCollectionsForFront } from 'actions/Collections';
 import { createSelectCollectionsWhichAreAlsoOnOtherFronts } from 'selectors/frontsSelectors';
 import { CollectionsWhichAreAlsoOnOtherFronts } from 'types/Collection';
-import { selectors as collectionSelectors } from 'bundles/collectionsBundle';
-import Raven from 'raven-js';
 import { selectFront } from 'selectors/shared';
-
-const STALENESS_THRESHOLD_IN_MILLIS = 30_000; // 30 seconds
 
 const CollectionContainer = styled.div`
 	position: relative;
@@ -37,25 +33,6 @@ const FrontCollectionsContainer = styled.div`
 	max-height: calc(100% - 43px);
 	padding-top: 1px;
 	padding-bottom: ${theme.front.paddingForAddFrontButton}px;
-`;
-
-const EditingLockedCollectionsOverlay = styled.div`
-	z-index: 80;
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	background-color: ${theme.colors.blackTransparent60};
-	color: ${theme.base.colors.textLight};
-	text-shadow: 0 0 10px ${theme.base.colors.textDark};
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	user-select: none;
-	text-align: center;
-	padding: 5px;
-	h2 {
-		margin: 0;
-	}
 `;
 
 const isDropFromCAPIFeed = (e: React.DragEvent) =>
@@ -87,13 +64,10 @@ type FrontProps = FrontPropsBeforeState & {
 	) => void;
 	moveCard: typeof moveCard;
 	insertCardFromDropEvent: typeof insertCardFromDropEvent;
-	collectionsError: string | null;
-	collectionsLastSuccessfulFetchTimestamp: number | null;
 };
 
 interface FrontState {
 	currentlyScrolledCollectionId: string | undefined;
-	isCollectionsStale: boolean | undefined;
 }
 
 function getNextGroupTarget(
@@ -215,7 +189,6 @@ export const buildMoveQueue = (move: Move<TCard>) => {
 class FrontContent extends React.Component<FrontProps, FrontState> {
 	public state = {
 		currentlyScrolledCollectionId: undefined,
-		isCollectionsStale: undefined,
 	};
 	private collectionElements: {
 		[collectionId: string]: HTMLDivElement | null;
@@ -264,26 +237,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 			this.props.initialiseCollectionsForFront(
 				this.props.id,
 				this.props.browsingStage,
-			);
-		}
-		if (
-			this.props.collectionsLastSuccessfulFetchTimestamp !==
-			newProps.collectionsLastSuccessfulFetchTimestamp
-		) {
-			this.updateCollectionsStalenessFlag();
-			setTimeout(
-				this.updateCollectionsStalenessFlag,
-				STALENESS_THRESHOLD_IN_MILLIS,
-			);
-		}
-		if (newProps.collectionsError && !this.props.collectionsError) {
-			Raven.captureException(
-				`Collections editing OUGHT TO BE locked due to error: ${newProps.collectionsError}`,
-				{
-					extra: {
-						error: newProps.collectionsError,
-					},
-				},
 			);
 		}
 	}
@@ -437,11 +390,7 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 	};
 
 	public render() {
-		const { front, collectionsError } = this.props;
-
-		// TODO remove the false bit when we're happy to actually lock users editing
-		const isEditingLocked =
-			false && (this.state.isCollectionsStale || !!collectionsError);
+		const { front } = this.props;
 
 		return (
 			<FrontCollectionsContainer
@@ -460,15 +409,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 										(this.collectionElements[collectionId] = ref)
 									}
 								>
-									{isEditingLocked && (
-										<EditingLockedCollectionsOverlay>
-											<h2>Editing Locked</h2>
-											<span>
-												We couldn't refresh this collection. It may be out of
-												date. Please wait or reload.
-											</span>
-										</EditingLockedCollectionsOverlay>
-									)}
 									<Collection
 										id={collectionId}
 										frontId={this.props.id}
@@ -503,31 +443,6 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		collectionId: string,
 		isSupporting: boolean,
 	) => this.props.selectCard(cardId, collectionId, this.props.id, isSupporting);
-
-	private updateCollectionsStalenessFlag = () => {
-		const collectionsStalenessInMillis = !!this.props
-			.collectionsLastSuccessfulFetchTimestamp
-			? Date.now() - this.props.collectionsLastSuccessfulFetchTimestamp
-			: 0;
-
-		const isCollectionsStale =
-			collectionsStalenessInMillis > STALENESS_THRESHOLD_IN_MILLIS;
-
-		if (!this.state.isCollectionsStale && isCollectionsStale) {
-			Raven.captureMessage(
-				'Collections editing OUGHT TO BE locked due to staleness.',
-				{
-					extra: {
-						collectionsStalenessInMillis,
-					},
-				},
-			);
-		}
-
-		if (this.state.isCollectionsStale !== isCollectionsStale) {
-			this.setState({ isCollectionsStale });
-		}
-	};
 }
 
 const mapStateToProps = () => {
@@ -538,9 +453,6 @@ const mapStateToProps = () => {
 			front: selectFront(state, { frontId: id }),
 			collectionsWhichAreAlsoOnOtherFronts:
 				selectCollectionsWhichAreAlsoOnOtherFronts(state, { frontId: id }),
-			collectionsError: collectionSelectors.selectCurrentError(state),
-			collectionsLastSuccessfulFetchTimestamp:
-				collectionSelectors.selectLastSuccessfulFetchTimestamp(state),
 		};
 	};
 };

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -5,7 +5,6 @@ import Article from 'components/card/article/ArticleCard';
 import type { State } from 'types/State';
 import { createSelectCardType } from 'selectors/cardSelectors';
 import {
-	selectCard,
 	selectExternalArticleFromCard,
 	selectSupportingArticleCount,
 } from 'selectors/shared';
@@ -124,7 +123,7 @@ type CardContainerProps = ContainerProps & {
 	isLive?: boolean;
 	pillarId?: string;
 	collectionType?: string;
-	selectOtherCard: { (uuid: string): CardType };
+	cards: { [uuid: string]: CardType };
 	groupSizeId?: number;
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
 };
@@ -485,7 +484,7 @@ class Card extends React.Component<CardContainerProps> {
 		imageCriteria: Criteria,
 	): ReturnType<typeof validateDimensions> => {
 		// check dragged image matches this card's collection's criteria.
-		const cardImageWasDraggedFrom = this.props.selectOtherCard(cardUuid);
+		const cardImageWasDraggedFrom = this.props.cards[cardUuid];
 
 		const { imageSlideshowReplace, slideshow } = cardImageWasDraggedFrom.meta;
 		if (imageSlideshowReplace) {
@@ -519,7 +518,7 @@ const createMapStateToProps = () => {
 			numSupportingArticles: selectSupportingArticleCount(state, uuid),
 			editMode: selectEditMode(state),
 			collectionType: collectionId && selectCollectionType(state, collectionId),
-			selectOtherCard: (uuid: string) => selectCard(state, uuid),
+			cards: state.cards,
 		};
 	};
 };

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -22,7 +22,6 @@ import { HoverActionsAreaOverlay } from '../../CollectionHoverItems';
 import {
 	BoostLevels,
 	CardSizes,
-	CollectionMap,
 	OtherCollectionsOnSameFrontThisCardIsOn,
 } from 'types/Collection';
 import CardMetaContent from '../CardMetaContent';
@@ -182,7 +181,6 @@ interface ArticleBodyProps {
 	collectionType?: string;
 	groupIndex?: number;
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
-	collectionMap?: CollectionMap;
 }
 
 const articleBodyDefault = React.memo(
@@ -239,13 +237,7 @@ const articleBodyDefault = React.memo(
 		mainMediaVideoAtom,
 		replacementVideoAtom,
 		otherCollectionsOnSameFrontThisCardIsOn,
-		collectionMap,
 	}: ArticleBodyProps) => {
-		const otherCollectionsOnSameFrontThisCardIsOnUuids =
-			otherCollectionsOnSameFrontThisCardIsOn?.collections.map(
-				(_) => _.collectionUuid,
-			);
-
 		const displayByline = size === 'default' && showByline && byline;
 		const now = Date.now();
 		const paths = urlPath ? getPaths(urlPath) : undefined;
@@ -364,19 +356,21 @@ const articleBodyDefault = React.memo(
 								{distanceInWordsStrict(new Date(firstPublicationDate), now)}
 							</FirstPublicationDate>
 						)}
-						{!!otherCollectionsOnSameFrontThisCardIsOnUuids &&
-							otherCollectionsOnSameFrontThisCardIsOnUuids.length > 0 && (
+						{!!otherCollectionsOnSameFrontThisCardIsOn &&
+							otherCollectionsOnSameFrontThisCardIsOn.collections.length >
+								0 && (
 								<AlsoOnOtherCollectionsSection>
 									Also on:
 									<AlsoOnOtherCollectionsList>
-										{otherCollectionsOnSameFrontThisCardIsOnUuids?.map(
-											(uuid) => {
-												const collection = collectionMap?.[uuid];
-												return collection !== undefined ? (
-													<AlsoOnOtherCollectionsListItem>
+										{otherCollectionsOnSameFrontThisCardIsOn.collections.map(
+											(collection) => {
+												return (
+													<AlsoOnOtherCollectionsListItem
+														key={collection.collectionUuid}
+													>
 														{collection.displayName}
 													</AlsoOnOtherCollectionsListItem>
-												) : null;
+												);
 											},
 										)}
 									</AlsoOnOtherCollectionsList>

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -6,7 +6,6 @@ import noop from 'lodash/noop';
 import {
 	createSelectArticleFromCard,
 	selectCard,
-	selectCollectionMap,
 } from '../../../selectors/shared';
 import { selectors } from 'bundles/externalArticlesBundle';
 import type { State } from 'types/State';
@@ -17,7 +16,6 @@ import CardMetaHeading from '../CardMetaHeading';
 import ArticleBody from './ArticleBody';
 import {
 	CardSizes,
-	CollectionMap,
 	OtherCollectionsOnSameFrontThisCardIsOn,
 } from 'types/Collection';
 import DragIntentContainer from '../../DragIntentContainer';
@@ -68,7 +66,6 @@ interface ArticleComponentProps {
 	collectionType?: string;
 	groupIndex?: number;
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
-	collectionMap?: CollectionMap;
 }
 
 interface ComponentProps extends ArticleComponentProps {
@@ -120,7 +117,6 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 			collectionType,
 			groupIndex,
 			otherCollectionsOnSameFrontThisCardIsOn,
-			collectionMap,
 		} = this.props;
 
 		const getArticleData = () =>
@@ -189,7 +185,6 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 								otherCollectionsOnSameFrontThisCardIsOn={
 									otherCollectionsOnSameFrontThisCardIsOn
 								}
-								collectionMap={collectionMap}
 							/>
 						</ArticleBodyContainer>
 					</DragIntentContainer>
@@ -209,9 +204,7 @@ const createMapStateToProps = () => {
 		article?: DerivedArticle;
 		isLoading: boolean;
 		featureFlagPageViewData: boolean;
-		collectionMap?: CollectionMap;
 	} => {
-		const collectionMap = selectCollectionMap(state);
 		const article = selectArticle(state, props.id);
 		const card = selectCard(state, props.id);
 		const getState = (s: any) => s;
@@ -223,7 +216,6 @@ const createMapStateToProps = () => {
 				getState(state),
 				'page-view-data-visualisation',
 			),
-			collectionMap,
 		};
 	};
 };

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -4,9 +4,13 @@ import type { State } from 'types/State';
 import { connect } from 'react-redux';
 import { Card, Group } from 'types/Collection';
 import DropZone, { DefaultDropContainer } from 'components/DropZone';
-import { createSelectArticlesFromIds } from 'selectors/shared';
+import {
+	createSelectArticlesFromIds,
+	selectCardsFromRootState,
+} from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
 import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
+import { createShallowEqualResultSelector } from 'util/selectorUtils';
 
 interface OuterProps {
 	groupId: string;
@@ -103,30 +107,29 @@ const GroupLevel = ({
 
 const createMapStateToProps = () => {
 	const selectArticlesFromIds = createSelectArticlesFromIds();
-
-	const getCardsForOtherGroups = () => {
-		return (state: State, groups: Group[] | undefined) => {
-			if (!groups) {
-				return [];
-			}
-
+	const selectCardsForOtherGroups = createShallowEqualResultSelector(
+		selectCardsFromRootState,
+		(_: any, { groups }: { groups: Group[] }) => groups,
+		(cards, groups) => {
 			return groups.map((group) => {
-				const cardsData = selectArticlesFromIds(state, {
-					cardIds: group.cards,
-				});
 				return {
 					...group,
-					cardsData,
+					cardsData: group.cards.map((afId) => cards[afId]),
 				};
 			});
+		},
+	);
+
+	return (state: State, { cardIds, groups }: OuterProps) => {
+		return {
+			cards: selectArticlesFromIds(state, {
+				cardIds,
+			}),
+			groupsWithCardsData: selectCardsForOtherGroups(state, {
+				groups: groups || [],
+			}),
 		};
 	};
-	return (state: State, { cardIds, groups }: OuterProps) => ({
-		cards: selectArticlesFromIds(state, {
-			cardIds,
-		}),
-		groupsWithCardsData: getCardsForOtherGroups()(state, groups),
-	});
 };
 
 export default connect(createMapStateToProps)(GroupLevel);

--- a/fronts-client/src/selectors/__tests__/alsoOnSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/alsoOnSelectors.spec.ts
@@ -26,10 +26,14 @@ const allFronts = editorialFrontsInConfig
 	.concat(additionalEditorialFronts)
 	.concat(trainingFronts.concat(commercialFronts));
 
-const collectionsExcept = (collectionToExclude: Collection) =>
-	allCollections.filter(
+const collectionsExcept = (collectionToExclude: Collection) => {
+	const filtered = allCollections.filter(
 		(collection) => collectionToExclude.id !== collection.id,
 	);
+	let result: { [uuid: string]: Collection } = {};
+	filtered.forEach((collection) => (result[collection.id] = collection));
+	return result;
+};
 
 describe('Selecting collections which are also on other fronts', () => {
 	it('return an object with all the collections on the current front', () => {

--- a/fronts-client/src/selectors/__tests__/alsoOnSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/alsoOnSelectors.spec.ts
@@ -151,8 +151,11 @@ describe('Selecting cards which are also on other collections on the same front'
 		).toEqual({
 			cardUuid2: {
 				collections: [
-					{ collectionUuid: 'sportCollectionUuid' },
-					{ collectionUuid: 'unpublishedCollectionUuid' },
+					{ collectionUuid: 'sportCollectionUuid', displayName: 'sport' },
+					{
+						collectionUuid: 'unpublishedCollectionUuid',
+						displayName: 'unpublished',
+					},
 				],
 			},
 		});
@@ -167,12 +170,20 @@ describe('Selecting cards which are also on other collections on the same front'
 		).toEqual({
 			cardUuid2: {
 				collections: [
-					{ collectionUuid: 'footballCollectionUuid' },
-					{ collectionUuid: 'unpublishedCollectionUuid' },
+					{ collectionUuid: 'footballCollectionUuid', displayName: 'football' },
+					{
+						collectionUuid: 'unpublishedCollectionUuid',
+						displayName: 'unpublished',
+					},
 				],
 			},
 			cardUuid3: {
-				collections: [{ collectionUuid: 'whatToWatchCollectionUuid' }],
+				collections: [
+					{
+						collectionUuid: 'whatToWatchCollectionUuid',
+						displayName: 'what-to-watch',
+					},
+				],
 			},
 		});
 
@@ -185,10 +196,14 @@ describe('Selecting cards which are also on other collections on the same front'
 			),
 		).toEqual({
 			cardUuid3: {
-				collections: [{ collectionUuid: 'sportCollectionUuid' }],
+				collections: [
+					{ collectionUuid: 'sportCollectionUuid', displayName: 'sport' },
+				],
 			},
 			cardUuid4: {
-				collections: [{ collectionUuid: 'cultureCollectionUuid' }],
+				collections: [
+					{ collectionUuid: 'cultureCollectionUuid', displayName: 'culture' },
+				],
 			},
 		});
 	});
@@ -203,7 +218,12 @@ describe('Selecting cards which are also on other collections on the same front'
 			),
 		).toEqual({
 			cardUuid4: {
-				collections: [{ collectionUuid: 'whatToWatchCollectionUuid' }],
+				collections: [
+					{
+						collectionUuid: 'whatToWatchCollectionUuid',
+						displayName: 'what-to-watch',
+					},
+				],
 			},
 			cardUuid5: {
 				collections: [],
@@ -226,7 +246,10 @@ describe('Selecting cards which are also on other collections on the same front'
 			expect.objectContaining({
 				cardUuid10: {
 					collections: expect.arrayContaining([
-						{ collectionUuid: 'championshipCollectionUuid' },
+						{
+							collectionUuid: 'championshipCollectionUuid',
+							displayName: 'championship',
+						},
 					]),
 				},
 			}),
@@ -245,7 +268,10 @@ describe('Selecting cards which are also on other collections on the same front'
 			expect.objectContaining({
 				cardUuid10: {
 					collections: expect.arrayContaining([
-						{ collectionUuid: 'footballLeagueCollectionUuid' },
+						{
+							collectionUuid: 'footballLeagueCollectionUuid',
+							displayName: 'football-league',
+						},
 					]),
 				},
 			}),
@@ -264,7 +290,10 @@ describe('Selecting cards which are also on other collections on the same front'
 			expect.objectContaining({
 				cardUuid10: {
 					collections: expect.arrayContaining([
-						{ collectionUuid: 'premierLeagueCollectionUuid' },
+						{
+							collectionUuid: 'premierLeagueCollectionUuid',
+							displayName: 'premier-league',
+						},
 					]),
 				},
 			}),
@@ -283,8 +312,11 @@ describe('Selecting cards which are also on other collections on the same front'
 			expect.objectContaining({
 				cardUuid2: {
 					collections: [
-						{ collectionUuid: 'footballCollectionUuid' },
-						{ collectionUuid: 'sportCollectionUuid' },
+						{
+							collectionUuid: 'footballCollectionUuid',
+							displayName: 'football',
+						},
+						{ collectionUuid: 'sportCollectionUuid', displayName: 'sport' },
 					],
 				},
 			}),
@@ -300,7 +332,12 @@ describe('Selecting cards which are also on other collections on the same front'
 		).not.toEqual(
 			expect.objectContaining({
 				cardUuid7: {
-					collections: [{ collectionUuid: 'premierLeagueCollectionUuid' }],
+					collections: [
+						{
+							collectionUuid: 'premierLeagueCollectionUuid',
+							displayName: 'premier-league',
+						},
+					],
 				},
 			}),
 		);

--- a/fronts-client/src/selectors/alsoOnSelectors.ts
+++ b/fronts-client/src/selectors/alsoOnSelectors.ts
@@ -203,6 +203,7 @@ const constructCardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap = (
 	cardIdToOtherCollectionUuidsMap: CardIdToOtherCollectionUuidsMap,
 	cardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap: CardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap,
 	cardUuids: string[],
+	otherCollectionsOnSameFront: Collection[],
 ) => {
 	iterateOverCards(cardMap, cardUuids, (card) => {
 		const matchingCollectionUuids =
@@ -210,6 +211,10 @@ const constructCardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap = (
 		cardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap[card.uuid] = {
 			collections: matchingCollectionUuids.map((collectionUuid) => ({
 				collectionUuid,
+				displayName:
+					otherCollectionsOnSameFront.find(
+						(collection) => collection.id === collectionUuid,
+					)?.displayName || '',
 			})),
 		};
 	});
@@ -287,6 +292,7 @@ const selectCardsWhichAreAlsoOnOtherCollectionsOnSameFront = (
 			cardIdToOtherCollectionUuidsMap,
 			cardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap,
 			cardUuids,
+			otherCollectionsOnSameFront,
 		);
 	});
 

--- a/fronts-client/src/selectors/alsoOnSelectors.ts
+++ b/fronts-client/src/selectors/alsoOnSelectors.ts
@@ -203,7 +203,7 @@ const constructCardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap = (
 	cardIdToOtherCollectionUuidsMap: CardIdToOtherCollectionUuidsMap,
 	cardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap: CardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap,
 	cardUuids: string[],
-	otherCollectionsOnSameFront: Collection[],
+	otherCollectionsOnSameFront: { [uuid: string]: Collection },
 ) => {
 	iterateOverCards(cardMap, cardUuids, (card) => {
 		const matchingCollectionUuids =
@@ -212,9 +212,7 @@ const constructCardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap = (
 			collections: matchingCollectionUuids.map((collectionUuid) => ({
 				collectionUuid,
 				displayName:
-					otherCollectionsOnSameFront.find(
-						(collection) => collection.id === collectionUuid,
-					)?.displayName || '',
+					otherCollectionsOnSameFront[collectionUuid]?.displayName || '',
 			})),
 		};
 	});
@@ -251,7 +249,7 @@ const constructCardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap = (
  */
 const selectCardsWhichAreAlsoOnOtherCollectionsOnSameFront = (
 	selectedCollection: Collection | undefined,
-	otherCollectionsOnSameFront: Collection[],
+	otherCollectionsOnSameFront: { [uuid: string]: Collection },
 	groupMap: GroupMap,
 	cardMap: CardMap,
 ): CardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap => {
@@ -269,7 +267,7 @@ const selectCardsWhichAreAlsoOnOtherCollectionsOnSameFront = (
 	// so we can do O(1) lookups instead of nested iterations per card
 	const cardIdToOtherCollectionUuidsMap: CardIdToOtherCollectionUuidsMap =
 		new Map<string, string[]>();
-	for (const otherCollection of otherCollectionsOnSameFront) {
+	for (const otherCollection of Object.values(otherCollectionsOnSameFront)) {
 		if (!otherCollection.draft) {
 			continue;
 		}

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -200,11 +200,11 @@ const createSelectCardsWhichAreAlsoOnOtherCollectionsOnSameFront = () => {
 		selectCollectionMap,
 		selectCollectionId,
 		(currentFront, collectionMap, currentCollectionId) => {
-			if (!currentFront) return [];
-			const result: Collection[] = [];
+			if (!currentFront) return {};
+			let result: { [uuid: string]: Collection } = {};
 			for (const id of currentFront.collections ?? []) {
 				if (id !== currentCollectionId && collectionMap[id]) {
-					result.push(collectionMap[id]);
+					result[id] = collectionMap[id];
 				}
 			}
 			return result;
@@ -220,8 +220,8 @@ const createSelectCardsWhichAreAlsoOnOtherCollectionsOnSameFront = () => {
 		(otherCollections, currentCollection, groupMap) => {
 			const result: GroupMap = {};
 			const allCollections = currentCollection
-				? [...otherCollections, currentCollection]
-				: otherCollections;
+				? [...Object.values(otherCollections), currentCollection]
+				: Object.values(otherCollections);
 			for (const collection of allCollections) {
 				for (const groupId of collection.draft ?? []) {
 					const group = groupMap[groupId];

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -19,7 +19,7 @@ interface CollectionsWhichAreAlsoOnOtherFronts {
 }
 
 interface OtherCollectionsOnSameFrontThisCardIsOn {
-	collections: Array<{ collectionUuid: string }>;
+	collections: Array<{ collectionUuid: string; displayName: string }>;
 }
 
 type CardIdToOtherCollectionUuidsMap = Map<string, string[]>;


### PR DESCRIPTION
## What's changed?

Changes to how state is managed to avoid unnecessary re-renders

## Implementation notes

I've been using the React dev tools to identify and resolve unnecessary screen redraws to hopefully improve the performance of the app. Each commit is a distinct fix.

- The "Other Collections" feature passed around a complete collectionMap which caused redraws on any fetch of the collections data - [commit](https://github.com/guardian/facia-tool/commit/a9452591313505cea78e5af4238a3b0d2e854ec0) 

- The logic to look at the other card an image was dragged from unnecessarily depended on the entire root state - [commit](https://github.com/guardian/facia-tool/commit/9921c9788782cdc4b8a82b2d63ea9253e37bffe0) 

- The inactive feature to disable editing when data is stale causes unnecessary redraws - [commit](https://github.com/guardian/facia-tool/commit/c8a82dd7644c55f20ba0df616a6921b5bc4ce425) 

- The way we map from groups to cards caused redraws on any change in state - [commit](https://github.com/guardian/facia-tool/commit/b837f3dacc5faa8e1269dbef8ca1be2418eec82f)

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
