### PR TITLE
Bump capiModelsVersion, capiClientVersion and FAPI

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -109,7 +109,7 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
   PublishEventsListener.apply(config, editionsDb).start
 
   // Controllers
-  val frontsApi = new FrontsApi(config, awsEndpoints)
+  val frontsApi = new FrontsApi(config)
   val s3FrontsApi = new S3FrontsApi(config, isTest, awsEndpoints)
   val faciaApiIO = new FaciaApiIO(frontsApi, s3FrontsApi)
   val configAgent = new ConfigAgent(config, frontsApi)

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -154,14 +154,32 @@ class ApplicationConfiguration(
           None
       }
     }
-    // NB this does not fail with exception (as the 'old' credentials above).  It is assumed that the code
-    // above would have already failed.
-    // If and when this code is rewritten to remove the 'old' approach, then that behaviour may be duplicated here.
-    def newStyleCmsFrontsAccountCredentials = NewAwsCredentialsProviderChain
-      .builder()
-      .addCredentialsProvider(NewProfileCredentialsProvider.create("cmsFronts"))
-      .addCredentialsProvider(DefaultCredentialsProvider.create())
-      .build()
+
+    def newStyleCmsFrontsAccountCredentials: NewAwsCredentialsProviderChain =
+      newStyleCredentials.getOrElse(
+        throw new BadConfigurationException(
+          "AWS credentials are not configured for CMS Fronts (v2)"
+        )
+      )
+    val newStyleCredentials: Option[NewAwsCredentialsProviderChain] = {
+      val provider = NewAwsCredentialsProviderChain
+        .builder()
+        .addCredentialsProvider(
+          NewProfileCredentialsProvider.create("cmsFronts")
+        )
+        .addCredentialsProvider(DefaultCredentialsProvider.create())
+        .build()
+
+      try {
+        provider.resolveCredentials()
+        Some(provider)
+      } catch {
+        case ex: Exception =>
+          logger.error("amazon client exception (v2 credentials)")
+          if (isProd) throw ex
+          None
+      }
+    }
 
     def frontendAccountCredentials: AWSCredentialsProvider =
       crossAccount.getOrElse(

--- a/app/services/FrontsApi.scala
+++ b/app/services/FrontsApi.scala
@@ -9,8 +9,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class FrontsApi(
-    val config: ApplicationConfiguration,
-    val awsEndpoints: AwsEndpoints
+    val config: ApplicationConfiguration
 ) {
   val amazonClient: ApiClient = {
 

--- a/app/services/FrontsApi.scala
+++ b/app/services/FrontsApi.scala
@@ -3,14 +3,8 @@ package services
 import com.gu.etagcaching.aws.sdkv2.s3.S3ObjectFetching
 import com.gu.facia.client.{ApiClient, Environment}
 import conf.ApplicationConfiguration
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.S3AsyncClient
-
-import software.amazon.awssdk.services.sts.StsClient
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
-import software.amazon.awssdk.auth.credentials._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -23,40 +17,10 @@ class FrontsApi(
     val bucket = config.aws.frontsBucket
     val stage = config.facia.stage.toUpperCase
 
-    val stsClient = StsClient
-      .builder()
-      .region(EU_WEST_1)
-      .build()
-
-    val assumeRoleRequest = AssumeRoleRequest
-      .builder()
-      .roleArn(config.faciatool.stsRoleToAssume)
-      .roleSessionName("frontsApi")
-      .build()
-
-    val credentialsProvider = AwsCredentialsProviderChain.of(
-      EnvironmentVariableCredentialsProvider.create(),
-      SystemPropertyCredentialsProvider.create(),
-      ProfileCredentialsProvider.builder().profileName("cmsFronts").build()
-    )
-
-    val provider = AwsCredentialsProviderChain
-      .builder()
-      .credentialsProviders(
-        ProfileCredentialsProvider.create("cmsFronts"),
-        StsAssumeRoleCredentialsProvider
-          .builder()
-          .stsClient(stsClient)
-          .refreshRequest(assumeRoleRequest)
-          .build(),
-        credentialsProvider
-      )
-      .build()
-
     val s3AsyncClient = S3AsyncClient
       .builder()
       .region(EU_WEST_1)
-      .credentialsProvider(provider)
+      .credentialsProvider(config.aws.newStyleCmsFrontsAccountCredentials)
       .build()
 
     ApiClient.withCaching(

--- a/app/services/FrontsApi.scala
+++ b/app/services/FrontsApi.scala
@@ -1,9 +1,16 @@
 package services
 
-import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
+import com.gu.etagcaching.aws.sdkv2.s3.S3ObjectFetching
+import com.gu.facia.client.{ApiClient, Environment}
 import conf.ApplicationConfiguration
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+import software.amazon.awssdk.services.s3.S3AsyncClient
+
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+import software.amazon.awssdk.auth.credentials._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -13,19 +20,50 @@ class FrontsApi(
 ) {
   val amazonClient: ApiClient = {
 
-    val endpoint = new AwsClientBuilder.EndpointConfiguration(
-      awsEndpoints.s3,
-      config.aws.region
-    )
-
-    val client: AmazonS3 = AmazonS3ClientBuilder
-      .standard()
-      .withCredentials(config.aws.cmsFrontsAccountCredentials)
-      .withEndpointConfiguration(endpoint)
-      .build()
-
     val bucket = config.aws.frontsBucket
     val stage = config.facia.stage.toUpperCase
-    ApiClient(bucket, stage, AmazonSdkS3Client(client))
+
+    val stsClient = StsClient
+      .builder()
+      .region(EU_WEST_1)
+      .build()
+
+    val assumeRoleRequest = AssumeRoleRequest
+      .builder()
+      .roleArn(config.faciatool.stsRoleToAssume)
+      .roleSessionName("frontsApi")
+      .build()
+
+    val credentialsProvider = AwsCredentialsProviderChain.of(
+      EnvironmentVariableCredentialsProvider.create(),
+      SystemPropertyCredentialsProvider.create(),
+      ProfileCredentialsProvider.builder().profileName("cmsFronts").build()
+    )
+
+    val provider = AwsCredentialsProviderChain
+      .builder()
+      .credentialsProviders(
+        ProfileCredentialsProvider.create("cmsFronts"),
+		StsAssumeRoleCredentialsProvider
+		  .builder()
+		  .stsClient(stsClient)
+		  .refreshRequest(assumeRoleRequest)
+		  .build(),
+		credentialsProvider
+
+      )
+      .build()
+
+    val s3AsyncClient = S3AsyncClient
+      .builder()
+      .region(EU_WEST_1)
+      .credentialsProvider(provider)
+      .build()
+
+    ApiClient.withCaching(
+      bucket,
+      Environment(stage),
+      S3ObjectFetching.byteArraysWith(s3AsyncClient)
+    )
   }
 }

--- a/app/services/FrontsApi.scala
+++ b/app/services/FrontsApi.scala
@@ -44,13 +44,12 @@ class FrontsApi(
       .builder()
       .credentialsProviders(
         ProfileCredentialsProvider.create("cmsFronts"),
-		StsAssumeRoleCredentialsProvider
-		  .builder()
-		  .stsClient(stsClient)
-		  .refreshRequest(assumeRoleRequest)
-		  .build(),
-		credentialsProvider
-
+        StsAssumeRoleCredentialsProvider
+          .builder()
+          .stsClient(stsClient)
+          .refreshRequest(assumeRoleRequest)
+          .build(),
+        credentialsProvider
       )
       .build()
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ val capiModelsVersion = "38.0.0"
 val capiClientVersion = "42.0.1"
 val json4sVersion = "4.0.3"
 val circeVersion = "0.13.0"
+val awsSdkVersion = "2.43.0"
 
 resolvers ++= Seq(
   Resolver.file("Local", file(Path.userHome.absolutePath + "/.ivy2/local"))(
@@ -108,7 +109,10 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-text" % "1.10.0",
   "com.beust" % "jcommander" % "1.75",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "org.mockito" % "mockito-core" % "5.11.0" % Test
+  "org.mockito" % "mockito-core" % "5.11.0" % Test,
+	"software.amazon.awssdk" % "sts" % awsSdkVersion,
+	"software.amazon.awssdk" % "s3" % awsSdkVersion,
+	"com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
 )
 
 excludeDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,6 @@ libraryDependencies ++= Seq(
   "com.beust" % "jcommander" % "1.75",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.mockito" % "mockito-core" % "5.11.0" % Test,
-  "software.amazon.awssdk" % "sts" % awsSdkVersion,
   "software.amazon.awssdk" % "s3" % awsSdkVersion,
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,8 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.12.470"
-val capiModelsVersion = "31.0.0"
-val capiClientVersion = "37.0.0"
+val capiModelsVersion = "38.0.0"
+val capiClientVersion = "42.0.1"
 val json4sVersion = "4.0.3"
 val circeVersion = "0.13.0"
 
@@ -83,7 +83,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "23.0.0",
+  "com.gu" %% "fapi-client-play30" % "30.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/build.sbt
+++ b/build.sbt
@@ -110,9 +110,9 @@ libraryDependencies ++= Seq(
   "com.beust" % "jcommander" % "1.75",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.mockito" % "mockito-core" % "5.11.0" % Test,
-	"software.amazon.awssdk" % "sts" % awsSdkVersion,
-	"software.amazon.awssdk" % "s3" % awsSdkVersion,
-	"com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
+  "software.amazon.awssdk" % "sts" % awsSdkVersion,
+  "software.amazon.awssdk" % "s3" % awsSdkVersion,
+  "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
 )
 
 excludeDependencies ++= Seq(

--- a/test/updates/BreakingNewsUpdateTest.scala
+++ b/test/updates/BreakingNewsUpdateTest.scala
@@ -37,12 +37,16 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
     "should set title to 'Breaking news' for global breaking news topic" in {
       BreakingNewsUpdate
-        .createPayload(createTrail(BreakingNewsUpdate.BreakingNewsGlobalTopicName), exampleEmail)
+        .createPayload(
+          createTrail(BreakingNewsUpdate.BreakingNewsGlobalTopicName),
+          exampleEmail
+        )
         .title shouldBe Some("Breaking news")
     }
 
     "should set title to 'Breaking news' for regional breaking news topics" in {
-      val breakingNewsTopicNames = BreakingNewsUpdate.BreakingNewsTopics.map(_.name)
+      val breakingNewsTopicNames =
+        BreakingNewsUpdate.BreakingNewsTopics.map(_.name)
       breakingNewsTopicNames.foreach { topicName =>
         BreakingNewsUpdate
           .createPayload(createTrail(topicName), exampleEmail)
@@ -58,13 +62,19 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
     "should set title to 'Sport news' for global sport topic" in {
       BreakingNewsUpdate
-        .createPayload(createTrail(BreakingNewsUpdate.SportGlobalTopicName), exampleEmail)
+        .createPayload(
+          createTrail(BreakingNewsUpdate.SportGlobalTopicName),
+          exampleEmail
+        )
         .title shouldBe Some("Sport news")
     }
 
     "should set title to 'Sport news' for regional sport topics" in {
-      val sportTopicNames = BreakingNewsUpdate.SportBreakingNewsTopics.map(_.name)
-        .filterNot(_ == BreakingNewsSportUs.name) // US sport is handled separately as "Sports news"
+      val sportTopicNames = BreakingNewsUpdate.SportBreakingNewsTopics
+        .map(_.name)
+        .filterNot(
+          _ == BreakingNewsSportUs.name
+        ) // US sport is handled separately as "Sports news"
       sportTopicNames.foreach { topicName =>
         BreakingNewsUpdate
           .createPayload(createTrail(topicName), exampleEmail)
@@ -74,12 +84,16 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
     "should set title to 'Editors' picks' for global editors picks topic" in {
       BreakingNewsUpdate
-        .createPayload(createTrail(BreakingNewsUpdate.EditorsPicksGlobalTopicName), exampleEmail)
+        .createPayload(
+          createTrail(BreakingNewsUpdate.EditorsPicksGlobalTopicName),
+          exampleEmail
+        )
         .title shouldBe Some("Editors' picks")
     }
 
     "should set title to 'Editors' picks' for regional editors picks topics" in {
-      val editorsPicksTopicNames = BreakingNewsUpdate.EditorsPicksTopics.map(_.name)
+      val editorsPicksTopicNames =
+        BreakingNewsUpdate.EditorsPicksTopics.map(_.name)
       editorsPicksTopicNames.foreach { topicName =>
         BreakingNewsUpdate
           .createPayload(createTrail(topicName), exampleEmail)
@@ -89,12 +103,16 @@ class BreakingNewsUpdateTest extends FreeSpec with Matchers {
 
     "should set title to 'One not to miss' for global one-not-to-miss topic" in {
       BreakingNewsUpdate
-        .createPayload(createTrail(BreakingNewsUpdate.OneNotToMissGlobalTopicName), exampleEmail)
+        .createPayload(
+          createTrail(BreakingNewsUpdate.OneNotToMissGlobalTopicName),
+          exampleEmail
+        )
         .title shouldBe Some("One not to miss")
     }
 
     "should set title to 'One not to miss' for regional one-not-to-miss topics" in {
-      val oneNotToMissTopicNames = BreakingNewsUpdate.OneNotToMissTopics.map(_.name)
+      val oneNotToMissTopicNames =
+        BreakingNewsUpdate.OneNotToMissTopics.map(_.name)
       oneNotToMissTopicNames.foreach { topicName =>
         BreakingNewsUpdate
           .createPayload(createTrail(topicName), exampleEmail)


### PR DESCRIPTION
## What's changed?
Bump capiModelsVersion to `38.0.0`
Bump capiClientVersion to `42.0.1`
Bump FAPI to `30.0.0`

FAPI v26 introduced a breaking change by removing legacy ApiClient, as part of the upgrade to AWS SDK v2. More details on this change can be found in https://github.com/guardian/facia-scala-client/pull/370. This PR migrates APIClient usage to `ApiClient.withCaching` with the already available `newStyleCredentials`to resolve this breaking change.


### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214351511823462