### PR TITLE
Valid platforms are Any, Web or App not Web/Platform 

### DIFF
--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -1,6 +1,10 @@
 import { Atom, CapiArticle } from 'types/Capi';
 import { Diff } from 'utility-types';
-import type { DisplayHints, FrontsToolSettings } from 'types/FaciaApi';
+import type {
+	DisplayHints,
+	FrontsToolSettings,
+	Platform,
+} from 'types/FaciaApi';
 import { CardTypes } from 'constants/cardTypes';
 
 interface CollectionArticles {
@@ -211,7 +215,7 @@ interface Collection {
 	lastUpdated?: number;
 	updatedBy?: string;
 	updatedEmail?: string;
-	platform?: string;
+	platform?: Platform;
 	displayName: string;
 	groups?: string[];
 	groupsConfig?: GroupConfig[];

--- a/fronts-client/src/types/FaciaApi.ts
+++ b/fronts-client/src/types/FaciaApi.ts
@@ -59,7 +59,6 @@ interface CollectionConfigResponse {
 	uneditable?: boolean;
 	showTags?: boolean;
 	hideKickers?: boolean;
-	excludedFromRss?: boolean;
 	hideShowMore?: boolean;
 	description?: string;
 	showSections?: boolean;

--- a/fronts-client/src/types/FaciaApi.ts
+++ b/fronts-client/src/types/FaciaApi.ts
@@ -32,7 +32,12 @@ interface EditionsFrontMetadata {
 	nameOverride?: string;
 }
 
-type Platform = 'Web' | 'Platform';
+export const isPlatform = (s: string): s is Platform =>
+	(platforms as readonly string[]).includes(s);
+
+export const platforms = ['Any', 'Web', 'App'] as const;
+
+export type Platform = (typeof platforms)[number];
 
 interface FrontsToolSettings {
 	displayEditWarning?: boolean;


### PR DESCRIPTION
## What's changed?

Fixing the type for Platform.

Also removes a field introduced in error (excludedFromRss)