### PR TITLE
Facia-tool doesn't require frontend credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can find the client for the Fronts tool in [fronts-client](./fronts-client).
 
 1. Install [NVM](https://github.com/creationix/nvm).
 2. Ensure [Docker](https://www.docker.com/products/docker-desktop) is installed
-3. Get credentials from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=cmsFronts-dev,capi-api-gateway,frontend-dev) (`cmsFronts`, `capi` & `frontend`).
+3. Get credentials from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=cmsFronts-dev,capi-api-gateway) (`cmsFronts` & `capi`).
 4. Grant [code](https://permissions.code.dev-gutools.co.uk/) permissions (used for local builds as well).  Any engineer on ed tools should be able to give you access. You need:
     1. fronts_access
     1. launch_commercial_fronts

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can find the client for the Fronts tool in [fronts-client](./fronts-client).
 
 1. Install [NVM](https://github.com/creationix/nvm).
 2. Ensure [Docker](https://www.docker.com/products/docker-desktop) is installed
-3. Get credentials from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=cmsFronts-dev,capi-api-gateway) (`cmsFronts` & `capi`).
+3. Get credentials from [Janus](https://janus.gutools.co.uk/credentials?permissionId=cmsFronts-iam-facia-CODE-RunFaciaToolLocally-nL42h4zEgHhf).
 4. Grant [code](https://permissions.code.dev-gutools.co.uk/) permissions (used for local builds as well).  Any engineer on ed tools should be able to give you access. You need:
     1. fronts_access
     1. launch_commercial_fronts

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -181,36 +181,6 @@ class ApplicationConfiguration(
       }
     }
 
-    def frontendAccountCredentials: AWSCredentialsProvider =
-      crossAccount.getOrElse(
-        throw new BadConfigurationException(
-          "AWS credentials are not configured for cross account Frontend"
-        )
-      )
-    var crossAccount: Option[AWSCredentialsProvider] = {
-      val provider = new AWSCredentialsProviderChain(
-        new ProfileCredentialsProvider("frontend"),
-        new STSAssumeRoleSessionCredentialsProvider.Builder(
-          faciatool.stsRoleToAssume,
-          "frontend"
-        ).build()
-      )
-
-      // this is a bit of a convoluted way to check whether we actually have credentials.
-      // I guess in an ideal world there would be some sort of isConfigued() method...
-      try {
-        val creds = provider.getCredentials
-        Some(provider)
-      } catch {
-        case ex: AmazonClientException =>
-          logger.error("amazon client cross account exception")
-
-          // We really, really want to ensure that PROD is configured before saying a box is OK
-          if (isProd) throw ex
-          // this means that on dev machines you only need to configure keys if you are actually going to use them
-          None
-      }
-    }
     lazy val rdsClient = AmazonRDSClientBuilder
       .standard()
       .withCredentials(cmsFrontsAccountCredentials)

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -10,6 +10,7 @@ import com.amazonaws.auth.{
   AWSCredentialsProviderChain,
   STSAssumeRoleSessionCredentialsProvider
 }
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Content, SearchResponse}
 import com.gu.contentapi.client.{GuardianContentClient, IAMSigner, Parameter}
@@ -69,12 +70,19 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit
   }
 
   private val previewSigner = {
+    val stsClient = AWSSecurityTokenServiceClientBuilder
+      .standard()
+      .withCredentials(config.aws.cmsFrontsAccountCredentials)
+      .withRegion(config.aws.region)
+      .build()
+
     val capiPreviewCredentials = new AWSCredentialsProviderChain(
-      new ProfileCredentialsProvider("capi"),
       new STSAssumeRoleSessionCredentialsProvider.Builder(
         config.contentApi.previewRole,
         "capi"
-      ).build()
+      )
+        .withStsClient(stsClient)
+        .build()
     )
     new IAMSigner(
       credentialsProvider = capiPreviewCredentials,


### PR DESCRIPTION
Since the connection between facia and facia-press has been done via SNS+SQS rather than just SQS for a long time.