### PR TITLE
Remove CAPI credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can find the client for the Fronts tool in [fronts-client](./fronts-client).
 
 1. Install [NVM](https://github.com/creationix/nvm).
 2. Ensure [Docker](https://www.docker.com/products/docker-desktop) is installed
-3. Get credentials from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=cmsFronts-dev,capi-api-gateway) (`cmsFronts` & `capi`).
+3. Get credentials from [Janus](https://janus.gutools.co.uk/credentials?permissionId=cmsFronts-iam-facia-CODE-RunFaciaToolLocally-nL42h4zEgHhf).
 4. Grant [code](https://permissions.code.dev-gutools.co.uk/) permissions (used for local builds as well).  Any engineer on ed tools should be able to give you access. You need:
     1. fronts_access
     1. launch_commercial_fronts

--- a/app/services/Capi.scala
+++ b/app/services/Capi.scala
@@ -10,6 +10,7 @@ import com.amazonaws.auth.{
   AWSCredentialsProviderChain,
   STSAssumeRoleSessionCredentialsProvider
 }
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Content, SearchResponse}
 import com.gu.contentapi.client.{GuardianContentClient, IAMSigner, Parameter}
@@ -69,12 +70,19 @@ class GuardianCapi(config: ApplicationConfiguration)(implicit
   }
 
   private val previewSigner = {
+    val stsClient = AWSSecurityTokenServiceClientBuilder
+      .standard()
+      .withCredentials(config.aws.cmsFrontsAccountCredentials)
+      .withRegion(config.aws.region)
+      .build()
+
     val capiPreviewCredentials = new AWSCredentialsProviderChain(
-      new ProfileCredentialsProvider("capi"),
       new STSAssumeRoleSessionCredentialsProvider.Builder(
         config.contentApi.previewRole,
         "capi"
-      ).build()
+      )
+        .withStsClient(stsClient)
+        .build()
     )
     new IAMSigner(
       credentialsProvider = capiPreviewCredentials,


### PR DESCRIPTION
## What's changed?

Use STS for CAPI for local dev. I cannot see any reason why developers should need explicit CAPI IAM access when they can just use the same STS Assume Role session credentials that PROD/CODE does.

This also changes the Janus link to suggest that developers fetch `run-fronts-tool-locally` developer policy access rather than full cms-fronts account access.