### PR TITLE
Make commonly failing fronts v1 tests more robust

### DIFF
--- a/public/test/spec/breaking-news.spec.js
+++ b/public/test/spec/breaking-news.spec.js
@@ -72,8 +72,7 @@ describe('Breaking News', function () {
         .then(() => {
             expect(regions.front().collection(1).publishText()).toBe('Send alert');
             return regions.front().collection(1).publish()
-            // Wait for modal to appear
-            .then(() => wait.ms(100));
+            .then(() => wait.condition(() => regions.breakingNewsModal().isVisible(), 2000, 10, 'first breaking news modal visible'));
         })
         .then(() => {
             expect(regions.breakingNewsModal().isVisible()).toBe(true);
@@ -82,8 +81,7 @@ describe('Breaking News', function () {
         .then(() => {
             expect(regions.front().collection(1).group(2).trailCount()).toBe(1);
             return regions.front().collection(1).publish()
-            // Wait for modal to appear
-            .then(() => wait.ms(100));
+            .then(() => wait.condition(() => regions.breakingNewsModal().isVisible(), 2000, 10, 'second breaking news modal visible'));
         })
         .then(() => {
             expect(regions.breakingNewsModal().isVisible()).toBe(true);
@@ -105,7 +103,7 @@ describe('Breaking News', function () {
             })
             .done;
         })
-        .then(() => wait.ms(100))
+        .then(() => wait.condition(() => regions.alert().isVisible(), 2000, 10, 'success alert visible'))
         .then(() => {
             // confirmation alert
             expect(regions.alert().message()).toMatch(/sent successfully/i);
@@ -119,8 +117,7 @@ describe('Breaking News', function () {
         })
         .then(() => {
             return regions.front().collection(1).group(1).pasteOver()
-            // wait for modal to appear
-            .then(() => wait.ms(100));
+            .then(() => wait.condition(() => regions.alert().isVisible(), 2000, 10, 'one-article-only alert visible'));
         })
         .then(() => {
             expect(regions.front().collection(1).group(1).trailCount()).toBe(0);

--- a/public/test/spec/breaking-news.spec.js
+++ b/public/test/spec/breaking-news.spec.js
@@ -35,7 +35,12 @@ describe('Breaking News', function () {
 
         expect(regions.front().frontSelector()).toBeNull();
 
-        regions.latest().trail(1).copy()
+        wait.condition(
+            () => regions.latest().trail(1).dom !== undefined,
+            5000, 50,
+            'latest trail 1 loaded'
+        )
+        .then(() => regions.latest().trail(1).copy())
         .then(() => {
             return this.testPage.actions.edit(() => {
                 return regions.front().collection(1).group(2).pasteOver();
@@ -238,7 +243,12 @@ describe('Breaking News', function () {
     it('Allows the same alert to be sent multiple times', function(done) {
         const regions = this.testPage.regions;
 
-        regions.latest().trail(1).copy()
+        wait.condition(
+            () => regions.latest().trail(1).dom !== undefined,
+            5000, 50,
+            'latest trail 1 loaded'
+        )
+        .then(() => regions.latest().trail(1).copy())
         .then(() => {
             return this.testPage.actions.edit(() => {
                 return regions.front().collection(1).group(2).pasteOver();

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -222,9 +222,12 @@ describe('Config Front', function () {
             $('.linky.tool--metadata').click();
 
             return wait.condition(
-                () => $('.metadata--title').is(':visible'),
+                () => {
+                    const el = $('.metadata--title')[0];
+                    return el && !!ko.contextFor(el);
+                },
                 2000, 10,
-                'editMetadata: metadata modal visible'
+                'editMetadata: metadata title bound'
             )
             .then(() => {
                 dom.type('.metadata--title', 'Nicer title');
@@ -250,9 +253,12 @@ describe('Config Front', function () {
             var imageUrl = images.path('square.png');
 
             return wait.condition(
-                () => $('.metadata--provisionalImage').is(':visible'),
+                () => {
+                    const el = $('.metadata--provisionalImage')[0];
+                    return el && !!ko.contextFor(el);
+                },
                 2000, 10,
-                'changeImageUrl: metadata modal visible'
+                'changeImageUrl: metadata image field bound'
             )
             .then(() => {
                 dom.type('.metadata--provisionalImage', imageUrl);

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -220,11 +220,23 @@ describe('Config Front', function () {
 
         function editMetadata () {
             $('.linky.tool--metadata').click();
-            dom.type('.metadata--title', 'Nicer title');
-            $('.toggle--hidden').click();
-            $('.save-metadata').click();
 
-            return wait.ms(100).then(() => {
+            return wait.condition(
+                () => $('.metadata--title').is(':visible'),
+                2000, 10,
+                'editMetadata: metadata modal visible'
+            )
+            .then(() => {
+                dom.type('.metadata--title', 'Nicer title');
+                $('.toggle--hidden').click();
+                $('.save-metadata').click();
+                return wait.condition(
+                    () => persistence.front.update.calls.any(),
+                    5000, 50,
+                    'editMetadata: front.update called after save'
+                );
+            })
+            .then(() => {
                 var front = frontWidget.pinnedFront();
                 expect(persistence.front.update).toHaveBeenCalledWith(front);
                 expect(front.props.webTitle()).toBe('Nicer title');
@@ -236,9 +248,21 @@ describe('Config Front', function () {
         function changeImageUrl () {
             $('.linky.tool--metadata').click();
             var imageUrl = images.path('square.png');
-            dom.type('.metadata--provisionalImage', imageUrl);
 
-            return wait.condition(() => persistence.front.update.calls.any()).then(() => {
+            return wait.condition(
+                () => $('.metadata--provisionalImage').is(':visible'),
+                2000, 10,
+                'changeImageUrl: metadata modal visible'
+            )
+            .then(() => {
+                dom.type('.metadata--provisionalImage', imageUrl);
+                return wait.condition(
+                    () => persistence.front.update.calls.any(),
+                    5000, 50,
+                    'changeImageUrl: front.update called after image typed'
+                );
+            })
+            .then(() => {
                 var front = frontWidget.pinnedFront();
                 expect(persistence.front.update).toHaveBeenCalledWith(front);
                 expect(front.props.webTitle()).toBe('Nicer title');

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -10,6 +10,7 @@ import images from 'test/utils/images';
 import configRegion from 'test/utils/regions/config';
 import * as wait from 'test/utils/wait';
 import * as mockjax from 'test/utils/mockjax';
+import * as validateImageSrcUtils from 'utils/validate-image-src';
 import observableNumeric from '../../src/js/utils/observable-numeric';
 
 describe('Config Front', function () {
@@ -71,6 +72,13 @@ describe('Config Front', function () {
                 });
             });
         });
+        spyOn(validateImageSrcUtils, 'validateImageSrc').and.callFake(src => Promise.resolve({
+            src: src,
+            origin: src,
+            thumb: src,
+            width: 140,
+            height: 140
+        }));
         this.scope = mockjax.scope();
         this.scope({
             url: '/api/usage/add',

--- a/public/test/spec/config.front.spec.js
+++ b/public/test/spec/config.front.spec.js
@@ -262,8 +262,26 @@ describe('Config Front', function () {
             )
             .then(() => {
                 dom.type('.metadata--provisionalImage', imageUrl);
+                // Verify KO actually received the value before waiting for the async image load
                 return wait.condition(
-                    () => persistence.front.update.calls.any(),
+                    () => frontWidget.pinnedFront().provisionalImageUrl() === imageUrl,
+                    1000, 10,
+                    'changeImageUrl: provisionalImageUrl updated by KO binding'
+                );
+            })
+            .then(() => {
+                return wait.condition(
+                    () => {
+                        // If validateImageSrc rejected, the subscriber resets provisionalImageUrl
+                        // to undefined. Detect this immediately rather than timing out.
+                        const currentUrl = frontWidget.pinnedFront().provisionalImageUrl();
+                        if (currentUrl !== imageUrl) {
+                            throw new Error(
+                                `Image validation failed: provisionalImageUrl was reset to "${currentUrl}"`
+                            );
+                        }
+                        return persistence.front.update.calls.any();
+                    },
                     5000, 50,
                     'changeImageUrl: front.update called after image typed'
                 );

--- a/public/test/spec/latest.articles.spec.js
+++ b/public/test/spec/latest.articles.spec.js
@@ -25,8 +25,16 @@ describe('Latest widget', function () {
         this.ko.dispose();
     });
     function getAutocomplete (host) {
-        return ko.contextFor(host.container.querySelector('autocomplete').firstChild)
-            .$component;
+        return wait.condition(
+            () => {
+                const el = host.container.querySelector('autocomplete');
+                return el && el.firstChild && !!ko.contextFor(el.firstChild);
+            },
+            2000, 10,
+            'getAutocomplete: autocomplete component bound'
+        ).then(() => {
+            return ko.contextFor(host.container.querySelector('autocomplete').firstChild).$component;
+        });
     }
 
     it('toggles draft and live content', function (done) {
@@ -100,7 +108,9 @@ describe('Latest widget', function () {
                 return widget.loaded;
             }),
             wait.event('widget:load').then(() => {
-                autocomplete = getAutocomplete(this.ko);
+                return getAutocomplete(this.ko).then(component => {
+                    autocomplete = component;
+                });
             })
         ]);
 

--- a/public/test/utils/actions/base-action.js
+++ b/public/test/utils/actions/base-action.js
@@ -12,7 +12,7 @@ export default class {
 
         this.timeoutID = setTimeout(() => {
             this.firstRequestReject(new Error(this.TIMEOUT_ERROR_MSG || 'action timeout'));
-        }, 2000);
+        }, 5000);
     }
 
     mockSingleRequest(mock) {
@@ -23,6 +23,7 @@ export default class {
                 this.responseText = mock.responseText;
             },
             onAfterComplete: function () {
+                clearTimeout(instance.timeoutID);
                 setTimeout(() => {
                     instance.firstRequestResolve(instance.lastRequest);
                 }, 20);
@@ -41,6 +42,7 @@ export default class {
     }
 
     dispose() {
+        clearTimeout(this.timeoutID);
         mockjax.clear(this.interceptor);
     }
 }

--- a/public/test/utils/regions/alert.js
+++ b/public/test/utils/regions/alert.js
@@ -18,7 +18,7 @@ export class Alert {
 
     close() {
         $('.button-action', this.dom).click();
-        return wait.ms(100).then(() => this);
+        return wait.condition(() => !this.isVisible(), 2000, 10, 'alert closed').then(() => this);
     }
 }
 

--- a/public/test/utils/wait.js
+++ b/public/test/utils/wait.js
@@ -27,7 +27,14 @@ export function condition (predicate, timeout = 5000, interval = 50, label = '')
 	return new Promise((resolve, reject) => {
 		const start = Date.now();
 		const check = () => {
-			if (predicate()) {
+			let result;
+			try {
+				result = predicate();
+			} catch (e) {
+				reject(e);
+				return;
+			}
+			if (result) {
 				resolve();
 			} else if (Date.now() - start >= timeout) {
 				let msg = label

--- a/public/test/utils/wait.js
+++ b/public/test/utils/wait.js
@@ -23,14 +23,17 @@ export function ms (time) {
     });
 }
 
-export function condition (predicate, timeout = 5000, interval = 50) {
+export function condition (predicate, timeout = 5000, interval = 50, label = '') {
 	return new Promise((resolve, reject) => {
 		const start = Date.now();
 		const check = () => {
 			if (predicate()) {
 				resolve();
 			} else if (Date.now() - start >= timeout) {
-				reject(new Error('Timeout waiting for condition'));
+				let msg = label
+					? `Timeout waiting for condition: ${label}`
+					: 'Timeout waiting for condition';
+				reject(new Error(msg));
 			} else {
 				setTimeout(check, interval);
 			}


### PR DESCRIPTION
## What's changed?

Improved logging in tests and added more wait conditions so that (hopefully) tests are less flaky