### PR TITLE
Add templates for Feast US regional edition

### DIFF
--- a/app/model/editions/EditionsAppTemplates.scala
+++ b/app/model/editions/EditionsAppTemplates.scala
@@ -10,7 +10,8 @@ import model.editions.templates._
 import model.editions.templates.feast.{
   FeastAppEdition,
   FeastNorthernHemisphere,
-  FeastSouthernHemisphere
+  FeastSouthernHemisphere,
+  FeastUSRegion
 }
 import org.postgresql.util.PGobject
 import play.api.libs.json.{Json, OFormat}
@@ -61,7 +62,8 @@ object EditionsAppTemplates {
 object FeastAppTemplates {
   val templates: Map[Edition, FeastAppEdition] = Map(
     Edition.FeastNorthernHemisphere -> FeastNorthernHemisphere,
-    Edition.FeastSouthernHemisphere -> FeastSouthernHemisphere
+    Edition.FeastSouthernHemisphere -> FeastSouthernHemisphere,
+    Edition.FeastUSRegion -> FeastUSRegion
   )
 
   val getAvailableTemplates: List[CuratedPlatformWithTemplate] =
@@ -142,6 +144,8 @@ object Edition extends PlayEnum[Edition] {
   case object FeastSouthernHemisphere extends Edition
 
   case object FeastNorthernHemisphere extends Edition
+
+  case object FeastUSRegion extends Edition
 
   override def values = findValues
 }

--- a/app/model/editions/templates/feast/FeastUSRegion.scala
+++ b/app/model/editions/templates/feast/FeastUSRegion.scala
@@ -1,0 +1,48 @@
+package model.editions.templates.feast
+
+import model.editions.templates.TemplateHelpers.{collection, front}
+import model.editions.{
+  CapiDateQueryParam,
+  CapiTimeWindowConfigInDays,
+  Daily,
+  Edition,
+  EditionTemplate,
+  FrontTemplate
+}
+
+import java.time.ZoneId
+
+object FeastUSRegion extends FeastAppEdition {
+  override val title: String = "Feast app [US region]"
+  override val edition = Edition.FeastUSRegion.entryName
+  override val locale = Some("en_US")
+  override val notificationUTCOffset: Int = 0
+
+  override val path: String = "us"
+
+  val MainFront: FrontTemplate = front(
+    "All Recipes",
+    collection("Dish of the day")
+  )
+
+  val MeatFreeFront: FrontTemplate = front(
+    "Meat-Free",
+    collection("Dish of the day")
+  )
+
+  val template: EditionTemplate = EditionTemplate(
+    fronts = List(
+      MainFront -> Daily(),
+      MeatFreeFront -> Daily()
+    ),
+    timeWindowConfig = CapiTimeWindowConfigInDays(
+      startOffset = 0,
+      endOffset = 0
+    ),
+    capiDateQueryParam = CapiDateQueryParam.Published,
+    zoneId = ZoneId.of("America/New_York"),
+    availability = Daily(),
+    maybeOphanPath = None,
+    ophanQueryPrefillParams = None
+  )
+}

--- a/app/services/editions/publishing/Publishing.scala
+++ b/app/services/editions/publishing/Publishing.scala
@@ -3,7 +3,7 @@ package services.editions.publishing
 import java.time.OffsetDateTime
 import com.gu.pandomainauth.model.User
 import logging.Logging
-import model.editions.Edition.{FeastNorthernHemisphere, FeastSouthernHemisphere}
+import model.editions.Edition.{FeastNorthernHemisphere, FeastSouthernHemisphere, FeastUSRegion}
 import model.editions.{EditionsIssue, PublishAction}
 import net.logstash.logback.marker.Markers
 import services.editions.db.EditionsDB
@@ -22,7 +22,7 @@ class Publishing(
 
     // Archive a copy
     issue.edition match {
-      case FeastNorthernHemisphere | FeastSouthernHemisphere =>
+      case FeastNorthernHemisphere | FeastSouthernHemisphere | FeastUSRegion =>
         // Feast does not currently support previewing, but we don't need to be reminded of that every time someone drag/drops something!
         // Preview will be implemented, when it exists.
         ()
@@ -59,7 +59,7 @@ class Publishing(
 
   def getPublicationTarget(issue: EditionsIssue): PublicationTarget = {
     issue.edition match {
-      case FeastNorthernHemisphere | FeastSouthernHemisphere =>
+      case FeastNorthernHemisphere | FeastSouthernHemisphere | FeastUSRegion =>
         feastAppPublicationTarget
       case _ =>
         editionsAppPublicationBucket

--- a/app/services/editions/publishing/Publishing.scala
+++ b/app/services/editions/publishing/Publishing.scala
@@ -3,7 +3,11 @@ package services.editions.publishing
 import java.time.OffsetDateTime
 import com.gu.pandomainauth.model.User
 import logging.Logging
-import model.editions.Edition.{FeastNorthernHemisphere, FeastSouthernHemisphere, FeastUSRegion}
+import model.editions.Edition.{
+  FeastNorthernHemisphere,
+  FeastSouthernHemisphere,
+  FeastUSRegion
+}
 import model.editions.{EditionsIssue, PublishAction}
 import net.logstash.logback.marker.Markers
 import services.editions.db.EditionsDB


### PR DESCRIPTION
## What's changed?

- Adds a "US Region" edtition for Feast app

## Implementation notes

- Added a new Edition to the tool to represent US Region, with the same templates as the existing regions
- In order to ensure that they publish correctly to the recipes-backend, it's necessary to explicitly add the edition names to the Publishing logic so they get directed to SNS rather than the Editions S3

To test correct publication see the steps at https://github.com/guardian/recipes-backend/pull/212

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
