### PR TITLE
Fix collection permissions check

### DIFF
--- a/app/controllers/FaciaToolController.scala
+++ b/app/controllers/FaciaToolController.scala
@@ -39,7 +39,7 @@ class FaciaToolController(
     with ModifyCollectionsPermissionsCheck
     with Logging {
 
-  private val collectionPermissions = CollectionPermissions(configAgent.get)
+  private val collectionPermissions = CollectionPermissions(configAgent)
 
   def getConfig = AccessAPIAuthAction.async { request =>
     FaciaToolMetrics.ApiUsageCount.increment()

--- a/app/controllers/FaciaToolV2Controller.scala
+++ b/app/controllers/FaciaToolV2Controller.scala
@@ -35,7 +35,7 @@ class FaciaToolV2Controller(
     with ModifyCollectionsPermissionsCheck
     with Logging {
 
-  private val collectionPermissions = CollectionPermissions(configAgent.get)
+  private val collectionPermissions = CollectionPermissions(configAgent)
 
   def getCollections() =
     AccessAPIAuthAction(parse.json[Seq[CollectionSpec]]).async {

--- a/app/permissions/CollectionPermissions.scala
+++ b/app/permissions/CollectionPermissions.scala
@@ -1,11 +1,12 @@
 package permissions
 
 import com.gu.facia.client.models.ConfigJson
+import services.ConfigAgent
 
-case class CollectionPermissions(val config: Option[ConfigJson]) {
+case class CollectionPermissions(config: ConfigAgent) {
   def getFrontsPermissionsPriorityByCollectionId(
       id: String
-  ): Set[PermissionsPriority] = config match {
+  ): Set[PermissionsPriority] = config.get match {
     case None =>
       Set.empty[
         PermissionsPriority

--- a/app/permissions/CollectionPermissions.scala
+++ b/app/permissions/CollectionPermissions.scala
@@ -1,13 +1,17 @@
 package permissions
 
 import com.gu.facia.client.models.ConfigJson
+import logging.Logging
 import services.ConfigAgent
 
-case class CollectionPermissions(config: ConfigAgent) {
+case class CollectionPermissions(config: ConfigAgent) extends Logging {
   def getFrontsPermissionsPriorityByCollectionId(
       id: String
   ): Set[PermissionsPriority] = config.get match {
     case None =>
+      logger.warn(
+        "No config found when checking required permissions for a collection"
+      )
       Set.empty[
         PermissionsPriority
       ] // if there are no fronts in config, there can be no permissions....?

--- a/test/permissions/CollectionPermissionsTest.scala
+++ b/test/permissions/CollectionPermissionsTest.scala
@@ -1,7 +1,10 @@
 package permissions
 
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
+import org.mockito.Mockito.when
 import org.scalatest.{FreeSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import services.ConfigAgent
 
 class CollectionPermissionsTest extends FreeSpec with Matchers {
 
@@ -40,21 +43,24 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
     Map()
   )
 
+  val mockConfigAgent: ConfigAgent = mock[ConfigAgent]
+  when(mockConfigAgent.get).thenReturn(Some(configJson))
+
   "Collection Permission correctly inferred" - {
     "a commercial collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId("a") should contain(
         CommercialPermission
       )
     }
     "a non commercial collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "c"
         ) should not contain (CommercialPermission)
     }
     "a non editions collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "a"
         ) should not contain (EditionsPermission)
@@ -64,19 +70,19 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
 
   "Editorial Permission correctly inferred" - {
     "an editorial collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId("c") should contain(
         EditorialPermission
       )
     }
     "a non editorial collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "a"
         ) should not contain (EditorialPermission)
     }
     "a non editions collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "c"
         ) should not contain (EditionsPermission)
@@ -86,19 +92,19 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
 
   "Email Permission correctly inferred" - {
     "an email collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId("e") should contain(
         EmailPermission
       )
     }
     "a non email collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "a"
         ) should not contain (EmailPermission)
     }
     "a non editions collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "e"
         ) should not contain (EditionsPermission)
@@ -108,19 +114,19 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
 
   "Training Permission correctly inferred" - {
     "an training collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId("g") should contain(
         TrainingPermission
       )
     }
     "a non training collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "a"
         ) should not contain (TrainingPermission)
     }
     "a non editions collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "g"
         ) should not contain (EditionsPermission)
@@ -130,7 +136,7 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
 
   "Dual Permissions correctly inferred" - {
     "an commercial AND email collection" in {
-      val s = CollectionPermissions(Some(configJson))
+      val s = CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId("x")
       s should contain(CommercialPermission)
       s should contain(EmailPermission)
@@ -140,31 +146,31 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
 
   "Editions Permission correctly inferred" - {
     "an editions collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId("z") should contain(
         EditionsPermission
       )
     }
     "a non commercial collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "z"
         ) should not contain (CommercialPermission)
     }
     "a non editorial collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "z"
         ) should not contain (EditorialPermission)
     }
     "a non training collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "z"
         ) should not contain (TrainingPermission)
     }
     "a non email collection" in {
-      CollectionPermissions(Some(configJson))
+      CollectionPermissions(mockConfigAgent)
         .getFrontsPermissionsPriorityByCollectionId(
           "z"
         ) should not contain (EmailPermission)

--- a/test/permissions/CollectionPermissionsTest.scala
+++ b/test/permissions/CollectionPermissionsTest.scala
@@ -178,4 +178,14 @@ class CollectionPermissionsTest extends FreeSpec with Matchers {
 
   }
 
+  "Permissions assumed to be not needed" - {
+    "Config is missing" in {
+      val mockConfigAgent: ConfigAgent = mock[ConfigAgent]
+      when(mockConfigAgent.get).thenReturn(None)
+      val s = CollectionPermissions(mockConfigAgent)
+        .getFrontsPermissionsPriorityByCollectionId("x")
+      s shouldBe Set.empty
+    }
+  }
+
 }


### PR DESCRIPTION
## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->
As pointed out by @andrew-nowak, the Fronts tool currently has a bug in the permissions checks for various endpoints which means a user can access and edit collections beyond their permissions. This is due to the config value used by `CollectionPermissions` is set when the controllers are instantiated and before the config has been updated.  

<details><summary>Original message and detailed issue explanation</summary>
<p>

Unfortunately I'm fairly sure I've just discovered that the fronts tool isn't properly checking user's permissions. Despite not having permissions to either edit or launch editorial fronts on CODE, I've still been able to do so. Reproduction is fairly straight forward - remove your permissions (and wait a couple of minutes), then go to https://fronts.code.dev-gutools.co.uk/ and open the editorial priority fronts. (Going directly to https://fronts.code.dev-gutools.co.uk/v2/editorial, or reloading the page while having it open, does do a permissions check and locks me out, but the SPA navigation does not)

I've had a quick dig, and I'm fairly sure the problem is here: https://github.com/guardian/facia-tool/blob/d490441acfc79da933f34d088ce549b367ad5267/app/controllers/FaciaToolV2Controller.scala#L38. The CollectionPermissions class is constructed with the cached state of the config as it was when the instance was first launched, and never updated, but the ConfigAgent initialises its cache to None https://github.com/guardian/facia-tool/blob/d490441acfc79da933f34d088ce549b367ad5267/app/services/ConfigAgent.scala#L21. This means that when the permissions check is done, it falls into this case, which skips checking the user's permission https://github.com/guardian/facia-tool/blob/d490441acfc79da933f34d088ce549b367ad5267/app/permissions/CollectionPermissions.scala#L9.

I think a quick fix would be to change the CollectionPermissions class to take the ConfigAgent directly, and only call get inside the method when the permission check is being performed. This should mean that it always gets the latest state of the cached Config object, though it leaves the permissions checks to fail "open" if for some reason it holds a None at the time the user sends a request (in practice I think this will be unlikely, and if it did occur would probably suggest a failure to talk to S3, which would prevent their queries or updates from going through anyhow! but may still be worth further investigation)

</p>
</details> 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->
As with the existing behaviour, if a user attempts to navigate to locked views directly they be rejected: 

<img width="1182" height="539" alt="image" src="https://github.com/user-attachments/assets/132f6c22-eff9-4bac-8d83-06608a26a3e2" />

However, if they access the root view and navigate to the editorial page they will be able to see the collections albeit with limited controls and visibility: 

<img width="1182" height="264" alt="image" src="https://github.com/user-attachments/assets/b5c2ec19-b6e4-46b8-a3cf-f91008819fbd" />

### Edge Case

As discussed with @abeddow91, there is still an edge case where if config is set to `None` the permissions required will be relaxed. We have added logging to check for this case and will raise a ticket to plug this gap. 

## Testing

To confirm this functionality works as expected, you can set your local / CODE permissions using the CODE permissions tool. Without edit permissions for front, you should not be able to access the page directly. Navigating via the SPA to collections should result in collections not loading with requests returning a 401.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
