### PR TITLE
Add intended audience signifier to the clipboard results

### DIFF
--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -423,6 +423,11 @@ const articleBodyDefault = React.memo(
 						<CardHeading html data-testid="headline" displaySize={size}>
 							{headline}
 						</CardHeading>
+						{(intendedAudience && !showMeta) &&
+							<CardMetaContent title="The intended audience of this article.">
+								<IntendedAudienceSignifier {...intendedAudience} />
+							</CardMetaContent>
+						}
 						{displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
 					</CardHeadingContainer>
 				</CardContent>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -423,11 +423,11 @@ const articleBodyDefault = React.memo(
 						<CardHeading html data-testid="headline" displaySize={size}>
 							{headline}
 						</CardHeading>
-						{(intendedAudience && !showMeta) &&
+						{intendedAudience && !showMeta && (
 							<CardMetaContent title="The intended audience of this article.">
 								<IntendedAudienceSignifier {...intendedAudience} />
 							</CardMetaContent>
-						}
+						)}
 						{displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
 					</CardHeadingContainer>
 				</CardContent>


### PR DESCRIPTION
## What's changed?
This pr adds the intended audience signifier to the clipboard results:

<img width="221" height="559" alt="Screenshot 2026-06-30 at 10 21 51" src="https://github.com/user-attachments/assets/24ff1c31-6742-45ce-bfc1-6c1898a384be" />

## Implementation notes
The intended audience signifier normally appears in the meta section (as added in this pr: https://github.com/guardian/facia-tool/pull/1993). As the clipboard results don't show the meta section, but share the article card code with the fronts container view on the right hand side, the audience signifier will show underneath the headline, only if showMeta is set to false. That way it will show in one of the locations, but not both.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
