### PR TITLE
Bring dependencies up to date with the latest FAPI release

### DIFF
--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -323,7 +323,7 @@ trait UpdateActionsTrait extends Logging {
           DateTime.now.getMillis,
           Some(getUserName(identity)),
           update.itemMeta,
-					None
+          None
         )
       )
 
@@ -366,7 +366,7 @@ trait UpdateActionsTrait extends Logging {
             DateTime.now.getMillis,
             Some(userName),
             update.itemMeta,
-						None
+            None
           )
         ),
         None,
@@ -389,7 +389,7 @@ trait UpdateActionsTrait extends Logging {
               DateTime.now.getMillis,
               Some(userName),
               update.itemMeta,
-							None
+              None
             )
           )
         ),
@@ -473,7 +473,7 @@ trait UpdateActionsTrait extends Logging {
       DateTime.now.getMillis,
       Some(getUserName(identity)),
       update.itemMeta,
-			None
+      None
     )
     CollectionJson(
       live = Nil,

--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -322,7 +322,8 @@ trait UpdateActionsTrait extends Logging {
           update.item,
           DateTime.now.getMillis,
           Some(getUserName(identity)),
-          update.itemMeta
+          update.itemMeta,
+					None
         )
       )
 
@@ -364,7 +365,8 @@ trait UpdateActionsTrait extends Logging {
             update.item,
             DateTime.now.getMillis,
             Some(userName),
-            update.itemMeta
+            update.itemMeta,
+						None
           )
         ),
         None,
@@ -386,7 +388,8 @@ trait UpdateActionsTrait extends Logging {
               update.item,
               DateTime.now.getMillis,
               Some(userName),
-              update.itemMeta
+              update.itemMeta,
+							None
             )
           )
         ),
@@ -469,7 +472,8 @@ trait UpdateActionsTrait extends Logging {
       update.item,
       DateTime.now.getMillis,
       Some(getUserName(identity)),
-      update.itemMeta
+      update.itemMeta,
+			None
     )
     CollectionJson(
       live = Nil,

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "35.0.0",
+  "com.gu" %% "fapi-client-play30" % "35.0.0-PREVIEW.introduce-ab-test-model.2026-07-29T1454.6787c72d",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),
@@ -111,7 +111,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.mockito" % "mockito-core" % "5.11.0" % Test,
   "software.amazon.awssdk" % "s3" % awsSdkVersion,
-  "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "18.0.0"
+	"com.gu.etag-caching" %% "aws-s3-sdk-v2" % "18.0.0"
 )
 
 excludeDependencies ++= Seq(

--- a/test/services/CollectionServiceTest.scala
+++ b/test/services/CollectionServiceTest.scala
@@ -59,8 +59,8 @@ class CollectionServiceTest extends FreeSpec with Matchers {
   }
 
   private def collectionJson: CollectionJson = {
-    val live = List(Trail("existingId", 0, Some(""), None))
-    val draft = Trail("newId", 0, Some(""), None) :: live
+    val live = List(Trail("existingId", 0, Some(""), None, None))
+    val draft = Trail("newId", 0, Some(""), None, None) :: live
     CollectionJson(
       live,
       Some(draft),

--- a/test/tools/FaciaApiTest.scala
+++ b/test/tools/FaciaApiTest.scala
@@ -26,12 +26,12 @@ class FaciaApiTest extends FreeSpec with Matchers {
     }
     "existing article should have the old date" in {
       newCollectionJson.live.collect {
-        case Trail("existingId", 0, Some(""), _) => true
+        case Trail("existingId", 0, Some(""), _, _) => true
       } should have(Symbol("length")(1))
     }
     "new article should have an updated timestamp" in {
       newCollectionJson.live.collect {
-        case Trail("newId", t, Some(""), _) if t != 0 => true
+        case Trail("newId", t, Some(""), _, _) if t != 0 => true
       } should have(Symbol("length")(1))
     }
 
@@ -56,7 +56,7 @@ class FaciaApiTest extends FreeSpec with Matchers {
     }
     "existing article should have the old date" in {
       newCollectionJson.live.collect {
-        case Trail("existingId", 0, Some(""), _) => true
+        case Trail("existingId", 0, Some(""), _, _) => true
       } should have(Symbol("length")(1))
     }
 
@@ -64,8 +64,8 @@ class FaciaApiTest extends FreeSpec with Matchers {
 
   private def scenarioOneLiveAnotherDraft: (User, CollectionJson) = {
     val identity = User("John", "Duffell", "email@email.com", None)
-    val live = List(Trail("existingId", 0, Some(""), None))
-    val draft = Trail("newId", 0, Some(""), None) :: live
+    val live = List(Trail("existingId", 0, Some(""), None, None))
+    val draft = Trail("newId", 0, Some(""), None, None) :: live
     val collectionJson = CollectionJson(
       live,
       Some(draft),


### PR DESCRIPTION
## What's changed?
Bumps FAPI to **35.0.0-PREVIEW.introduce-ab-test-model.2026-07-28T0818.68e860ad** <- 🚨 **this needs to be updated before final release**
This includes the following version bumps
- capiModelsVersion from "38.0.0" to"46.0.0"
- capiClientVersion from "42.0.0" to "47.0.0"
- circeVersion from "0.13.0" to "0.14.10"

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
