### PR TITLE
Add test indicator icons to container overview

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -19,7 +19,7 @@ import {
 } from 'selectors/configSelectors';
 import {
 	createSelectGroupArticles,
-	createSelectAllCardsInCollection,
+	createSelectAllCardsInCollections,
 	selectCard,
 	selectFront,
 } from 'selectors/shared';
@@ -76,7 +76,7 @@ import { groupBy, uniqBy } from 'lodash';
 import { fetchChefsById } from 'bundles/chefsBundle';
 import { fetchRecipesById } from '../bundles/recipesBundle';
 
-const selectAllCardsInCollection = createSelectAllCardsInCollection();
+const selectAllCardsInCollections = createSelectAllCardsInCollections();
 
 function fetchStaleCollections(
 	collectionIds: string[],
@@ -86,7 +86,7 @@ function fetchStaleCollections(
 		const fetchedCollectionIds = await dispatch(
 			getCollections(collectionIds, true),
 		);
-		const prevArticleIds = selectAllCardsInCollection(
+		const prevArticleIds = selectAllCardsInCollections(
 			prevState,
 			fetchedCollectionIds,
 		);

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -84,10 +84,11 @@ const TextContainerLeft = styled.div`
 `;
 
 const TextContainerRight = styled.div`
-	flex: 0 0 auto;
+	display: flex;
+	flex-wrap: wrap;
 	font-size: 14px;
-	overflow: hidden;
-	white-space: nowrap;
+	justify-content: center;
+	gap: 2px;
 `;
 
 const Name = styled.span<{ isSecondaryContainer: boolean }>`
@@ -108,13 +109,9 @@ const ItemCount = styled.span`
 
 const StatusWarning = styled(ButtonDefault)`
 	outline: transparent;
-	:not(:first-child) {
-		margin-left: 5px;
-	}
 	color: ${theme.button.color};
-	height: 20px;
-	width: 20px;
-	border-radius: 20px;
+	height: 18px;
+	width: 18px;
 	&:hover,
 	&:active {
 		outline: transparent;
@@ -122,11 +119,8 @@ const StatusWarning = styled(ButtonDefault)`
 `;
 
 const TestIndicator = styled(ButtonDefault)`
-	:not(:first-child) {
-		margin-left: 5px;
-	}
-	height: 20px;
-	width: 20px;
+	height: 18px;
+	width: 18px;
 	&&:hover,
 	&&:active {
 		background: ${theme.base.colors.abTestActiveColor};
@@ -203,7 +197,7 @@ const CollectionOverview = ({
 				{liveAndDraftCards.some((card) => card.meta.abTestEnabled) && (
 					<EditModeVisibility visibleMode="fronts">
 						<TestIndicator priority="primary" size="s" title="Active tests">
-							<ConicalFlaskIcon size={'xs'} fill={'white'} />
+							<ConicalFlaskIcon size={'xxs'} fill={'white'} />
 						</TestIndicator>
 					</EditModeVisibility>
 				)}

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -122,19 +122,16 @@ const StatusWarning = styled(ButtonDefault)`
 `;
 
 const TestIndicator = styled(ButtonDefault)`
-	outline: transparent;
 	:not(:first-child) {
 		margin-left: 5px;
 	}
-	color: ${theme.button.color};
 	height: 20px;
 	width: 20px;
-	border-radius: 20px;
-	&:hover,
-	&:active {
-		outline: transparent;
+	&&:hover,
+	&&:active {
+		background: ${theme.base.colors.abTestActiveColor};
 	}
-	background-color: ${theme.base.colors.abTestActiveColor};
+	background: ${theme.base.colors.abTestActiveColor};
 `;
 
 const CollectionOverview = ({

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -8,16 +8,18 @@ import { Dispatch } from 'types/Store';
 import { selectHasUnpublishedChanges } from 'selectors/frontsSelectors';
 import { openCollectionsAndFetchTheirArticles } from 'actions/Collections';
 
-import { Collection, CardSets } from 'types/Collection';
+import { Collection, CardSets, Card } from 'types/Collection';
 import { createCollectionId } from 'components/CollectionDisplay';
 import ButtonDefault from 'components/inputs/ButtonCircular';
 import {
 	createSelectCollection,
 	createSelectCardsInCollection,
+	createSelectAllLiveAndDraftCardsInCollection,
 } from 'selectors/shared';
 import EditModeVisibility from 'components/util/EditModeVisibility';
 import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUI';
 import { css } from 'styled-components';
+import { ConicalFlaskIcon } from 'components/icons/Icons';
 
 interface FrontCollectionOverviewContainerProps {
 	frontId: string;
@@ -32,6 +34,7 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
 	openCollection: (id: string) => void;
 	hasUnpublishedChanges: boolean;
 	hasOpenForms: boolean;
+	liveAndDraftCards: Card[];
 };
 
 const Container = styled.div<{
@@ -118,6 +121,22 @@ const StatusWarning = styled(ButtonDefault)`
 	}
 `;
 
+const TestIndicator = styled(ButtonDefault)`
+	outline: transparent;
+	:not(:first-child) {
+		margin-left: 5px;
+	}
+	color: ${theme.button.color};
+	height: 20px;
+	width: 20px;
+	border-radius: 20px;
+	&:hover,
+	&:active {
+		outline: transparent;
+	}
+	background-color: ${theme.base.colors.abTestActiveColor};
+`;
+
 const CollectionOverview = ({
 	collection,
 	cardCount,
@@ -126,6 +145,7 @@ const CollectionOverview = ({
 	hasUnpublishedChanges,
 	isSelected,
 	hasOpenForms,
+	liveAndDraftCards,
 }: FrontCollectionOverviewProps) =>
 	collection ? (
 		<Container
@@ -183,6 +203,13 @@ const CollectionOverview = ({
 							</StatusWarning>
 						</EditModeVisibility>
 					) : null)}
+				{liveAndDraftCards.some((card) => card.meta.abTestEnabled) && (
+					<EditModeVisibility visibleMode="fronts">
+						<TestIndicator priority="primary" size="s" title="Active tests">
+							<ConicalFlaskIcon size={'xs'} fill={'white'} />
+						</TestIndicator>
+					</EditModeVisibility>
+				)}
 			</TextContainerRight>
 		</Container>
 	) : null;
@@ -192,6 +219,9 @@ const mapStateToProps = () => {
 	const selectCardsInCollection = createSelectCardsInCollection();
 	const selectCollectionIdsWithOpenForms =
 		createSelectCollectionIdsWithOpenForms();
+
+	const selectLiveAndDraftCards =
+		createSelectAllLiveAndDraftCardsInCollection();
 	return (
 		state: State,
 		{
@@ -215,6 +245,7 @@ const mapStateToProps = () => {
 			selectCollectionIdsWithOpenForms(state, { frontId }).indexOf(
 				collectionId,
 			) !== -1,
+		liveAndDraftCards: selectLiveAndDraftCards(state, collectionId),
 	});
 };
 

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -446,7 +446,7 @@ const createSelectLiveCardForGivenCardId = () => {
 	};
 };
 
-const createSelectAllCardsInCollection = () => {
+const createSelectAllCardsInCollections = () => {
 	const selectCardsInCollection = createSelectCardsInCollection();
 
 	return (state: State, collectionIds: string[]) =>
@@ -466,6 +466,26 @@ const createSelectAllCardsInCollection = () => {
 			],
 			[] as string[],
 		);
+};
+
+const createSelectAllLiveAndDraftCardsInCollection = () => {
+	const selectCardsInCollection = createSelectCardsInCollection();
+
+	return (state: State, collectionId: string) => {
+		const liveAndDraftCardIds = (['live', 'draft'] as CardSets[]).reduce(
+			(acc, collectionSet) => [
+				...acc,
+				...selectCardsInCollection(state, {
+					collectionId,
+					collectionSet,
+				}),
+			],
+			[] as string[],
+		);
+
+		const cardMap = selectCardMap(state);
+		return liveAndDraftCardIds.map((cardId) => cardMap[cardId]);
+	};
 };
 
 const selectCardId = (_: unknown, { cardId }: { cardId: string }) => cardId;
@@ -620,10 +640,11 @@ export {
 	selectExternalArticleFromCard,
 	createSelectArticleFromCard,
 	selectCardsFromRootState,
+	createSelectAllLiveAndDraftCardsInCollection,
 	createSelectCardsInCollectionGroup,
 	createSelectCardsInCollection,
 	createSelectLiveCardForGivenCardId,
-	createSelectAllCardsInCollection,
+	createSelectAllCardsInCollections,
 	createSelectGroupArticles,
 	createSelectSupportingArticles,
 	createSelectCollection,


### PR DESCRIPTION
## What's changed?
In the container overview, adds conical flask icons to any container with live or draft tests. Also updates the icon styling to allow them to wrap instead of overflowing the container when they don't fit on one line. This is done using the `flex-wrap` property. The icons are now also a little smaller, and are spaced out using `gap` instead of `margin-left`. The spacing has also been reduced from `5px` to `2px`. This makes the styling a bit more resilient for different container names and icon numbers.

<img width="176" height="243" alt="Screenshot 2026-08-04 at 12 06 28" src="https://github.com/user-attachments/assets/5e80fbb4-cdb5-4b72-a710-4533d1616b0c" />
