### PR TITLE
Update Facia client and associated dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,11 +52,11 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.12.470"
-val capiModelsVersion = "38.0.0"
-val capiClientVersion = "42.0.1"
+val capiModelsVersion = "46.0.0"
+val capiClientVersion = "47.0.0"
 val json4sVersion = "4.0.3"
-val circeVersion = "0.13.0"
-val awsSdkVersion = "2.43.0"
+val circeVersion = "0.14.10"
+val awsSdkVersion = "2.49.6"
 
 resolvers ++= Seq(
   Resolver.file("Local", file(Path.userHome.absolutePath + "/.ivy2/local"))(
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "30.0.0",
+  "com.gu" %% "fapi-client-play30" % "35.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),
@@ -111,7 +111,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.mockito" % "mockito-core" % "5.11.0" % Test,
   "software.amazon.awssdk" % "s3" % awsSdkVersion,
-  "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
+  "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "18.0.0"
 )
 
 excludeDependencies ++= Seq(


### PR DESCRIPTION
Example of a similar update PR:

* https://github.com/guardian/apple-news/pull/733

## Testing

[Deployed](https://riffraff.gutools.co.uk/deployment/view/8a6558ac-8666-4640-b19b-042437836caf) to CODE,  https://fronts.code.dev-gutools.co.uk/v2/editorial looks good:

<img width="1916" height="1039" alt="image" src="https://github.com/user-attachments/assets/7e23acba-23de-4bc3-81c9-b76137be1102" />

