### PR TITLE
Connect model with UI

### DIFF
--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -323,7 +323,7 @@ trait UpdateActionsTrait extends Logging {
           DateTime.now.getMillis,
           Some(getUserName(identity)),
           update.itemMeta,
-					None
+          None
         )
       )
 
@@ -366,7 +366,7 @@ trait UpdateActionsTrait extends Logging {
             DateTime.now.getMillis,
             Some(userName),
             update.itemMeta,
-						None
+            None
           )
         ),
         None,
@@ -389,7 +389,7 @@ trait UpdateActionsTrait extends Logging {
               DateTime.now.getMillis,
               Some(userName),
               update.itemMeta,
-							None
+              None
             )
           )
         ),
@@ -473,7 +473,7 @@ trait UpdateActionsTrait extends Logging {
       DateTime.now.getMillis,
       Some(getUserName(identity)),
       update.itemMeta,
-			None
+      None
     )
     CollectionJson(
       live = Nil,

--- a/app/model/frontsapi.scala
+++ b/app/model/frontsapi.scala
@@ -322,7 +322,8 @@ trait UpdateActionsTrait extends Logging {
           update.item,
           DateTime.now.getMillis,
           Some(getUserName(identity)),
-          update.itemMeta
+          update.itemMeta,
+					None
         )
       )
 
@@ -364,7 +365,8 @@ trait UpdateActionsTrait extends Logging {
             update.item,
             DateTime.now.getMillis,
             Some(userName),
-            update.itemMeta
+            update.itemMeta,
+						None
           )
         ),
         None,
@@ -386,7 +388,8 @@ trait UpdateActionsTrait extends Logging {
               update.item,
               DateTime.now.getMillis,
               Some(userName),
-              update.itemMeta
+              update.itemMeta,
+							None
             )
           )
         ),
@@ -469,7 +472,8 @@ trait UpdateActionsTrait extends Logging {
       update.item,
       DateTime.now.getMillis,
       Some(getUserName(identity)),
-      update.itemMeta
+      update.itemMeta,
+			None
     )
     CollectionJson(
       live = Nil,

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "35.0.0",
+  "com.gu" %% "fapi-client-play30" % "37.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -10,7 +10,7 @@ import {
 	insertSupportingCard,
 	removeGroupCard,
 	removeSupportingCard,
-	updateCardMeta,
+	updateCard,
 	cardsReceived,
 	maybeAddFrontPublicationDate,
 	copyCardImageMeta,
@@ -201,8 +201,8 @@ const getRemoveActionCreatorFromType = (
 		: actionCreator;
 };
 
-const updateCardMetaWithPersist = (persistTo: PersistTo) =>
-	addPersistMetaToAction(updateCardMeta, {
+const updateCardWithPersist = (persistTo: PersistTo) =>
+	addPersistMetaToAction(updateCard, {
 		persistTo,
 	});
 
@@ -219,7 +219,7 @@ const minimumGroupBoostLevel = (groupName: string) => {
 	}
 };
 
-export type UpdateCardMetaParams = {
+export type UpdateCardParams = {
 	from: PosSpec | null;
 	to: PosSpec;
 	card: Card;
@@ -238,11 +238,11 @@ export const mayResetBoostLevel = ({
 	card,
 	persistTo,
 	state,
-}: UpdateCardMetaParams) => {
+}: UpdateCardParams) => {
 	if (to.type !== 'group' || persistTo !== 'collection') return;
 	if (from?.id === to.id) return;
 	const groupName = to.groupName ?? 'standard';
-	return updateCardMeta(
+	return updateCard(
 		card.uuid,
 		{
 			boostLevel: minimumGroupBoostLevel(groupName),
@@ -262,7 +262,7 @@ export const mayResetImageReplace = ({
 	card,
 	persistTo,
 	state,
-}: UpdateCardMetaParams) => {
+}: UpdateCardParams) => {
 	if (
 		to.type === 'group' &&
 		persistTo === 'collection' &&
@@ -283,7 +283,7 @@ export const mayResetImageReplace = ({
 
 		if (replacementImageIsPortrait && !movingToPortraitCollection) {
 			// disable replacement image
-			return updateCardMeta(
+			return updateCard(
 				card.uuid,
 				{
 					imageReplace: false,
@@ -300,7 +300,7 @@ export const mayResetImmersive = ({
 	card,
 	persistTo,
 	state,
-}: UpdateCardMetaParams) => {
+}: UpdateCardParams) => {
 	if (
 		to.type === 'group' &&
 		persistTo === 'collection' &&
@@ -316,7 +316,7 @@ export const mayResetImmersive = ({
 
 		if (!toCollectionSupportsImmersive) {
 			// turn off immersive
-			return updateCardMeta(
+			return updateCard(
 				card.uuid,
 				{
 					isImmersive: false,
@@ -337,7 +337,7 @@ export const mayResetVideoReplace = ({
 	card,
 	persistTo,
 	state,
-}: UpdateCardMetaParams) => {
+}: UpdateCardParams) => {
 	if (
 		to.type === 'group' &&
 		persistTo === 'collection' &&
@@ -365,7 +365,7 @@ export const mayResetVideoReplace = ({
 		// if we found some dimensions and the video doesn't match the target container...
 		if (dimensions && replacementVideoIsPortrait !== toCollectionIsPortrait) {
 			// disable replacement video
-			return updateCardMeta(
+			return updateCard(
 				card.uuid,
 				{
 					videoReplace: false,
@@ -515,7 +515,7 @@ const moveCard = (
 					dispatch(cardsReceived([parent, ...supporting]));
 				}
 
-				const actionParams: UpdateCardMetaParams = {
+				const actionParams: UpdateCardParams = {
 					from,
 					to,
 					card: parent,
@@ -566,7 +566,7 @@ const addCardToClipboard = (uuid: string) =>
 
 const addImageToCard =
 	(persistTo: PersistTo) => (uuid: string, imageData: ValidationResponse) =>
-		updateCardMetaWithPersist(persistTo)(
+		updateCardWithPersist(persistTo)(
 			uuid,
 			{
 				...getImageMetaFromValidationResponse(imageData),
@@ -607,7 +607,7 @@ export const createArticleEntitiesFromDrop = (
 export {
 	insertCardWithCreate,
 	moveCard,
-	updateCardMetaWithPersist,
+	updateCardWithPersist,
 	removeCard,
 	addImageToCard,
 	copyCardImageMetaWithPersist,

--- a/fronts-client/src/actions/CardsCommon.ts
+++ b/fronts-client/src/actions/CardsCommon.ts
@@ -1,7 +1,7 @@
 import keyBy from 'lodash/keyBy';
-import type { Card, CardMeta } from '../types/Collection';
+import type { Card, CardMeta, Test } from '../types/Collection';
 
-export const UPDATE_CARD_META = 'UPDATE_CARD_META' as const;
+export const UPDATE_CARD = 'UPDATE_CARD' as const;
 export const CARDS_RECEIVED = 'CARDS_RECEIVED' as const;
 export const CLEAR_CARDS = 'CLEAR_CARDS' as const;
 export const REMOVE_GROUP_CARD = 'REMOVE_GROUP_CARD' as const;
@@ -12,22 +12,24 @@ export const COPY_CARD_IMAGE_META = 'COPY_CARD_IMAGE_META' as const;
 export const MAYBE_ADD_FRONT_PUBLICATION =
 	'MAYBE_ADD_FRONT_PUBLICATION' as const;
 
-function updateCardMeta(
+function updateCard(
 	id: string,
 	meta: CardMeta,
 	{ merge }: { merge: boolean } = { merge: false },
+	test?: Test,
 ) {
 	return {
-		type: UPDATE_CARD_META,
+		type: UPDATE_CARD,
 		payload: {
 			id,
 			meta,
 			merge,
+			test,
 		},
 	};
 }
 
-type UpdateCardMeta = ReturnType<typeof updateCardMeta>;
+type UpdateCard = ReturnType<typeof updateCard>;
 
 // This can accept either a map of cards or an array (from which a
 // map will be generated)
@@ -151,10 +153,10 @@ export type CardActions =
 	| RemoveGroupCard
 	| RemoveSupportingCard
 	| ClearCards
-	| UpdateCardMeta;
+	| UpdateCard;
 
 export {
-	updateCardMeta,
+	updateCard,
 	cardsReceived,
 	insertGroupCard,
 	insertSupportingCard,

--- a/fronts-client/src/components/Clipboard.tsx
+++ b/fronts-client/src/components/Clipboard.tsx
@@ -8,7 +8,7 @@ import {
 	addImageToCard,
 	moveCard,
 	removeCard as removeCardAction,
-	updateCardMetaWithPersist as updateCardMetaAction,
+	updateCardWithPersist as updateCardAction,
 } from 'actions/Cards';
 import {
 	editorSelectCard,
@@ -92,7 +92,7 @@ interface ClipboardProps {
 	isClipboardFocused: boolean;
 	clipboardHasOpenForms: boolean;
 	clipboardHasContent: boolean;
-	updateCardMeta: (id: string, meta: CardMeta) => void;
+	updateCard: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
 }
 
@@ -146,7 +146,7 @@ class Clipboard extends React.Component<ClipboardProps> {
 			selectCard,
 			removeCard,
 			removeSupportingCard,
-			updateCardMeta,
+			updateCard,
 			addImageToCard,
 		} = this.props;
 		return (
@@ -205,7 +205,7 @@ class Clipboard extends React.Component<ClipboardProps> {
 														textSize="small"
 														onSelect={selectCard}
 														onDelete={() => removeCard(card.uuid)}
-														updateCardMeta={updateCardMeta}
+														updateCard={updateCard}
 														addImageToCard={addImageToCard}
 													>
 														<CardLevel
@@ -229,7 +229,7 @@ class Clipboard extends React.Component<ClipboardProps> {
 																			supporting.uuid,
 																		)
 																	}
-																	updateCardMeta={updateCardMeta}
+																	updateCard={updateCard}
 																	addImageToCard={addImageToCard}
 																/>
 															)}
@@ -302,7 +302,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 	...bindActionCreators(
 		{
 			selectCard: editorSelectCard,
-			updateCardMeta: updateCardMetaAction('clipboard'),
+			updateCard: updateCardAction('clipboard'),
 			handleBlur: resetFocusState,
 			addImageToCard: addImageToCard('clipboard'),
 		},

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -20,7 +20,7 @@ import type { State } from 'types/State';
 import { createSelectArticleVisibilityDetails } from 'selectors/frontsSelectors';
 import FocusWrapper from 'components/FocusWrapper';
 import { CardTypes } from 'constants/cardTypes';
-import { updateCardMetaWithPersist as updateCardMetaAction } from 'actions/Cards';
+import { updateCardWithPersist as updateCardAction } from 'actions/Cards';
 import { ValidationResponse } from '../../util/validateImageSrc';
 import { bindActionCreators } from 'redux';
 import { createSelectCardsWhichAreAlsoOnOtherCollectionsOnSameFront } from '../../selectors/shared';
@@ -120,7 +120,7 @@ interface ConnectedCollectionContextProps extends CollectionContextProps {
 	lastDesktopArticle?: string;
 	lastMobileArticle?: string;
 	cardsWhichAreAlsoOnOtherCollectionsOnSameFront?: CardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap;
-	updateCardMeta: (id: string, meta: CardMeta) => void;
+	updateCard: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
 }
 
@@ -143,7 +143,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			lastDesktopArticle,
 			lastMobileArticle,
 			cardsWhichAreAlsoOnOtherCollectionsOnSameFront,
-			updateCardMeta,
+			updateCard,
 			addImageToCard,
 		} = this.props;
 
@@ -205,7 +205,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 													onSelect={() => selectCard(card.uuid, id, false)}
 													onDelete={() => removeCard(group.uuid, card.uuid)}
 													groupSizeId={group.id ? parseInt(group.id) : 0}
-													updateCardMeta={updateCardMeta}
+													updateCard={updateCard}
 													addImageToCard={addImageToCard}
 													otherCollectionsOnSameFrontThisCardIsOn={
 														otherCollectionsOnSameFrontThisCardIsOn
@@ -249,7 +249,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 																		)
 																	}
 																	size="small"
-																	updateCardMeta={updateCardMeta}
+																	updateCard={updateCard}
 																	addImageToCard={addImageToCard}
 																	otherCollectionsOnSameFrontThisCardIsOn={
 																		otherCollectionsOnSameFrontThisSublinkIsOn
@@ -322,7 +322,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 	handleBlur: () => dispatch(resetFocusState()),
 	...bindActionCreators(
 		{
-			updateCardMeta: updateCardMetaAction('collection'),
+			updateCard: updateCardAction('collection'),
 			addImageToCard: addImageToCard('collection'),
 		},
 		dispatch,

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -20,6 +20,7 @@ import EditModeVisibility from 'components/util/EditModeVisibility';
 import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUI';
 import { css } from 'styled-components';
 import { ConicalFlaskIcon } from 'components/icons/Icons';
+import { hasAbTestOnCard } from '../../util/abTests';
 
 interface FrontCollectionOverviewContainerProps {
 	frontId: string;
@@ -194,7 +195,7 @@ const CollectionOverview = ({
 							</StatusWarning>
 						</EditModeVisibility>
 					) : null)}
-				{liveAndDraftCards.some((card) => card.meta.abTestEnabled) && (
+				{liveAndDraftCards.some((card) => hasAbTestOnCard(card)) && (
 					<EditModeVisibility visibleMode="fronts">
 						<TestIndicator priority="primary" size="s" title="Active tests">
 							<ConicalFlaskIcon size={'xxs'} fill={'white'} />

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -12,6 +12,7 @@ import {
 	CardSizes,
 	CardMeta,
 	OtherCollectionsOnSameFrontThisCardIsOn,
+	Test,
 } from 'types/Collection';
 import SnapLink from 'components/card/snapLink/SnapLinkCard';
 import {
@@ -107,7 +108,12 @@ interface ContainerProps {
 	isSupporting?: boolean;
 	canDragImage?: boolean;
 	canShowPageViewData: boolean;
-	updateCardMeta: (id: string, meta: CardMeta) => void;
+	updateCard: (
+		id: string,
+		meta: CardMeta,
+		merge?: boolean,
+		test?: Test,
+	) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
 }
 
@@ -166,7 +172,7 @@ class Card extends React.Component<CardContainerProps> {
 			pillarId,
 			collectionType,
 			groupSizeId,
-			updateCardMeta,
+			updateCard,
 			otherCollectionsOnSameFrontThisCardIsOn,
 		} = this.props;
 
@@ -322,7 +328,7 @@ class Card extends React.Component<CardContainerProps> {
 							key={uuid}
 							form={uuid}
 							onSave={(meta) => {
-								updateCardMeta(uuid, meta);
+								updateCard(uuid, meta);
 								clearCardSelection(uuid);
 							}}
 							onCancel={() => clearCardSelection(uuid)}
@@ -336,7 +342,7 @@ class Card extends React.Component<CardContainerProps> {
 							key={uuid}
 							form={uuid}
 							onSave={(meta) => {
-								updateCardMeta(uuid, meta);
+								updateCard(uuid, meta);
 								clearCardSelection(uuid);
 							}}
 							onCancel={() => clearCardSelection(uuid)}
@@ -351,9 +357,9 @@ class Card extends React.Component<CardContainerProps> {
 							key={uuid}
 							form={uuid}
 							frontId={frontId}
-							onSave={(meta) => {
+							onSave={(meta, test) => {
 								//TODO: check if we need an updateCardTest function here.
-								updateCardMeta(uuid, meta);
+								updateCard(uuid, meta, false, test);
 								clearCardSelection(uuid);
 							}}
 							onCancel={() => clearCardSelection(uuid)}

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -352,6 +352,7 @@ class Card extends React.Component<CardContainerProps> {
 							form={uuid}
 							frontId={frontId}
 							onSave={(meta) => {
+								//TODO: check if we need an updateCardTest function here.
 								updateCardMeta(uuid, meta);
 								clearCardSelection(uuid);
 							}}

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -358,7 +358,6 @@ class Card extends React.Component<CardContainerProps> {
 							form={uuid}
 							frontId={frontId}
 							onSave={(meta, test) => {
-								//TODO: check if we need an updateCardTest function here.
 								updateCard(uuid, meta, false, test);
 								clearCardSelection(uuid);
 							}}

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -27,6 +27,7 @@ import { dragEventHasImageData } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
 import { getMainMediaVideoAtom } from '../../../util/externalArticle';
 import { intendedAudienceFromTags } from 'lib/capi/IntendedAudience';
+import { hasAbTestOnCard } from '../../../util/abTests';
 
 const ArticleBodyContainer = styled(CardBody)<{
 	pillarId: string | undefined;
@@ -226,7 +227,7 @@ const createMapStateToProps = () => {
 			card.id,
 			props.collectionId,
 		);
-		const hasLiveAbTest = liveCard?.meta.abTestEnabled;
+		const hasLiveAbTest = hasAbTestOnCard(liveCard);
 
 		return {
 			article,

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -1242,9 +1242,13 @@ const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({
 				props.cardId,
 				values,
 			);
-			const test = getCardTestFromFormValues(getState(), props.cardId, values);
+			const maybeTest = getCardTestFromFormValues(
+				getState(),
+				props.cardId,
+				values,
+			);
 
-			props.onSave(meta, test);
+			props.onSave(meta, maybeTest);
 		});
 	},
 })(FormComponent);

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -18,7 +18,13 @@ import {
 } from 'selectors/shared';
 import { createSelectFormFieldsForCard } from 'selectors/formSelectors';
 import { emptyObject } from 'util/selectorUtils';
-import { CardMeta, ArticleTag, CardSizes, ImageData } from 'types/Collection';
+import {
+	CardMeta,
+	ArticleTag,
+	CardSizes,
+	ImageData,
+	Test,
+} from 'types/Collection';
 import InputText from 'components/inputs/InputText';
 import InputTextArea from 'components/inputs/InputTextArea';
 import InputCheckboxToggleInline from 'components/inputs/InputCheckboxToggleInline';
@@ -37,6 +43,7 @@ import {
 	getCapiValuesForArticleFields,
 	shouldRenderField,
 	maxSlideshowImages,
+	getCardTestFromFormValues,
 } from 'util/form';
 import { CapiFields } from 'util/form';
 import { Dispatch } from 'types/Store';
@@ -1235,7 +1242,9 @@ const CardForm = reduxForm<CardFormData, ComponentProps & InterfaceProps, {}>({
 				props.cardId,
 				values,
 			);
-			props.onSave(meta);
+			const test = getCardTestFromFormValues(getState(), props.cardId, values);
+
+			props.onSave(meta, test);
 		});
 	},
 })(FormComponent);
@@ -1276,7 +1285,7 @@ interface InterfaceProps {
 	cardId: string;
 	isSupporting?: boolean;
 	onCancel: () => void;
-	onSave: (meta: CardMeta) => void;
+	onSave: (meta: CardMeta, test?: Test) => void;
 	frontId: string;
 	size?: CardSizes;
 	groupSizeId?: number;

--- a/fronts-client/src/reducers/__tests__/cardsReducer.spec.ts
+++ b/fronts-client/src/reducers/__tests__/cardsReducer.spec.ts
@@ -1,5 +1,5 @@
 import reducer from 'reducers/cardsReducer';
-import { updateCardMeta } from '../../actions/CardsCommon';
+import { updateCard } from '../../actions/CardsCommon';
 import { stateWithClipboard } from 'fixtures/clipboard';
 
 describe('cardsReducer', () => {
@@ -7,7 +7,7 @@ describe('cardsReducer', () => {
 		expect(
 			reducer(
 				stateWithClipboard.cards as any,
-				updateCardMeta('article', {
+				updateCard('article', {
 					headline: 'headline',
 				}),
 			).article.meta,
@@ -19,7 +19,7 @@ describe('cardsReducer', () => {
 		expect(
 			reducer(
 				stateWithClipboard.cards as any,
-				updateCardMeta('article2', {
+				updateCard('article2', {
 					headline: 'headline',
 				}),
 			).article2.meta,
@@ -31,7 +31,7 @@ describe('cardsReducer', () => {
 		expect(
 			reducer(
 				stateWithClipboard.cards as any,
-				updateCardMeta(
+				updateCard(
 					'article2',
 					{
 						headline: 'headline',

--- a/fronts-client/src/reducers/cardsReducer.ts
+++ b/fronts-client/src/reducers/cardsReducer.ts
@@ -25,7 +25,6 @@ const cards = (state: State['cards'] = {}, action: Action) => {
 				[id]: {
 					...state[id],
 					meta: merge ? { ...(state[id].meta || {}), ...meta } : meta,
-					// let's revisit merge behaviour here to see if we should handle it
 					tests: updatedTests,
 				},
 			};

--- a/fronts-client/src/reducers/cardsReducer.ts
+++ b/fronts-client/src/reducers/cardsReducer.ts
@@ -2,7 +2,7 @@ import { insertAndDedupeSiblings } from '../util/insertAndDedupeSiblings';
 import type { Action } from 'types/Action';
 import type { State } from 'types/State';
 import {
-	UPDATE_CARD_META,
+	UPDATE_CARD,
 	CARDS_RECEIVED,
 	CLEAR_CARDS,
 	REMOVE_SUPPORTING_CARD,
@@ -13,15 +13,20 @@ import { cloneActiveImageMeta } from 'util/card';
 
 const cards = (state: State['cards'] = {}, action: Action) => {
 	switch (action.type) {
-		case UPDATE_CARD_META: {
-			const { id } = action.payload;
+		case UPDATE_CARD: {
+			const { id, meta, merge, test } = action.payload;
+			const unchangedTests =
+				state[id].tests?.filter(
+					(existingTest) => existingTest.testUuid !== test?.testUuid,
+				) || [];
+			const updatedTests = test ? [...unchangedTests, test] : state[id].tests;
 			return {
 				...state,
 				[id]: {
 					...state[id],
-					meta: action.payload.merge
-						? { ...(state[id].meta || {}), ...action.payload.meta }
-						: action.payload.meta,
+					meta: merge ? { ...(state[id].meta || {}), ...meta } : meta,
+					// let's revisit merge behaviour here to see if we should handle it
+					tests: updatedTests,
 				},
 			};
 		}

--- a/fronts-client/src/selectors/__tests__/shared.spec.ts
+++ b/fronts-client/src/selectors/__tests__/shared.spec.ts
@@ -159,26 +159,97 @@ const state: any = {
 		},
 	},
 	cards: {
-		af1: {
+		af1WithNoRunningTest: {
 			uuid: 'af1',
 			id: 'ea1',
 			frontPublicationDate: 1,
 			publishedBy: 'A. N. Author',
 			meta: {},
 		},
-		af1WithOverrides: {
+		af1WithOverridesAndNoRunningTest: {
 			uuid: 'af1',
 			id: 'ea1',
 			frontPublicationDate: 1,
 			publishedBy: 'A. N. Author',
 			meta: {
 				headline: 'card-headline',
-				headlineA: 'card-headline-a',
 				trailText: 'card-trailText',
 				byline: 'card-byline',
 				customKicker: 'card-kicker',
 				showKickerCustom: true,
 			},
+		},
+		af1WithOverridesAndTestOnFirstDraft: {
+			uuid: 'af1',
+			id: 'ea1',
+			frontPublicationDate: 1,
+			publishedBy: 'A. N. Author',
+			meta: {
+				headline: 'card-headline',
+				trailText: 'card-trailText',
+				byline: 'card-byline',
+				customKicker: 'card-kicker',
+				showKickerCustom: true,
+			},
+			tests: [
+				{
+					testUuid: 'testUuid1',
+					variantMeta: [
+						{
+							id: 'A',
+							meta: {
+								headline: undefined,
+							},
+						},
+						{
+							id: 'B',
+							meta: {
+								headline: undefined,
+							},
+						},
+					],
+					createdByName: 'Jane Doe',
+					createdByEmail: 'jane.doe@guardian.co.uk',
+					frontsThisTestCanRunOn: ['uk'],
+					hasManuallyEndedOnThisTrail: false,
+				},
+			],
+		},
+		af1WithOverridesAndRunningTest: {
+			uuid: 'af1',
+			id: 'ea1',
+			frontPublicationDate: 1,
+			publishedBy: 'A. N. Author',
+			meta: {
+				headline: 'card-headline',
+				trailText: 'card-trailText',
+				byline: 'card-byline',
+				customKicker: 'card-kicker',
+				showKickerCustom: true,
+			},
+			tests: [
+				{
+					testUuid: 'testUuid1',
+					variantMeta: [
+						{
+							id: 'A',
+							meta: {
+								headline: 'card-headline-a',
+							},
+						},
+						{
+							id: 'B',
+							meta: {
+								headline: 'card-headline-b',
+							},
+						},
+					],
+					createdByName: 'Jane Doe',
+					createdByEmail: 'jane.doe@guardian.co.uk',
+					frontsThisTestCanRunOn: ['uk'],
+					hasManuallyEndedOnThisTrail: false,
+				},
+			],
 		},
 		afWithInvalidReference: {
 			uuid: 'afWithInvalidReference',
@@ -268,14 +339,15 @@ describe('Shared selectors', () => {
 	describe('createArticleFromCardSelector', () => {
 		it('should create a selector that returns an article (externalArticle + card) referenced by the given card', () => {
 			const selector = createSelectArticleFromCard();
-			expect(selector(state, 'af1')).toMatchObject({
+			expect(selector(state, 'af1WithNoRunningTest')).toMatchObject({
 				id: 'ea1',
 				pillarName: 'external-pillar',
 				frontPublicationDate: 1,
 				publishedBy: 'A. N. Author',
 				uuid: 'af1',
 				headline: 'external-headline',
-				headlineA: 'external-headline',
+				headlineA: undefined,
+				headlineB: undefined,
 				thumbnail: undefined,
 				trailText: 'external-trailText',
 				byline: 'external-byline',
@@ -283,7 +355,31 @@ describe('Shared selectors', () => {
 				firstPublicationDate: '2018-10-19T10:30:39Z',
 			});
 
-			expect(selector(state, 'af1WithOverrides')).toMatchObject({
+			expect(selector(state, 'af1WithOverridesAndNoRunningTest')).toMatchObject(
+				{
+					id: 'ea1',
+					customKicker: 'card-kicker',
+					pillarName: 'external-pillar',
+					frontPublicationDate: 1,
+					publishedBy: 'A. N. Author',
+					uuid: 'af1',
+					headline: 'card-headline',
+					headlineA: undefined,
+					headlineB: undefined,
+					thumbnail: undefined,
+					trailText: 'card-trailText',
+					kicker: 'card-kicker',
+					byline: 'card-byline',
+					isLive: true,
+					firstPublicationDate: '2018-10-19T10:30:39Z',
+					pillarId: undefined,
+					showKickerCustom: true,
+				},
+			);
+
+			expect(
+				selector(state, 'af1WithOverridesAndTestOnFirstDraft'),
+			).toMatchObject({
 				id: 'ea1',
 				customKicker: 'card-kicker',
 				pillarName: 'external-pillar',
@@ -291,7 +387,8 @@ describe('Shared selectors', () => {
 				publishedBy: 'A. N. Author',
 				uuid: 'af1',
 				headline: 'card-headline',
-				headlineA: 'card-headline-a',
+				headlineA: 'card-headline',
+				headlineB: undefined,
 				thumbnail: undefined,
 				trailText: 'card-trailText',
 				kicker: 'card-kicker',
@@ -301,6 +398,27 @@ describe('Shared selectors', () => {
 				pillarId: undefined,
 				showKickerCustom: true,
 			});
+
+			expect(selector(state, 'af1WithOverridesAndRunningTest')).toMatchObject({
+				id: 'ea1',
+				customKicker: 'card-kicker',
+				pillarName: 'external-pillar',
+				frontPublicationDate: 1,
+				publishedBy: 'A. N. Author',
+				uuid: 'af1',
+				headline: 'card-headline',
+				headlineA: 'card-headline-a',
+				headlineB: 'card-headline-b',
+				thumbnail: undefined,
+				trailText: 'card-trailText',
+				kicker: 'card-kicker',
+				byline: 'card-byline',
+				isLive: true,
+				firstPublicationDate: '2018-10-19T10:30:39Z',
+				pillarId: undefined,
+				showKickerCustom: true,
+			});
+
 			expect(selector(state, 'invalid')).toEqual(undefined);
 		});
 		it('should set isLive property to false if article is not live', () => {

--- a/fronts-client/src/selectors/__tests__/shared.spec.ts
+++ b/fronts-client/src/selectors/__tests__/shared.spec.ts
@@ -327,9 +327,9 @@ describe('Shared selectors', () => {
 
 	describe('externalArticleFromCardSelector', () => {
 		it('should create a selector that returns an external article referenced by the given card', () => {
-			expect(selectExternalArticleFromCard(state, 'af1')).toEqual(
-				state.externalArticles.data.ea1,
-			);
+			expect(
+				selectExternalArticleFromCard(state, 'af1WithNoRunningTest'),
+			).toEqual(state.externalArticles.data.ea1);
 			expect(selectExternalArticleFromCard(state, 'invalid')).toEqual(
 				undefined,
 			);
@@ -440,7 +440,9 @@ describe('Shared selectors', () => {
 				pillarName: 'external-pillar',
 				uuid: 'af4',
 				headline: 'external-headline',
-				headlineA: 'external-headline',
+				headlineA: undefined,
+				headlineB: undefined,
+				abTestEnabled: false,
 				thumbnail: undefined,
 				trailText: 'external-trailText',
 				byline: 'external-byline',

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -28,6 +28,7 @@ import { hasMainVideo } from 'util/externalArticle';
 import { selectCardsWhichAreAlsoOnOtherCollectionsOnSameFront } from './alsoOnSelectors';
 import { selectors as frontsConfigSelectors } from '../bundles/frontsConfigBundle';
 import { FrontConfigMap } from 'types/FaciaApi';
+import { findActiveOrDraftTest, getVariantHeadline } from 'util/abTests';
 
 const selectCollectionMap: (state: State) => CollectionMap =
 	collectionSelectors.selectAll;
@@ -152,7 +153,8 @@ const createSelectArticleFromCard = () =>
 				...articleMeta,
 				headline: headlineField,
 				// if headlineA is not present, populate it with the headline field
-				headlineA: card.meta.headlineA || headlineField,
+				headlineA:
+					getVariantHeadline(findActiveOrDraftTest(card), 'A') || headlineField,
 				trailText:
 					card.meta.trailText ||
 					(externalArticle ? externalArticle.fields.trailText : undefined),

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -148,6 +148,9 @@ const createSelectArticleFromCard = () =>
 
 			const activeOrDraftTest = findActiveOrDraftTest(card);
 
+			const headlineFieldVariantA = getVariantHeadline(activeOrDraftTest, 'A');
+			const headlineFieldVariantB = getVariantHeadline(activeOrDraftTest, 'B');
+
 			return {
 				...omit(externalArticle || {}, 'fields', 'frontsMeta'),
 				...(externalArticle ? externalArticle.fields : {}),
@@ -155,8 +158,10 @@ const createSelectArticleFromCard = () =>
 				...articleMeta,
 				headline: headlineField,
 				// if headlineA is not present, populate it with the headline field
-				headlineA: getVariantHeadline(activeOrDraftTest, 'A') || headlineField,
-				headlineB: getVariantHeadline(activeOrDraftTest, 'B'),
+				headlineA: activeOrDraftTest
+					? headlineFieldVariantA || headlineField
+					: undefined,
+				headlineB: activeOrDraftTest ? headlineFieldVariantB : undefined,
 				abTestEnabled: !!activeOrDraftTest,
 				trailText:
 					card.meta.trailText ||

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -146,6 +146,8 @@ const createSelectArticleFromCard = () =>
 				card.meta.headline ||
 				(externalArticle ? externalArticle.fields.headline : undefined);
 
+			const activeOrDraftTest = findActiveOrDraftTest(card);
+
 			return {
 				...omit(externalArticle || {}, 'fields', 'frontsMeta'),
 				...(externalArticle ? externalArticle.fields : {}),
@@ -153,8 +155,9 @@ const createSelectArticleFromCard = () =>
 				...articleMeta,
 				headline: headlineField,
 				// if headlineA is not present, populate it with the headline field
-				headlineA:
-					getVariantHeadline(findActiveOrDraftTest(card), 'A') || headlineField,
+				headlineA: getVariantHeadline(activeOrDraftTest, 'A') || headlineField,
+				headlineB: getVariantHeadline(activeOrDraftTest, 'B'),
+				abTestEnabled: !!activeOrDraftTest,
 				trailText:
 					card.meta.trailText ||
 					(externalArticle ? externalArticle.fields.trailText : undefined),

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -158,6 +158,7 @@ const createSelectArticleFromCard = () =>
 				...articleMeta,
 				headline: headlineField,
 				// if headlineA is not present, populate it with the headline field
+				// TODO: this is currently broken because the test doesn't exist when you first hit the toggle
 				headlineA: activeOrDraftTest
 					? headlineFieldVariantA || headlineField
 					: undefined,

--- a/fronts-client/src/types/Action.ts
+++ b/fronts-client/src/types/Action.ts
@@ -11,7 +11,7 @@ import type {
 	VisibleArticlesResponse,
 	EditionsFrontMetadata,
 } from './FaciaApi';
-import type { Stages, Collection, CardMeta } from 'types/Collection';
+import type { Stages, Collection, CardMeta, Test } from 'types/Collection';
 import {
 	EDITOR_OPEN_CURRENT_FRONTS_MENU,
 	EDITOR_CLOSE_CURRENT_FRONTS_MENU,
@@ -289,12 +289,13 @@ interface PageViewDataReceived {
 	};
 }
 
-interface UpdateCardMeta {
-	type: 'UPDATE_CARD_META';
+interface UpdateCard {
+	type: 'UPDATE_CARD';
 	payload: {
 		id: string;
 		meta: CardMeta;
 		merge: boolean;
+		test?: Test;
 	};
 }
 
@@ -372,7 +373,7 @@ type Action =
 	| EndOptionsModal
 	| Actions<ExternalArticle>
 	| Actions<Collection>
-	| UpdateCardMeta
+	| UpdateCard
 	| MaybeAddFrontPublicationDate
 	| CapGroupSiblings
 	| CopyCardImageMeta
@@ -420,7 +421,7 @@ export {
 	ChangedBrowsingStage,
 	StartOptionsModal,
 	EndOptionsModal,
-	UpdateCardMeta,
+	UpdateCard,
 	InsertCardPayload,
 	CapGroupSiblings,
 	MaybeAddFrontPublicationDate,

--- a/fronts-client/src/types/Article.ts
+++ b/fronts-client/src/types/Article.ts
@@ -19,6 +19,9 @@ type DerivedArticle = Partial<
 		isLive: boolean;
 		tone: string | undefined;
 		hasMainVideo: boolean;
+		headlineA?: string | undefined;
+		headlineB?: string | undefined;
+		abTestEnabled?: boolean;
 	};
 
 export { DerivedArticle };

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -70,67 +70,62 @@ type NestedCard = NestedCardRootFields & {
 	};
 };
 
-type CardRootMeta = ChefCardMeta &
-	FeastCollectionCardMeta & {
-		group?: string;
-		headline?: string;
-		/** Whether this card has A/B headline testing enabled */
-		abTestEnabled?: boolean;
-		/** Text for headline variant A, shown when abTestEnabled is true */
-		headlineA?: string;
-		/** Text for headline variant B, shown when abTestEnabled is true */
-		headlineB?: string;
-		trailText?: string;
-		byline?: string;
-		sportScore?: string;
-		customKicker?: string;
-		href?: string;
-		imageSrc?: string;
-		imageSrcThumb?: string;
-		imageSrcWidth?: string;
-		imageSrcHeight?: string;
-		imageSrcOrigin?: string;
-		imageCutoutSrc?: string;
-		imageCutoutSrcWidth?: string;
-		imageCutoutSrcHeight?: string;
-		imageCutoutSrcOrigin?: string;
-		isBreaking?: boolean;
-		/** For dynamic collections only */
-		isBoosted?: boolean;
-		/** For flexible collections only */
-		boostLevel?: BoostLevels;
-		isImmersive?: boolean;
-		showLivePlayable?: boolean;
-		showMainVideo?: boolean;
-		showLargeHeadline?: boolean;
-		showQuotedHeadline?: boolean;
-		showByline?: boolean;
-		imageCutoutReplace?: boolean;
-		imageReplace?: boolean;
-		videoReplace?: boolean;
-		replaceVideoUri?: string;
-		imageHide?: boolean;
-		showKickerTag?: boolean;
-		showKickerSection?: boolean;
-		showKickerCustom?: boolean;
-		snapUri?: string;
-		snapType?: string;
-		snapCss?: string;
-		atomId?: string;
-		imageSlideshowReplace?: boolean;
-		replacementVideoAtom?: Atom | string;
-		slideshow?: Array<{
-			src?: string;
-			thumb?: string;
-			width?: string;
-			height?: string;
-			origin?: string;
-		}>;
-		overrideArticleMainMedia?: boolean;
-		coverCardImageReplace?: boolean;
-		coverCardMobileImage?: ImageData;
-		coverCardTabletImage?: ImageData;
-	};
+type RegularCardMeta = {
+	group?: string;
+	headline?: string;
+	trailText?: string;
+	byline?: string;
+	sportScore?: string;
+	customKicker?: string;
+	href?: string;
+	imageSrc?: string;
+	imageSrcThumb?: string;
+	imageSrcWidth?: string;
+	imageSrcHeight?: string;
+	imageSrcOrigin?: string;
+	imageCutoutSrc?: string;
+	imageCutoutSrcWidth?: string;
+	imageCutoutSrcHeight?: string;
+	imageCutoutSrcOrigin?: string;
+	isBreaking?: boolean;
+	/** For dynamic collections only */
+	isBoosted?: boolean;
+	/** For flexible collections only */
+	boostLevel?: BoostLevels;
+	isImmersive?: boolean;
+	showLivePlayable?: boolean;
+	showMainVideo?: boolean;
+	showLargeHeadline?: boolean;
+	showQuotedHeadline?: boolean;
+	showByline?: boolean;
+	imageCutoutReplace?: boolean;
+	imageReplace?: boolean;
+	videoReplace?: boolean;
+	replaceVideoUri?: string;
+	imageHide?: boolean;
+	showKickerTag?: boolean;
+	showKickerSection?: boolean;
+	showKickerCustom?: boolean;
+	snapUri?: string;
+	snapType?: string;
+	snapCss?: string;
+	atomId?: string;
+	imageSlideshowReplace?: boolean;
+	replacementVideoAtom?: Atom | string;
+	slideshow?: Array<{
+		src?: string;
+		thumb?: string;
+		width?: string;
+		height?: string;
+		origin?: string;
+	}>;
+	overrideArticleMainMedia?: boolean;
+	coverCardImageReplace?: boolean;
+	coverCardMobileImage?: ImageData;
+	coverCardTabletImage?: ImageData;
+};
+
+type CardRootMeta = ChefCardMeta & FeastCollectionCardMeta & RegularCardMeta;
 
 type CardRootFields = NestedCardRootFields & {
 	uuid: string;
@@ -173,8 +168,29 @@ export interface FeastCollectionCardMeta {
 	};
 }
 
+type VariantId = 'A' | 'B';
+
+type VariantMeta = {
+	id: VariantId;
+	meta: RegularCardMeta;
+};
+
+type Test = {
+	testUuid: string;
+	variantMeta: VariantMeta[];
+	createdByName: string;
+	createdByEmail: string;
+	startDate?: number;
+	expiryDate?: number;
+	frontsThisTestCanRunOn?: string[];
+	hasManuallyEndedOnThisTrail: boolean;
+	manuallyEndedOnThisTrailByName?: string;
+	manuallyEndedOnThisTrailByEmail?: string;
+};
+
 interface Card extends CardRootFields {
 	meta: CardMeta;
+	tests?: Test[];
 }
 
 interface CardMetaDenormalised extends CardRootMeta {

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -170,7 +170,7 @@ export interface FeastCollectionCardMeta {
 
 export type VariantId = 'A' | 'B';
 
-type VariantMeta = {
+export type VariantMeta = {
 	id: VariantId;
 	meta: RegularCardMeta;
 };

--- a/fronts-client/src/types/Collection.ts
+++ b/fronts-client/src/types/Collection.ts
@@ -168,14 +168,14 @@ export interface FeastCollectionCardMeta {
 	};
 }
 
-type VariantId = 'A' | 'B';
+export type VariantId = 'A' | 'B';
 
 type VariantMeta = {
 	id: VariantId;
 	meta: RegularCardMeta;
 };
 
-type Test = {
+export type Test = {
 	testUuid: string;
 	variantMeta: VariantMeta[];
 	createdByName: string;

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -1,0 +1,18 @@
+import { Card } from '../types/Collection';
+
+// TODO: add unit test
+export const hasAbTestOnCard = (card: Card | undefined) => {
+	if (!card) {
+		return false;
+	}
+	if (!card.tests) {
+		return false;
+	}
+
+	return card.tests.some(
+		(test) =>
+			!test.hasManuallyEndedOnThisTrail &&
+			test.expiryDate &&
+			test.expiryDate > Date.now(),
+	);
+};

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -1,4 +1,4 @@
-import { Card } from '../types/Collection';
+import { Card, VariantId, Test } from '../types/Collection';
 
 // TODO: add unit test
 export const hasAbTestOnCard = (card: Card | undefined) => {
@@ -15,4 +15,27 @@ export const hasAbTestOnCard = (card: Card | undefined) => {
 			test.expiryDate &&
 			test.expiryDate > Date.now(),
 	);
+};
+
+// TODO: add unit test
+export const findActiveOrDraftTest = (card: Card) => {
+	if (!card.tests) {
+		return undefined;
+	}
+
+	return card.tests.find(
+		(test) =>
+			!test.hasManuallyEndedOnThisTrail &&
+			((test.expiryDate && test.expiryDate > Date.now()) ||
+				typeof test.expiryDate === 'undefined'),
+	);
+};
+
+// we can extend this in future to 'getVariantField'
+export const getVariantHeadline = (
+	test: Test | undefined,
+	variantId: VariantId,
+) => {
+	return test?.variantMeta.find((variant) => variant.id === variantId)?.meta
+		.headline;
 };

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -190,7 +190,7 @@ export const getCardTestFromFormValues = (
 	state: State,
 	id: string,
 	values: CardFormData,
-): Test => {
+): Test | undefined => {
 	const { headlineA, headlineB, abTestEnabled } = values;
 
 	const existingCard = selectCard(state, id);
@@ -199,7 +199,7 @@ export const getCardTestFromFormValues = (
 	// If there's no existing test and the toggle is off, there's nothing to save
 	if (!maybeTest && !abTestEnabled) {
 		return undefined;
-	};
+	}
 
 	if (maybeTest) {
 		const updatedVariantMeta = maybeTest.variantMeta.map((variant) => {

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -196,8 +196,9 @@ export const getCardTestFromFormValues = (
 	const existingCard = selectCard(state, id);
 	const maybeTest = findActiveOrDraftTest(existingCard);
 
-	// If there's no existing test and the toggle is off, there's nothing to save
-	if (!maybeTest && !abTestEnabled) {
+	const hasNoTestToSave = !maybeTest && !abTestEnabled;
+
+	if (hasNoTestToSave) {
 		return undefined;
 	}
 

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -10,7 +10,6 @@ import { Atom, CapiArticle } from 'types/Capi';
 import type { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
 import { findActiveOrDraftTest } from './abTests';
-import crypto from 'crypto';
 
 export interface CardFormData {
 	headline: string;
@@ -237,6 +236,7 @@ export const getCardTestFromFormValues = (
 		createdByEmail: 'dummy@guardian.com',
 		//TODO: ensure that an expired test will not reach this point.
 		hasManuallyEndedOnThisTrail: !abTestEnabled,
+		frontsThisTestCanRunOn: [],
 	};
 };
 
@@ -265,8 +265,6 @@ export const getCardMetaFromFormValues = (
 		{
 			...values,
 			headline: getStringField(values.headline),
-			headlineA: getStringField(values.headlineA),
-			headlineB: getStringField(values.headlineB),
 			trailText: getStringField(values.trailText),
 			byline: getStringField(values.byline),
 			sportScore: getStringField(values.sportScore),
@@ -279,6 +277,9 @@ export const getCardMetaFromFormValues = (
 		},
 		'primaryImage',
 		'cutoutImage',
+		'headlineA',
+		'headlineB',
+		'abTestEnabled',
 	);
 
 	// We only return dirtied values.

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -4,12 +4,13 @@ import compact from 'lodash/compact';
 import clamp from 'lodash/clamp';
 import pickBy from 'lodash/pickBy';
 import { isDirty } from 'redux-form';
-// import pageConfig from 'util/extractConfigFromPage';
-import { CardMeta, ImageData } from 'types/Collection';
+import { CardMeta, ImageData, Test } from 'types/Collection';
 import { DerivedArticle } from 'types/Article';
 import { Atom, CapiArticle } from 'types/Capi';
 import type { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
+import { findActiveOrDraftTest } from './abTests';
+import crypto from 'crypto';
 
 export interface CardFormData {
 	headline: string;
@@ -185,6 +186,59 @@ export const getImageMetaFromValidationResponse = (image: ImageData) => ({
 	imageSrcHeight: intToStr(image.height),
 	imageSrcOrigin: image.origin,
 });
+
+export const getCardTestFromFormValues = (
+	state: State,
+	id: string,
+	values: CardFormData,
+): Test => {
+	const { headlineA, headlineB, abTestEnabled } = values;
+
+	const existingCard = selectCard(state, id);
+	const maybeTest = findActiveOrDraftTest(existingCard);
+
+	if (maybeTest) {
+		const updatedVariantMeta = maybeTest.variantMeta.map((variant) => {
+			// TODO: Allow for additional variant ids (eg c, d, etc)
+			const headlineVariant = variant.id === 'A' ? headlineA : headlineB;
+			return {
+				...variant,
+				meta: {
+					...variant.meta,
+					headline: headlineVariant,
+				},
+			};
+		});
+
+		return {
+			...maybeTest,
+			variantMeta: updatedVariantMeta,
+		};
+	}
+
+	return {
+		testUuid: crypto.randomUUID(),
+		variantMeta: [
+			{
+				id: 'A',
+				meta: {
+					headline: headlineA,
+				},
+			},
+			{
+				id: 'B',
+				meta: {
+					headline: headlineB,
+				},
+			},
+		],
+		// TODO: Populate createdBy fields
+		createdByName: 'dummy guardian',
+		createdByEmail: 'dummy@guardian.com',
+		//TODO: ensure that an expired test will not reach this point.
+		hasManuallyEndedOnThisTrail: !abTestEnabled,
+	};
+};
 
 export const getCardMetaFromFormValues = (
 	state: State,

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -196,6 +196,11 @@ export const getCardTestFromFormValues = (
 	const existingCard = selectCard(state, id);
 	const maybeTest = findActiveOrDraftTest(existingCard);
 
+	// If there's no existing test and the toggle is off, there's nothing to save
+	if (!maybeTest && !abTestEnabled) {
+		return undefined;
+	};
+
 	if (maybeTest) {
 		const updatedVariantMeta = maybeTest.variantMeta.map((variant) => {
 			// TODO: Allow for additional variant ids (eg c, d, etc)

--- a/test/services/CollectionServiceTest.scala
+++ b/test/services/CollectionServiceTest.scala
@@ -59,8 +59,8 @@ class CollectionServiceTest extends FreeSpec with Matchers {
   }
 
   private def collectionJson: CollectionJson = {
-    val live = List(Trail("existingId", 0, Some(""), None))
-    val draft = Trail("newId", 0, Some(""), None) :: live
+    val live = List(Trail("existingId", 0, Some(""), None, None))
+    val draft = Trail("newId", 0, Some(""), None, None) :: live
     CollectionJson(
       live,
       Some(draft),

--- a/test/tools/FaciaApiTest.scala
+++ b/test/tools/FaciaApiTest.scala
@@ -26,12 +26,12 @@ class FaciaApiTest extends FreeSpec with Matchers {
     }
     "existing article should have the old date" in {
       newCollectionJson.live.collect {
-        case Trail("existingId", 0, Some(""), _) => true
+        case Trail("existingId", 0, Some(""), _, _) => true
       } should have(Symbol("length")(1))
     }
     "new article should have an updated timestamp" in {
       newCollectionJson.live.collect {
-        case Trail("newId", t, Some(""), _) if t != 0 => true
+        case Trail("newId", t, Some(""), _, _) if t != 0 => true
       } should have(Symbol("length")(1))
     }
 
@@ -56,7 +56,7 @@ class FaciaApiTest extends FreeSpec with Matchers {
     }
     "existing article should have the old date" in {
       newCollectionJson.live.collect {
-        case Trail("existingId", 0, Some(""), _) => true
+        case Trail("existingId", 0, Some(""), _, _) => true
       } should have(Symbol("length")(1))
     }
 
@@ -64,8 +64,8 @@ class FaciaApiTest extends FreeSpec with Matchers {
 
   private def scenarioOneLiveAnotherDraft: (User, CollectionJson) = {
     val identity = User("John", "Duffell", "email@email.com", None)
-    val live = List(Trail("existingId", 0, Some(""), None))
-    val draft = Trail("newId", 0, Some(""), None) :: live
+    val live = List(Trail("existingId", 0, Some(""), None, None))
+    val draft = Trail("newId", 0, Some(""), None, None) :: live
     val collectionJson = CollectionJson(
       live,
       Some(draft),


### PR DESCRIPTION
## What's changed?
This PR begins the process of wiring up the headline test UI with the underlying data model. 

Changelist:
- Bump FAPI to [37.0.0](https://github.com/guardian/facia-scala-client/releases/tag/v37.0.0) which introduces the Test model
- Adds typescript definition for Test models
- Extracts RegularCardMeta from CardRootMeta so that it can be used in isolation from ChefCardMeta and FeastCollectionCardMeta. 
- Generalise `updateCardMeta` action to `updateCard` as this is now responsible for updating card meta and card tests. 
- Wires up checks for active ab tests to tests that maybe exist on a card, rather than depending on toggle state alone. 
- Update the ArticleMetaForm onSave function. This now retrieves tests from form values and saves them alongside meta
- Add tests for cards with running tests and without running tests to ensure headline and test headline fields are being set correctly
- 
## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->


### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
