### PR TITLE
Add new page for subnav creation

### DIFF
--- a/app/controllers/V2App.scala
+++ b/app/controllers/V2App.scala
@@ -57,6 +57,10 @@ class V2App(
         Permissions.ConfigureFronts,
         "facia-tool-allow-config-for-all"
       )(req.user.email)
+      val hasConfigureSubnavs = acl.testUser(
+        Permissions.ConfigureCustomSubnavs,
+        "facia-tool-allow-configure-subnavs-for-all"
+      )(req.user.email)
       val hasEditionsPermissions = acl.testUser(
         Permissions.EditEditions,
         "facia-tool-allow-edit-editions-for-all"
@@ -70,7 +74,10 @@ class V2App(
         fronts = Map(config.faciatool.breakingNewsFront -> hasBreakingNews),
         editions =
           Map(config.faciatool.canEditEditions -> hasEditionsPermissions),
-        permissions = Map("configure-config" -> hasConfigureFronts)
+        permissions = Map(
+          "configure-config" -> hasConfigureFronts,
+          "configure-subnavs" -> hasConfigureSubnavs
+        )
       )
 
       val userEmail: String = req.user.email

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -15,6 +15,8 @@ object Permissions {
   val EditEditions = PermissionDefinition("edit_editions", app)
   val LaunchAndEditEmailFronts =
     PermissionDefinition("edit_and_launch_email_fronts", app)
+  val ConfigureCustomSubnavs =
+    PermissionDefinition("configure_custom_subnavs", app)
 
   val Pinboard = PermissionDefinition("pinboard", "pinboard")
 }

--- a/app/permissions/PermissionsActionCheck.scala
+++ b/app/permissions/PermissionsActionCheck.scala
@@ -179,6 +179,18 @@ class ConfigPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext)
   val restrictedAction = "configure fronts"
 }
 
+class ConfigureSubnavsPermissionCheck(val acl: Acl)(implicit
+    ec: ExecutionContext
+) extends PermissionActionFilter {
+  val executionContext = ec
+  val testAccess: String => Authorization =
+    acl.testUser(
+      Permissions.ConfigureCustomSubnavs,
+      "facia-tool-allow-configure-subnavs-for-all"
+    )
+  val restrictedAction = "configure subnavs"
+}
+
 class BreakingNewsPermissionCheck(val acl: Acl)(implicit ec: ExecutionContext)
     extends PermissionActionFilter {
   val executionContext = ec

--- a/fronts-client/src/components/App.tsx
+++ b/fronts-client/src/components/App.tsx
@@ -34,9 +34,11 @@ import {
 	frontsEditPathProps,
 	issuePathProps,
 	frontsFeatureProps,
+	subnavSectionProps,
 } from 'routes/routes';
 import ManageView from './Editions/ManageView';
 import FeaturesView from './Features/FeaturesView';
+import SubnavSection from './Subnav';
 import { PlaceholderAnimation } from 'components/BasePlaceholder';
 import OptionsModal from './modals/OptionsModal';
 import BannerNotification from './notifications/BannerNotification';
@@ -165,6 +167,7 @@ const App = () => {
 						<Route {...frontsEditPathProps} component={FrontsEdit} />
 						<Route {...issuePathProps} component={FrontsEdit} />
 						<Route {...frontsFeatureProps} component={FeaturesView} />
+						<Route {...subnavSectionProps} component={SubnavSection} />
 						<Route exact path="/" component={Home} />
 						<Route exact path={manageEditions} component={ManageView} />
 						<Route component={NotFound} />

--- a/fronts-client/src/components/Home.tsx
+++ b/fronts-client/src/components/Home.tsx
@@ -8,6 +8,7 @@ import HomeContainer from './layout/HomeContainer';
 import {
 	selectAvailableEditions,
 	selectEditionsPermission,
+	selectHasSubnavPermission,
 } from 'selectors/configSelectors';
 import type { State } from 'types/State';
 
@@ -26,7 +27,11 @@ const renderEditionPriority = (editionPriority: EditionPriority) => (
 
 type IProps = ReturnType<typeof mapStateToProps>;
 
-const Home = ({ availableEditions, editEditionsIsPermitted }: IProps) => {
+const Home = ({
+	availableEditions,
+	editEditionsIsPermitted,
+	subnavIsPermitted,
+}: IProps) => {
 	const { editions, feast } = groupBy(availableEditions || [], 'platform');
 
 	return (
@@ -58,6 +63,16 @@ const Home = ({ availableEditions, editEditionsIsPermitted }: IProps) => {
 			</ul>
 			<h3>Manage Feast app</h3>
 			<ul>{feast.map(renderEditionPriority)}</ul>
+			{subnavIsPermitted && (
+				<>
+					<h3>Custom subnavs</h3>
+					<ul>
+						<li>
+							<Link to="/subnavs">Manage custom subnavs</Link>
+						</li>
+					</ul>
+				</>
+			)}
 		</HomeContainer>
 	);
 };
@@ -65,6 +80,7 @@ const Home = ({ availableEditions, editEditionsIsPermitted }: IProps) => {
 const mapStateToProps = (state: State) => ({
 	availableEditions: selectAvailableEditions(state),
 	editEditionsIsPermitted: selectEditionsPermission(state)?.['edit-editions'],
+	subnavIsPermitted: selectHasSubnavPermission(state),
 });
 
 const displayNoPermissionMessage = (onContent: string) => {

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectHasSubnavPermission } from 'selectors/configSelectors';
+import { Message, SubnavContainer, SubnavContainerHeading } from './styles';
+
+const NoPermission = () => (
+	<SubnavContainer>
+		<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
+		<Message>
+			You do not have permission to configure subnavs. Please contact{' '}
+			<a href="mailto:central.production@guardian.co.uk">Central Production</a>{' '}
+			to request access.
+		</Message>
+	</SubnavContainer>
+);
+
+const SubnavSection = () => {
+	const hasPermission = useSelector(selectHasSubnavPermission);
+
+	if (!hasPermission) {
+		return <NoPermission />;
+	}
+
+	return (
+		<SubnavContainer>
+			<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
+			<Message>Subnav management coming soon.</Message>
+		</SubnavContainer>
+	);
+};
+
+export default SubnavSection;

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -1,0 +1,18 @@
+import { styled } from 'constants/theme';
+
+export const SubnavContainer = styled.div`
+	padding: 70px 20px 40px;
+	max-width: 720px;
+`;
+
+export const SubnavContainerHeading = styled.h1`
+	font-family: GHGuardianHeadline, Georgia, serif;
+	font-size: 24px;
+	font-weight: 500;
+	margin-bottom: 16px;
+`;
+
+export const Message = styled.p`
+	color: ${({ theme }) => theme.base.colors.textDark};
+	font-size: 14px;
+`;

--- a/fronts-client/src/routes/routes.ts
+++ b/fronts-client/src/routes/routes.ts
@@ -49,11 +49,24 @@ const EditionsRoutes = {
 		editionsApi(`/editions/collections/${collectionId}`),
 };
 
+/**
+ * Custom subnavs
+ */
+
+export const subnavRoutes = {
+	base: '/subnavs',
+};
+
+const subnavSectionProps = {
+	path: subnavRoutes.base,
+};
+
 export {
 	matchFrontsEditPath,
 	frontsEditPathProps,
 	matchIssuePath,
 	issuePathProps,
 	frontsFeatureProps,
+	subnavSectionProps,
 	EditionsRoutes,
 };

--- a/fronts-client/src/selectors/configSelectors.ts
+++ b/fronts-client/src/selectors/configSelectors.ts
@@ -59,6 +59,10 @@ const selectEditionsPermission = createSelector(
 	(config) => config && config.acl.editions,
 );
 
+const selectHasSubnavPermission = createSelector(selectConfig, (config) =>
+	Boolean(config && config.acl.permissions['configure-subnavs']),
+);
+
 export {
 	selectCapiLiveURL,
 	selectCapiPreviewURL,
@@ -71,4 +75,5 @@ export {
 	selectAvailableEditions,
 	selectShouldUseCODELinks,
 	selectEditionsPermission,
+	selectHasSubnavPermission,
 };


### PR DESCRIPTION
## What's changed?

Part of this eventkit [ticket](https://github.com/guardian/eventkit-mission/issues/48) - this just sets up a new page in the fronts v2 client where we'll add the interface to create and view custom subnavs. 

This is behind a new set of permissions following this [PR](https://github.com/guardian/permissions/pull/409).

AI was used, mainly for the frontend routing and index.ts/styles.ts files. 

## Testing

We can test both this PR and the permissions at the same time:

- deploy the permissions PR to code, and grant yourself the `configure_custom_subnavs` permission under fronts (if you don't know how or are not able to do this, let me know and I can help):
<img width="1182" height="375" alt="image" src="https://github.com/user-attachments/assets/8581b4d9-7a75-4dfd-a6f6-c5f5018ab370" />

- then run this branch locally or on code. On the main menu you should see a link to the subnav page, and clicking on it should lead to a `/subnavs` page. 

If you don't have the relevant permissions, you shouldn't be able to see the link to the subnav, and if you did try to access the page directly via the URL, would get a message stating you don't have permission and need to contact central prod to access. 

## Screenshots
<img width="431" height="766" alt="Screenshot 2026-08-05 at 00 23 42" src="https://github.com/user-attachments/assets/a798664f-993f-4220-bc04-51b966359777" />
<img width="619" height="444" alt="Screenshot 2026-08-05 at 00 24 01" src="https://github.com/user-attachments/assets/59a47d3b-79d5-4623-a0de-f5f2d244e5d9" />

## Next steps

Once the relevant facia scala client PR adding the model of a custom subnav is merged, then we can add the relevant API and interface (to be properly styled following designs) to create and store a subnav.

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
