### PR TITLE
Batch card update actions to improve performance

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -241,11 +241,17 @@ export const mayResetBoostLevel = ({
 }: UpdateCardParams) => {
 	if (to.type !== 'group' || persistTo !== 'collection') return;
 	if (from?.id === to.id) return;
+
 	const groupName = to.groupName ?? 'standard';
+	const newBoostLevel = minimumGroupBoostLevel(groupName);
+
+	/* Nothing to do if the card is already at the target boost level. */
+	if (card.meta?.boostLevel === newBoostLevel) return;
+
 	return updateCard(
 		card.uuid,
 		{
-			boostLevel: minimumGroupBoostLevel(groupName),
+			boostLevel: newBoostLevel,
 		},
 		{ merge: true },
 	);

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -237,7 +237,6 @@ export const mayResetBoostLevel = ({
 	to,
 	card,
 	persistTo,
-	state,
 }: UpdateCardParams) => {
 	if (to.type !== 'group' || persistTo !== 'collection') return;
 	if (from?.id === to.id) return;
@@ -533,8 +532,10 @@ const moveCard = (
 				 * noticeably laggy with several fronts open.
 				 */
 				const preInsertActions = [
-					// if from is not null we're moving an existing card, so it's already
-					// in state; otherwise we've cloned it and need to add it.
+					/**
+					 * if from is not null we're moving an existing card, so it's already
+					 * in state; otherwise we've cloned it and need to add it.
+					 */
 					...(!fromWithRespectToState
 						? [cardsReceived([parent, ...supporting])]
 						: []),

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -517,10 +517,6 @@ const moveCard = (
 				: { parent: card, supporting: [] };
 
 			if (toWithRespectToState) {
-				if (!fromWithRespectToState) {
-					dispatch(cardsReceived([parent, ...supporting]));
-				}
-
 				const actionParams: UpdateCardParams = {
 					from,
 					to,
@@ -529,17 +525,33 @@ const moveCard = (
 					state,
 				};
 
-				const modifyCardActions = [
+				/**
+				 * Collect the plain actions that prepare the card in state (adding a
+				 * cloned card, then any meta resets) and dispatch them in a single
+				 * batch. This avoids multiple separate dispatches - each of which
+				 * triggers its own subscriber notification and render pass - which is
+				 * noticeably laggy with several fronts open.
+				 */
+				const preInsertActions = [
+					// if from is not null we're moving an existing card, so it's already
+					// in state; otherwise we've cloned it and need to add it.
+					...(!fromWithRespectToState
+						? [cardsReceived([parent, ...supporting])]
+						: []),
 					mayResetBoostLevel(actionParams),
 					mayResetImageReplace(actionParams),
 					mayResetImmersive(actionParams),
 					mayResetVideoReplace(actionParams),
-				];
+				].filter(Boolean) as Action[];
 
-				modifyCardActions.forEach((action) => {
-					if (action) dispatch(action);
-				});
+				if (preInsertActions.length) {
+					dispatch(batchActions(preInsertActions));
+				}
 
+				/**
+				 * The insert action creator is a thunk, so it can't be included in the
+				 * batch above; it's dispatched separately.
+				 */
 				dispatch(
 					insertActionCreator(
 						toWithRespectToState.id,


### PR DESCRIPTION
## What's changed?
Moving cards between groups/collections currently triggers several separate Redux dispatches in `moveCard`, one for adding the card, plus one for each meta reset (boost level, image replace, immersive, video replace). 

Each dispatch fires its own subscriber notification and render pass, which is noticeably laggy when several fronts are open.

This PR reduces the number of dispatches and avoids redundant work, which should help reduce fronts tool lag. 

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
