### PR TITLE
Refactor card movement logic to support batch operations for improved…

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -472,6 +472,105 @@ const removeCard = (
 	};
 };
 
+/**
+ * Given a single move, compute the plain "prep" actions that must be applied to
+ * state before the card is inserted (adding a cloned card, then any meta
+ * resets), plus a callback that performs the insert itself.
+ *
+ * The insert is returned as a callback rather than dispatched here because the
+ * insert action creator is a thunk (it can contain a modal/cap check), so it
+ * can't be included in a `batchActions` call. Returning the pieces separately
+ * lets callers batch the prep actions across several moves (see `moveCards`).
+ *
+ * Returns `null` if the move can't be applied (e.g. no valid insert target).
+ */
+const planMove = (
+	to: PosSpec,
+	card: Card,
+	from: PosSpec | null,
+	persistTo: 'collection' | 'clipboard',
+	state: State,
+): {
+	preInsertActions: Action[];
+	insert: (dispatch: Dispatch) => void;
+} | null => {
+	const removeActionCreator =
+		from && getRemoveActionCreatorFromType(from.type, persistTo);
+	const insertActionCreator = getInsertionActionCreatorFromType(
+		to.type,
+		persistTo,
+	);
+
+	if (!insertActionCreator) {
+		return null;
+	}
+
+	// If move actions are happening to/from groups which have cards displayed
+	// in them which don't belong to these groups we need to adjust the indices of
+	// the move actions in these groups.
+	const fromDetails: {
+		fromWithRespectToState: PosSpec | null;
+		fromOrphanedGroup: boolean;
+	} = getFromGroupIndicesWithRespectToState(from, state);
+
+	const toWithRespectToState: PosSpec | null =
+		getToGroupIndicesWithRespectToState(
+			to,
+			state,
+			fromDetails.fromOrphanedGroup,
+		);
+
+	if (!toWithRespectToState) {
+		return null;
+	}
+
+	const { fromWithRespectToState } = fromDetails;
+
+	// if from is not null then assume we're copying a moved card into this position
+	const { parent, supporting } = !fromWithRespectToState
+		? cloneCard(card, selectCardMap(state))
+		: { parent: card, supporting: [] };
+
+	const actionParams: UpdateCardMetaParams = {
+		from,
+		to,
+		card: parent,
+		persistTo,
+		state,
+	};
+
+	// Plain actions that prepare the card in state (adding a cloned card, then any
+	// meta resets). Collected so the caller can dispatch them in a single batch -
+	// each separate dispatch triggers its own subscriber notification and render
+	// pass, which is noticeably laggy with several fronts open, and worse still
+	// during cascading moves.
+	const preInsertActions = [
+		// if from is not null we're moving an existing card, so it's already
+		// in state; otherwise we've cloned it and need to add it.
+		...(!fromWithRespectToState
+			? [cardsReceived([parent, ...supporting])]
+			: []),
+		mayResetBoostLevel(actionParams),
+		mayResetImageReplace(actionParams),
+		mayResetImmersive(actionParams),
+		mayResetVideoReplace(actionParams),
+	].filter(Boolean) as Action[];
+
+	const insert = (dispatch: Dispatch) =>
+		dispatch(
+			insertActionCreator(
+				toWithRespectToState.id,
+				toWithRespectToState.index,
+				parent.uuid,
+				fromWithRespectToState && removeActionCreator
+					? removeActionCreator(fromWithRespectToState.id, card.uuid)
+					: undefined,
+			),
+		);
+
+	return { preInsertActions, insert };
+};
+
 const moveCard = (
 	to: PosSpec,
 	card: Card,
@@ -479,86 +578,50 @@ const moveCard = (
 	persistTo: 'collection' | 'clipboard',
 ): ThunkResult<void> => {
 	return (dispatch: Dispatch, getState) => {
-		const removeActionCreator =
-			from && getRemoveActionCreatorFromType(from.type, persistTo);
-		const insertActionCreator = getInsertionActionCreatorFromType(
-			to.type,
-			persistTo,
-		);
-
-		if (!insertActionCreator) {
+		const plan = planMove(to, card, from, persistTo, getState());
+		if (!plan) {
 			return;
 		}
-
-		const state = getState();
-
-		// If move actions are happening to/from groups which have cards displayed
-		// in them which don't belong to these groups we need to adjust the indices of the move
-		// actions in these groups.
-		const fromDetails: {
-			fromWithRespectToState: PosSpec | null;
-			fromOrphanedGroup: boolean;
-		} = getFromGroupIndicesWithRespectToState(from, state);
-
-		const toWithRespectToState: PosSpec | null =
-			getToGroupIndicesWithRespectToState(
-				to,
-				state,
-				fromDetails.fromOrphanedGroup,
-			);
-		if (toWithRespectToState) {
-			const { fromWithRespectToState } = fromDetails;
-
-			// if from is not null then assume we're copying a moved card
-			// into this new position
-			const { parent, supporting } = !fromWithRespectToState
-				? cloneCard(card, selectCardMap(state))
-				: { parent: card, supporting: [] };
-
-			if (toWithRespectToState) {
-				const actionParams: UpdateCardMetaParams = {
-					from,
-					to,
-					card: parent,
-					persistTo,
-					state,
-				};
-
-				// Collect the plain actions that prepare the card in state (adding a
-				// cloned card, then any meta resets) and dispatch them in a single
-				// batch. This avoids multiple separate dispatches - each of which
-				// triggers its own subscriber notification and render pass - which is
-				// noticeably laggy with several fronts open.
-				const preInsertActions = [
-					// if from is not null we're moving an existing card, so it's already
-					// in state; otherwise we've cloned it and need to add it.
-					...(!fromWithRespectToState
-						? [cardsReceived([parent, ...supporting])]
-						: []),
-					mayResetBoostLevel(actionParams),
-					mayResetImageReplace(actionParams),
-					mayResetImmersive(actionParams),
-					mayResetVideoReplace(actionParams),
-				].filter(Boolean) as Action[];
-
-				if (preInsertActions.length) {
-					dispatch(batchActions(preInsertActions));
-				}
-
-				// The insert action creator is a thunk, so it can't be included in the
-				// batch above; it's dispatched separately.
-				dispatch(
-					insertActionCreator(
-						toWithRespectToState.id,
-						toWithRespectToState.index,
-						parent.uuid,
-						fromWithRespectToState && removeActionCreator
-							? removeActionCreator(fromWithRespectToState.id, card.uuid)
-							: undefined,
-					),
-				);
-			}
+		if (plan.preInsertActions.length) {
+			dispatch(batchActions(plan.preInsertActions));
 		}
+		plan.insert(dispatch);
+	};
+};
+
+/**
+ * Move several cards as a single logical operation (e.g. a cascading shift of
+ * cards through full groups).
+ *
+ * Each move's prep actions are collected and dispatched together in one
+ * `batchActions` call, so a cascade of N moves produces a single batch (plus
+ * the N insert thunks) rather than ~2N separate dispatches - drastically
+ * reducing subscriber notifications and render passes.
+ */
+const moveCards = (
+	moves: Array<{ to: PosSpec; card: Card; from: PosSpec | null }>,
+	persistTo: 'collection' | 'clipboard',
+): ThunkResult<void> => {
+	return (dispatch: Dispatch, getState) => {
+		const inserts: Array<(dispatch: Dispatch) => void> = [];
+		const allPreInsertActions: Action[] = [];
+
+		// Each plan is computed against the current state; prep actions are batched,
+		// but the inserts (thunks) still run in order afterwards, preserving
+		// ordering between moves.
+		moves.forEach(({ to, card, from }) => {
+			const plan = planMove(to, card, from, persistTo, getState());
+			if (!plan) {
+				return;
+			}
+			allPreInsertActions.push(...plan.preInsertActions);
+			inserts.push(plan.insert);
+		});
+
+		if (allPreInsertActions.length) {
+			dispatch(batchActions(allPreInsertActions));
+		}
+		inserts.forEach((insert) => insert(dispatch));
 	};
 };
 
@@ -620,6 +683,7 @@ export const createArticleEntitiesFromDrop = (
 export {
 	insertCardWithCreate,
 	moveCard,
+	moveCards,
 	updateCardMetaWithPersist,
 	removeCard,
 	addImageToCard,

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -237,15 +237,20 @@ export const mayResetBoostLevel = ({
 	to,
 	card,
 	persistTo,
-	state,
 }: UpdateCardMetaParams) => {
 	if (to.type !== 'group' || persistTo !== 'collection') return;
 	if (from?.id === to.id) return;
+
 	const groupName = to.groupName ?? 'standard';
+	const newBoostLevel = minimumGroupBoostLevel(groupName);
+
+	// Nothing to do if the card is already at the target boost level.
+	if (card.meta?.boostLevel === newBoostLevel) return;
+
 	return updateCardMeta(
 		card.uuid,
 		{
-			boostLevel: minimumGroupBoostLevel(groupName),
+			boostLevel: newBoostLevel,
 		},
 		{ merge: true },
 	);
@@ -511,10 +516,6 @@ const moveCard = (
 				: { parent: card, supporting: [] };
 
 			if (toWithRespectToState) {
-				if (!fromWithRespectToState) {
-					dispatch(cardsReceived([parent, ...supporting]));
-				}
-
 				const actionParams: UpdateCardMetaParams = {
 					from,
 					to,
@@ -523,17 +524,29 @@ const moveCard = (
 					state,
 				};
 
-				const modifyCardActions = [
+				// Collect the plain actions that prepare the card in state (adding a
+				// cloned card, then any meta resets) and dispatch them in a single
+				// batch. This avoids multiple separate dispatches - each of which
+				// triggers its own subscriber notification and render pass - which is
+				// noticeably laggy with several fronts open.
+				const preInsertActions = [
+					// if from is not null we're moving an existing card, so it's already
+					// in state; otherwise we've cloned it and need to add it.
+					...(!fromWithRespectToState
+						? [cardsReceived([parent, ...supporting])]
+						: []),
 					mayResetBoostLevel(actionParams),
 					mayResetImageReplace(actionParams),
 					mayResetImmersive(actionParams),
 					mayResetVideoReplace(actionParams),
-				];
+				].filter(Boolean) as Action[];
 
-				modifyCardActions.forEach((action) => {
-					if (action) dispatch(action);
-				});
+				if (preInsertActions.length) {
+					dispatch(batchActions(preInsertActions));
+				}
 
+				// The insert action creator is a thunk, so it can't be included in the
+				// batch above; it's dispatched separately.
 				dispatch(
 					insertActionCreator(
 						toWithRespectToState.id,

--- a/fronts-client/src/components/FrontsEdit/FrontContent.tsx
+++ b/fronts-client/src/components/FrontsEdit/FrontContent.tsx
@@ -11,7 +11,7 @@ import WithDimensions from 'components/util/WithDimensions';
 import { Dispatch } from 'types/Store';
 import { Card as TCard, CardSets, Group } from 'types/Collection';
 import { FrontConfig } from 'types/FaciaApi';
-import { moveCard } from 'actions/Cards';
+import { moveCard, moveCards } from 'actions/Cards';
 import { insertCardFromDropEvent } from 'util/collectionUtils';
 import { bindActionCreators } from 'redux';
 import { editorSelectCard } from 'bundles/frontsUI';
@@ -63,6 +63,7 @@ type FrontProps = FrontPropsBeforeState & {
 		isSupporting: boolean,
 	) => void;
 	moveCard: typeof moveCard;
+	moveCards: typeof moveCards;
 	insertCardFromDropEvent: typeof insertCardFromDropEvent;
 };
 
@@ -282,8 +283,16 @@ class FrontContent extends React.Component<FrontProps, FrontState> {
 		// Otherwise, we need to build a move queue to handle cascading shifts of cards
 		const moveQueue = buildMoveQueue(move);
 
-		moveQueue.map((move) =>
-			this.props.moveCard(move.to, move.data, move.from, 'collection'),
+		// Dispatch the whole cascade as a single batched operation, rather than a
+		// separate moveCard dispatch per queued move (which caused a burst of
+		// render passes).
+		this.props.moveCards(
+			moveQueue.map((queuedMove) => ({
+				to: queuedMove.to,
+				card: queuedMove.data,
+				from: queuedMove.from,
+			})),
+			'collection',
 		);
 	};
 
@@ -463,6 +472,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 			selectCard: editorSelectCard,
 			initialiseCollectionsForFront,
 			moveCard,
+			moveCards,
 			insertCardFromDropEvent,
 		},
 		dispatch,


### PR DESCRIPTION
… performance

actions/Cards.ts
Extracted a planMove helper that computes a single move's plain prep actions (cardsReceived + mayReset*) and returns an insert callback (the insert stays a callback because it's a thunk that can't be batched). moveCard now delegates to planMove — identical behaviour, dispatches one batch + the insert. Added moveCards(moves, persistTo): collects prep actions across all queued moves into a single batchActions dispatch, then runs the inserts in order. Exported it. components/FrontsEdit/FrontContent.tsx
Imported moveCards, added it to FrontProps and mapDispatchToProps. The cascade branch of handleMove now calls this.props.moveCards(...) once with the whole queue, instead of a moveCard dispatch per queued move. Effect
A cascading move through N full groups goes from ~2N top-level dispatches (each waking subscribers and re-rendering the heavy 3-fronts tree) to 1 batched prep dispatch + N insert thunks — collapsing the render-triggering state churn into a single notification. Behaviour is preserved: same clone/meta-reset logic, inserts still applied in queue order.

## What's changed?
<!-- Detail the main feature of this PR and optionally a link to the relevant issue / card -->

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
