### PR TITLE
Update start and expiry dates on first publish of test

### DIFF
--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -129,7 +129,7 @@ object FaciaApi {
     Some(collectionJson)
       .filter(_.draft.isDefined)
       .map(updatePublicationDateForNew)
-      .map(updateTestDatesForNew)
+      .map(addTestDatesToTrails)
       .map(CollectionJsonFunctions.updatePreviouslyForPublish)
       .map(collectionJson =>
         collectionJson.copy(live = collectionJson.draft.get, draft = None)
@@ -163,8 +163,7 @@ object FaciaApi {
     collectionJson.copy(draft = Some(draftsWithNewDate))
   }
 
-  // per-trail helper: updates the tests inside a single Trail
-  private def updateTestDatesForTrail(trail: Trail): Trail = {
+  private def addTestDatesToTrail(trail: Trail): Trail = {
     val now = DateTime.now
     val updatedTests = trail.tests.map(_.map { test =>
       val startDate = test.startDate.orElse(Some(now.getMillis))
@@ -174,16 +173,14 @@ object FaciaApi {
     trail.copy(tests = updatedTests)
   }
 
-	def updateTestDatesForNew(
+	def addTestDatesToTrails(
       collectionJson: CollectionJson
   ): CollectionJson = {
-
     collectionJson.draft match {
       case None => collectionJson
       case Some(drafts) =>
-        val updated = drafts.map(updateTestDatesForTrail)
+        val updated = drafts.map(addTestDatesToTrail)
         collectionJson.copy(draft = Some(updated))
     }
-
   }
 }

--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -1,6 +1,6 @@
 package tools
 
-import com.gu.facia.client.models.{CollectionJson, ConfigJson}
+import com.gu.facia.client.models.{CollectionJson, ConfigJson, Trail}
 import com.gu.pandomainauth.model.User
 import frontsapi.model.CollectionJsonFunctions
 import org.joda.time.DateTime
@@ -163,33 +163,27 @@ object FaciaApi {
     collectionJson.copy(draft = Some(draftsWithNewDate))
   }
 
-  def updateTestDatesForNew(
+  // per-trail helper: updates the tests inside a single Trail
+  private def updateTestDatesForTrail(trail: Trail): Trail = {
+    val now = DateTime.now
+    val updatedTests = trail.tests.map(_.map { test =>
+      val startDate = test.startDate.orElse(Some(now.getMillis))
+      val expiryDate = test.expiryDate.orElse(Some(now.plusDays(1).getMillis))
+      test.copy(startDate = startDate, expiryDate = expiryDate)
+    })
+    trail.copy(tests = updatedTests)
+  }
+
+	def updateTestDatesForNew(
       collectionJson: CollectionJson
   ): CollectionJson = {
-    val draftsWithUpdatedTestDates = collectionJson.draft.get.map { draft =>
-      val updatedTests = draft.tests.map(_.map(test => {
-        val now = DateTime.now
 
-        val startDate: Option[Long] = test.startDate match {
-          case None              => Some(now.getMillis)
-          case existingStartDate => existingStartDate
-        }
-
-        val expiryDate: Option[Long] = test.expiryDate match {
-          // expiry date should be 24 hours after the start date
-          case None               => Some(now.plusDays(1).getMillis)
-          case existingExpiryDate => existingExpiryDate
-        }
-
-        test.copy(
-          startDate = startDate,
-          expiryDate = expiryDate
-        )
-      }))
-
-      draft.copy(tests = updatedTests)
+    collectionJson.draft match {
+      case None => collectionJson
+      case Some(drafts) =>
+        val updated = drafts.map(updateTestDatesForTrail)
+        collectionJson.copy(draft = Some(updated))
     }
 
-    collectionJson.copy(draft = Some(draftsWithUpdatedTestDates))
   }
 }

--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -163,8 +163,7 @@ object FaciaApi {
     collectionJson.copy(draft = Some(draftsWithNewDate))
   }
 
-  private def addTestDatesToTrail(trail: Trail): Trail = {
-    val now = DateTime.now
+  private def addTestDatesToTrail(trail: Trail, now: DateTime): Trail = {
     val updatedTests = trail.tests.map(_.map { test =>
       val startDate = test.startDate.orElse(Some(now.getMillis))
       val expiryDate = test.expiryDate.orElse(Some(now.plusDays(1).getMillis))
@@ -173,13 +172,14 @@ object FaciaApi {
     trail.copy(tests = updatedTests)
   }
 
-	def addTestDatesToTrails(
+  def addTestDatesToTrails(
       collectionJson: CollectionJson
   ): CollectionJson = {
     collectionJson.draft match {
       case None => collectionJson
       case Some(drafts) =>
-        val updated = drafts.map(addTestDatesToTrail)
+        val now = DateTime.now
+        val updated = drafts.map(draft => addTestDatesToTrail(draft, now))
         collectionJson.copy(draft = Some(updated))
     }
   }

--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -129,6 +129,7 @@ object FaciaApi {
     Some(collectionJson)
       .filter(_.draft.isDefined)
       .map(updatePublicationDateForNew)
+      .map(updateTestDatesForNew)
       .map(CollectionJsonFunctions.updatePreviouslyForPublish)
       .map(collectionJson =>
         collectionJson.copy(live = collectionJson.draft.get, draft = None)
@@ -162,4 +163,33 @@ object FaciaApi {
     collectionJson.copy(draft = Some(draftsWithNewDate))
   }
 
+  def updateTestDatesForNew(
+      collectionJson: CollectionJson
+  ): CollectionJson = {
+    val draftsWithUpdatedTestDates = collectionJson.draft.get.map { draft =>
+      val updatedTests = draft.tests.map(_.map(test => {
+        val now = DateTime.now
+
+        val startDate: Option[Long] = test.startDate match {
+          case None              => Some(now.getMillis)
+          case existingStartDate => existingStartDate
+        }
+
+        val expiryDate: Option[Long] = test.expiryDate match {
+          // expiry date should be 24 hours after the start date
+          case None               => Some(now.plusDays(1).getMillis)
+          case existingExpiryDate => existingExpiryDate
+        }
+
+        test.copy(
+          startDate = startDate,
+          expiryDate = expiryDate
+        )
+      }))
+
+      draft.copy(tests = updatedTests)
+    }
+
+    collectionJson.copy(draft = Some(draftsWithUpdatedTestDates))
+  }
 }


### PR DESCRIPTION
## What's changed?
Adds a function to `preparePublishCollectionJson` to  add start and expiry dates when a test is first published.

the `startDate` and `expiryDate` of a `test` on an unpublished trails are instantiated as undefined. These fields populate together during first publish of the trail. If a previously published test exists in draft, the existing start and expiry date is used. 

## Screenshots

Test after saving trail
<img width="1158" height="484" alt="Screenshot 2026-08-10 at 17 02 25" src="https://github.com/user-attachments/assets/df4057b8-fe08-4d03-b429-d4db481a59b9" />

Test after publishing trail
<img width="1157" height="505" alt="Screenshot 2026-08-10 at 17 02 47" src="https://github.com/user-attachments/assets/c20018fe-96da-4738-b9e1-d33d3aa7acd6" />



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
