### PR TITLE
Populate frontsThisTestCanRunOn property when test is created

### DIFF
--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -18,6 +18,7 @@ import {
 	selectFrontId,
 } from 'selectors/shared';
 import { createShallowEqualResultSelector } from 'util/selectorUtils';
+import { selectors as collectionSelectors } from 'bundles/collectionsBundle';
 
 interface FrontConfigMap {
 	[id: string]: FrontConfig;
@@ -105,6 +106,20 @@ const selectFrontsWithPriority = (
 	priority: string,
 ): FrontConfig[] =>
 	getFrontsByPriority(state)[priority] || defaultFrontsWithPriority;
+
+const getFrontsWithCollection = (
+	parentCollectionOfCard: string | null,
+	fronts: FrontConfig[],
+): string[] => {
+	// at the moment we are always returning early as we're getting null for the parentCollection - investigate
+	if (!parentCollectionOfCard) return [];
+
+	const frontsWithCollection = fronts.filter((front) =>
+		front.collections.includes(parentCollectionOfCard),
+	);
+
+	return frontsWithCollection.map((front) => front.id);
+};
 
 const getCollections = (state: State): CollectionConfigMap =>
 	frontsConfigSelectors.selectAll(state).collections || {};
@@ -256,6 +271,11 @@ const selectHasUnpublishedChanges = createSelector(
 	getUnpublishedChangesStatus,
 );
 
+const selectFrontsWithCollection = createSelector(
+	[collectionSelectors.selectParentCollectionOfCard, selectFrontsAsArray],
+	getFrontsWithCollection,
+);
+
 const createSelectCollectionsWhichAreAlsoOnOtherFronts = () =>
 	createSelector(
 		[selectFront, selectFrontsAsArray],
@@ -336,4 +356,5 @@ export {
 	selectVisibleArticles,
 	selectUnlockedFrontCollections,
 	createSelectArticleVisibilityDetails,
+	selectFrontsWithCollection,
 };

--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -111,7 +111,6 @@ const getFrontsWithCollection = (
 	parentCollectionOfCard: string | null,
 	fronts: FrontConfig[],
 ): string[] => {
-	// at the moment we are always returning early as we're getting null for the parentCollection - investigate
 	if (!parentCollectionOfCard) return [];
 
 	const frontsWithCollection = fronts.filter((front) =>

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -581,6 +581,7 @@ const selectGroupCollectionMap = createSelector(
 		),
 );
 
+// use this too
 const selectGroupCollection = (state: State, groupId: string) => {
 	const { collectionId, cardSet } = selectGroupCollectionMap(state)[groupId];
 	const collection = collectionSelectors.selectById(state, collectionId);
@@ -595,6 +596,7 @@ const selectGroupSiblings = (state: State, groupId: string) => {
 	return (collection[cardSet] || []).map((id) => selectGroupMap(state)[id]);
 };
 
+// use this
 const selectArticleGroup = (
 	state: State,
 	groupIdFromAction: string,

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -581,7 +581,6 @@ const selectGroupCollectionMap = createSelector(
 		),
 );
 
-// use this too
 const selectGroupCollection = (state: State, groupId: string) => {
 	const { collectionId, cardSet } = selectGroupCollectionMap(state)[groupId];
 	const collection = collectionSelectors.selectById(state, collectionId);
@@ -596,7 +595,6 @@ const selectGroupSiblings = (state: State, groupId: string) => {
 	return (collection[cardSet] || []).map((id) => selectGroupMap(state)[id]);
 };
 
-// use this
 const selectArticleGroup = (
 	state: State,
 	groupIdFromAction: string,

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -243,7 +243,10 @@ export const getCardTestFromFormValues = (
 		createdByEmail: 'dummy@guardian.com',
 		//TODO: ensure that an expired test will not reach this point.
 		hasManuallyEndedOnThisTrail: !abTestEnabled,
-		frontsThisTestCanRunOn: selectFrontsWithCollection(state, existingCard.id),
+		frontsThisTestCanRunOn: selectFrontsWithCollection(
+			state,
+			existingCard.uuid,
+		),
 	};
 };
 

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -10,6 +10,7 @@ import { Atom, CapiArticle } from 'types/Capi';
 import type { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
 import { findActiveOrDraftTest } from './abTests';
+import { selectFrontsWithCollection } from 'selectors/frontsSelectors';
 
 export interface CardFormData {
 	headline: string;
@@ -242,7 +243,7 @@ export const getCardTestFromFormValues = (
 		createdByEmail: 'dummy@guardian.com',
 		//TODO: ensure that an expired test will not reach this point.
 		hasManuallyEndedOnThisTrail: !abTestEnabled,
-		frontsThisTestCanRunOn: [],
+		frontsThisTestCanRunOn: selectFrontsWithCollection(state, existingCard.id),
 	};
 };
 


### PR DESCRIPTION
## What's changed?
Adds a new selector `selectFrontsWithCollection`, which selects any fronts with a given collection ID. This is used to populate the value of the `frontsThisTestCanRunOn` property when a new headline test is created.

Testing locally you can see this value being populated:


<img width="435" height="378" alt="Screenshot 2026-08-10 at 12 43 16" src="https://github.com/user-attachments/assets/a9e545bd-13d9-4bec-a16c-10a9c3534a0a" />

