### PR TITLE
Populate `createdBy` fields

### DIFF
--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -11,6 +11,11 @@ import type { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
 import { findActiveOrDraftTest } from './abTests';
 import { selectFrontsWithCollection } from 'selectors/frontsSelectors';
+import {
+	selectFirstName,
+	selectLastName,
+	selectUserEmail,
+} from 'selectors/configSelectors';
 
 export interface CardFormData {
 	headline: string;
@@ -238,9 +243,11 @@ export const getCardTestFromFormValues = (
 				},
 			},
 		],
-		// TODO: Populate createdBy fields
-		createdByName: 'dummy guardian',
-		createdByEmail: 'dummy@guardian.com',
+		createdByName: compact([
+			selectFirstName(state),
+			selectLastName(state),
+		]).join(' '),
+		createdByEmail: selectUserEmail(state) || '',
 		//TODO: ensure that an expired test will not reach this point.
 		hasManuallyEndedOnThisTrail: !abTestEnabled,
 		frontsThisTestCanRunOn: selectFrontsWithCollection(


### PR DESCRIPTION
## What's changed?

Populates the `createdByName` and `createdByEmail` fields.

These values are only set when the test is created, not every time it is edited.

<img width="533" height="634" alt="Screenshot 2026-08-07 at 14 11 33" src="https://github.com/user-attachments/assets/8d7bfaa0-f469-4a8a-a8f2-f82f58022e69" />



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
