### PR TITLE
Update hasManuallyEndedOnThisTrail when toggle is turned off

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -12,11 +12,7 @@ import {
 	publishCollection as publishCollectionApi,
 	getCollection as getCollectionApi,
 } from 'services/faciaApi';
-import {
-	selectUserEmail,
-	selectFirstName,
-	selectLastName,
-} from 'selectors/configSelectors';
+import { selectUserEmail, selectUserFullName } from 'selectors/configSelectors';
 import {
 	createSelectGroupArticles,
 	createSelectAllCardsInCollections,
@@ -277,7 +273,7 @@ function updateCollection(
 					...collection,
 					displayName: collection.displayName && collection.displayName.trim(),
 					updatedEmail: selectUserEmail(getState()) || '',
-					updatedBy: `${selectFirstName(state)} ${selectLastName(state)}`,
+					updatedBy: selectUserFullName(state),
 					lastUpdated: Date.now(),
 				}),
 				recordUnpublishedChanges(collection.id, true),

--- a/fronts-client/src/selectors/configSelectors.ts
+++ b/fronts-client/src/selectors/configSelectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import compact from 'lodash/compact';
 import type { State } from 'types/State';
 import { selectEditMode } from './pathSelectors';
 
@@ -15,6 +16,12 @@ const selectFirstName = createSelector(
 const selectLastName = createSelector(
 	selectConfig,
 	(config) => config && config.lastName,
+);
+
+const selectUserFullName = createSelector(
+	selectFirstName,
+	selectLastName,
+	(firstName, lastName) => compact([firstName, lastName]).join(' '),
 );
 
 const selectCapiLiveURL = createSelector(
@@ -69,6 +76,7 @@ export {
 	selectUserEmail,
 	selectFirstName,
 	selectLastName,
+	selectUserFullName,
 	selectCollectionCap,
 	selectGridUrl,
 	selectVideoBaseUrl,

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -224,6 +224,8 @@ export const getCardTestFromFormValues = (
 		return {
 			...maybeTest,
 			variantMeta: updatedVariantMeta,
+			// When the "Headline test" toggle is switched off, end the test on this trail
+			hasManuallyEndedOnThisTrail: !abTestEnabled,
 		};
 	}
 

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -221,11 +221,20 @@ export const getCardTestFromFormValues = (
 			};
 		});
 
+		// When the "Headline test" toggle is switched off, end the test on this
+		// trail and record who ended it
+		const hasManuallyEndedOnThisTrail = !abTestEnabled;
+
 		return {
 			...maybeTest,
 			variantMeta: updatedVariantMeta,
-			// When the "Headline test" toggle is switched off, end the test on this trail
-			hasManuallyEndedOnThisTrail: !abTestEnabled,
+			hasManuallyEndedOnThisTrail,
+			manuallyEndedOnThisTrailByName: hasManuallyEndedOnThisTrail
+				? compact([selectFirstName(state), selectLastName(state)]).join(' ')
+				: undefined,
+			manuallyEndedOnThisTrailByEmail: hasManuallyEndedOnThisTrail
+				? selectUserEmail(state) || ''
+				: undefined,
 		};
 	}
 

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -11,11 +11,7 @@ import type { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
 import { findActiveOrDraftTest } from './abTests';
 import { selectFrontsWithCollection } from 'selectors/frontsSelectors';
-import {
-	selectFirstName,
-	selectLastName,
-	selectUserEmail,
-} from 'selectors/configSelectors';
+import { selectUserFullName, selectUserEmail } from 'selectors/configSelectors';
 
 export interface CardFormData {
 	headline: string;
@@ -230,7 +226,7 @@ export const getCardTestFromFormValues = (
 			variantMeta: updatedVariantMeta,
 			hasManuallyEndedOnThisTrail,
 			manuallyEndedOnThisTrailByName: hasManuallyEndedOnThisTrail
-				? compact([selectFirstName(state), selectLastName(state)]).join(' ')
+				? selectUserFullName(state)
 				: undefined,
 			manuallyEndedOnThisTrailByEmail: hasManuallyEndedOnThisTrail
 				? selectUserEmail(state) || ''
@@ -254,10 +250,7 @@ export const getCardTestFromFormValues = (
 				},
 			},
 		],
-		createdByName: compact([
-			selectFirstName(state),
-			selectLastName(state),
-		]).join(' '),
+		createdByName: selectUserFullName(state),
 		createdByEmail: selectUserEmail(state) || '',
 		//TODO: ensure that an expired test will not reach this point.
 		hasManuallyEndedOnThisTrail: !abTestEnabled,


### PR DESCRIPTION
## What's changed?

Update `hasManuallyEndedOnThisTrail`, `manuallyEndedOnThisTrailByName` and `manuallyEndedOnThisTrailByEmail` when toggle is turned off.

<img width="588" height="532" alt="Screenshot 2026-08-07 at 14 40 06" src="https://github.com/user-attachments/assets/e58f776b-ec82-49c5-b648-e239235b444a" />

## Implementation notes


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
