### PR TITLE
Set variant headlines to undefined when empty

### DIFF
--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -1,6 +1,7 @@
 import { reducer, initialize, change } from 'redux-form';
 import {
 	getCardMetaFromFormValues,
+	getCardTestFromFormValues,
 	getInitialValuesForCardForm,
 	maxSlideshowImages,
 } from 'util/form';
@@ -357,6 +358,100 @@ describe('CardForm transform functions', () => {
 					...values,
 				}),
 			).toEqual({ showQuotedHeadline: false, headline: 'Bill Shorten' });
+		});
+	});
+	describe('Derive card tests from form values', () => {
+		const originalRandomUUID = crypto.randomUUID;
+		beforeAll(() => {
+			// jsdom does not implement crypto.randomUUID
+			crypto.randomUUID = jest
+				.fn()
+				.mockReturnValue('00000000-0000-0000-0000-000000000000');
+		});
+		afterAll(() => {
+			crypto.randomUUID = originalRandomUUID;
+		});
+		it('should set variant headlines from headlineA and headlineB when non-empty', () => {
+			const values = {
+				abTestEnabled: true,
+				headlineA: 'Headline variant A',
+				headlineB: 'Headline variant B',
+			};
+			const state = createStateWithChangedFormFields(
+				initialState,
+				'exampleId',
+				values,
+			);
+			const test = getCardTestFromFormValues(state, 'exampleId', {
+				...formValues,
+				...values,
+			});
+			expect(test.variantMeta).toEqual([
+				{ id: 'A', meta: { headline: 'Headline variant A' } },
+				{ id: 'B', meta: { headline: 'Headline variant B' } },
+			]);
+		});
+
+		it('should set variant headlines to undefined when headlineA and headlineB are empty strings', () => {
+			const values = {
+				abTestEnabled: true,
+				headlineA: '',
+				headlineB: '',
+			};
+			const state = createStateWithChangedFormFields(
+				initialState,
+				'exampleId',
+				values,
+			);
+			const test = getCardTestFromFormValues(state, 'exampleId', {
+				...formValues,
+				...values,
+			});
+			expect(test.variantMeta).toEqual([
+				{ id: 'A', meta: { headline: undefined } },
+				{ id: 'B', meta: { headline: undefined } },
+			]);
+		});
+
+		it('should update an existing test, setting variant headlines to undefined when empty', () => {
+			const existingTest = {
+				testUuid: 'test-uuid',
+				variantMeta: [
+					{ id: 'A' as const, meta: { headline: 'Old A' } },
+					{ id: 'B' as const, meta: { headline: 'Old B' } },
+				],
+				createdByName: 'Someone',
+				createdByEmail: 'someone@example.com',
+				hasManuallyEndedOnThisTrail: false,
+			};
+			const stateWithTest = {
+				...initialState,
+				cards: {
+					...initialState.cards,
+					exampleId: {
+						...initialState.cards.exampleId,
+						tests: [existingTest],
+					},
+				},
+			};
+			const values = {
+				abTestEnabled: true,
+				headlineA: '',
+				headlineB: '',
+			};
+			const state = createStateWithChangedFormFields(
+				stateWithTest,
+				'exampleId',
+				values,
+			);
+			const test = getCardTestFromFormValues(state, 'exampleId', {
+				...formValues,
+				...values,
+			});
+			expect(test.variantMeta).toEqual([
+				{ id: 'A', meta: { headline: undefined } },
+				{ id: 'B', meta: { headline: undefined } },
+			]);
 		});
 	});
 });

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -559,6 +559,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			pristine,
 			showByline,
 			abTestEnabled,
+			headline,
 			editableFields = [],
 			showKickerTag,
 			showKickerSection,
@@ -609,6 +610,16 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			['showKickerTag', 'showKickerSection'].forEach((field) =>
 				change(field, false),
 			);
+		};
+
+		const handleAbTestToggle: EventWithDataHandler<React.ChangeEvent<any>> = (
+			_event: unknown,
+			abTestEnabled?: boolean,
+		) => {
+			// set variant A with the card's current headline when the test is enabled
+			if (abTestEnabled) {
+				change('headlineA', headline);
+			}
 		};
 
 		const renderKickerSuggestion = (
@@ -715,6 +726,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								cardId={this.props.cardId}
 								editableFields={editableFields}
 								snapType={this.props.snapType}
+								onAbTestToggle={handleAbTestToggle}
 							/>
 						)}
 						<CheckboxFieldsContainer
@@ -1267,6 +1279,7 @@ interface ContainerProps {
 	pickedKicker: string | undefined;
 	showByline: boolean;
 	abTestEnabled: boolean;
+	headline: string;
 	editableFields?: string[];
 	showKickerTag: boolean;
 	showKickerSection: boolean;
@@ -1348,6 +1361,7 @@ const createMapStateToProps = () => {
 			replaceVideoUri: valueSelector(state, 'replaceVideoUri'),
 			showByline: valueSelector(state, 'showByline'),
 			abTestEnabled: valueSelector(state, 'abTestEnabled'),
+			headline: valueSelector(state, 'headline'),
 			showKickerTag: valueSelector(state, 'showKickerTag'),
 			showKickerSection: valueSelector(state, 'showKickerSection'),
 			isBreaking: valueSelector(state, 'isBreaking'),

--- a/fronts-client/src/components/form/__tests__/ArticleMetaForm.spec.tsx
+++ b/fronts-client/src/components/form/__tests__/ArticleMetaForm.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent, render, cleanup } from 'react-testing-library';
+import { ThemeProvider } from 'styled-components';
+import { theme } from 'constants/theme';
+import configureStore from 'util/configureStore';
+import { state as initialState } from 'fixtures/initialState';
+import ArticleMetaForm from '../ArticleMetaForm';
+
+// TODO: Remove when no longer gated behind feature switch
+jest.mock('util/extractConfigFromPage', () => {
+	const baseConfig = jest.requireActual('fixtures/config').default;
+	return {
+		__esModule: true,
+		default: {
+			...baseConfig,
+			userData: {
+				featureSwitches: [{ key: 'headline-ab-testing', enabled: true }],
+			},
+		},
+	};
+});
+
+afterEach(cleanup);
+
+describe('ArticleMetaForm - headline AB testing', () => {
+	it('copies the card headline into headlineA when the AB test toggle is switched on', () => {
+		const store = configureStore(initialState);
+		const cardId = 'exampleId';
+
+		const { getByTestId } = render(
+			<Provider store={store}>
+				<ThemeProvider theme={theme}>
+					<ArticleMetaForm
+						cardId={cardId}
+						form={cardId}
+						frontId="frontId"
+						onSave={jest.fn()}
+						onCancel={jest.fn()}
+					/>
+				</ThemeProvider>
+			</Provider>,
+		);
+
+		const abTestToggle = getByTestId(
+			'edit-form-ab-test-toggle',
+		) as HTMLInputElement;
+		expect(abTestToggle.checked).toBe(false);
+		// headlineA is an empty string by default, we transform it to undefined later using getStringField
+		expect(store.getState().form[cardId]?.values?.headlineA).toBe('');
+
+		fireEvent.click(abTestToggle);
+
+		expect(abTestToggle.checked).toBe(true);
+		expect(store.getState().form[cardId]?.values?.headlineA).toBe(
+			'Bill Shorten',
+		);
+
+		const headlineAField = getByTestId(
+			'edit-form-headline-a-field',
+		) as HTMLTextAreaElement;
+		expect(headlineAField.value).toBe('Bill Shorten');
+	});
+});

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Field } from 'redux-form';
+import type { EventWithDataHandler } from 'redux-form';
 import { RichTextInput } from './RichTextInput';
 import InputTextArea from './InputTextArea';
 import InputCheckboxToggleInline from './InputCheckboxToggleInline';
@@ -13,6 +14,7 @@ interface HeadlineInputProps {
 	cardId: string;
 	editableFields: string[];
 	snapType: string | undefined;
+	onAbTestToggle?: EventWithDataHandler<React.ChangeEvent<any>>;
 }
 
 const HeadlineInputContainer = styled('div')<{ abTestEnabled: boolean }>`
@@ -73,6 +75,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						data-testid="edit-form-ab-test-toggle"
 						useABTestStyling={true}
 						activeABTest={props.abTestEnabled}
+						onChange={props.onAbTestToggle}
 					/>
 				</ABTestToggleContainer>
 			)}

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -212,7 +212,7 @@ export const getCardTestFromFormValues = (
 				...variant,
 				meta: {
 					...variant.meta,
-					headline: headlineVariant,
+					headline: getStringField(headlineVariant),
 				},
 			};
 		});
@@ -240,13 +240,13 @@ export const getCardTestFromFormValues = (
 			{
 				id: 'A',
 				meta: {
-					headline: headlineA,
+					headline: getStringField(headlineA),
 				},
 			},
 			{
 				id: 'B',
 				meta: {
-					headline: headlineB,
+					headline: getStringField(headlineB),
 				},
 			},
 		],
@@ -259,6 +259,13 @@ export const getCardTestFromFormValues = (
 			existingCard.uuid,
 		),
 	};
+};
+
+const getStringField = (field: string) => {
+	if (field.length === 0) {
+		return undefined;
+	}
+	return field;
 };
 
 export const getCardMetaFromFormValues = (
@@ -275,12 +282,6 @@ export const getCardMetaFromFormValues = (
 			height: intToStr(image.height),
 		}),
 	);
-	const getStringField = (field: string) => {
-		if (field.length === 0) {
-			return undefined;
-		}
-		return field;
-	};
 
 	const completeMeta = omit(
 		{


### PR DESCRIPTION
This PR:
* Sets variant headline fields to undefined when empty (in the same way we handle the OG headline field)
* Populates headlineA field with the OG headline field value when the toggle is switched on

I opted for this approach over initialising headlineA with the OG headline field, because then you would still need to react to any OG headline field changes and mutate headlineA accordingly.

If you untoggle the test and retoggle it on, you will lose your persisted headlineA field in favour of the current value of the OG headline field. I think this is okay in practice but welcome to discuss, I can't imagine it will be a common user story.

I've kept the logic in selectors/shared.ts (`// if headlineA is not present, populate it with the headline field`) in case the headlineA field is still empty for some reason, but we could now get rid of this logic and rely on it being set correctly at the point the toggle switch is used.