### PR TITLE
subnav initial frontend interface

### DIFF
--- a/fronts-client/src/components/App.tsx
+++ b/fronts-client/src/components/App.tsx
@@ -34,7 +34,7 @@ import {
 	frontsEditPathProps,
 	issuePathProps,
 	frontsFeatureProps,
-	subnavSectionProps,
+	subnavRoutes,
 } from 'routes/routes';
 import ManageView from './Editions/ManageView';
 import FeaturesView from './Features/FeaturesView';
@@ -167,7 +167,7 @@ const App = () => {
 						<Route {...frontsEditPathProps} component={FrontsEdit} />
 						<Route {...issuePathProps} component={FrontsEdit} />
 						<Route {...frontsFeatureProps} component={FeaturesView} />
-						<Route {...subnavSectionProps} component={SubnavSection} />
+						<Route {...subnavRoutes.sectionProps} component={SubnavSection} />
 						<Route exact path="/" component={Home} />
 						<Route exact path={manageEditions} component={ManageView} />
 						<Route component={NotFound} />

--- a/fronts-client/src/components/Subnav/SubnavEditRoute.tsx
+++ b/fronts-client/src/components/Subnav/SubnavEditRoute.tsx
@@ -24,11 +24,6 @@ interface SubnavEditRouteProps {
 	saving: boolean;
 }
 
-/**
- * Resolves the `:id` route param against the loaded config. While the config is
- * still loading we show a placeholder; if the id is unknown (e.g. deleted or a
- * stale link) we send the user back to the list.
- */
 export const SubnavEditRoute = ({
 	config,
 	isLoading,

--- a/fronts-client/src/components/Subnav/SubnavEditRoute.tsx
+++ b/fronts-client/src/components/Subnav/SubnavEditRoute.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import { useParams } from 'react-router';
+import { subnavRoutes } from 'routes/routes';
+import { SubnavFormView } from './SubnavFormView';
+import { SubnavStatusActions, SubnavStatusTags } from './SubnavStatusActions';
+import { findSubnav, RunAction } from './helpers';
+import { CustomSubnav, CustomSubnavConfig } from './types';
+import {
+	EditStatusBar,
+	ListItemActions,
+	Message,
+	SubnavContainer,
+	SubnavContainerHeading,
+} from './styles';
+
+interface SubnavEditRouteProps {
+	config: CustomSubnavConfig | null;
+	isLoading: boolean;
+	pendingActionId: string | null;
+	runAction: RunAction;
+	onSave: (subnav: CustomSubnav) => Promise<void>;
+	onCancel: () => void;
+	saving: boolean;
+}
+
+/**
+ * Resolves the `:id` route param against the loaded config. While the config is
+ * still loading we show a placeholder; if the id is unknown (e.g. deleted or a
+ * stale link) we send the user back to the list.
+ */
+export const SubnavEditRoute = ({
+	config,
+	isLoading,
+	pendingActionId,
+	runAction,
+	onSave,
+	onCancel,
+	saving,
+}: SubnavEditRouteProps) => {
+	const { id } = useParams<{ id: string }>();
+
+	if (isLoading || !config) {
+		return (
+			<SubnavContainer>
+				<SubnavContainerHeading>Edit custom subnav</SubnavContainerHeading>
+				<Message>Loading…</Message>
+			</SubnavContainer>
+		);
+	}
+
+	const subnav = findSubnav(config, id);
+	if (!subnav) {
+		return <Redirect to={subnavRoutes.base} />;
+	}
+
+	const hasLive = config.live.some((s) => s.id === id);
+	const hasDraft = config.draft.some((s) => s.id === id);
+
+	return (
+		<SubnavFormView
+			heading="Edit custom subnav"
+			statusBar={
+				<EditStatusBar>
+					<div>
+						<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
+					</div>
+					<ListItemActions>
+						<SubnavStatusActions
+							id={id}
+							hasLive={hasLive}
+							hasDraft={hasDraft}
+							isBusy={pendingActionId === id}
+							runAction={runAction}
+						/>
+					</ListItemActions>
+				</EditStatusBar>
+			}
+			initialSubnav={subnav}
+			onSave={onSave}
+			onCancel={onCancel}
+			saving={saving}
+		/>
+	);
+};

--- a/fronts-client/src/components/Subnav/SubnavForm.tsx
+++ b/fronts-client/src/components/Subnav/SubnavForm.tsx
@@ -1,0 +1,245 @@
+import React, { useState } from 'react';
+import v4 from 'uuid/v4';
+import ButtonDefault from 'components/inputs/ButtonDefault';
+import {
+	CustomSubnav,
+	SubnavLink,
+	TargetedPage,
+	TargetedPageType,
+} from './types';
+import {
+	ErrorMessage,
+	Field,
+	Form,
+	FormActions,
+	RepeatableRow,
+	RowFields,
+	Section,
+	SectionHeading,
+	Select,
+	TextInput,
+} from './styles';
+
+interface SubnavFormProps {
+	initialSubnav?: CustomSubnav;
+	onSave: (subnav: CustomSubnav) => Promise<void> | void;
+	onCancel: () => void;
+	saving?: boolean;
+}
+
+const pageTypeOptions: { value: TargetedPageType; label: string }[] = [
+	{ value: 'front', label: 'Front' },
+	{ value: 'article', label: 'Article' },
+	{ value: 'hasTag', label: 'Tag' },
+];
+
+const emptyLink = (): SubnavLink => ({ linkText: '', dotcomPath: '' });
+const emptyPage = (): TargetedPage => ({ type: 'front', path: '' });
+
+const SubnavForm = ({
+	initialSubnav,
+	onSave,
+	onCancel,
+	saving = false,
+}: SubnavFormProps) => {
+	const [headerText, setHeaderText] = useState(
+		initialSubnav?.header.headerText ?? '',
+	);
+	const [headerDotcomPath, setHeaderDotcomPath] = useState(
+		initialSubnav?.header.dotcomPath ?? '',
+	);
+	const [headerCopy, setHeaderCopy] = useState(
+		initialSubnav?.header.copy ?? '',
+	);
+	const [links, setLinks] = useState<SubnavLink[]>(
+		initialSubnav?.links.length ? initialSubnav.links : [emptyLink()],
+	);
+	const [pages, setPages] = useState<TargetedPage[]>(
+		initialSubnav?.pages.length ? initialSubnav.pages : [emptyPage()],
+	);
+	const [error, setError] = useState<string | null>(null);
+
+	const updateLink = (index: number, patch: Partial<SubnavLink>) =>
+		setLinks((prev) =>
+			prev.map((link, i) => (i === index ? { ...link, ...patch } : link)),
+		);
+	const addLink = () => setLinks((prev) => [...prev, emptyLink()]);
+	const removeLink = (index: number) =>
+		setLinks((prev) => prev.filter((_, i) => i !== index));
+
+	const updatePage = (index: number, patch: Partial<TargetedPage>) =>
+		setPages((prev) =>
+			prev.map((page, i) => (i === index ? { ...page, ...patch } : page)),
+		);
+	const addPage = () => setPages((prev) => [...prev, emptyPage()]);
+	const removePage = (index: number) =>
+		setPages((prev) => prev.filter((_, i) => i !== index));
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+
+		if (!headerText.trim()) {
+			setError('Header text is required.');
+			return;
+		}
+
+		const cleanedLinks = links.filter(
+			(link) => link.linkText.trim() || link.dotcomPath.trim(),
+		);
+		const cleanedPages = pages.filter((page) => page.path.trim());
+
+		if (cleanedPages.length === 0) {
+			setError('Add at least one targeted page where the subnav will show.');
+			return;
+		}
+
+		setError(null);
+
+		const subnav: CustomSubnav = {
+			id: initialSubnav?.id ?? v4(),
+			header: {
+				headerText: headerText.trim(),
+				dotcomPath: headerDotcomPath.trim() || undefined,
+				copy: headerCopy.trim(),
+			},
+			format: initialSubnav?.format ?? 'large',
+			links: cleanedLinks.map((link) => ({
+				linkText: link.linkText.trim(),
+				dotcomPath: link.dotcomPath.trim(),
+			})),
+			pages: cleanedPages.map((page) => ({
+				type: page.type,
+				path: page.path.trim(),
+			})),
+			images: initialSubnav?.images,
+			palette: initialSubnav?.palette,
+			lastUpdated: Date.now(),
+			updatedBy: initialSubnav?.updatedBy ?? '',
+			updatedEmail: initialSubnav?.updatedEmail ?? '',
+		};
+
+		await onSave(subnav);
+	};
+
+	return (
+		<Form onSubmit={handleSubmit}>
+			<Section>
+				<SectionHeading>Header</SectionHeading>
+				<Field>
+					Header text
+					<TextInput
+						value={headerText}
+						onChange={(e) => setHeaderText(e.target.value)}
+						placeholder="e.g. UK election 2024"
+					/>
+				</Field>
+				<Field>
+					Header copy (optional)
+					<TextInput
+						value={headerCopy}
+						onChange={(e) => setHeaderCopy(e.target.value)}
+						placeholder="Supporting copy shown alongside the header"
+					/>
+				</Field>
+				<Field>
+					Header dotcom path (optional)
+					<TextInput
+						value={headerDotcomPath}
+						onChange={(e) => setHeaderDotcomPath(e.target.value)}
+						placeholder="e.g. politics/uk-election-2024"
+					/>
+				</Field>
+			</Section>
+
+			<Section>
+				<SectionHeading>Links</SectionHeading>
+				{links.map((link, index) => (
+					<RepeatableRow key={index}>
+						<RowFields>
+							<TextInput
+								value={link.linkText}
+								onChange={(e) =>
+									updateLink(index, { linkText: e.target.value })
+								}
+								placeholder="Link text"
+							/>
+							<TextInput
+								value={link.dotcomPath}
+								onChange={(e) =>
+									updateLink(index, { dotcomPath: e.target.value })
+								}
+								placeholder="Dotcom path"
+							/>
+						</RowFields>
+						<ButtonDefault
+							type="button"
+							size="s"
+							priority="muted"
+							onClick={() => removeLink(index)}
+							disabled={links.length === 1}
+						>
+							Remove
+						</ButtonDefault>
+					</RepeatableRow>
+				))}
+				<ButtonDefault type="button" size="s" onClick={addLink}>
+					+ Add link
+				</ButtonDefault>
+			</Section>
+
+			<Section>
+				<SectionHeading>Targeted pages</SectionHeading>
+				{pages.map((page, index) => (
+					<RepeatableRow key={index}>
+						<RowFields>
+							<Select
+								value={page.type}
+								onChange={(e) =>
+									updatePage(index, {
+										type: e.target.value as TargetedPageType,
+									})
+								}
+							>
+								{pageTypeOptions.map((option) => (
+									<option key={option.value} value={option.value}>
+										{option.label}
+									</option>
+								))}
+							</Select>
+							<TextInput
+								value={page.path}
+								onChange={(e) => updatePage(index, { path: e.target.value })}
+								placeholder="Path (e.g. politics/uk-election-2024)"
+							/>
+						</RowFields>
+						<ButtonDefault
+							type="button"
+							size="s"
+							priority="muted"
+							onClick={() => removePage(index)}
+							disabled={pages.length === 1}
+						>
+							Remove
+						</ButtonDefault>
+					</RepeatableRow>
+				))}
+				<ButtonDefault type="button" size="s" onClick={addPage}>
+					+ Add page
+				</ButtonDefault>
+			</Section>
+
+			{error && <ErrorMessage>{error}</ErrorMessage>}
+
+			<FormActions>
+				<ButtonDefault type="submit" priority="primary" disabled={saving}>
+					{saving ? 'Saving…' : 'Save draft'}
+				</ButtonDefault>
+				<ButtonDefault type="button" onClick={onCancel} disabled={saving}>
+					Cancel
+				</ButtonDefault>
+			</FormActions>
+		</Form>
+	);
+};
+
+export default SubnavForm;

--- a/fronts-client/src/components/Subnav/SubnavForm.tsx
+++ b/fronts-client/src/components/Subnav/SubnavForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import v4 from 'uuid/v4';
 import ButtonDefault from 'components/inputs/ButtonDefault';
 import {
@@ -14,6 +14,7 @@ import {
 	FormActions,
 	RepeatableRow,
 	RowFields,
+	SavedMessage,
 	Section,
 	SectionHeading,
 	Select,
@@ -23,7 +24,6 @@ import {
 interface SubnavFormProps {
 	initialSubnav?: CustomSubnav;
 	onSave: (subnav: CustomSubnav) => Promise<void> | void;
-	onCancel: () => void;
 	saving?: boolean;
 }
 
@@ -36,28 +36,67 @@ const pageTypeOptions: { value: TargetedPageType; label: string }[] = [
 const emptyLink = (): SubnavLink => ({ linkText: '', dotcomPath: '' });
 const emptyPage = (): TargetedPage => ({ type: 'front', path: '' });
 
+/**
+ * The form's editable state, derived from the subnav being edited (or blank
+ * defaults when creating). Arrays are cloned so edits never mutate the config
+ * and so this snapshot can be used to detect changes and to reset the form.
+ */
+const toInitialFormState = (subnav?: CustomSubnav) => ({
+	headerText: subnav?.header.headerText ?? '',
+	headerDotcomPath: subnav?.header.dotcomPath ?? '',
+	headerCopy: subnav?.header.copy ?? '',
+	links: subnav?.links.length
+		? subnav.links.map((link) => ({ ...link }))
+		: [emptyLink()],
+	pages: subnav?.pages.length
+		? subnav.pages.map((page) => ({ ...page }))
+		: [emptyPage()],
+});
+
 const SubnavForm = ({
 	initialSubnav,
 	onSave,
-	onCancel,
 	saving = false,
 }: SubnavFormProps) => {
-	const [headerText, setHeaderText] = useState(
-		initialSubnav?.header.headerText ?? '',
+	const mountedRef = useRef(true);
+	useEffect(
+		() => () => {
+			mountedRef.current = false;
+		},
+		[],
 	);
+
+	const [baseline, setBaseline] = useState(() =>
+		toInitialFormState(initialSubnav),
+	);
+
+	const [headerText, setHeaderText] = useState(baseline.headerText);
 	const [headerDotcomPath, setHeaderDotcomPath] = useState(
-		initialSubnav?.header.dotcomPath ?? '',
+		baseline.headerDotcomPath,
 	);
-	const [headerCopy, setHeaderCopy] = useState(
-		initialSubnav?.header.copy ?? '',
-	);
-	const [links, setLinks] = useState<SubnavLink[]>(
-		initialSubnav?.links.length ? initialSubnav.links : [emptyLink()],
-	);
-	const [pages, setPages] = useState<TargetedPage[]>(
-		initialSubnav?.pages.length ? initialSubnav.pages : [emptyPage()],
-	);
+	const [headerCopy, setHeaderCopy] = useState(baseline.headerCopy);
+	const [links, setLinks] = useState<SubnavLink[]>(baseline.links);
+	const [pages, setPages] = useState<TargetedPage[]>(baseline.pages);
 	const [error, setError] = useState<string | null>(null);
+	const [justSaved, setJustSaved] = useState(false);
+
+	const isDirty =
+		JSON.stringify({
+			headerText,
+			headerDotcomPath,
+			headerCopy,
+			links,
+			pages,
+		}) !== JSON.stringify(baseline);
+
+	const handleCancel = () => {
+		setHeaderText(baseline.headerText);
+		setHeaderDotcomPath(baseline.headerDotcomPath);
+		setHeaderCopy(baseline.headerCopy);
+		setLinks(baseline.links.map((link) => ({ ...link })));
+		setPages(baseline.pages.map((page) => ({ ...page })));
+		setError(null);
+	};
 
 	const updateLink = (index: number, patch: Partial<SubnavLink>) =>
 		setLinks((prev) =>
@@ -118,7 +157,28 @@ const SubnavForm = ({
 			updatedEmail: initialSubnav?.updatedEmail ?? '',
 		};
 
-		await onSave(subnav);
+		try {
+			await onSave(subnav);
+		} catch {
+			// The parent surfaces save failures via the global banner; keep the
+			// user's edits in place so they can retry.
+			return;
+		}
+
+		if (!mountedRef.current) {
+			return;
+		}
+
+		// Re-seed the form from what we just persisted so it is no longer "dirty"
+		// and we can confirm the save without navigating away.
+		const savedState = toInitialFormState(subnav);
+		setBaseline(savedState);
+		setHeaderText(savedState.headerText);
+		setHeaderDotcomPath(savedState.headerDotcomPath);
+		setHeaderCopy(savedState.headerCopy);
+		setLinks(savedState.links);
+		setPages(savedState.pages);
+		setJustSaved(true);
 	};
 
 	return (
@@ -230,14 +290,18 @@ const SubnavForm = ({
 
 			{error && <ErrorMessage>{error}</ErrorMessage>}
 
-			<FormActions>
-				<ButtonDefault type="submit" priority="primary" disabled={saving}>
-					{saving ? 'Saving…' : 'Save draft'}
-				</ButtonDefault>
-				<ButtonDefault type="button" onClick={onCancel} disabled={saving}>
-					Cancel
-				</ButtonDefault>
-			</FormActions>
+			{isDirty ? (
+				<FormActions>
+					<ButtonDefault type="submit" priority="primary" disabled={saving}>
+						{saving ? 'Saving…' : 'Save draft'}
+					</ButtonDefault>
+					<ButtonDefault type="button" onClick={handleCancel} disabled={saving}>
+						Cancel
+					</ButtonDefault>
+				</FormActions>
+			) : (
+				justSaved && <SavedMessage>Changes saved</SavedMessage>
+			)}
 		</Form>
 	);
 };

--- a/fronts-client/src/components/Subnav/SubnavFormView.tsx
+++ b/fronts-client/src/components/Subnav/SubnavFormView.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import SubnavForm from './SubnavForm';
+import { CustomSubnav } from './types';
+import { BackButton, SubnavContainer, SubnavContainerHeading } from './styles';
+
+export interface SubnavFormViewProps {
+	heading: string;
+	statusBar?: React.ReactNode;
+	initialSubnav?: CustomSubnav;
+	onSave: (subnav: CustomSubnav) => Promise<void>;
+	onCancel: () => void;
+	saving: boolean;
+}
+
+export const SubnavFormView = ({
+	heading,
+	statusBar,
+	initialSubnav,
+	onSave,
+	onCancel,
+	saving,
+}: SubnavFormViewProps) => (
+	<SubnavContainer>
+		<BackButton type="button" onClick={onCancel}>
+			← Back to subnavs
+		</BackButton>
+		<SubnavContainerHeading>{heading}</SubnavContainerHeading>
+		{statusBar}
+		<SubnavForm initialSubnav={initialSubnav} onSave={onSave} saving={saving} />
+	</SubnavContainer>
+);

--- a/fronts-client/src/components/Subnav/SubnavListView.tsx
+++ b/fronts-client/src/components/Subnav/SubnavListView.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import ButtonDefault from 'components/inputs/ButtonDefault';
+import { SubnavStatusActions, SubnavStatusTags } from './SubnavStatusActions';
+import { RunAction, SubnavListEntry } from './helpers';
+import {
+	List,
+	ListHeader,
+	ListItem,
+	ListItemActions,
+	ListItemMeta,
+	ListItemTitle,
+	Message,
+	SubnavContainer,
+	SubnavContainerHeading,
+} from './styles';
+
+interface SubnavListViewProps {
+	entries: SubnavListEntry[];
+	isLoading: boolean;
+	pendingActionId: string | null;
+	onCreate: () => void;
+	onEdit: (id: string) => void;
+	runAction: RunAction;
+}
+
+export const SubnavListView = ({
+	entries,
+	isLoading,
+	pendingActionId,
+	onCreate,
+	onEdit,
+	runAction,
+}: SubnavListViewProps) => (
+	<SubnavContainer>
+		<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
+
+		<ListHeader>
+			<ButtonDefault type="button" priority="primary" onClick={onCreate}>
+				+ Create new subnav
+			</ButtonDefault>
+		</ListHeader>
+
+		{isLoading ? (
+			<Message>Loading…</Message>
+		) : entries.length === 0 ? (
+			<Message>No custom subnavs yet. Create one to get started.</Message>
+		) : (
+			<List>
+				{entries.map(({ id, subnav, hasLive, hasDraft }) => {
+					const isBusy = pendingActionId === id;
+					return (
+						<ListItem key={id}>
+							<div>
+								<ListItemTitle>
+									{subnav.header.headerText || 'Untitled subnav'}
+									<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
+								</ListItemTitle>
+								<ListItemMeta>
+									{subnav.pages.length} page
+									{subnav.pages.length === 1 ? '' : 's'} · {subnav.links.length}{' '}
+									link
+									{subnav.links.length === 1 ? '' : 's'}
+								</ListItemMeta>
+							</div>
+							<ListItemActions>
+								<ButtonDefault
+									type="button"
+									size="s"
+									disabled={isBusy}
+									onClick={() => onEdit(id)}
+								>
+									Edit
+								</ButtonDefault>
+								<SubnavStatusActions
+									id={id}
+									hasLive={hasLive}
+									hasDraft={hasDraft}
+									isBusy={isBusy}
+									runAction={runAction}
+								/>
+							</ListItemActions>
+						</ListItem>
+					);
+				})}
+			</List>
+		)}
+	</SubnavContainer>
+);

--- a/fronts-client/src/components/Subnav/SubnavStatusActions.tsx
+++ b/fronts-client/src/components/Subnav/SubnavStatusActions.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import ButtonDefault from 'components/inputs/ButtonDefault';
+import {
+	deleteSubnav,
+	discardSubnav,
+	publishSubnav,
+	unpublishSubnav,
+} from './subnavApi';
+import { RunAction } from './helpers';
+import { StatusTag } from './styles';
+
+interface SubnavStatusActionsProps {
+	id: string;
+	hasLive: boolean;
+	hasDraft: boolean;
+	isBusy: boolean;
+	runAction: RunAction;
+}
+
+/**
+ * Publish / discard / unpublish / delete buttons for a single subnav, shared by
+ * the list rows and the individual edit page. Which buttons show depends on
+ * whether the subnav currently has a live and/or draft version.
+ */
+export const SubnavStatusActions = ({
+	id,
+	hasLive,
+	hasDraft,
+	isBusy,
+	runAction,
+}: SubnavStatusActionsProps) => (
+	<>
+		{hasDraft && (
+			<ButtonDefault
+				type="button"
+				size="s"
+				priority="primary"
+				disabled={isBusy}
+				onClick={() =>
+					runAction(
+						id,
+						publishSubnav,
+						'Publish this subnav? It will go live on the targeted pages.',
+					)
+				}
+			>
+				Publish
+			</ButtonDefault>
+		)}
+		{hasDraft && hasLive && (
+			<ButtonDefault
+				type="button"
+				size="s"
+				priority="muted"
+				disabled={isBusy}
+				onClick={() =>
+					runAction(
+						id,
+						discardSubnav,
+						'Discard draft changes and revert to the live version?',
+					)
+				}
+			>
+				Discard changes
+			</ButtonDefault>
+		)}
+		{hasLive && (
+			<ButtonDefault
+				type="button"
+				size="s"
+				priority="muted"
+				disabled={isBusy}
+				onClick={() =>
+					runAction(
+						id,
+						unpublishSubnav,
+						hasDraft
+							? 'Take this subnav down? You have draft changes — taking it down will undo them.'
+							: 'Take this subnav down? It will no longer show on the targeted pages (kept as a draft).',
+					)
+				}
+			>
+				Unpublish
+			</ButtonDefault>
+		)}
+		<ButtonDefault
+			type="button"
+			size="s"
+			priority="muted"
+			disabled={isBusy}
+			onClick={() =>
+				runAction(
+					id,
+					deleteSubnav,
+					'Delete this subnav entirely? This removes both the live and draft versions.',
+				)
+			}
+		>
+			Delete
+		</ButtonDefault>
+	</>
+);
+
+export const SubnavStatusTags = ({
+	hasLive,
+	hasDraft,
+}: {
+	hasLive: boolean;
+	hasDraft: boolean;
+}) => (
+	<>
+		{hasLive && <StatusTag>Live</StatusTag>}
+		{hasDraft && (
+			<StatusTag draft>{hasLive ? 'Draft changes' : 'New draft'}</StatusTag>
+		)}
+	</>
+);

--- a/fronts-client/src/components/Subnav/helpers.ts
+++ b/fronts-client/src/components/Subnav/helpers.ts
@@ -8,7 +8,6 @@ export type RunAction = (
 
 export interface SubnavListEntry {
 	id: string;
-	/** The version shown/edited: the draft if present, otherwise the live copy. */
 	subnav: CustomSubnav;
 	hasLive: boolean;
 	hasDraft: boolean;

--- a/fronts-client/src/components/Subnav/helpers.ts
+++ b/fronts-client/src/components/Subnav/helpers.ts
@@ -1,0 +1,47 @@
+import { CustomSubnav, CustomSubnavConfig } from './types';
+
+export type RunAction = (
+	id: string,
+	action: (id: string) => Promise<CustomSubnavConfig>,
+	confirmMessage?: string,
+) => void;
+
+export interface SubnavListEntry {
+	id: string;
+	/** The version shown/edited: the draft if present, otherwise the live copy. */
+	subnav: CustomSubnav;
+	hasLive: boolean;
+	hasDraft: boolean;
+}
+
+/**
+ * Build a de-duplicated list of subnavs for display. A subnav can exist in
+ * `draft`, `live`, or both; each id appears once, preferring the draft copy.
+ */
+export const toListEntries = (
+	config: CustomSubnavConfig,
+): SubnavListEntry[] => {
+	const liveById = new Map(config.live.map((s) => [s.id, s]));
+	const draftById = new Map(config.draft.map((s) => [s.id, s]));
+	const ids = [
+		...config.draft.map((s) => s.id),
+		...config.live.filter((s) => !draftById.has(s.id)).map((s) => s.id),
+	];
+	return ids.map((id) => {
+		const draft = draftById.get(id);
+		const live = liveById.get(id);
+		return {
+			id,
+			subnav: (draft ?? live) as CustomSubnav,
+			hasLive: live !== undefined,
+			hasDraft: draft !== undefined,
+		};
+	});
+};
+
+// The version shown when editing: the draft if present, otherwise the live copy.
+export const findSubnav = (
+	config: CustomSubnavConfig,
+	id: string,
+): CustomSubnav | undefined =>
+	config.draft.find((s) => s.id === id) ?? config.live.find((s) => s.id === id);

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -2,13 +2,21 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectHasSubnavPermission } from 'selectors/configSelectors';
 import ButtonDefault from 'components/inputs/ButtonDefault';
-import { fetchSubnavConfig, upsertSubnav } from './subnavApi';
+import {
+	deleteSubnav,
+	discardSubnav,
+	fetchSubnavConfig,
+	publishSubnav,
+	unpublishSubnav,
+	upsertSubnav,
+} from './subnavApi';
 import SubnavForm from './SubnavForm';
 import { CustomSubnav, CustomSubnavConfig } from './types';
 import {
 	List,
 	ListHeader,
 	ListItem,
+	ListItemActions,
 	ListItemMeta,
 	ListItemTitle,
 	Message,
@@ -29,40 +37,56 @@ const NoPermission = () => (
 );
 
 interface SubnavListEntry {
+	id: string;
+	/** The version shown/edited: the draft if present, otherwise the live copy. */
 	subnav: CustomSubnav;
-	isDraft: boolean;
+	hasLive: boolean;
+	hasDraft: boolean;
 }
 
 /**
- * Build a de-duplicated list of subnavs for display. A subnav that exists in
- * both `draft` and `live` is shown once, tagged as a draft.
+ * Build a de-duplicated list of subnavs for display. A subnav can exist in
+ * `draft`, `live`, or both; each id appears once, preferring the draft copy.
  */
 const toListEntries = (config: CustomSubnavConfig): SubnavListEntry[] => {
-	const draftIds = new Set(config.draft.map((s) => s.id));
-	const draftEntries = config.draft.map((subnav) => ({
-		subnav,
-		isDraft: true,
-	}));
-	const liveOnlyEntries = config.live
-		.filter((subnav) => !draftIds.has(subnav.id))
-		.map((subnav) => ({ subnav, isDraft: false }));
-	return [...draftEntries, ...liveOnlyEntries];
+	const liveById = new Map(config.live.map((s) => [s.id, s]));
+	const draftById = new Map(config.draft.map((s) => [s.id, s]));
+	const ids = [
+		...config.draft.map((s) => s.id),
+		...config.live.filter((s) => !draftById.has(s.id)).map((s) => s.id),
+	];
+	return ids.map((id) => {
+		const draft = draftById.get(id);
+		const live = liveById.get(id);
+		return {
+			id,
+			subnav: (draft ?? live) as CustomSubnav,
+			hasLive: live !== undefined,
+			hasDraft: draft !== undefined,
+		};
+	});
 };
+
+// null = list view; 'new' = create form; a subnav = edit form
+type FormMode = CustomSubnav | 'new' | null;
 
 const SubnavSection = () => {
 	const hasPermission = useSelector(selectHasSubnavPermission);
 
-	const [config, setConfig] = useState<CustomSubnavConfig | null>(null);
+	const [subnavConfig, setSubnavConfig] = useState<CustomSubnavConfig | null>(
+		null,
+	);
 	const [isLoading, setIsLoading] = useState(true);
 	const [loadError, setLoadError] = useState<string | null>(null);
-	const [isCreating, setIsCreating] = useState(false);
+	const [formMode, setFormMode] = useState<FormMode>(null);
 	const [isSaving, setIsSaving] = useState(false);
+	const [pendingActionId, setPendingActionId] = useState<string | null>(null);
 
 	const loadConfig = useCallback(async () => {
 		setIsLoading(true);
 		setLoadError(null);
 		try {
-			setConfig(await fetchSubnavConfig());
+			setSubnavConfig(await fetchSubnavConfig());
 		} catch (e) {
 			setLoadError(e instanceof Error ? e.message : 'Failed to load subnavs.');
 		} finally {
@@ -80,8 +104,8 @@ const SubnavSection = () => {
 		setIsSaving(true);
 		try {
 			const updated = await upsertSubnav(subnav);
-			setConfig(updated);
-			setIsCreating(false);
+			setSubnavConfig(updated);
+			setFormMode(null);
 		} catch (e) {
 			setLoadError(e instanceof Error ? e.message : 'Failed to save subnav.');
 		} finally {
@@ -89,63 +113,172 @@ const SubnavSection = () => {
 		}
 	};
 
+	const runAction = async (
+		id: string,
+		action: (id: string) => Promise<CustomSubnavConfig>,
+		confirmMessage?: string,
+	) => {
+		if (confirmMessage && !window.confirm(confirmMessage)) {
+			return;
+		}
+		setPendingActionId(id);
+		setLoadError(null);
+		try {
+			setSubnavConfig(await action(id));
+		} catch (e) {
+			setLoadError(e instanceof Error ? e.message : 'Action failed.');
+		} finally {
+			setPendingActionId(null);
+		}
+	};
+
 	if (!hasPermission) {
 		return <NoPermission />;
 	}
 
-	const entries = config ? toListEntries(config) : [];
+	if (formMode !== null) {
+		return (
+			<SubnavContainer>
+				<SubnavContainerHeading>
+					{formMode === 'new' ? 'Create custom subnav' : 'Edit custom subnav'}
+				</SubnavContainerHeading>
+				<SubnavForm
+					initialSubnav={formMode === 'new' ? undefined : formMode}
+					onSave={handleSave}
+					onCancel={() => setFormMode(null)}
+					saving={isSaving}
+				/>
+			</SubnavContainer>
+		);
+	}
+
+	const entries = subnavConfig ? toListEntries(subnavConfig) : [];
 
 	return (
 		<SubnavContainer>
 			<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
 
-			{isCreating ? (
-				<SubnavForm
-					onSave={handleSave}
-					onCancel={() => setIsCreating(false)}
-					saving={isSaving}
-				/>
+			<ListHeader>
+				<ButtonDefault
+					type="button"
+					priority="primary"
+					onClick={() => setFormMode('new')}
+				>
+					+ Create new subnav
+				</ButtonDefault>
+			</ListHeader>
+
+			{loadError && <Message>{loadError}</Message>}
+
+			{isLoading ? (
+				<Message>Loading…</Message>
+			) : entries.length === 0 ? (
+				<Message>No custom subnavs yet. Create one to get started.</Message>
 			) : (
-				<>
-					<ListHeader>
-						<ButtonDefault
-							type="button"
-							priority="primary"
-							onClick={() => setIsCreating(true)}
-						>
-							+ Create new subnav
-						</ButtonDefault>
-					</ListHeader>
-
-					{loadError && <Message>{loadError}</Message>}
-
-					{isLoading ? (
-						<Message>Loading…</Message>
-					) : entries.length === 0 ? (
-						<Message>No custom subnavs yet. Create one to get started.</Message>
-					) : (
-						<List>
-							{entries.map(({ subnav, isDraft }) => (
-								<ListItem key={subnav.id}>
-									<div>
-										<ListItemTitle>
-											{subnav.header.headerText || 'Untitled subnav'}
-											<StatusTag draft={isDraft}>
-												{isDraft ? 'Draft' : 'Live'}
+				<List>
+					{entries.map(({ id, subnav, hasLive, hasDraft }) => {
+						const isBusy = pendingActionId === id;
+						return (
+							<ListItem key={id}>
+								<div>
+									<ListItemTitle>
+										{subnav.header.headerText || 'Untitled subnav'}
+										{hasLive && <StatusTag>Live</StatusTag>}
+										{hasDraft && (
+											<StatusTag draft>
+												{hasLive ? 'Draft changes' : 'New draft'}
 											</StatusTag>
-										</ListItemTitle>
-										<ListItemMeta>
-											{subnav.pages.length} page
-											{subnav.pages.length === 1 ? '' : 's'} ·{' '}
-											{subnav.links.length} link
-											{subnav.links.length === 1 ? '' : 's'}
-										</ListItemMeta>
-									</div>
-								</ListItem>
-							))}
-						</List>
-					)}
-				</>
+										)}
+									</ListItemTitle>
+									<ListItemMeta>
+										{subnav.pages.length} page
+										{subnav.pages.length === 1 ? '' : 's'} ·{' '}
+										{subnav.links.length} link
+										{subnav.links.length === 1 ? '' : 's'}
+									</ListItemMeta>
+								</div>
+								<ListItemActions>
+									<ButtonDefault
+										type="button"
+										size="s"
+										disabled={isBusy}
+										onClick={() => setFormMode(subnav)}
+									>
+										Edit
+									</ButtonDefault>
+									{hasDraft && (
+										<ButtonDefault
+											type="button"
+											size="s"
+											priority="primary"
+											disabled={isBusy}
+											onClick={() =>
+												runAction(
+													id,
+													publishSubnav,
+													'Publish this subnav? It will go live on the targeted pages.',
+												)
+											}
+										>
+											Publish
+										</ButtonDefault>
+									)}
+									{hasDraft && hasLive && (
+										<ButtonDefault
+											type="button"
+											size="s"
+											priority="muted"
+											disabled={isBusy}
+											onClick={() =>
+												runAction(
+													id,
+													discardSubnav,
+													'Discard draft changes and revert to the live version?',
+												)
+											}
+										>
+											Discard changes
+										</ButtonDefault>
+									)}
+									{hasLive && (
+										<ButtonDefault
+											type="button"
+											size="s"
+											priority="muted"
+											disabled={isBusy}
+											onClick={() =>
+												runAction(
+													id,
+													unpublishSubnav,
+													hasDraft
+														? 'Take this subnav down? You have draft changes — taking it down will undo them.'
+														: 'Take this subnav down? It will no longer show on the targeted pages (kept as a draft).',
+												)
+											}
+										>
+											Unpublish
+										</ButtonDefault>
+									)}
+									<ButtonDefault
+										type="button"
+										size="s"
+										priority="muted"
+										disabled={isBusy}
+										onClick={() =>
+											runAction(
+												id,
+												deleteSubnav,
+												'Delete this subnav entirely? This removes both the live and draft versions.',
+											)
+										}
+									>
+										Delete
+									</ButtonDefault>
+								</ListItemActions>
+							</ListItem>
+						);
+					})}
+				</List>
 			)}
 		</SubnavContainer>
 	);

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -1,7 +1,21 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectHasSubnavPermission } from 'selectors/configSelectors';
-import { Message, SubnavContainer, SubnavContainerHeading } from './styles';
+import ButtonDefault from 'components/inputs/ButtonDefault';
+import { fetchSubnavConfig, upsertSubnav } from './subnavApi';
+import SubnavForm from './SubnavForm';
+import { CustomSubnav, CustomSubnavConfig } from './types';
+import {
+	List,
+	ListHeader,
+	ListItem,
+	ListItemMeta,
+	ListItemTitle,
+	Message,
+	StatusTag,
+	SubnavContainer,
+	SubnavContainerHeading,
+} from './styles';
 
 const NoPermission = () => (
 	<SubnavContainer>
@@ -14,17 +28,125 @@ const NoPermission = () => (
 	</SubnavContainer>
 );
 
+interface SubnavListEntry {
+	subnav: CustomSubnav;
+	isDraft: boolean;
+}
+
+/**
+ * Build a de-duplicated list of subnavs for display. A subnav that exists in
+ * both `draft` and `live` is shown once, tagged as a draft.
+ */
+const toListEntries = (config: CustomSubnavConfig): SubnavListEntry[] => {
+	const draftIds = new Set(config.draft.map((s) => s.id));
+	const draftEntries = config.draft.map((subnav) => ({
+		subnav,
+		isDraft: true,
+	}));
+	const liveOnlyEntries = config.live
+		.filter((subnav) => !draftIds.has(subnav.id))
+		.map((subnav) => ({ subnav, isDraft: false }));
+	return [...draftEntries, ...liveOnlyEntries];
+};
+
 const SubnavSection = () => {
 	const hasPermission = useSelector(selectHasSubnavPermission);
+
+	const [config, setConfig] = useState<CustomSubnavConfig | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [isCreating, setIsCreating] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+
+	const loadConfig = useCallback(async () => {
+		setIsLoading(true);
+		setLoadError(null);
+		try {
+			setConfig(await fetchSubnavConfig());
+		} catch (e) {
+			setLoadError(e instanceof Error ? e.message : 'Failed to load subnavs.');
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (hasPermission) {
+			void loadConfig();
+		}
+	}, [hasPermission, loadConfig]);
+
+	const handleSave = async (subnav: CustomSubnav) => {
+		setIsSaving(true);
+		try {
+			const updated = await upsertSubnav(subnav);
+			setConfig(updated);
+			setIsCreating(false);
+		} catch (e) {
+			setLoadError(e instanceof Error ? e.message : 'Failed to save subnav.');
+		} finally {
+			setIsSaving(false);
+		}
+	};
 
 	if (!hasPermission) {
 		return <NoPermission />;
 	}
 
+	const entries = config ? toListEntries(config) : [];
+
 	return (
 		<SubnavContainer>
 			<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
-			<Message>Subnav management coming soon.</Message>
+
+			{isCreating ? (
+				<SubnavForm
+					onSave={handleSave}
+					onCancel={() => setIsCreating(false)}
+					saving={isSaving}
+				/>
+			) : (
+				<>
+					<ListHeader>
+						<ButtonDefault
+							type="button"
+							priority="primary"
+							onClick={() => setIsCreating(true)}
+						>
+							+ Create new subnav
+						</ButtonDefault>
+					</ListHeader>
+
+					{loadError && <Message>{loadError}</Message>}
+
+					{isLoading ? (
+						<Message>Loading…</Message>
+					) : entries.length === 0 ? (
+						<Message>No custom subnavs yet. Create one to get started.</Message>
+					) : (
+						<List>
+							{entries.map(({ subnav, isDraft }) => (
+								<ListItem key={subnav.id}>
+									<div>
+										<ListItemTitle>
+											{subnav.header.headerText || 'Untitled subnav'}
+											<StatusTag draft={isDraft}>
+												{isDraft ? 'Draft' : 'Live'}
+											</StatusTag>
+										</ListItemTitle>
+										<ListItemMeta>
+											{subnav.pages.length} page
+											{subnav.pages.length === 1 ? '' : 's'} ·{' '}
+											{subnav.links.length} link
+											{subnav.links.length === 1 ? '' : 's'}
+										</ListItemMeta>
+									</div>
+								</ListItem>
+							))}
+						</List>
+					)}
+				</>
+			)}
 		</SubnavContainer>
 	);
 };

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -22,6 +22,7 @@ import {
 import SubnavForm from './SubnavForm';
 import { CustomSubnav, CustomSubnavConfig } from './types';
 import {
+	BackButton,
 	EditStatusBar,
 	List,
 	ListHeader,
@@ -278,7 +279,7 @@ interface SubnavFormViewProps {
 	heading: string;
 	statusBar?: React.ReactNode;
 	initialSubnav?: CustomSubnav;
-	onSave: (subnav: CustomSubnav) => void;
+	onSave: (subnav: CustomSubnav) => Promise<void>;
 	onCancel: () => void;
 	saving: boolean;
 }
@@ -292,14 +293,12 @@ const SubnavFormView = ({
 	saving,
 }: SubnavFormViewProps) => (
 	<SubnavContainer>
+		<BackButton type="button" onClick={onCancel}>
+			← Back to subnavs
+		</BackButton>
 		<SubnavContainerHeading>{heading}</SubnavContainerHeading>
 		{statusBar}
-		<SubnavForm
-			initialSubnav={initialSubnav}
-			onSave={onSave}
-			onCancel={onCancel}
-			saving={saving}
-		/>
+		<SubnavForm initialSubnav={initialSubnav} onSave={onSave} saving={saving} />
 	</SubnavContainer>
 );
 
@@ -308,7 +307,7 @@ interface SubnavEditRouteProps {
 	isLoading: boolean;
 	pendingActionId: string | null;
 	runAction: RunAction;
-	onSave: (subnav: CustomSubnav) => void;
+	onSave: (subnav: CustomSubnav) => Promise<void>;
 	onCancel: () => void;
 	saving: boolean;
 }
@@ -420,14 +419,20 @@ const SubnavSection = () => {
 	const handleSave = async (subnav: CustomSubnav) => {
 		setIsSaving(true);
 		try {
-			const updated = await upsertSubnav(subnav);
-			setSubnavConfig(updated);
-			goToList();
+			setSubnavConfig(await upsertSubnav(subnav));
 		} catch (e) {
 			notifyError(e instanceof Error ? e.message : 'Failed to save subnav.');
+			throw e;
 		} finally {
 			setIsSaving(false);
 		}
+	};
+
+	// New subnavs are created on their own route; once saved we move to that
+	// subnav's edit route so the URL and the publish/take-down actions reflect it.
+	const handleCreate = async (subnav: CustomSubnav) => {
+		await handleSave(subnav);
+		history.push(subnavRoutes.edit(subnav.id));
 	};
 
 	const runAction = async (
@@ -459,7 +464,7 @@ const SubnavSection = () => {
 			<Route {...subnavCreateProps}>
 				<SubnavFormView
 					heading="Create custom subnav"
-					onSave={handleSave}
+					onSave={handleCreate}
 					onCancel={goToList}
 					saving={isSaving}
 				/>

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -1,40 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Switch, Route, Redirect } from 'react-router-dom';
-import { useHistory, useParams } from 'react-router';
+import { Switch, Route } from 'react-router-dom';
+import { useHistory } from 'react-router';
 import { selectHasSubnavPermission } from 'selectors/configSelectors';
-import {
-	subnavRoutes,
-	subnavListProps,
-	subnavCreateProps,
-	subnavEditProps,
-} from 'routes/routes';
+import { subnavRoutes } from 'routes/routes';
 import { actionAddNotificationBanner } from 'bundles/notificationsBundle';
-import ButtonDefault from 'components/inputs/ButtonDefault';
-import {
-	deleteSubnav,
-	discardSubnav,
-	fetchSubnavConfig,
-	publishSubnav,
-	unpublishSubnav,
-	upsertSubnav,
-} from './subnavApi';
-import SubnavForm from './SubnavForm';
+import { fetchSubnavConfig, upsertSubnav } from './subnavApi';
+import { SubnavFormView } from './SubnavFormView';
+import { SubnavEditRoute } from './SubnavEditRoute';
+import { SubnavListView } from './SubnavListView';
+import { toListEntries } from './helpers';
 import { CustomSubnav, CustomSubnavConfig } from './types';
-import {
-	BackButton,
-	EditStatusBar,
-	List,
-	ListHeader,
-	ListItem,
-	ListItemActions,
-	ListItemMeta,
-	ListItemTitle,
-	Message,
-	StatusTag,
-	SubnavContainer,
-	SubnavContainerHeading,
-} from './styles';
+import { Message, SubnavContainer, SubnavContainerHeading } from './styles';
 
 const NoPermission = () => (
 	<SubnavContainer>
@@ -46,331 +23,6 @@ const NoPermission = () => (
 		</Message>
 	</SubnavContainer>
 );
-
-interface SubnavListEntry {
-	id: string;
-	/** The version shown/edited: the draft if present, otherwise the live copy. */
-	subnav: CustomSubnav;
-	hasLive: boolean;
-	hasDraft: boolean;
-}
-
-/**
- * Build a de-duplicated list of subnavs for display. A subnav can exist in
- * `draft`, `live`, or both; each id appears once, preferring the draft copy.
- */
-const toListEntries = (config: CustomSubnavConfig): SubnavListEntry[] => {
-	const liveById = new Map(config.live.map((s) => [s.id, s]));
-	const draftById = new Map(config.draft.map((s) => [s.id, s]));
-	const ids = [
-		...config.draft.map((s) => s.id),
-		...config.live.filter((s) => !draftById.has(s.id)).map((s) => s.id),
-	];
-	return ids.map((id) => {
-		const draft = draftById.get(id);
-		const live = liveById.get(id);
-		return {
-			id,
-			subnav: (draft ?? live) as CustomSubnav,
-			hasLive: live !== undefined,
-			hasDraft: draft !== undefined,
-		};
-	});
-};
-
-// The version shown when editing: the draft if present, otherwise the live copy.
-const findSubnav = (
-	config: CustomSubnavConfig,
-	id: string,
-): CustomSubnav | undefined =>
-	config.draft.find((s) => s.id === id) ?? config.live.find((s) => s.id === id);
-
-type RunAction = (
-	id: string,
-	action: (id: string) => Promise<CustomSubnavConfig>,
-	confirmMessage?: string,
-) => void;
-
-interface SubnavStatusActionsProps {
-	id: string;
-	hasLive: boolean;
-	hasDraft: boolean;
-	isBusy: boolean;
-	runAction: RunAction;
-}
-
-/**
- * Publish / discard / unpublish / delete buttons for a single subnav, shared by
- * the list rows and the individual edit page. Which buttons show depends on
- * whether the subnav currently has a live and/or draft version.
- */
-const SubnavStatusActions = ({
-	id,
-	hasLive,
-	hasDraft,
-	isBusy,
-	runAction,
-}: SubnavStatusActionsProps) => (
-	<>
-		{hasDraft && (
-			<ButtonDefault
-				type="button"
-				size="s"
-				priority="primary"
-				disabled={isBusy}
-				onClick={() =>
-					runAction(
-						id,
-						publishSubnav,
-						'Publish this subnav? It will go live on the targeted pages.',
-					)
-				}
-			>
-				Publish
-			</ButtonDefault>
-		)}
-		{hasDraft && hasLive && (
-			<ButtonDefault
-				type="button"
-				size="s"
-				priority="muted"
-				disabled={isBusy}
-				onClick={() =>
-					runAction(
-						id,
-						discardSubnav,
-						'Discard draft changes and revert to the live version?',
-					)
-				}
-			>
-				Discard changes
-			</ButtonDefault>
-		)}
-		{hasLive && (
-			<ButtonDefault
-				type="button"
-				size="s"
-				priority="muted"
-				disabled={isBusy}
-				onClick={() =>
-					runAction(
-						id,
-						unpublishSubnav,
-						hasDraft
-							? 'Take this subnav down? You have draft changes — taking it down will undo them.'
-							: 'Take this subnav down? It will no longer show on the targeted pages (kept as a draft).',
-					)
-				}
-			>
-				Unpublish
-			</ButtonDefault>
-		)}
-		<ButtonDefault
-			type="button"
-			size="s"
-			priority="muted"
-			disabled={isBusy}
-			onClick={() =>
-				runAction(
-					id,
-					deleteSubnav,
-					'Delete this subnav entirely? This removes both the live and draft versions.',
-				)
-			}
-		>
-			Delete
-		</ButtonDefault>
-	</>
-);
-
-const SubnavStatusTags = ({
-	hasLive,
-	hasDraft,
-}: {
-	hasLive: boolean;
-	hasDraft: boolean;
-}) => (
-	<>
-		{hasLive && <StatusTag>Live</StatusTag>}
-		{hasDraft && (
-			<StatusTag draft>{hasLive ? 'Draft changes' : 'New draft'}</StatusTag>
-		)}
-	</>
-);
-
-interface SubnavListViewProps {
-	entries: SubnavListEntry[];
-	isLoading: boolean;
-	pendingActionId: string | null;
-	onCreate: () => void;
-	onEdit: (id: string) => void;
-	runAction: (
-		id: string,
-		action: (id: string) => Promise<CustomSubnavConfig>,
-		confirmMessage?: string,
-	) => void;
-}
-
-const SubnavListView = ({
-	entries,
-	isLoading,
-	pendingActionId,
-	onCreate,
-	onEdit,
-	runAction,
-}: SubnavListViewProps) => (
-	<SubnavContainer>
-		<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
-
-		<ListHeader>
-			<ButtonDefault type="button" priority="primary" onClick={onCreate}>
-				+ Create new subnav
-			</ButtonDefault>
-		</ListHeader>
-
-		{isLoading ? (
-			<Message>Loading…</Message>
-		) : entries.length === 0 ? (
-			<Message>No custom subnavs yet. Create one to get started.</Message>
-		) : (
-			<List>
-				{entries.map(({ id, subnav, hasLive, hasDraft }) => {
-					const isBusy = pendingActionId === id;
-					return (
-						<ListItem key={id}>
-							<div>
-								<ListItemTitle>
-									{subnav.header.headerText || 'Untitled subnav'}
-									<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
-								</ListItemTitle>
-								<ListItemMeta>
-									{subnav.pages.length} page
-									{subnav.pages.length === 1 ? '' : 's'} · {subnav.links.length}{' '}
-									link
-									{subnav.links.length === 1 ? '' : 's'}
-								</ListItemMeta>
-							</div>
-							<ListItemActions>
-								<ButtonDefault
-									type="button"
-									size="s"
-									disabled={isBusy}
-									onClick={() => onEdit(id)}
-								>
-									Edit
-								</ButtonDefault>
-								<SubnavStatusActions
-									id={id}
-									hasLive={hasLive}
-									hasDraft={hasDraft}
-									isBusy={isBusy}
-									runAction={runAction}
-								/>
-							</ListItemActions>
-						</ListItem>
-					);
-				})}
-			</List>
-		)}
-	</SubnavContainer>
-);
-
-interface SubnavFormViewProps {
-	heading: string;
-	statusBar?: React.ReactNode;
-	initialSubnav?: CustomSubnav;
-	onSave: (subnav: CustomSubnav) => Promise<void>;
-	onCancel: () => void;
-	saving: boolean;
-}
-
-const SubnavFormView = ({
-	heading,
-	statusBar,
-	initialSubnav,
-	onSave,
-	onCancel,
-	saving,
-}: SubnavFormViewProps) => (
-	<SubnavContainer>
-		<BackButton type="button" onClick={onCancel}>
-			← Back to subnavs
-		</BackButton>
-		<SubnavContainerHeading>{heading}</SubnavContainerHeading>
-		{statusBar}
-		<SubnavForm initialSubnav={initialSubnav} onSave={onSave} saving={saving} />
-	</SubnavContainer>
-);
-
-interface SubnavEditRouteProps {
-	config: CustomSubnavConfig | null;
-	isLoading: boolean;
-	pendingActionId: string | null;
-	runAction: RunAction;
-	onSave: (subnav: CustomSubnav) => Promise<void>;
-	onCancel: () => void;
-	saving: boolean;
-}
-
-/**
- * Resolves the `:id` route param against the loaded config. While the config is
- * still loading we show a placeholder; if the id is unknown (e.g. deleted or a
- * stale link) we send the user back to the list.
- */
-const SubnavEditRoute = ({
-	config,
-	isLoading,
-	pendingActionId,
-	runAction,
-	onSave,
-	onCancel,
-	saving,
-}: SubnavEditRouteProps) => {
-	const { id } = useParams<{ id: string }>();
-
-	if (isLoading || !config) {
-		return (
-			<SubnavContainer>
-				<SubnavContainerHeading>Edit custom subnav</SubnavContainerHeading>
-				<Message>Loading…</Message>
-			</SubnavContainer>
-		);
-	}
-
-	const subnav = findSubnav(config, id);
-	if (!subnav) {
-		return <Redirect to={subnavRoutes.base} />;
-	}
-
-	const hasLive = config.live.some((s) => s.id === id);
-	const hasDraft = config.draft.some((s) => s.id === id);
-
-	return (
-		<SubnavFormView
-			heading="Edit custom subnav"
-			statusBar={
-				<EditStatusBar>
-					<div>
-						<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
-					</div>
-					<ListItemActions>
-						<SubnavStatusActions
-							id={id}
-							hasLive={hasLive}
-							hasDraft={hasDraft}
-							isBusy={pendingActionId === id}
-							runAction={runAction}
-						/>
-					</ListItemActions>
-				</EditStatusBar>
-			}
-			initialSubnav={subnav}
-			onSave={onSave}
-			onCancel={onCancel}
-			saving={saving}
-		/>
-	);
-};
 
 const SubnavSection = () => {
 	const hasPermission = useSelector(selectHasSubnavPermission);
@@ -461,7 +113,7 @@ const SubnavSection = () => {
 
 	return (
 		<Switch>
-			<Route {...subnavCreateProps}>
+			<Route {...subnavRoutes.createProps}>
 				<SubnavFormView
 					heading="Create custom subnav"
 					onSave={handleCreate}
@@ -469,7 +121,7 @@ const SubnavSection = () => {
 					saving={isSaving}
 				/>
 			</Route>
-			<Route {...subnavEditProps}>
+			<Route {...subnavRoutes.editProps}>
 				<SubnavEditRoute
 					config={subnavConfig}
 					isLoading={isLoading}
@@ -480,7 +132,7 @@ const SubnavSection = () => {
 					saving={isSaving}
 				/>
 			</Route>
-			<Route {...subnavListProps}>
+			<Route {...subnavRoutes.listProps}>
 				<SubnavListView
 					entries={entries}
 					isLoading={isLoading}

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -1,6 +1,15 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { Switch, Route, Redirect } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router';
 import { selectHasSubnavPermission } from 'selectors/configSelectors';
+import {
+	subnavRoutes,
+	subnavListProps,
+	subnavCreateProps,
+	subnavEditProps,
+} from 'routes/routes';
+import { actionAddNotificationBanner } from 'bundles/notificationsBundle';
 import ButtonDefault from 'components/inputs/ButtonDefault';
 import {
 	deleteSubnav,
@@ -13,6 +22,7 @@ import {
 import SubnavForm from './SubnavForm';
 import { CustomSubnav, CustomSubnavConfig } from './types';
 import {
+	EditStatusBar,
 	List,
 	ListHeader,
 	ListItem,
@@ -67,32 +77,334 @@ const toListEntries = (config: CustomSubnavConfig): SubnavListEntry[] => {
 	});
 };
 
-// null = list view; 'new' = create form; a subnav = edit form
-type FormMode = CustomSubnav | 'new' | null;
+// The version shown when editing: the draft if present, otherwise the live copy.
+const findSubnav = (
+	config: CustomSubnavConfig,
+	id: string,
+): CustomSubnav | undefined =>
+	config.draft.find((s) => s.id === id) ?? config.live.find((s) => s.id === id);
+
+type RunAction = (
+	id: string,
+	action: (id: string) => Promise<CustomSubnavConfig>,
+	confirmMessage?: string,
+) => void;
+
+interface SubnavStatusActionsProps {
+	id: string;
+	hasLive: boolean;
+	hasDraft: boolean;
+	isBusy: boolean;
+	runAction: RunAction;
+}
+
+/**
+ * Publish / discard / unpublish / delete buttons for a single subnav, shared by
+ * the list rows and the individual edit page. Which buttons show depends on
+ * whether the subnav currently has a live and/or draft version.
+ */
+const SubnavStatusActions = ({
+	id,
+	hasLive,
+	hasDraft,
+	isBusy,
+	runAction,
+}: SubnavStatusActionsProps) => (
+	<>
+		{hasDraft && (
+			<ButtonDefault
+				type="button"
+				size="s"
+				priority="primary"
+				disabled={isBusy}
+				onClick={() =>
+					runAction(
+						id,
+						publishSubnav,
+						'Publish this subnav? It will go live on the targeted pages.',
+					)
+				}
+			>
+				Publish
+			</ButtonDefault>
+		)}
+		{hasDraft && hasLive && (
+			<ButtonDefault
+				type="button"
+				size="s"
+				priority="muted"
+				disabled={isBusy}
+				onClick={() =>
+					runAction(
+						id,
+						discardSubnav,
+						'Discard draft changes and revert to the live version?',
+					)
+				}
+			>
+				Discard changes
+			</ButtonDefault>
+		)}
+		{hasLive && (
+			<ButtonDefault
+				type="button"
+				size="s"
+				priority="muted"
+				disabled={isBusy}
+				onClick={() =>
+					runAction(
+						id,
+						unpublishSubnav,
+						hasDraft
+							? 'Take this subnav down? You have draft changes — taking it down will undo them.'
+							: 'Take this subnav down? It will no longer show on the targeted pages (kept as a draft).',
+					)
+				}
+			>
+				Unpublish
+			</ButtonDefault>
+		)}
+		<ButtonDefault
+			type="button"
+			size="s"
+			priority="muted"
+			disabled={isBusy}
+			onClick={() =>
+				runAction(
+					id,
+					deleteSubnav,
+					'Delete this subnav entirely? This removes both the live and draft versions.',
+				)
+			}
+		>
+			Delete
+		</ButtonDefault>
+	</>
+);
+
+const SubnavStatusTags = ({
+	hasLive,
+	hasDraft,
+}: {
+	hasLive: boolean;
+	hasDraft: boolean;
+}) => (
+	<>
+		{hasLive && <StatusTag>Live</StatusTag>}
+		{hasDraft && (
+			<StatusTag draft>{hasLive ? 'Draft changes' : 'New draft'}</StatusTag>
+		)}
+	</>
+);
+
+interface SubnavListViewProps {
+	entries: SubnavListEntry[];
+	isLoading: boolean;
+	pendingActionId: string | null;
+	onCreate: () => void;
+	onEdit: (id: string) => void;
+	runAction: (
+		id: string,
+		action: (id: string) => Promise<CustomSubnavConfig>,
+		confirmMessage?: string,
+	) => void;
+}
+
+const SubnavListView = ({
+	entries,
+	isLoading,
+	pendingActionId,
+	onCreate,
+	onEdit,
+	runAction,
+}: SubnavListViewProps) => (
+	<SubnavContainer>
+		<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
+
+		<ListHeader>
+			<ButtonDefault type="button" priority="primary" onClick={onCreate}>
+				+ Create new subnav
+			</ButtonDefault>
+		</ListHeader>
+
+		{isLoading ? (
+			<Message>Loading…</Message>
+		) : entries.length === 0 ? (
+			<Message>No custom subnavs yet. Create one to get started.</Message>
+		) : (
+			<List>
+				{entries.map(({ id, subnav, hasLive, hasDraft }) => {
+					const isBusy = pendingActionId === id;
+					return (
+						<ListItem key={id}>
+							<div>
+								<ListItemTitle>
+									{subnav.header.headerText || 'Untitled subnav'}
+									<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
+								</ListItemTitle>
+								<ListItemMeta>
+									{subnav.pages.length} page
+									{subnav.pages.length === 1 ? '' : 's'} · {subnav.links.length}{' '}
+									link
+									{subnav.links.length === 1 ? '' : 's'}
+								</ListItemMeta>
+							</div>
+							<ListItemActions>
+								<ButtonDefault
+									type="button"
+									size="s"
+									disabled={isBusy}
+									onClick={() => onEdit(id)}
+								>
+									Edit
+								</ButtonDefault>
+								<SubnavStatusActions
+									id={id}
+									hasLive={hasLive}
+									hasDraft={hasDraft}
+									isBusy={isBusy}
+									runAction={runAction}
+								/>
+							</ListItemActions>
+						</ListItem>
+					);
+				})}
+			</List>
+		)}
+	</SubnavContainer>
+);
+
+interface SubnavFormViewProps {
+	heading: string;
+	statusBar?: React.ReactNode;
+	initialSubnav?: CustomSubnav;
+	onSave: (subnav: CustomSubnav) => void;
+	onCancel: () => void;
+	saving: boolean;
+}
+
+const SubnavFormView = ({
+	heading,
+	statusBar,
+	initialSubnav,
+	onSave,
+	onCancel,
+	saving,
+}: SubnavFormViewProps) => (
+	<SubnavContainer>
+		<SubnavContainerHeading>{heading}</SubnavContainerHeading>
+		{statusBar}
+		<SubnavForm
+			initialSubnav={initialSubnav}
+			onSave={onSave}
+			onCancel={onCancel}
+			saving={saving}
+		/>
+	</SubnavContainer>
+);
+
+interface SubnavEditRouteProps {
+	config: CustomSubnavConfig | null;
+	isLoading: boolean;
+	pendingActionId: string | null;
+	runAction: RunAction;
+	onSave: (subnav: CustomSubnav) => void;
+	onCancel: () => void;
+	saving: boolean;
+}
+
+/**
+ * Resolves the `:id` route param against the loaded config. While the config is
+ * still loading we show a placeholder; if the id is unknown (e.g. deleted or a
+ * stale link) we send the user back to the list.
+ */
+const SubnavEditRoute = ({
+	config,
+	isLoading,
+	pendingActionId,
+	runAction,
+	onSave,
+	onCancel,
+	saving,
+}: SubnavEditRouteProps) => {
+	const { id } = useParams<{ id: string }>();
+
+	if (isLoading || !config) {
+		return (
+			<SubnavContainer>
+				<SubnavContainerHeading>Edit custom subnav</SubnavContainerHeading>
+				<Message>Loading…</Message>
+			</SubnavContainer>
+		);
+	}
+
+	const subnav = findSubnav(config, id);
+	if (!subnav) {
+		return <Redirect to={subnavRoutes.base} />;
+	}
+
+	const hasLive = config.live.some((s) => s.id === id);
+	const hasDraft = config.draft.some((s) => s.id === id);
+
+	return (
+		<SubnavFormView
+			heading="Edit custom subnav"
+			statusBar={
+				<EditStatusBar>
+					<div>
+						<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
+					</div>
+					<ListItemActions>
+						<SubnavStatusActions
+							id={id}
+							hasLive={hasLive}
+							hasDraft={hasDraft}
+							isBusy={pendingActionId === id}
+							runAction={runAction}
+						/>
+					</ListItemActions>
+				</EditStatusBar>
+			}
+			initialSubnav={subnav}
+			onSave={onSave}
+			onCancel={onCancel}
+			saving={saving}
+		/>
+	);
+};
 
 const SubnavSection = () => {
 	const hasPermission = useSelector(selectHasSubnavPermission);
+	const dispatch = useDispatch();
+	const history = useHistory();
+
+	const notifyError = useCallback(
+		(message: string) =>
+			dispatch(actionAddNotificationBanner({ message, level: 'error' })),
+		[dispatch],
+	);
 
 	const [subnavConfig, setSubnavConfig] = useState<CustomSubnavConfig | null>(
 		null,
 	);
 	const [isLoading, setIsLoading] = useState(true);
-	const [loadError, setLoadError] = useState<string | null>(null);
-	const [formMode, setFormMode] = useState<FormMode>(null);
 	const [isSaving, setIsSaving] = useState(false);
 	const [pendingActionId, setPendingActionId] = useState<string | null>(null);
 
 	const loadConfig = useCallback(async () => {
 		setIsLoading(true);
-		setLoadError(null);
 		try {
-			setSubnavConfig(await fetchSubnavConfig());
+			const { warning, ...config } = await fetchSubnavConfig();
+			setSubnavConfig(config);
+			if (warning) {
+				notifyError(warning);
+			}
 		} catch (e) {
-			setLoadError(e instanceof Error ? e.message : 'Failed to load subnavs.');
+			notifyError(e instanceof Error ? e.message : 'Failed to load subnavs.');
 		} finally {
 			setIsLoading(false);
 		}
-	}, []);
+	}, [notifyError]);
 
 	useEffect(() => {
 		if (hasPermission) {
@@ -100,14 +412,19 @@ const SubnavSection = () => {
 		}
 	}, [hasPermission, loadConfig]);
 
+	const goToList = useCallback(
+		() => history.push(subnavRoutes.base),
+		[history],
+	);
+
 	const handleSave = async (subnav: CustomSubnav) => {
 		setIsSaving(true);
 		try {
 			const updated = await upsertSubnav(subnav);
 			setSubnavConfig(updated);
-			setFormMode(null);
+			goToList();
 		} catch (e) {
-			setLoadError(e instanceof Error ? e.message : 'Failed to save subnav.');
+			notifyError(e instanceof Error ? e.message : 'Failed to save subnav.');
 		} finally {
 			setIsSaving(false);
 		}
@@ -122,11 +439,10 @@ const SubnavSection = () => {
 			return;
 		}
 		setPendingActionId(id);
-		setLoadError(null);
 		try {
 			setSubnavConfig(await action(id));
 		} catch (e) {
-			setLoadError(e instanceof Error ? e.message : 'Action failed.');
+			notifyError(e instanceof Error ? e.message : 'Action failed.');
 		} finally {
 			setPendingActionId(null);
 		}
@@ -136,151 +452,40 @@ const SubnavSection = () => {
 		return <NoPermission />;
 	}
 
-	if (formMode !== null) {
-		return (
-			<SubnavContainer>
-				<SubnavContainerHeading>
-					{formMode === 'new' ? 'Create custom subnav' : 'Edit custom subnav'}
-				</SubnavContainerHeading>
-				<SubnavForm
-					initialSubnav={formMode === 'new' ? undefined : formMode}
-					onSave={handleSave}
-					onCancel={() => setFormMode(null)}
-					saving={isSaving}
-				/>
-			</SubnavContainer>
-		);
-	}
-
 	const entries = subnavConfig ? toListEntries(subnavConfig) : [];
 
 	return (
-		<SubnavContainer>
-			<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
-
-			<ListHeader>
-				<ButtonDefault
-					type="button"
-					priority="primary"
-					onClick={() => setFormMode('new')}
-				>
-					+ Create new subnav
-				</ButtonDefault>
-			</ListHeader>
-
-			{loadError && <Message>{loadError}</Message>}
-
-			{isLoading ? (
-				<Message>Loading…</Message>
-			) : entries.length === 0 ? (
-				<Message>No custom subnavs yet. Create one to get started.</Message>
-			) : (
-				<List>
-					{entries.map(({ id, subnav, hasLive, hasDraft }) => {
-						const isBusy = pendingActionId === id;
-						return (
-							<ListItem key={id}>
-								<div>
-									<ListItemTitle>
-										{subnav.header.headerText || 'Untitled subnav'}
-										{hasLive && <StatusTag>Live</StatusTag>}
-										{hasDraft && (
-											<StatusTag draft>
-												{hasLive ? 'Draft changes' : 'New draft'}
-											</StatusTag>
-										)}
-									</ListItemTitle>
-									<ListItemMeta>
-										{subnav.pages.length} page
-										{subnav.pages.length === 1 ? '' : 's'} ·{' '}
-										{subnav.links.length} link
-										{subnav.links.length === 1 ? '' : 's'}
-									</ListItemMeta>
-								</div>
-								<ListItemActions>
-									<ButtonDefault
-										type="button"
-										size="s"
-										disabled={isBusy}
-										onClick={() => setFormMode(subnav)}
-									>
-										Edit
-									</ButtonDefault>
-									{hasDraft && (
-										<ButtonDefault
-											type="button"
-											size="s"
-											priority="primary"
-											disabled={isBusy}
-											onClick={() =>
-												runAction(
-													id,
-													publishSubnav,
-													'Publish this subnav? It will go live on the targeted pages.',
-												)
-											}
-										>
-											Publish
-										</ButtonDefault>
-									)}
-									{hasDraft && hasLive && (
-										<ButtonDefault
-											type="button"
-											size="s"
-											priority="muted"
-											disabled={isBusy}
-											onClick={() =>
-												runAction(
-													id,
-													discardSubnav,
-													'Discard draft changes and revert to the live version?',
-												)
-											}
-										>
-											Discard changes
-										</ButtonDefault>
-									)}
-									{hasLive && (
-										<ButtonDefault
-											type="button"
-											size="s"
-											priority="muted"
-											disabled={isBusy}
-											onClick={() =>
-												runAction(
-													id,
-													unpublishSubnav,
-													hasDraft
-														? 'Take this subnav down? You have draft changes — taking it down will undo them.'
-														: 'Take this subnav down? It will no longer show on the targeted pages (kept as a draft).',
-												)
-											}
-										>
-											Unpublish
-										</ButtonDefault>
-									)}
-									<ButtonDefault
-										type="button"
-										size="s"
-										priority="muted"
-										disabled={isBusy}
-										onClick={() =>
-											runAction(
-												id,
-												deleteSubnav,
-												'Delete this subnav entirely? This removes both the live and draft versions.',
-											)
-										}
-									>
-										Delete
-									</ButtonDefault>
-								</ListItemActions>
-							</ListItem>
-						);
-					})}
-				</List>
-			)}
-		</SubnavContainer>
+		<Switch>
+			<Route {...subnavCreateProps}>
+				<SubnavFormView
+					heading="Create custom subnav"
+					onSave={handleSave}
+					onCancel={goToList}
+					saving={isSaving}
+				/>
+			</Route>
+			<Route {...subnavEditProps}>
+				<SubnavEditRoute
+					config={subnavConfig}
+					isLoading={isLoading}
+					pendingActionId={pendingActionId}
+					runAction={runAction}
+					onSave={handleSave}
+					onCancel={goToList}
+					saving={isSaving}
+				/>
+			</Route>
+			<Route {...subnavListProps}>
+				<SubnavListView
+					entries={entries}
+					isLoading={isLoading}
+					pendingActionId={pendingActionId}
+					onCreate={() => history.push(subnavRoutes.create)}
+					onEdit={(id) => history.push(subnavRoutes.edit(id))}
+					runAction={runAction}
+				/>
+			</Route>
+		</Switch>
 	);
 };
 

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -80,13 +80,12 @@ const SubnavSection = () => {
 		}
 	};
 
-	// New subnavs are created on their own route; once saved we move to that
-	// subnav's edit route so the URL and the publish/take-down actions reflect it.
 	const handleCreate = async (subnav: CustomSubnav) => {
 		await handleSave(subnav);
 		history.push(subnavRoutes.edit(subnav.id));
 	};
 
+	// Likely temporary browser confirmation dialog component
 	const runAction = async (
 		id: string,
 		action: (id: string) => Promise<CustomSubnavConfig>,

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -66,6 +66,15 @@ export const ListItemActions = styled.div`
 	flex-shrink: 0;
 `;
 
+export const EditStatusBar = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 16px;
+`;
+
 export const StatusTag = styled.span<{ draft?: boolean }>`
 	display: inline-block;
 	font-size: 11px;

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -17,6 +17,29 @@ export const Message = styled.p`
 	font-size: 14px;
 `;
 
+export const SavedMessage = styled.p`
+	font-size: 13px;
+	color: ${({ theme }) => theme.base.colors.textMuted};
+	margin: 0;
+`;
+
+export const BackButton = styled.button`
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	background: none;
+	border: none;
+	padding: 0;
+	margin-bottom: 12px;
+	font-size: 13px;
+	color: ${({ theme }) => theme.base.colors.textDark};
+	cursor: pointer;
+
+	&:hover {
+		text-decoration: underline;
+	}
+`;
+
 /**
  * List
  */

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -16,3 +16,144 @@ export const Message = styled.p`
 	color: ${({ theme }) => theme.base.colors.textDark};
 	font-size: 14px;
 `;
+
+/**
+ * List
+ */
+
+export const ListHeader = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 16px;
+`;
+
+export const List = styled.ul`
+	list-style: none;
+	margin: 0;
+	padding: 0;
+`;
+
+export const ListItem = styled.li`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 12px 16px;
+	margin-bottom: 8px;
+	background-color: ${({ theme }) => theme.base.colors.backgroundColorLight};
+	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+	border-radius: 4px;
+`;
+
+export const ListItemTitle = styled.span`
+	font-size: 15px;
+	font-weight: 500;
+	color: ${({ theme }) => theme.base.colors.textDark};
+`;
+
+export const ListItemMeta = styled.span`
+	display: block;
+	font-size: 12px;
+	color: ${({ theme }) => theme.base.colors.textMuted};
+`;
+
+export const StatusTag = styled.span<{ draft?: boolean }>`
+	display: inline-block;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	padding: 2px 6px;
+	margin-left: 8px;
+	border-radius: 3px;
+	color: ${({ theme }) => theme.base.colors.textLight};
+	background-color: ${({ theme, draft }) =>
+		draft ? theme.base.colors.brandColor : theme.base.colors.button};
+`;
+
+/**
+ * Form
+ */
+
+export const Form = styled.form`
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+`;
+
+export const Section = styled.fieldset`
+	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+	border-radius: 4px;
+	padding: 16px;
+	margin: 0;
+`;
+
+export const SectionHeading = styled.legend`
+	font-size: 13px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: ${({ theme }) => theme.base.colors.textMuted};
+	padding: 0 4px;
+`;
+
+export const Field = styled.label`
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-bottom: 12px;
+	font-size: 13px;
+	color: ${({ theme }) => theme.base.colors.textDark};
+`;
+
+export const TextInput = styled.input`
+	height: 32px;
+	padding: 0 8px;
+	font-size: 14px;
+	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+	border-radius: 3px;
+	background-color: ${({ theme }) => theme.base.colors.backgroundColorLight};
+
+	&:focus {
+		outline: none;
+		border-color: ${({ theme }) => theme.base.colors.borderColorFocus};
+	}
+`;
+
+export const Select = styled.select`
+	height: 32px;
+	padding: 0 8px;
+	font-size: 14px;
+	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+	border-radius: 3px;
+	background-color: ${({ theme }) => theme.base.colors.backgroundColorLight};
+`;
+
+export const RepeatableRow = styled.div`
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
+	margin-bottom: 12px;
+`;
+
+export const RowFields = styled.div`
+	display: flex;
+	gap: 8px;
+	flex: 1;
+
+	> * {
+		flex: 1;
+	}
+`;
+
+export const FormActions = styled.div`
+	display: flex;
+	gap: 8px;
+`;
+
+export const ErrorMessage = styled.p`
+	color: ${({ theme }) => theme.base.colors.dangerColor};
+	font-size: 13px;
+	margin: 0;
+`;

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -58,6 +58,14 @@ export const ListItemMeta = styled.span`
 	color: ${({ theme }) => theme.base.colors.textMuted};
 `;
 
+export const ListItemActions = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	gap: 6px;
+	flex-shrink: 0;
+`;
+
 export const StatusTag = styled.span<{ draft?: boolean }>`
 	display: inline-block;
 	font-size: 11px;

--- a/fronts-client/src/components/Subnav/subnavApi.ts
+++ b/fronts-client/src/components/Subnav/subnavApi.ts
@@ -1,10 +1,14 @@
 import pandaFetch from 'services/pandaFetch';
 import { attemptFriendlyErrorMessage } from 'util/error';
-import { CustomSubnav, CustomSubnavConfig } from './types';
+import {
+	CustomSubnav,
+	CustomSubnavConfig,
+	CustomSubnavConfigResponse,
+} from './types';
 
 const baseUrl = '/custom-subnav';
 
-export async function fetchSubnavConfig(): Promise<CustomSubnavConfig> {
+export async function fetchSubnavConfig(): Promise<CustomSubnavConfigResponse> {
 	try {
 		const response = await pandaFetch(baseUrl, {
 			method: 'get',
@@ -24,7 +28,7 @@ export async function upsertSubnav(
 	subnav: CustomSubnav,
 ): Promise<CustomSubnavConfig> {
 	try {
-		const response = await pandaFetch(baseUrl, {
+		const response = await pandaFetch(`${baseUrl}/${subnav.id}`, {
 			method: 'put',
 			headers: {
 				'Content-Type': 'application/json',
@@ -43,20 +47,20 @@ export async function upsertSubnav(
 }
 
 export async function publishSubnav(id: string): Promise<CustomSubnavConfig> {
-	return mutateSubnav('post', `${baseUrl}/publish/${id}`, id, 'publish');
+	return mutateSubnav('post', `${baseUrl}/${id}/publish`, id, 'publish');
 }
 
 export async function discardSubnav(id: string): Promise<CustomSubnavConfig> {
 	return mutateSubnav(
 		'post',
-		`${baseUrl}/discard/${id}`,
+		`${baseUrl}/${id}/discard`,
 		id,
 		'discard changes to',
 	);
 }
 
 export async function unpublishSubnav(id: string): Promise<CustomSubnavConfig> {
-	return mutateSubnav('post', `${baseUrl}/unpublish/${id}`, id, 'take down');
+	return mutateSubnav('post', `${baseUrl}/${id}/unpublish`, id, 'take down');
 }
 
 export async function deleteSubnav(id: string): Promise<CustomSubnavConfig> {

--- a/fronts-client/src/components/Subnav/subnavApi.ts
+++ b/fronts-client/src/components/Subnav/subnavApi.ts
@@ -1,0 +1,85 @@
+import pandaFetch from 'services/pandaFetch';
+import { attemptFriendlyErrorMessage } from 'util/error';
+import { CustomSubnav, CustomSubnavConfig } from './types';
+
+const baseUrl = '/custom-subnav';
+
+export async function fetchSubnavConfig(): Promise<CustomSubnavConfig> {
+	try {
+		const response = await pandaFetch(baseUrl, {
+			method: 'get',
+			credentials: 'same-origin',
+		});
+		return await response.json();
+	} catch (e) {
+		throw new Error(
+			`Tried to fetch custom subnavs, but the server responded with ${attemptFriendlyErrorMessage(
+				e,
+			)}`,
+		);
+	}
+}
+
+export async function upsertSubnav(
+	subnav: CustomSubnav,
+): Promise<CustomSubnavConfig> {
+	try {
+		const response = await pandaFetch(baseUrl, {
+			method: 'put',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			credentials: 'same-origin',
+			body: JSON.stringify(subnav),
+		});
+		return await response.json();
+	} catch (e) {
+		throw new Error(
+			`Tried to save custom subnav with id ${subnav.id}, but the server responded with ${attemptFriendlyErrorMessage(
+				e,
+			)}`,
+		);
+	}
+}
+
+export async function publishSubnav(id: string): Promise<CustomSubnavConfig> {
+	return mutateSubnav('post', `${baseUrl}/publish/${id}`, id, 'publish');
+}
+
+export async function discardSubnav(id: string): Promise<CustomSubnavConfig> {
+	return mutateSubnav(
+		'post',
+		`${baseUrl}/discard/${id}`,
+		id,
+		'discard changes to',
+	);
+}
+
+export async function unpublishSubnav(id: string): Promise<CustomSubnavConfig> {
+	return mutateSubnav('post', `${baseUrl}/unpublish/${id}`, id, 'take down');
+}
+
+export async function deleteSubnav(id: string): Promise<CustomSubnavConfig> {
+	return mutateSubnav('delete', `${baseUrl}/${id}`, id, 'delete');
+}
+
+async function mutateSubnav(
+	method: string,
+	url: string,
+	id: string,
+	action: string,
+): Promise<CustomSubnavConfig> {
+	try {
+		const response = await pandaFetch(url, {
+			method,
+			credentials: 'same-origin',
+		});
+		return await response.json();
+	} catch (e) {
+		throw new Error(
+			`Tried to ${action} custom subnav with id ${id}, but the server responded with ${attemptFriendlyErrorMessage(
+				e,
+			)}`,
+		);
+	}
+}

--- a/fronts-client/src/components/Subnav/types.ts
+++ b/fronts-client/src/components/Subnav/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Types mirroring the CustomSubnav model from facia-scala-client
+ * (com.gu.facia.client.models). See app/services/CustomSubnavApi.scala.
+ *
+ * Phase one only edits the header, links and targeted pages. `images` and
+ * `palette` are part of the model but are not yet surfaced in the UI.
+ */
+
+export type TargetedPageType = 'front' | 'article' | 'hasTag';
+
+export type CustomSubnavFormat = 'large' | 'compact';
+
+export type ImageBreakpoint = 'mobile' | 'tablet' | 'web';
+
+export interface SubnavLink {
+	linkText: string;
+	dotcomPath: string;
+}
+
+export interface TargetedPage {
+	type: TargetedPageType;
+	path: string;
+}
+
+export interface CustomSubnavHeader {
+	headerText: string;
+	dotcomPath?: string;
+	copy: string;
+}
+
+export interface SubnavImage {
+	imageSrc: string;
+	breakpoint: ImageBreakpoint;
+}
+
+export interface Palette {
+	text?: string;
+	header?: string;
+	link?: string;
+}
+
+export interface Palettes {
+	light: Palette;
+	dark: Palette;
+}
+
+export interface CustomSubnav {
+	id: string;
+	header: CustomSubnavHeader;
+	format: CustomSubnavFormat;
+	links: SubnavLink[];
+	pages: TargetedPage[];
+	images?: SubnavImage[];
+	palette?: Palettes;
+	// Serialised as epoch milliseconds by the server (JodaFormat).
+	lastUpdated: number;
+	updatedBy: string;
+	updatedEmail: string;
+}
+
+export interface CustomSubnavConfig {
+	live: CustomSubnav[];
+	draft: CustomSubnav[];
+}

--- a/fronts-client/src/components/Subnav/types.ts
+++ b/fronts-client/src/components/Subnav/types.ts
@@ -1,9 +1,6 @@
 /**
  * Types mirroring the CustomSubnav model from facia-scala-client
  * (com.gu.facia.client.models). See app/services/CustomSubnavApi.scala.
- *
- * Phase one only edits the header, links and targeted pages. `images` and
- * `palette` are part of the model but are not yet surfaced in the UI.
  */
 
 export type TargetedPageType = 'front' | 'article' | 'hasTag';
@@ -52,7 +49,6 @@ export interface CustomSubnav {
 	pages: TargetedPage[];
 	images?: SubnavImage[];
 	palette?: Palettes;
-	// Serialised as epoch milliseconds by the server (JodaFormat).
 	lastUpdated: number;
 	updatedBy: string;
 	updatedEmail: string;
@@ -63,11 +59,6 @@ export interface CustomSubnavConfig {
 	draft: CustomSubnav[];
 }
 
-/**
- * Shape returned by `GET /custom-subnav`. The server reads the stored document
- * tolerantly: if it cannot be parsed it returns an empty config plus a
- * `warning` explaining that the stored data could not be shown.
- */
 export interface CustomSubnavConfigResponse extends CustomSubnavConfig {
 	warning?: string | null;
 }

--- a/fronts-client/src/components/Subnav/types.ts
+++ b/fronts-client/src/components/Subnav/types.ts
@@ -62,3 +62,12 @@ export interface CustomSubnavConfig {
 	live: CustomSubnav[];
 	draft: CustomSubnav[];
 }
+
+/**
+ * Shape returned by `GET /custom-subnav`. The server reads the stored document
+ * tolerantly: if it cannot be parsed it returns an empty config plus a
+ * `warning` explaining that the stored data could not be shown.
+ */
+export interface CustomSubnavConfigResponse extends CustomSubnavConfig {
+	warning?: string | null;
+}

--- a/fronts-client/src/routes/routes.ts
+++ b/fronts-client/src/routes/routes.ts
@@ -53,29 +53,16 @@ const EditionsRoutes = {
  * Custom subnavs
  */
 
+const subnavBase = '/subnavs';
+
 export const subnavRoutes = {
-	base: '/subnavs',
-	create: '/subnavs/new',
-	edit: (id: string) => `/subnavs/${id}`,
-};
-
-const subnavSectionProps = {
-	path: subnavRoutes.base,
-};
-
-const subnavListProps = {
-	exact: true,
-	path: subnavRoutes.base,
-};
-
-const subnavCreateProps = {
-	exact: true,
-	path: subnavRoutes.create,
-};
-
-const subnavEditProps = {
-	exact: true,
-	path: `${subnavRoutes.base}/:id`,
+	base: subnavBase,
+	create: `${subnavBase}/new`,
+	edit: (id: string) => `${subnavBase}/${id}`,
+	sectionProps: { path: subnavBase },
+	listProps: { exact: true, path: subnavBase },
+	createProps: { exact: true, path: `${subnavBase}/new` },
+	editProps: { exact: true, path: `${subnavBase}/:id` },
 };
 
 export {
@@ -84,9 +71,5 @@ export {
 	matchIssuePath,
 	issuePathProps,
 	frontsFeatureProps,
-	subnavSectionProps,
-	subnavListProps,
-	subnavCreateProps,
-	subnavEditProps,
 	EditionsRoutes,
 };

--- a/fronts-client/src/routes/routes.ts
+++ b/fronts-client/src/routes/routes.ts
@@ -55,10 +55,27 @@ const EditionsRoutes = {
 
 export const subnavRoutes = {
 	base: '/subnavs',
+	create: '/subnavs/new',
+	edit: (id: string) => `/subnavs/${id}`,
 };
 
 const subnavSectionProps = {
 	path: subnavRoutes.base,
+};
+
+const subnavListProps = {
+	exact: true,
+	path: subnavRoutes.base,
+};
+
+const subnavCreateProps = {
+	exact: true,
+	path: subnavRoutes.create,
+};
+
+const subnavEditProps = {
+	exact: true,
+	path: `${subnavRoutes.base}/:id`,
 };
 
 export {
@@ -68,5 +85,8 @@ export {
 	issuePathProps,
 	frontsFeatureProps,
 	subnavSectionProps,
+	subnavListProps,
+	subnavCreateProps,
+	subnavEditProps,
 	EditionsRoutes,
 };

--- a/fronts-client/src/routes/routes.ts
+++ b/fronts-client/src/routes/routes.ts
@@ -54,14 +54,15 @@ const EditionsRoutes = {
  */
 
 const subnavBase = '/subnavs';
+const subnavCreate = `${subnavBase}/new`;
 
 export const subnavRoutes = {
 	base: subnavBase,
-	create: `${subnavBase}/new`,
+	create: subnavCreate,
 	edit: (id: string) => `${subnavBase}/${id}`,
 	sectionProps: { path: subnavBase },
 	listProps: { exact: true, path: subnavBase },
-	createProps: { exact: true, path: `${subnavBase}/new` },
+	createProps: { exact: true, path: subnavCreate },
 	editProps: { exact: true, path: `${subnavBase}/:id` },
 };
 


### PR DESCRIPTION
Co-written with Claude AI

## What's changed?

Uses the backend logic from #2039 to set up a basic subnav listing, creation/editing interface. This interface is temporary (and mostly AI-generated); the purpose of this more to check that the backend wiring has worked and enables us to create a custom subnav so that work on platforms can be unblocked - essentially, the view presented is not meant to be seen by users as it currently is. 

As such, certain elements of this PR, e.g in terms of UX (browser alert dialogs), should, I'd argue, be reviewed with some leniency, a fair amount of this will be revisited shortly (and potentially with a view to use a component library). The styling certainly should not be reviewed in detail. 

The third PR in the stack will add the capability to add images and palettes to the interface; in the meantime this should correspond to the first phase of the wireframe - adding header info, links and pages, as well as the draft/publish/take down logic. 

Follow up work includes:

- styling the interface properly based on designs (still a WIP)
- wiring up a preview function to be able to view the custom subnav before publication

## Testing

Run this branch locally or on code, ensuring you've got the relevant permission for the fronts tool (configure_custom_subnavs). In the main menu you should see a link to the Manage Subnavs interface, clicking on it should show the below (the test subnav I created).

You should then be able to edit it or create a new subnav yourself. 

As work on the platforms hasn't been done yet, the subnav itself will appear nowhere, but you can view the generated json in the relevant S3 bucket. 

## Screenshots

<img width="775" height="264" alt="image" src="https://github.com/user-attachments/assets/74020045-cd13-4f54-8969-c1a054df63c0" />

Editing page:
<img width="799" height="876" alt="image" src="https://github.com/user-attachments/assets/4393866a-e786-4a2c-99d6-5f19fda81a6f" />



## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
