### PR TITLE
Hide test status icons when headline testing feature switch is off

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -37,7 +37,7 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
 	hasUnpublishedChanges: boolean;
 	hasOpenForms: boolean;
 	liveAndDraftCards: Card[];
-	headlineABTestingIsEnabled: boolean;
+	headlineABTestingIsEnabled?: boolean;
 };
 
 const Container = styled.div<{

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -20,6 +20,7 @@ import EditModeVisibility from 'components/util/EditModeVisibility';
 import { createSelectCollectionIdsWithOpenForms } from 'bundles/frontsUI';
 import { css } from 'styled-components';
 import { ConicalFlaskIcon } from 'components/icons/Icons';
+import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import { hasActiveAbTestOnCard } from '../../util/abTests';
 
 interface FrontCollectionOverviewContainerProps {
@@ -36,6 +37,7 @@ type FrontCollectionOverviewProps = FrontCollectionOverviewContainerProps & {
 	hasUnpublishedChanges: boolean;
 	hasOpenForms: boolean;
 	liveAndDraftCards: Card[];
+	headlineABTestingIsEnabled: boolean;
 };
 
 const Container = styled.div<{
@@ -138,6 +140,7 @@ const CollectionOverview = ({
 	isSelected,
 	hasOpenForms,
 	liveAndDraftCards,
+	headlineABTestingIsEnabled,
 }: FrontCollectionOverviewProps) =>
 	collection ? (
 		<Container
@@ -195,7 +198,9 @@ const CollectionOverview = ({
 							</StatusWarning>
 						</EditModeVisibility>
 					) : null)}
-				{liveAndDraftCards.some((card) => hasActiveAbTestOnCard(card)) && (
+				{liveAndDraftCards.some(
+					(card) => hasActiveAbTestOnCard(card) && headlineABTestingIsEnabled,
+				) && (
 					<EditModeVisibility visibleMode="fronts">
 						<TestIndicator priority="primary" size="s" title="Active tests">
 							<ConicalFlaskIcon size={'xxs'} fill={'white'} />
@@ -238,6 +243,10 @@ const mapStateToProps = () => {
 				collectionId,
 			) !== -1,
 		liveAndDraftCards: selectLiveAndDraftCards(state, collectionId),
+		headlineABTestingIsEnabled: selectFeatureValue(
+			state,
+			'headline-ab-testing',
+		),
 	});
 };
 

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -225,7 +225,7 @@ interface ArticleBodyProps {
 	};
 	abTestEnabled?: boolean;
 	hasLiveAbTest?: boolean;
-	headlineABTestingIsEnabled: boolean;
+	headlineABTestingIsEnabled?: boolean;
 }
 
 const articleBodyDefault = React.memo(

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -225,6 +225,7 @@ interface ArticleBodyProps {
 	};
 	abTestEnabled?: boolean;
 	hasLiveAbTest?: boolean;
+	headlineABTestingIsEnabled: boolean;
 }
 
 const articleBodyDefault = React.memo(
@@ -284,6 +285,7 @@ const articleBodyDefault = React.memo(
 		intendedAudience,
 		abTestEnabled,
 		hasLiveAbTest,
+		headlineABTestingIsEnabled,
 	}: ArticleBodyProps) => {
 		const displayByline = size === 'default' && showByline && byline;
 		const now = Date.now();
@@ -496,7 +498,7 @@ const articleBodyDefault = React.memo(
 						)}
 						{displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
 					</CardHeadingContainer>
-					{abTestStatusMessage && (
+					{abTestStatusMessage && headlineABTestingIsEnabled && (
 						<ABTestStatus useSecondaryTheme={useSecondaryTheme}>
 							<ConicalFlaskIcon
 								size={'xs'}

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -70,7 +70,7 @@ interface ArticleComponentProps {
 	groupIndex?: number;
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
 	hasLiveAbTest?: boolean;
-	headlineABTestingIsEnabled: boolean;
+	headlineABTestingIsEnabled?: boolean;
 }
 
 interface ComponentProps extends ArticleComponentProps {

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -70,6 +70,7 @@ interface ArticleComponentProps {
 	groupIndex?: number;
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
 	hasLiveAbTest?: boolean;
+	headlineABTestingIsEnabled: boolean;
 }
 
 interface ComponentProps extends ArticleComponentProps {
@@ -122,6 +123,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 			groupIndex,
 			otherCollectionsOnSameFrontThisCardIsOn,
 			hasLiveAbTest,
+			headlineABTestingIsEnabled,
 		} = this.props;
 
 		const getArticleData = () =>
@@ -196,6 +198,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 									intendedAudienceFromTags(article.tags)
 								}
 								hasLiveAbTest={hasLiveAbTest}
+								headlineABTestingIsEnabled={headlineABTestingIsEnabled}
 							/>
 						</ArticleBodyContainer>
 					</DragIntentContainer>
@@ -218,6 +221,7 @@ const createMapStateToProps = () => {
 		isLoading: boolean;
 		featureFlagPageViewData: boolean;
 		hasLiveAbTest?: boolean;
+		headlineABTestingIsEnabled: boolean;
 	} => {
 		const article = selectArticle(state, props.id);
 		const card = selectCard(state, props.id);
@@ -237,6 +241,10 @@ const createMapStateToProps = () => {
 				'page-view-data-visualisation',
 			),
 			hasLiveAbTest: hasLiveAbTest,
+			headlineABTestingIsEnabled: selectFeatureValue(
+				state,
+				'headline-ab-testing',
+			),
 		};
 	};
 };


### PR DESCRIPTION
## What's changed?
Hides test status icons when the headline AB testing feature switch is off. At the moment the test status icons will show to all users regardless of whether the feature switch is on or not. We want to only show these icons when a user has switched on headline AB testing.

## Screenshots

Collection overview:

| Before      | After     |
| ------------- | ------------- |
| <img width="190" height="207" alt="Screenshot 2026-08-10 at 16 06 15" src="https://github.com/user-attachments/assets/bd1f51bf-e3ad-4a2a-b3fe-8ddb1a631bc1" /> | <img width="190" height="179" alt="Screenshot 2026-08-10 at 16 12 29" src="https://github.com/user-attachments/assets/31aea894-a6aa-466a-8d4d-314464ef2a41" /> |
| <img width="636" height="73" alt="Screenshot 2026-08-10 at 17 22 19" src="https://github.com/user-attachments/assets/81a5237e-83a9-44b9-a305-ebbc1a656720" /> | <img width="637" height="75" alt="Screenshot 2026-08-10 at 17 22 39" src="https://github.com/user-attachments/assets/a4526bd2-1b2d-4045-b26b-f85915ebe237" /> |



