### PR TITLE
Replace UUID generator

### DIFF
--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -361,16 +361,6 @@ describe('CardForm transform functions', () => {
 		});
 	});
 	describe('Derive card tests from form values', () => {
-		const originalRandomUUID = crypto.randomUUID;
-		beforeAll(() => {
-			// jsdom does not implement crypto.randomUUID
-			crypto.randomUUID = jest
-				.fn()
-				.mockReturnValue('00000000-0000-0000-0000-000000000000');
-		});
-		afterAll(() => {
-			crypto.randomUUID = originalRandomUUID;
-		});
 		it('should set variant headlines from headlineA and headlineB when non-empty', () => {
 			const values = {
 				abTestEnabled: true,

--- a/fronts-client/src/util/form.ts
+++ b/fronts-client/src/util/form.ts
@@ -12,6 +12,7 @@ import { selectCard } from 'selectors/shared';
 import { findActiveOrDraftTest } from './abTests';
 import { selectFrontsWithCollection } from 'selectors/frontsSelectors';
 import { selectUserFullName, selectUserEmail } from 'selectors/configSelectors';
+import v4 from 'uuid/v4';
 
 export interface CardFormData {
 	headline: string;
@@ -235,7 +236,7 @@ export const getCardTestFromFormValues = (
 	}
 
 	return {
-		testUuid: crypto.randomUUID(),
+		testUuid: v4(),
 		variantMeta: [
 			{
 				id: 'A',


### PR DESCRIPTION
## What's changed?
Replaces crypto with v4 as the uuid generator. This is preferred elsewhere in the codebase e.g. [`fronts-client/src/util/card.ts:114`](https://github.com/guardian/facia-tool/blob/b96a62df0e2174d326d212d42e7ffd1022515ffb/fronts-client/src/util/card.ts#L114)

It also means we do not have to mock `crypto` in the test suite