### PR TITLE
Enable adding images to subnav

### DIFF
--- a/fronts-client/src/components/Subnav/SubnavForm.tsx
+++ b/fronts-client/src/components/Subnav/SubnavForm.tsx
@@ -92,6 +92,9 @@ const toInitialFormState = (subnav?: CustomSubnav) => ({
 	pages: subnav?.pages.length
 		? subnav.pages.map((page) => ({ ...page }))
 		: [emptyPage()],
+	images: subnav?.images?.map((image) => ({ ...image })) ?? [],
+	lightPalette: toPaletteFields(subnav?.palette?.light),
+	darkPalette: toPaletteFields(subnav?.palette?.dark),
 });
 
 const SubnavForm = ({
@@ -99,7 +102,6 @@ const SubnavForm = ({
 	onSave,
 	saving = false,
 }: SubnavFormProps) => {
-
 	const mountedRef = useRef(true);
 	useEffect(
 		() => () => {
@@ -119,14 +121,12 @@ const SubnavForm = ({
 	const [links, setLinks] = useState<SubnavLink[]>(baseline.links);
 	const [pages, setPages] = useState<TargetedPage[]>(baseline.pages);
 
-	const [images, setImages] = useState<SubnavImage[]>(
-		initialSubnav?.images ?? [],
-	);
+	const [images, setImages] = useState<SubnavImage[]>(baseline.images);
 	const [lightPalette, setLightPalette] = useState<PaletteFields>(
-		toPaletteFields(initialSubnav?.palette?.light),
+		baseline.lightPalette,
 	);
 	const [darkPalette, setDarkPalette] = useState<PaletteFields>(
-		toPaletteFields(initialSubnav?.palette?.dark),
+		baseline.darkPalette,
 	);
 	const [error, setError] = useState<string | null>(null);
 	const [justSaved, setJustSaved] = useState(false);
@@ -138,6 +138,9 @@ const SubnavForm = ({
 			headerCopy,
 			links,
 			pages,
+			images,
+			lightPalette,
+			darkPalette,
 		}) !== JSON.stringify(baseline);
 
 	const handleCancel = () => {
@@ -146,6 +149,9 @@ const SubnavForm = ({
 		setHeaderCopy(baseline.headerCopy);
 		setLinks(baseline.links.map((link) => ({ ...link })));
 		setPages(baseline.pages.map((page) => ({ ...page })));
+		setImages(baseline.images.map((image) => ({ ...image })));
+		setLightPalette({ ...baseline.lightPalette });
+		setDarkPalette({ ...baseline.darkPalette });
 		setError(null);
 	};
 
@@ -249,6 +255,9 @@ const SubnavForm = ({
 		setHeaderCopy(savedState.headerCopy);
 		setLinks(savedState.links);
 		setPages(savedState.pages);
+		setImages(savedState.images);
+		setLightPalette(savedState.lightPalette);
+		setDarkPalette(savedState.darkPalette);
 		setJustSaved(true);
 	};
 

--- a/fronts-client/src/components/Subnav/SubnavForm.tsx
+++ b/fronts-client/src/components/Subnav/SubnavForm.tsx
@@ -5,7 +5,6 @@ import SubnavImageInput from './SubnavImageInput';
 import {
 	CustomSubnav,
 	ImageBreakpoint,
-	Palette,
 	SubnavImage,
 	SubnavLink,
 	TargetedPage,
@@ -18,9 +17,6 @@ import {
 	FormActions,
 	ImageRow,
 	ImageRowHeader,
-	PaletteColumn,
-	PaletteColumnHeading,
-	PaletteGrid,
 	RepeatableRow,
 	RowFields,
 	SavedMessage,
@@ -52,31 +48,6 @@ const emptyLink = (): SubnavLink => ({ linkText: '', dotcomPath: '' });
 const emptyPage = (): TargetedPage => ({ type: 'front', path: '' });
 const emptyImage = (): SubnavImage => ({ imageSrc: '', breakpoint: 'web' });
 
-// Palette hex fields are held as plain strings; '' means "not set" (omitted).
-interface PaletteFields {
-	text: string;
-	header: string;
-	link: string;
-}
-
-const toPaletteFields = (palette?: Palette): PaletteFields => ({
-	text: palette?.text ?? '',
-	header: palette?.header ?? '',
-	link: palette?.link ?? '',
-});
-
-const toOptional = (value: string): string | undefined =>
-	value.trim() || undefined;
-
-const buildPalette = (fields: PaletteFields): Palette => ({
-	text: toOptional(fields.text),
-	header: toOptional(fields.header),
-	link: toOptional(fields.link),
-});
-
-const isPaletteEmpty = (palette: Palette): boolean =>
-	!palette.text && !palette.header && !palette.link;
-
 /**
  * The form's editable state, derived from the subnav being edited (or blank
  * defaults when creating). Arrays are cloned so edits never mutate the config
@@ -93,8 +64,6 @@ const toInitialFormState = (subnav?: CustomSubnav) => ({
 		? subnav.pages.map((page) => ({ ...page }))
 		: [emptyPage()],
 	images: subnav?.images?.map((image) => ({ ...image })) ?? [],
-	lightPalette: toPaletteFields(subnav?.palette?.light),
-	darkPalette: toPaletteFields(subnav?.palette?.dark),
 });
 
 const SubnavForm = ({
@@ -122,12 +91,6 @@ const SubnavForm = ({
 	const [pages, setPages] = useState<TargetedPage[]>(baseline.pages);
 
 	const [images, setImages] = useState<SubnavImage[]>(baseline.images);
-	const [lightPalette, setLightPalette] = useState<PaletteFields>(
-		baseline.lightPalette,
-	);
-	const [darkPalette, setDarkPalette] = useState<PaletteFields>(
-		baseline.darkPalette,
-	);
 	const [error, setError] = useState<string | null>(null);
 	const [justSaved, setJustSaved] = useState(false);
 
@@ -139,8 +102,6 @@ const SubnavForm = ({
 			links,
 			pages,
 			images,
-			lightPalette,
-			darkPalette,
 		}) !== JSON.stringify(baseline);
 
 	const handleCancel = () => {
@@ -150,8 +111,6 @@ const SubnavForm = ({
 		setLinks(baseline.links.map((link) => ({ ...link })));
 		setPages(baseline.pages.map((page) => ({ ...page })));
 		setImages(baseline.images.map((image) => ({ ...image })));
-		setLightPalette({ ...baseline.lightPalette });
-		setDarkPalette({ ...baseline.darkPalette });
 		setError(null);
 	};
 
@@ -178,13 +137,6 @@ const SubnavForm = ({
 	const addImage = () => setImages((prev) => [...prev, emptyImage()]);
 	const removeImage = (index: number) =>
 		setImages((prev) => prev.filter((_, i) => i !== index));
-	// Read the value eagerly (see call sites): react-dom 16 pools synthetic
-	// events, so the event is nulled before a functional state updater runs.
-	const updatePaletteField = (
-		setPalette: React.Dispatch<React.SetStateAction<PaletteFields>>,
-		key: keyof PaletteFields,
-		value: string,
-	) => setPalette((prev) => ({ ...prev, [key]: value }));
 
 	const handleSubmit = async (event: React.FormEvent) => {
 		event.preventDefault();
@@ -207,9 +159,6 @@ const SubnavForm = ({
 		setError(null);
 
 		const cleanedImages = images.filter((image) => image.imageSrc.trim());
-		const light = buildPalette(lightPalette);
-		const dark = buildPalette(darkPalette);
-		const paletteIsEmpty = isPaletteEmpty(light) && isPaletteEmpty(dark);
 
 		const subnav: CustomSubnav = {
 			id: initialSubnav?.id ?? v4(),
@@ -228,7 +177,6 @@ const SubnavForm = ({
 				path: page.path.trim(),
 			})),
 			images: cleanedImages.length ? cleanedImages : undefined,
-			palette: paletteIsEmpty ? undefined : { light, dark },
 			lastUpdated: Date.now(),
 			updatedBy: initialSubnav?.updatedBy ?? '',
 			updatedEmail: initialSubnav?.updatedEmail ?? '',
@@ -256,8 +204,6 @@ const SubnavForm = ({
 		setLinks(savedState.links);
 		setPages(savedState.pages);
 		setImages(savedState.images);
-		setLightPalette(savedState.lightPalette);
-		setDarkPalette(savedState.darkPalette);
 		setJustSaved(true);
 	};
 
@@ -409,78 +355,6 @@ const SubnavForm = ({
 				<ButtonDefault type="button" size="s" onClick={addImage}>
 					+ Add image
 				</ButtonDefault>
-			</Section>
-
-			<Section>
-				<SectionHeading>Palette</SectionHeading>
-				<PaletteGrid>
-					<PaletteColumn>
-						<PaletteColumnHeading>Light</PaletteColumnHeading>
-						<Field>
-							Text colour (hex)
-							<TextInput
-								value={lightPalette.text}
-								onChange={(e) =>
-									updatePaletteField(setLightPalette, 'text', e.target.value)
-								}
-								placeholder="#121212"
-							/>
-						</Field>
-						<Field>
-							Header colour (hex)
-							<TextInput
-								value={lightPalette.header}
-								onChange={(e) =>
-									updatePaletteField(setLightPalette, 'header', e.target.value)
-								}
-								placeholder="#121212"
-							/>
-						</Field>
-						<Field>
-							Link colour (hex)
-							<TextInput
-								value={lightPalette.link}
-								onChange={(e) =>
-									updatePaletteField(setLightPalette, 'link', e.target.value)
-								}
-								placeholder="#c70000"
-							/>
-						</Field>
-					</PaletteColumn>
-					<PaletteColumn>
-						<PaletteColumnHeading>Dark</PaletteColumnHeading>
-						<Field>
-							Text colour (hex)
-							<TextInput
-								value={darkPalette.text}
-								onChange={(e) =>
-									updatePaletteField(setDarkPalette, 'text', e.target.value)
-								}
-								placeholder="#ffffff"
-							/>
-						</Field>
-						<Field>
-							Header colour (hex)
-							<TextInput
-								value={darkPalette.header}
-								onChange={(e) =>
-									updatePaletteField(setDarkPalette, 'header', e.target.value)
-								}
-								placeholder="#ffffff"
-							/>
-						</Field>
-						<Field>
-							Link colour (hex)
-							<TextInput
-								value={darkPalette.link}
-								onChange={(e) =>
-									updatePaletteField(setDarkPalette, 'link', e.target.value)
-								}
-								placeholder="#ff5943"
-							/>
-						</Field>
-					</PaletteColumn>
-				</PaletteGrid>
 			</Section>
 
 			{error && <ErrorMessage>{error}</ErrorMessage>}

--- a/fronts-client/src/components/Subnav/SubnavForm.tsx
+++ b/fronts-client/src/components/Subnav/SubnavForm.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import v4 from 'uuid/v4';
 import ButtonDefault from 'components/inputs/ButtonDefault';
+import SubnavImageInput from './SubnavImageInput';
 import {
 	CustomSubnav,
+	ImageBreakpoint,
+	Palette,
+	SubnavImage,
 	SubnavLink,
 	TargetedPage,
 	TargetedPageType,
@@ -12,6 +16,11 @@ import {
 	Field,
 	Form,
 	FormActions,
+	ImageRow,
+	ImageRowHeader,
+	PaletteColumn,
+	PaletteColumnHeading,
+	PaletteGrid,
 	RepeatableRow,
 	RowFields,
 	SavedMessage,
@@ -33,8 +42,40 @@ const pageTypeOptions: { value: TargetedPageType; label: string }[] = [
 	{ value: 'hasTag', label: 'Tag' },
 ];
 
+const breakpointOptions: { value: ImageBreakpoint; label: string }[] = [
+	{ value: 'mobile', label: 'Mobile' },
+	{ value: 'tablet', label: 'Tablet' },
+	{ value: 'web', label: 'Web' },
+];
+
 const emptyLink = (): SubnavLink => ({ linkText: '', dotcomPath: '' });
 const emptyPage = (): TargetedPage => ({ type: 'front', path: '' });
+const emptyImage = (): SubnavImage => ({ imageSrc: '', breakpoint: 'web' });
+
+// Palette hex fields are held as plain strings; '' means "not set" (omitted).
+interface PaletteFields {
+	text: string;
+	header: string;
+	link: string;
+}
+
+const toPaletteFields = (palette?: Palette): PaletteFields => ({
+	text: palette?.text ?? '',
+	header: palette?.header ?? '',
+	link: palette?.link ?? '',
+});
+
+const toOptional = (value: string): string | undefined =>
+	value.trim() || undefined;
+
+const buildPalette = (fields: PaletteFields): Palette => ({
+	text: toOptional(fields.text),
+	header: toOptional(fields.header),
+	link: toOptional(fields.link),
+});
+
+const isPaletteEmpty = (palette: Palette): boolean =>
+	!palette.text && !palette.header && !palette.link;
 
 /**
  * The form's editable state, derived from the subnav being edited (or blank
@@ -58,6 +99,7 @@ const SubnavForm = ({
 	onSave,
 	saving = false,
 }: SubnavFormProps) => {
+
 	const mountedRef = useRef(true);
 	useEffect(
 		() => () => {
@@ -65,7 +107,6 @@ const SubnavForm = ({
 		},
 		[],
 	);
-
 	const [baseline, setBaseline] = useState(() =>
 		toInitialFormState(initialSubnav),
 	);
@@ -77,6 +118,16 @@ const SubnavForm = ({
 	const [headerCopy, setHeaderCopy] = useState(baseline.headerCopy);
 	const [links, setLinks] = useState<SubnavLink[]>(baseline.links);
 	const [pages, setPages] = useState<TargetedPage[]>(baseline.pages);
+
+	const [images, setImages] = useState<SubnavImage[]>(
+		initialSubnav?.images ?? [],
+	);
+	const [lightPalette, setLightPalette] = useState<PaletteFields>(
+		toPaletteFields(initialSubnav?.palette?.light),
+	);
+	const [darkPalette, setDarkPalette] = useState<PaletteFields>(
+		toPaletteFields(initialSubnav?.palette?.dark),
+	);
 	const [error, setError] = useState<string | null>(null);
 	const [justSaved, setJustSaved] = useState(false);
 
@@ -114,6 +165,21 @@ const SubnavForm = ({
 	const removePage = (index: number) =>
 		setPages((prev) => prev.filter((_, i) => i !== index));
 
+	const updateImage = (index: number, patch: Partial<SubnavImage>) =>
+		setImages((prev) =>
+			prev.map((image, i) => (i === index ? { ...image, ...patch } : image)),
+		);
+	const addImage = () => setImages((prev) => [...prev, emptyImage()]);
+	const removeImage = (index: number) =>
+		setImages((prev) => prev.filter((_, i) => i !== index));
+	// Read the value eagerly (see call sites): react-dom 16 pools synthetic
+	// events, so the event is nulled before a functional state updater runs.
+	const updatePaletteField = (
+		setPalette: React.Dispatch<React.SetStateAction<PaletteFields>>,
+		key: keyof PaletteFields,
+		value: string,
+	) => setPalette((prev) => ({ ...prev, [key]: value }));
+
 	const handleSubmit = async (event: React.FormEvent) => {
 		event.preventDefault();
 
@@ -134,6 +200,11 @@ const SubnavForm = ({
 
 		setError(null);
 
+		const cleanedImages = images.filter((image) => image.imageSrc.trim());
+		const light = buildPalette(lightPalette);
+		const dark = buildPalette(darkPalette);
+		const paletteIsEmpty = isPaletteEmpty(light) && isPaletteEmpty(dark);
+
 		const subnav: CustomSubnav = {
 			id: initialSubnav?.id ?? v4(),
 			header: {
@@ -150,8 +221,8 @@ const SubnavForm = ({
 				type: page.type,
 				path: page.path.trim(),
 			})),
-			images: initialSubnav?.images,
-			palette: initialSubnav?.palette,
+			images: cleanedImages.length ? cleanedImages : undefined,
+			palette: paletteIsEmpty ? undefined : { light, dark },
 			lastUpdated: Date.now(),
 			updatedBy: initialSubnav?.updatedBy ?? '',
 			updatedEmail: initialSubnav?.updatedEmail ?? '',
@@ -286,6 +357,121 @@ const SubnavForm = ({
 				<ButtonDefault type="button" size="s" onClick={addPage}>
 					+ Add page
 				</ButtonDefault>
+			</Section>
+
+			<Section>
+				<SectionHeading>Images</SectionHeading>
+				{images.length === 0 ? (
+					<Field as="p">No images added.</Field>
+				) : (
+					images.map((image, index) => (
+						<ImageRow key={index}>
+							<ImageRowHeader>
+								<Select
+									value={image.breakpoint}
+									onChange={(e) =>
+										updateImage(index, {
+											breakpoint: e.target.value as ImageBreakpoint,
+										})
+									}
+								>
+									{breakpointOptions.map((option) => (
+										<option key={option.value} value={option.value}>
+											{option.label}
+										</option>
+									))}
+								</Select>
+								<ButtonDefault
+									type="button"
+									size="s"
+									priority="muted"
+									onClick={() => removeImage(index)}
+								>
+									Remove
+								</ButtonDefault>
+							</ImageRowHeader>
+							<SubnavImageInput
+								value={image.imageSrc || undefined}
+								onChange={(src) => updateImage(index, { imageSrc: src ?? '' })}
+							/>
+						</ImageRow>
+					))
+				)}
+				<ButtonDefault type="button" size="s" onClick={addImage}>
+					+ Add image
+				</ButtonDefault>
+			</Section>
+
+			<Section>
+				<SectionHeading>Palette</SectionHeading>
+				<PaletteGrid>
+					<PaletteColumn>
+						<PaletteColumnHeading>Light</PaletteColumnHeading>
+						<Field>
+							Text colour (hex)
+							<TextInput
+								value={lightPalette.text}
+								onChange={(e) =>
+									updatePaletteField(setLightPalette, 'text', e.target.value)
+								}
+								placeholder="#121212"
+							/>
+						</Field>
+						<Field>
+							Header colour (hex)
+							<TextInput
+								value={lightPalette.header}
+								onChange={(e) =>
+									updatePaletteField(setLightPalette, 'header', e.target.value)
+								}
+								placeholder="#121212"
+							/>
+						</Field>
+						<Field>
+							Link colour (hex)
+							<TextInput
+								value={lightPalette.link}
+								onChange={(e) =>
+									updatePaletteField(setLightPalette, 'link', e.target.value)
+								}
+								placeholder="#c70000"
+							/>
+						</Field>
+					</PaletteColumn>
+					<PaletteColumn>
+						<PaletteColumnHeading>Dark</PaletteColumnHeading>
+						<Field>
+							Text colour (hex)
+							<TextInput
+								value={darkPalette.text}
+								onChange={(e) =>
+									updatePaletteField(setDarkPalette, 'text', e.target.value)
+								}
+								placeholder="#ffffff"
+							/>
+						</Field>
+						<Field>
+							Header colour (hex)
+							<TextInput
+								value={darkPalette.header}
+								onChange={(e) =>
+									updatePaletteField(setDarkPalette, 'header', e.target.value)
+								}
+								placeholder="#ffffff"
+							/>
+						</Field>
+						<Field>
+							Link colour (hex)
+							<TextInput
+								value={darkPalette.link}
+								onChange={(e) =>
+									updatePaletteField(setDarkPalette, 'link', e.target.value)
+								}
+								placeholder="#ff5943"
+							/>
+						</Field>
+					</PaletteColumn>
+				</PaletteGrid>
 			</Section>
 
 			{error && <ErrorMessage>{error}</ErrorMessage>}

--- a/fronts-client/src/components/Subnav/SubnavImageInput.tsx
+++ b/fronts-client/src/components/Subnav/SubnavImageInput.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectGridUrl } from 'selectors/configSelectors';
+import { OverlayModal } from 'components/modals/OverlayModal';
+import ButtonDefault from 'components/inputs/ButtonDefault';
+import {
+	dragEventHasImageData,
+	validateImageEvent,
+	validateImageSrc,
+	validateMediaItem,
+} from 'util/validateImageSrc';
+import { GridData } from 'types/Grid';
+import {
+	ImageEmpty,
+	ImagePicker,
+	ImagePickerActions,
+	ImageThumb,
+	TextInput,
+} from './styles';
+
+// Used only for Grid usage-recording / analytics on the shared validators.
+const FRONT_ID = 'custom-subnav';
+
+interface SubnavImageInputProps {
+	value?: string;
+	onChange: (src: string | undefined) => void;
+	disabled?: boolean;
+}
+
+/**
+ * A controlled image picker that mirrors the fronts "replace image" flow:
+ * pick/crop an image in the Grid (opened in a modal), drag a Grid image in, or
+ * paste a Grid crop URL. The resulting crop `src` is stored as the imageSrc.
+ */
+const SubnavImageInput = ({
+	value,
+	onChange,
+	disabled,
+}: SubnavImageInputProps) => {
+	const gridUrl = useSelector(selectGridUrl);
+	const [modalOpen, setModalOpen] = useState(false);
+	const [isValidating, setIsValidating] = useState(false);
+	const [isDragging, setIsDragging] = useState(false);
+	const [pasteUrl, setPasteUrl] = useState('');
+
+	useEffect(() => {
+		if (!modalOpen || !gridUrl) {
+			return;
+		}
+		const onMessage = (event: MessageEvent) => {
+			if (event.origin !== gridUrl) {
+				return;
+			}
+			const data: GridData = event.data;
+			if (!data || !data.crop?.data || !data.image?.data) {
+				return;
+			}
+			setModalOpen(false);
+			const imageOrigin = `${gridUrl}/images/${data.image.data.id}`;
+			setIsValidating(true);
+			validateMediaItem(data.crop.data, imageOrigin, FRONT_ID)
+				.then((mediaItem) => onChange(mediaItem.src))
+				.catch((err) => window.alert(err))
+				.finally(() => setIsValidating(false));
+		};
+		window.addEventListener('message', onMessage, false);
+		return () => window.removeEventListener('message', onMessage, false);
+	}, [modalOpen, gridUrl, onChange]);
+
+	if (!gridUrl) {
+		return <ImageEmpty>Grid URL config missing</ImageEmpty>;
+	}
+
+	const gridModalUrl = `${gridUrl}?${new URLSearchParams({
+		cropType: 'portrait,landscape',
+	}).toString()}`;
+
+	const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		setIsDragging(false);
+		setIsValidating(true);
+		validateImageEvent(e, FRONT_ID)
+			.then((mediaItem) => onChange(mediaItem.src))
+			.catch((err) => window.alert(err))
+			.finally(() => setIsValidating(false));
+	};
+
+	const handlePaste = () => {
+		const trimmed = pasteUrl.trim();
+		if (!trimmed) {
+			return;
+		}
+		setIsValidating(true);
+		validateImageSrc(trimmed, FRONT_ID)
+			.then((mediaItem) => {
+				onChange(mediaItem.src);
+				setPasteUrl('');
+			})
+			.catch((err) => window.alert(err))
+			.finally(() => setIsValidating(false));
+	};
+
+	return (
+		<ImagePicker>
+			<OverlayModal
+				url={gridModalUrl}
+				isOpen={modalOpen}
+				onClose={() => setModalOpen(false)}
+			/>
+			{value ? (
+				<ImageThumb style={{ backgroundImage: `url(${value})` }} />
+			) : (
+				<ImageEmpty
+					isDragging={isDragging}
+					onDragOver={(e) => {
+						if (dragEventHasImageData(e)) {
+							e.preventDefault();
+							setIsDragging(true);
+						}
+					}}
+					onDragLeave={() => setIsDragging(false)}
+					onDrop={handleDrop}
+				>
+					{isValidating
+						? 'Validating…'
+						: 'Drag a Grid image here, or use the options below'}
+				</ImageEmpty>
+			)}
+			<ImagePickerActions>
+				<ButtonDefault
+					type="button"
+					size="s"
+					disabled={disabled || isValidating}
+					onClick={() => setModalOpen(true)}
+				>
+					{value ? 'Replace image' : 'Add image from Grid'}
+				</ButtonDefault>
+				{value && (
+					<ButtonDefault
+						type="button"
+						size="s"
+						priority="muted"
+						disabled={disabled}
+						onClick={() => onChange(undefined)}
+					>
+						Remove
+					</ButtonDefault>
+				)}
+			</ImagePickerActions>
+			{!value && (
+				<ImagePickerActions>
+					<TextInput
+						value={pasteUrl}
+						onChange={(e) => setPasteUrl(e.target.value)}
+						placeholder="…or paste a Grid crop URL"
+						disabled={disabled}
+					/>
+					<ButtonDefault
+						type="button"
+						size="s"
+						disabled={disabled || isValidating || !pasteUrl.trim()}
+						onClick={handlePaste}
+					>
+						Use URL
+					</ButtonDefault>
+				</ImagePickerActions>
+			)}
+		</ImagePicker>
+	);
+};
+
+export default SubnavImageInput;

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -197,3 +197,94 @@ export const ErrorMessage = styled.p`
 	font-size: 13px;
 	margin: 0;
 `;
+
+/**
+ * Images
+ */
+
+export const ImageRow = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 12px 0;
+	border-top: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+
+	&:first-of-type {
+		border-top: none;
+		padding-top: 0;
+	}
+`;
+
+export const ImageRowHeader = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+`;
+
+export const ImagePicker = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+`;
+
+export const ImageThumb = styled.div`
+	width: 100%;
+	max-width: 320px;
+	aspect-ratio: 5 / 3;
+	background-size: cover;
+	background-position: center;
+	background-repeat: no-repeat;
+	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+	border-radius: 3px;
+`;
+
+export const ImageEmpty = styled.div<{ isDragging?: boolean }>`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	width: 100%;
+	max-width: 320px;
+	aspect-ratio: 5 / 3;
+	padding: 12px;
+	font-size: 12px;
+	color: ${({ theme }) => theme.base.colors.textMuted};
+	border: 2px dashed
+		${({ theme, isDragging }) =>
+			isDragging
+				? theme.base.colors.brandColor
+				: theme.base.colors.borderColor};
+	border-radius: 3px;
+	background-color: ${({ theme }) => theme.base.colors.backgroundColorFocused};
+`;
+
+export const ImagePickerActions = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 8px;
+`;
+
+/**
+ * Palette
+ */
+
+export const PaletteGrid = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 24px;
+`;
+
+export const PaletteColumn = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+export const PaletteColumnHeading = styled.h4`
+	margin: 0 0 8px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: ${({ theme }) => theme.base.colors.textMuted};
+`;

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -264,27 +264,3 @@ export const ImagePickerActions = styled.div`
 	align-items: center;
 	gap: 8px;
 `;
-
-/**
- * Palette
- */
-
-export const PaletteGrid = styled.div`
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 24px;
-`;
-
-export const PaletteColumn = styled.div`
-	display: flex;
-	flex-direction: column;
-`;
-
-export const PaletteColumnHeading = styled.h4`
-	margin: 0 0 8px;
-	font-size: 12px;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-	color: ${({ theme }) => theme.base.colors.textMuted};
-`;

--- a/fronts-client/src/components/Subnav/types.ts
+++ b/fronts-client/src/components/Subnav/types.ts
@@ -30,17 +30,6 @@ export interface SubnavImage {
 	breakpoint: ImageBreakpoint;
 }
 
-export interface Palette {
-	text?: string;
-	header?: string;
-	link?: string;
-}
-
-export interface Palettes {
-	light: Palette;
-	dark: Palette;
-}
-
 export interface CustomSubnav {
 	id: string;
 	header: CustomSubnavHeader;
@@ -48,7 +37,6 @@ export interface CustomSubnav {
 	links: SubnavLink[];
 	pages: TargetedPage[];
 	images?: SubnavImage[];
-	palette?: Palettes;
 	lastUpdated: number;
 	updatedBy: string;
 	updatedEmail: string;


### PR DESCRIPTION
## What's changed?

Includes a basic interface to add images - originally this was going to include palette fields too, but from a recent conversation we've decided to park that part of the feature set.

This'll be made more robust when the designs are finalised, in the meantime this enables us to create a subnav with the full initial set of data. 

## Images

<img width="789" height="736" alt="image" src="https://github.com/user-attachments/assets/79301ee9-de71-4b9b-91f2-6d95d2082d16" />



<img width="720" height="436" alt="image" src="https://github.com/user-attachments/assets/459b8f0a-55cf-4f3d-af55-486f96e4cc3c" />


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
