### PR TITLE
Subnav backend

### DIFF
--- a/app/Components.scala
+++ b/app/Components.scala
@@ -191,6 +191,8 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
   )
   val userDataController = new UserDataController(frontsApi, dynamo, this)
   val gridProxy = new GridProxy(this)
+  val customSubnavApi = new CustomSubnavApi(s3FrontsApi)
+  val customSubnav = new CustomSubnavController(acl, customSubnavApi, this)
   val loggingFilter = new LoggingFilter
 
   final override lazy val corsConfig: CORSConfig = CORSConfig
@@ -222,7 +224,8 @@ class AppComponents(context: Context, val config: ApplicationConfiguration)
     troubleshoot,
     v2App,
     gridProxy,
-    editions
+    editions,
+    customSubnav
   )
 
   override lazy val httpFilters = Seq(

--- a/app/controllers/CustomSubnavController.scala
+++ b/app/controllers/CustomSubnavController.scala
@@ -1,20 +1,33 @@
 package controllers
 
-import com.gu.facia.client.models.CustomSubnav
+import com.gu.facia.client.models.{CustomSubnav, CustomSubnavConfig}
 import model.NoCache
 import permissions.ConfigureSubnavsPermissionCheck
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Result
 import services.{CustomSubnavApi, CustomSubnavConfigFunctions}
 import util.Acl
 import util.Requests._
 import logging.Logging
 
 import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
 
-/** CRUD-style endpoints for managing custom subnavs. All actions are gated
-  * behind the `configure_custom_subnavs` permission. Reads and writes go
-  * through [[CustomSubnavApi]] (uncached S3) and mutate a single shared config
-  * document.
+/** Endpoints for managing custom subnavs. All actions are gated behind the
+  * `configure_custom_subnavs` permission, S3 operations mutate a single shared
+  * config document holding two parallel lists: `live` (rendered by platforms)
+  * and `draft` (unpublished versions edited in the fronts tool).
+  *
+  * API contract:
+  *   - `GET /custom-subnav` – return the whole config (`{ live, draft }`).
+  *   - `PUT /custom-subnav/:id` – upsert a single subnav into `draft` (create
+  *     or update the entry with that id). The id is client-supplied (a uuid)
+  *     and must match the body; audit fields are stamped server-side. 200 on a
+  *     valid body, 400 on a malformed one, 409 if the body id != path id.
+  *   - `POST /custom-subnav/:id/publish` – promote a draft entry into `live`.
+  *   - `POST /custom-subnav/:id/discard` – drop a draft entry.
+  *   - `POST /custom-subnav/:id/unpublish` – move a live entry back to `draft`.
+  *   - `DELETE /custom-subnav/:id` – remove the id from both lists.
   */
 class CustomSubnavController(
     val acl: Acl,
@@ -24,27 +37,69 @@ class CustomSubnavController(
     extends BaseFaciaController(deps)
     with Logging {
 
+  /** Load the config to base a mutation on
+    */
+  private def configForMutation: Either[Result, CustomSubnavConfig] =
+    customSubnavApi
+      .getConfig()
+      .left
+      .map(message =>
+        InternalServerError(s"Refusing to modify custom subnavs: $message")
+      )
+
+  private def persist(config: CustomSubnavConfig): Result =
+    customSubnavApi.putConfig(config) match {
+      case Success(saved) => Ok(Json.toJson(saved)).as("application/json")
+      case Failure(_) =>
+        InternalServerError("Failed to save custom subnav config")
+    }
+
+  private def mutate(
+      id: String
+  )(f: CustomSubnavConfig => Option[CustomSubnavConfig]): Result =
+    configForMutation match {
+      case Left(error) => error
+      case Right(config) =>
+        f(config) match {
+          case Some(updated) => persist(updated)
+          case None => NotFound(s"No custom subnav found with id '$id'")
+        }
+    }
+
   def getSubnavConfig =
     (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
       _ =>
         NoCache {
-          Ok(Json.toJson(customSubnavApi.getConfig())).as("application/json")
+          val (config, warning) = customSubnavApi.getConfig() match {
+            case Right(c) => (c, None)
+            case Left(message) =>
+              (CustomSubnavConfigFunctions.empty, Some(message))
+          }
+          val body = Json.toJson(config).as[JsObject] ++ Json.obj(
+            "warning" -> warning
+          )
+          Ok(body).as("application/json")
         }
     }
 
-  def upsertSubnav =
+  def upsertSubnav(id: String) =
     (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
       request =>
         request.body.read[CustomSubnav] match {
-          case Some(subnav) =>
-            val stamped =
-              CustomSubnavConfigFunctions.stamp(subnav, request.user)
-            val updated = CustomSubnavConfigFunctions.upsertDraft(
-              customSubnavApi.getConfig(),
-              stamped
+          case Some(subnav) if subnav.id != id =>
+            Conflict(
+              s"Body id '${subnav.id}' does not match path id '$id'"
             )
-            customSubnavApi.putConfig(updated)
-            Ok(Json.toJson(updated)).as("application/json")
+          case Some(subnav) =>
+            configForMutation match {
+              case Left(error) => error
+              case Right(config) =>
+                val stamped =
+                  CustomSubnavConfigFunctions.stamp(subnav, request.user)
+                persist(
+                  CustomSubnavConfigFunctions.upsertDraft(config, stamped)
+                )
+            }
           case None => BadRequest
         }
     }
@@ -52,36 +107,24 @@ class CustomSubnavController(
   def publishSubnav(id: String) =
     (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
       _ =>
-        val updated =
-          CustomSubnavConfigFunctions.publish(customSubnavApi.getConfig(), id)
-        customSubnavApi.putConfig(updated)
-        Ok(Json.toJson(updated)).as("application/json")
+        mutate(id)(CustomSubnavConfigFunctions.publish(_, id))
     }
 
   def discardSubnav(id: String) =
     (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
       _ =>
-        val updated =
-          CustomSubnavConfigFunctions.discard(customSubnavApi.getConfig(), id)
-        customSubnavApi.putConfig(updated)
-        Ok(Json.toJson(updated)).as("application/json")
+        mutate(id)(CustomSubnavConfigFunctions.discard(_, id))
     }
 
   def unpublishSubnav(id: String) =
     (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
       _ =>
-        val updated =
-          CustomSubnavConfigFunctions.unpublish(customSubnavApi.getConfig(), id)
-        customSubnavApi.putConfig(updated)
-        Ok(Json.toJson(updated)).as("application/json")
+        mutate(id)(CustomSubnavConfigFunctions.unpublish(_, id))
     }
 
   def deleteSubnav(id: String) =
     (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
       _ =>
-        val updated =
-          CustomSubnavConfigFunctions.delete(customSubnavApi.getConfig(), id)
-        customSubnavApi.putConfig(updated)
-        Ok(Json.toJson(updated)).as("application/json")
+        mutate(id)(CustomSubnavConfigFunctions.delete(_, id))
     }
 }

--- a/app/controllers/CustomSubnavController.scala
+++ b/app/controllers/CustomSubnavController.scala
@@ -1,0 +1,81 @@
+package controllers
+
+import com.gu.facia.client.models.CustomSubnav
+import model.NoCache
+import permissions.ConfigureSubnavsPermissionCheck
+import play.api.libs.json.Json
+import services.{CustomSubnavApi, CustomSubnavConfigFunctions}
+import util.Acl
+import util.Requests._
+import logging.Logging
+
+import scala.concurrent.ExecutionContext
+
+/** CRUD-style endpoints for managing custom subnavs. All actions are gated behind
+  * the `configure_custom_subnavs` permission. Reads and writes go through
+  * [[CustomSubnavApi]] (uncached S3) and mutate a single shared config document.
+  */
+class CustomSubnavController(
+    val acl: Acl,
+    customSubnavApi: CustomSubnavApi,
+    val deps: BaseFaciaControllerComponents
+)(implicit ec: ExecutionContext)
+    extends BaseFaciaController(deps)
+    with Logging {
+
+  def getSubnavConfig =
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
+      NoCache {
+        Ok(Json.toJson(customSubnavApi.getConfig())).as("application/json")
+      }
+    }
+
+  def upsertSubnav =
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
+      request =>
+        request.body.read[CustomSubnav] match {
+          case Some(subnav) =>
+            val stamped =
+              CustomSubnavConfigFunctions.stamp(subnav, request.user)
+            val updated = CustomSubnavConfigFunctions.upsertDraft(
+              customSubnavApi.getConfig(),
+              stamped
+            )
+            customSubnavApi.putConfig(updated)
+            Ok(Json.toJson(updated)).as("application/json")
+          case None => BadRequest
+        }
+    }
+
+  def publishSubnav(id: String) =
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
+      val updated =
+        CustomSubnavConfigFunctions.publish(customSubnavApi.getConfig(), id)
+      customSubnavApi.putConfig(updated)
+      Ok(Json.toJson(updated)).as("application/json")
+    }
+
+  def discardSubnav(id: String) =
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
+      val updated =
+        CustomSubnavConfigFunctions.discard(customSubnavApi.getConfig(), id)
+      customSubnavApi.putConfig(updated)
+      Ok(Json.toJson(updated)).as("application/json")
+    }
+
+  def unpublishSubnav(id: String) =
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
+      val updated =
+        CustomSubnavConfigFunctions.unpublish(customSubnavApi.getConfig(), id)
+      customSubnavApi.putConfig(updated)
+      Ok(Json.toJson(updated)).as("application/json")
+    }
+
+  def deleteSubnav(id: String) =
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
+      val updated =
+        CustomSubnavConfigFunctions.delete(customSubnavApi.getConfig(), id)
+      customSubnavApi.putConfig(updated)
+      Ok(Json.toJson(updated)).as("application/json")
+    }
+}

--- a/app/controllers/CustomSubnavController.scala
+++ b/app/controllers/CustomSubnavController.scala
@@ -11,9 +11,10 @@ import logging.Logging
 
 import scala.concurrent.ExecutionContext
 
-/** CRUD-style endpoints for managing custom subnavs. All actions are gated behind
-  * the `configure_custom_subnavs` permission. Reads and writes go through
-  * [[CustomSubnavApi]] (uncached S3) and mutate a single shared config document.
+/** CRUD-style endpoints for managing custom subnavs. All actions are gated
+  * behind the `configure_custom_subnavs` permission. Reads and writes go
+  * through [[CustomSubnavApi]] (uncached S3) and mutate a single shared config
+  * document.
   */
 class CustomSubnavController(
     val acl: Acl,
@@ -24,10 +25,11 @@ class CustomSubnavController(
     with Logging {
 
   def getSubnavConfig =
-    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
-      NoCache {
-        Ok(Json.toJson(customSubnavApi.getConfig())).as("application/json")
-      }
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
+      _ =>
+        NoCache {
+          Ok(Json.toJson(customSubnavApi.getConfig())).as("application/json")
+        }
     }
 
   def upsertSubnav =
@@ -48,34 +50,38 @@ class CustomSubnavController(
     }
 
   def publishSubnav(id: String) =
-    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
-      val updated =
-        CustomSubnavConfigFunctions.publish(customSubnavApi.getConfig(), id)
-      customSubnavApi.putConfig(updated)
-      Ok(Json.toJson(updated)).as("application/json")
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
+      _ =>
+        val updated =
+          CustomSubnavConfigFunctions.publish(customSubnavApi.getConfig(), id)
+        customSubnavApi.putConfig(updated)
+        Ok(Json.toJson(updated)).as("application/json")
     }
 
   def discardSubnav(id: String) =
-    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
-      val updated =
-        CustomSubnavConfigFunctions.discard(customSubnavApi.getConfig(), id)
-      customSubnavApi.putConfig(updated)
-      Ok(Json.toJson(updated)).as("application/json")
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
+      _ =>
+        val updated =
+          CustomSubnavConfigFunctions.discard(customSubnavApi.getConfig(), id)
+        customSubnavApi.putConfig(updated)
+        Ok(Json.toJson(updated)).as("application/json")
     }
 
   def unpublishSubnav(id: String) =
-    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
-      val updated =
-        CustomSubnavConfigFunctions.unpublish(customSubnavApi.getConfig(), id)
-      customSubnavApi.putConfig(updated)
-      Ok(Json.toJson(updated)).as("application/json")
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
+      _ =>
+        val updated =
+          CustomSubnavConfigFunctions.unpublish(customSubnavApi.getConfig(), id)
+        customSubnavApi.putConfig(updated)
+        Ok(Json.toJson(updated)).as("application/json")
     }
 
   def deleteSubnav(id: String) =
-    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) { _ =>
-      val updated =
-        CustomSubnavConfigFunctions.delete(customSubnavApi.getConfig(), id)
-      customSubnavApi.putConfig(updated)
-      Ok(Json.toJson(updated)).as("application/json")
+    (AccessAPIAuthAction andThen new ConfigureSubnavsPermissionCheck(acl)) {
+      _ =>
+        val updated =
+          CustomSubnavConfigFunctions.delete(customSubnavApi.getConfig(), id)
+        customSubnavApi.putConfig(updated)
+        Ok(Json.toJson(updated)).as("application/json")
     }
 }

--- a/app/services/CustomSubnavApi.scala
+++ b/app/services/CustomSubnavApi.scala
@@ -1,0 +1,127 @@
+package services
+
+import com.gu.facia.client.models.{CustomSubnav, CustomSubnavConfig}
+import com.gu.pandomainauth.model.User
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+import logging.Logging
+
+import scala.util.Try
+
+/** Pure, unit-testable transforms over a [[CustomSubnavConfig]].
+  *
+  * The stored document (`{stage}/frontsapi/navigation/custom-subnav.json`) holds
+  * two parallel lists of subnavs:
+  *   - `live`  – what dotcom renders in production
+  *   - `draft` – previewable, unpublished changes (an overlay on top of live)
+  *
+  * The lifecycle mirrors fronts/collections but operates per-subnav (matched by
+  * `id`): saving upserts into `draft`, publishing promotes a single draft entry
+  * into `live`, and discarding drops a single entry from `draft`.
+  */
+object CustomSubnavConfigFunctions {
+  val empty: CustomSubnavConfig = CustomSubnavConfig(live = Nil, draft = Nil)
+
+  /** Stamp the audit fields server-side so we never trust client-supplied values. */
+  def stamp(
+      subnav: CustomSubnav,
+      identity: User,
+      now: DateTime = DateTime.now
+  ): CustomSubnav =
+    subnav.copy(
+      lastUpdated = now,
+      updatedBy = s"${identity.firstName} ${identity.lastName}",
+      updatedEmail = identity.email
+    )
+
+  /** Two subnavs are considered content-equal if they only differ by audit fields. */
+  private def contentEquals(a: CustomSubnav, b: CustomSubnav): Boolean =
+    a.copy(
+      lastUpdated = b.lastUpdated,
+      updatedBy = b.updatedBy,
+      updatedEmail = b.updatedEmail
+    ) == b
+
+  /** Upsert the subnav into the draft list (matched by id, preserving position).
+    * If the draft copy is content-identical to its live counterpart, the change
+    * is a no-op and the entry is dropped from draft instead.
+    */
+  def upsertDraft(
+      config: CustomSubnavConfig,
+      subnav: CustomSubnav
+  ): CustomSubnavConfig = {
+    val collapsesIntoLive =
+      config.live.find(_.id == subnav.id).exists(contentEquals(_, subnav))
+
+    val newDraft =
+      if (collapsesIntoLive)
+        config.draft.filterNot(_.id == subnav.id)
+      else if (config.draft.exists(_.id == subnav.id))
+        config.draft.map(s => if (s.id == subnav.id) subnav else s)
+      else
+        config.draft :+ subnav
+
+    config.copy(draft = newDraft)
+  }
+
+  /** Promote the draft subnav with the given id into live (replacing any existing
+    * live entry with the same id), and remove it from draft. No-op if the id is
+    * not present in draft.
+    */
+  def publish(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
+    config.draft.find(_.id == id) match {
+      case Some(subnav) =>
+        val newLive =
+          if (config.live.exists(_.id == id))
+            config.live.map(s => if (s.id == id) subnav else s)
+          else
+            config.live :+ subnav
+        config.copy(live = newLive, draft = config.draft.filterNot(_.id == id))
+      case None => config
+    }
+
+  /** Discard unpublished changes for the given id (remove from draft only). */
+  def discard(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
+    config.copy(draft = config.draft.filterNot(_.id == id))
+
+  /** Take a published subnav off production: move the live entry into draft and
+    * remove it from live, so it stops rendering but stays editable. Any existing
+    * draft edits for that id are overwritten by the live copy (the UI warns the
+    * editor that pending draft changes will be undone). No-op if the id is not
+    * currently live.
+    */
+  def unpublish(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
+    config.live.find(_.id == id) match {
+      case Some(liveSubnav) =>
+        val newDraft =
+          if (config.draft.exists(_.id == id))
+            config.draft.map(s => if (s.id == id) liveSubnav else s)
+          else
+            config.draft :+ liveSubnav
+        config.copy(live = config.live.filterNot(_.id == id), draft = newDraft)
+      case None => config
+    }
+
+  /** Remove the subnav entirely, dropping it from both live and draft. */
+  def delete(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
+    config.copy(
+      live = config.live.filterNot(_.id == id),
+      draft = config.draft.filterNot(_.id == id)
+    )
+}
+
+/** Reads and writes the custom subnav config directly from S3 (uncached) so that
+  * read-modify-write edits always see the latest persisted state.
+  */
+class CustomSubnavApi(s3FrontsApi: S3FrontsApi) extends Logging {
+
+  def getConfig(): CustomSubnavConfig =
+    s3FrontsApi.getCustomSubnav
+      .flatMap(raw => Json.parse(raw).asOpt[CustomSubnavConfig])
+      .getOrElse(CustomSubnavConfigFunctions.empty)
+
+  def putConfig(config: CustomSubnavConfig): CustomSubnavConfig = {
+    Try(s3FrontsApi.putCustomSubnav(Json.prettyPrint(Json.toJson(config))))
+    config
+  }
+}

--- a/app/services/CustomSubnavApi.scala
+++ b/app/services/CustomSubnavApi.scala
@@ -8,7 +8,7 @@ import logging.Logging
 
 import scala.util.{Failure, Success, Try}
 
-object CustomSubnavConfigFunctions {
+object CustomSubnavConfigFunctions extends Logging {
   val empty: CustomSubnavConfig = CustomSubnavConfig(live = Nil, draft = Nil)
 
   /** Stamp the audit fields server-side */
@@ -40,9 +40,10 @@ object CustomSubnavConfigFunctions {
     val newDraft =
       if (collapsesIntoLive)
         config.draft.filterNot(_.id == subnav.id)
-      else if (config.draft.exists(_.id == subnav.id))
+      else if (config.draft.exists(_.id == subnav.id)) {
+        logger.info(s"Updating existing draft subnav with id ${subnav.id}")
         config.draft.map(s => if (s.id == subnav.id) subnav else s)
-      else
+      } else
         config.draft :+ subnav
 
     config.copy(draft = newDraft)

--- a/app/services/CustomSubnavApi.scala
+++ b/app/services/CustomSubnavApi.scala
@@ -10,9 +10,9 @@ import scala.util.Try
 
 /** Pure, unit-testable transforms over a [[CustomSubnavConfig]].
   *
-  * The stored document (`{stage}/frontsapi/navigation/custom-subnav.json`) holds
-  * two parallel lists of subnavs:
-  *   - `live`  – what dotcom renders in production
+  * The stored document (`{stage}/frontsapi/navigation/custom-subnav.json`)
+  * holds two parallel lists of subnavs:
+  *   - `live` – what dotcom renders in production
   *   - `draft` – previewable, unpublished changes (an overlay on top of live)
   *
   * The lifecycle mirrors fronts/collections but operates per-subnav (matched by
@@ -22,7 +22,9 @@ import scala.util.Try
 object CustomSubnavConfigFunctions {
   val empty: CustomSubnavConfig = CustomSubnavConfig(live = Nil, draft = Nil)
 
-  /** Stamp the audit fields server-side so we never trust client-supplied values. */
+  /** Stamp the audit fields server-side so we never trust client-supplied
+    * values.
+    */
   def stamp(
       subnav: CustomSubnav,
       identity: User,
@@ -34,7 +36,9 @@ object CustomSubnavConfigFunctions {
       updatedEmail = identity.email
     )
 
-  /** Two subnavs are considered content-equal if they only differ by audit fields. */
+  /** Two subnavs are considered content-equal if they only differ by audit
+    * fields.
+    */
   private def contentEquals(a: CustomSubnav, b: CustomSubnav): Boolean =
     a.copy(
       lastUpdated = b.lastUpdated,
@@ -42,9 +46,9 @@ object CustomSubnavConfigFunctions {
       updatedEmail = b.updatedEmail
     ) == b
 
-  /** Upsert the subnav into the draft list (matched by id, preserving position).
-    * If the draft copy is content-identical to its live counterpart, the change
-    * is a no-op and the entry is dropped from draft instead.
+  /** Upsert the subnav into the draft list (matched by id, preserving
+    * position). If the draft copy is content-identical to its live counterpart,
+    * the change is a no-op and the entry is dropped from draft instead.
     */
   def upsertDraft(
       config: CustomSubnavConfig,
@@ -64,9 +68,9 @@ object CustomSubnavConfigFunctions {
     config.copy(draft = newDraft)
   }
 
-  /** Promote the draft subnav with the given id into live (replacing any existing
-    * live entry with the same id), and remove it from draft. No-op if the id is
-    * not present in draft.
+  /** Promote the draft subnav with the given id into live (replacing any
+    * existing live entry with the same id), and remove it from draft. No-op if
+    * the id is not present in draft.
     */
   def publish(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
     config.draft.find(_.id == id) match {
@@ -85,10 +89,10 @@ object CustomSubnavConfigFunctions {
     config.copy(draft = config.draft.filterNot(_.id == id))
 
   /** Take a published subnav off production: move the live entry into draft and
-    * remove it from live, so it stops rendering but stays editable. Any existing
-    * draft edits for that id are overwritten by the live copy (the UI warns the
-    * editor that pending draft changes will be undone). No-op if the id is not
-    * currently live.
+    * remove it from live, so it stops rendering but stays editable. Any
+    * existing draft edits for that id are overwritten by the live copy (the UI
+    * warns the editor that pending draft changes will be undone). No-op if the
+    * id is not currently live.
     */
   def unpublish(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
     config.live.find(_.id == id) match {
@@ -110,8 +114,8 @@ object CustomSubnavConfigFunctions {
     )
 }
 
-/** Reads and writes the custom subnav config directly from S3 (uncached) so that
-  * read-modify-write edits always see the latest persisted state.
+/** Reads and writes the custom subnav config directly from S3 (uncached) so
+  * that read-modify-write edits always see the latest persisted state.
   */
 class CustomSubnavApi(s3FrontsApi: S3FrontsApi) extends Logging {
 

--- a/app/services/CustomSubnavApi.scala
+++ b/app/services/CustomSubnavApi.scala
@@ -6,25 +6,12 @@ import org.joda.time.DateTime
 import play.api.libs.json.Json
 import logging.Logging
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
-/** Pure, unit-testable transforms over a [[CustomSubnavConfig]].
-  *
-  * The stored document (`{stage}/frontsapi/navigation/custom-subnav.json`)
-  * holds two parallel lists of subnavs:
-  *   - `live` – what dotcom renders in production
-  *   - `draft` – previewable, unpublished changes (an overlay on top of live)
-  *
-  * The lifecycle mirrors fronts/collections but operates per-subnav (matched by
-  * `id`): saving upserts into `draft`, publishing promotes a single draft entry
-  * into `live`, and discarding drops a single entry from `draft`.
-  */
 object CustomSubnavConfigFunctions {
   val empty: CustomSubnavConfig = CustomSubnavConfig(live = Nil, draft = Nil)
 
-  /** Stamp the audit fields server-side so we never trust client-supplied
-    * values.
-    */
+  /** Stamp the audit fields server-side */
   def stamp(
       subnav: CustomSubnav,
       identity: User,
@@ -36,9 +23,6 @@ object CustomSubnavConfigFunctions {
       updatedEmail = identity.email
     )
 
-  /** Two subnavs are considered content-equal if they only differ by audit
-    * fields.
-    */
   private def contentEquals(a: CustomSubnav, b: CustomSubnav): Boolean =
     a.copy(
       lastUpdated = b.lastUpdated,
@@ -46,10 +30,6 @@ object CustomSubnavConfigFunctions {
       updatedEmail = b.updatedEmail
     ) == b
 
-  /** Upsert the subnav into the draft list (matched by id, preserving
-    * position). If the draft copy is content-identical to its live counterpart,
-    * the change is a no-op and the entry is dropped from draft instead.
-    */
   def upsertDraft(
       config: CustomSubnavConfig,
       subnav: CustomSubnav
@@ -68,64 +48,83 @@ object CustomSubnavConfigFunctions {
     config.copy(draft = newDraft)
   }
 
-  /** Promote the draft subnav with the given id into live (replacing any
-    * existing live entry with the same id), and remove it from draft. No-op if
-    * the id is not present in draft.
-    */
-  def publish(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
-    config.draft.find(_.id == id) match {
-      case Some(subnav) =>
-        val newLive =
-          if (config.live.exists(_.id == id))
-            config.live.map(s => if (s.id == id) subnav else s)
-          else
-            config.live :+ subnav
-        config.copy(live = newLive, draft = config.draft.filterNot(_.id == id))
-      case None => config
+  def publish(
+      config: CustomSubnavConfig,
+      id: String
+  ): Option[CustomSubnavConfig] =
+    config.draft.find(_.id == id).map { subnav =>
+      val newLive =
+        if (config.live.exists(_.id == id))
+          config.live.map(s => if (s.id == id) subnav else s)
+        else
+          config.live :+ subnav
+      config.copy(live = newLive, draft = config.draft.filterNot(_.id == id))
     }
 
-  /** Discard unpublished changes for the given id (remove from draft only). */
-  def discard(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
-    config.copy(draft = config.draft.filterNot(_.id == id))
+  def discard(
+      config: CustomSubnavConfig,
+      id: String
+  ): Option[CustomSubnavConfig] =
+    if (config.draft.exists(_.id == id))
+      Some(config.copy(draft = config.draft.filterNot(_.id == id)))
+    else None
 
-  /** Take a published subnav off production: move the live entry into draft and
-    * remove it from live, so it stops rendering but stays editable. Any
-    * existing draft edits for that id are overwritten by the live copy (the UI
-    * warns the editor that pending draft changes will be undone). No-op if the
-    * id is not currently live.
+  /** Drops a published subnav from the live entry into draft. Any existing
+    * draft edits for that id are overwritten by the live copy
     */
-  def unpublish(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
-    config.live.find(_.id == id) match {
-      case Some(liveSubnav) =>
-        val newDraft =
-          if (config.draft.exists(_.id == id))
-            config.draft.map(s => if (s.id == id) liveSubnav else s)
-          else
-            config.draft :+ liveSubnav
-        config.copy(live = config.live.filterNot(_.id == id), draft = newDraft)
-      case None => config
+  def unpublish(
+      config: CustomSubnavConfig,
+      id: String
+  ): Option[CustomSubnavConfig] =
+    config.live.find(_.id == id).map { liveSubnav =>
+      val newDraft =
+        if (config.draft.exists(_.id == id))
+          config.draft.map(s => if (s.id == id) liveSubnav else s)
+        else
+          config.draft :+ liveSubnav
+      config.copy(live = config.live.filterNot(_.id == id), draft = newDraft)
     }
 
-  /** Remove the subnav entirely, dropping it from both live and draft. */
-  def delete(config: CustomSubnavConfig, id: String): CustomSubnavConfig =
-    config.copy(
-      live = config.live.filterNot(_.id == id),
-      draft = config.draft.filterNot(_.id == id)
-    )
+  def delete(
+      config: CustomSubnavConfig,
+      id: String
+  ): Option[CustomSubnavConfig] =
+    if (config.live.exists(_.id == id) || config.draft.exists(_.id == id))
+      Some(
+        config.copy(
+          live = config.live.filterNot(_.id == id),
+          draft = config.draft.filterNot(_.id == id)
+        )
+      )
+    else None
 }
 
-/** Reads and writes the custom subnav config directly from S3 (uncached) so
-  * that read-modify-write edits always see the latest persisted state.
-  */
 class CustomSubnavApi(s3FrontsApi: S3FrontsApi) extends Logging {
 
-  def getConfig(): CustomSubnavConfig =
-    s3FrontsApi.getCustomSubnav
-      .flatMap(raw => Json.parse(raw).asOpt[CustomSubnavConfig])
-      .getOrElse(CustomSubnavConfigFunctions.empty)
+  def getConfig(): Either[String, CustomSubnavConfig] =
+    s3FrontsApi.getCustomSubnav match {
+      case None => Right(CustomSubnavConfigFunctions.empty)
+      case Some(raw) =>
+        Try(Json.parse(raw).as[CustomSubnavConfig]) match {
+          case Success(config) => Right(config)
+          case Failure(e) =>
+            logger.error(
+              "Stored custom subnav config could not be parsed; falling back to empty config",
+              e
+            )
+            Left(
+              "Stored custom subnav config could not be parsed and an empty config is being shown."
+            )
+        }
+    }
 
-  def putConfig(config: CustomSubnavConfig): CustomSubnavConfig = {
-    Try(s3FrontsApi.putCustomSubnav(Json.prettyPrint(Json.toJson(config))))
-    config
+  def putConfig(config: CustomSubnavConfig): Try[CustomSubnavConfig] = {
+    val result =
+      Try(s3FrontsApi.putCustomSubnav(Json.prettyPrint(Json.toJson(config))))
+        .map(_ => config)
+    result.failed.foreach(e =>
+      logger.error("Failed to persist custom subnav config to S3", e)
+    )
+    result
   }
 }

--- a/app/services/S3.scala
+++ b/app/services/S3.scala
@@ -211,6 +211,18 @@ class S3FrontsApi(
     putPrivate(putLocation, json, "application/json", List(cmsFrontsS3Account))
   }
 
+  val customSubnavKey = s"$location/navigation/custom-subnav.json"
+
+  def getCustomSubnav: Option[String] = get(customSubnavKey)
+
+  def putCustomSubnav(json: String): Unit =
+    putPrivate(
+      customSubnavKey,
+      json,
+      "application/json",
+      List(cmsFrontsS3Account)
+    )
+
   def archiveMasterConfig(json: String, identity: User) = {
     val now = DateTime.now
     val putLocation =

--- a/conf/routes
+++ b/conf/routes
@@ -130,8 +130,8 @@ POST        /editions-api/fronts/:frontId/collections/:collectionId/feastCollect
 
 # Custom subnavs
 GET         /custom-subnav                           controllers.CustomSubnavController.getSubnavConfig
-PUT         /custom-subnav                           controllers.CustomSubnavController.upsertSubnav
-POST        /custom-subnav/publish/:id               controllers.CustomSubnavController.publishSubnav(id)
-POST        /custom-subnav/discard/:id               controllers.CustomSubnavController.discardSubnav(id)
-POST        /custom-subnav/unpublish/:id             controllers.CustomSubnavController.unpublishSubnav(id)
+PUT         /custom-subnav/:id                        controllers.CustomSubnavController.upsertSubnav(id)
+POST        /custom-subnav/:id/publish               controllers.CustomSubnavController.publishSubnav(id)
+POST        /custom-subnav/:id/discard               controllers.CustomSubnavController.discardSubnav(id)
+POST        /custom-subnav/:id/unpublish             controllers.CustomSubnavController.unpublishSubnav(id)
 DELETE      /custom-subnav/:id                        controllers.CustomSubnavController.deleteSubnav(id)

--- a/conf/routes
+++ b/conf/routes
@@ -127,3 +127,11 @@ PATCH       /editions-api/collections/:collectionId/update-regions          cont
 GET         /editions-api/collections/:collectionId/prefill                 controllers.EditionsController.getPrefillForCollection(collectionId)
 
 POST        /editions-api/fronts/:frontId/collections/:collectionId/feastCollectionToContainer/:collectionCardId    controllers.EditionsController.feastCollectionToContainer(frontId, collectionId, collectionCardId)
+
+# Custom subnavs
+GET         /custom-subnav                           controllers.CustomSubnavController.getSubnavConfig
+PUT         /custom-subnav                           controllers.CustomSubnavController.upsertSubnav
+POST        /custom-subnav/publish/:id               controllers.CustomSubnavController.publishSubnav(id)
+POST        /custom-subnav/discard/:id               controllers.CustomSubnavController.discardSubnav(id)
+POST        /custom-subnav/unpublish/:id             controllers.CustomSubnavController.unpublishSubnav(id)
+DELETE      /custom-subnav/:id                        controllers.CustomSubnavController.deleteSubnav(id)

--- a/test/services/CustomSubnavConfigFunctionsTest.scala
+++ b/test/services/CustomSubnavConfigFunctionsTest.scala
@@ -1,0 +1,172 @@
+package services
+
+import com.gu.facia.client.models._
+import com.gu.pandomainauth.model.User
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+
+class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
+
+  private val epoch = new DateTime(0)
+
+  private def subnav(
+      id: String,
+      headerText: String = "Header",
+      pages: List[TargetedPage] = Nil
+  ): CustomSubnav =
+    CustomSubnav(
+      id = id,
+      header = CustomSubnavHeader(headerText, None, "Copy"),
+      format = CustomSubnavFormat.Large,
+      links = Nil,
+      pages = pages,
+      images = None,
+      palette = None,
+      lastUpdated = epoch,
+      updatedBy = "Ada Lovelace",
+      updatedEmail = "ada@example.com"
+    )
+
+  import CustomSubnavConfigFunctions._
+
+  private val emptyConfig = CustomSubnavConfigFunctions.empty
+
+  "upsertDraft" - {
+    "adds a brand-new subnav to draft, leaving live untouched" in {
+      val result = upsertDraft(emptyConfig, subnav("abc"))
+      result.draft.map(_.id) should be(List("abc"))
+      result.live should be(emptyConfig.live)
+    }
+
+    "updates an existing draft entry in place (no duplicates, order preserved)" in {
+      val config =
+        CustomSubnavConfig(live = Nil, draft = List(subnav("a"), subnav("b")))
+      val result = upsertDraft(config, subnav("a", headerText = "Changed"))
+      result.draft.map(_.id) should be(List("a", "b"))
+      result.draft.find(_.id == "a").map(_.header.headerText) should be(
+        Some("Changed")
+      )
+    }
+
+    "does not affect other subnavs when editing one" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("xyz")),
+        draft = List(subnav("xyz"))
+      )
+      val result = upsertDraft(config, subnav("abc", headerText = "New"))
+      result.draft.map(_.id).sorted should be(List("abc", "xyz"))
+      result.live.map(_.id) should be(List("xyz"))
+    }
+
+    "collapses the draft entry when it is content-identical to live (ignoring audit fields)" in {
+      val live = subnav("abc", headerText = "Same")
+      val config = CustomSubnavConfig(live = List(live), draft = Nil)
+      // same content but different audit stamp
+      val incoming =
+        live.copy(lastUpdated = DateTime.now, updatedBy = "Someone Else")
+      val result = upsertDraft(config, incoming)
+      result.draft should be(Nil)
+    }
+
+    "keeps the draft entry when it differs in content from live" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("abc", headerText = "Old")),
+        draft = Nil
+      )
+      val result = upsertDraft(config, subnav("abc", headerText = "New"))
+      result.draft.map(_.header.headerText) should be(List("New"))
+    }
+  }
+
+  "publish" - {
+    "promotes a new draft subnav into live and removes it from draft" in {
+      val config =
+        CustomSubnavConfig(live = Nil, draft = List(subnav("abc")))
+      val result = publish(config, "abc")
+      result.live.map(_.id) should be(List("abc"))
+      result.draft should be(Nil)
+    }
+
+    "replaces the matching live entry in place, preserving position" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("a"), subnav("b", headerText = "Old")),
+        draft = List(subnav("b", headerText = "New"))
+      )
+      val result = publish(config, "b")
+      result.live.map(_.id) should be(List("a", "b"))
+      result.live.find(_.id == "b").map(_.header.headerText) should be(
+        Some("New")
+      )
+      result.draft should be(Nil)
+    }
+
+    "is a no-op when the id is not in draft" in {
+      val config = CustomSubnavConfig(live = List(subnav("a")), draft = Nil)
+      publish(config, "missing") should be(config)
+    }
+  }
+
+  "discard" - {
+    "removes only the given id from draft, leaving live and other drafts intact" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("a")),
+        draft = List(subnav("a", headerText = "Edited"), subnav("b"))
+      )
+      val result = discard(config, "a")
+      result.draft.map(_.id) should be(List("b"))
+      result.live.map(_.id) should be(List("a"))
+    }
+  }
+
+  "unpublish" - {
+    "moves a published subnav into draft and removes it from live" in {
+      val config =
+        CustomSubnavConfig(live = List(subnav("abc")), draft = Nil)
+      val result = unpublish(config, "abc")
+      result.live should be(Nil)
+      result.draft.map(_.id) should be(List("abc"))
+    }
+
+    "overwrites any pending draft edits with the live copy (option b)" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("abc", headerText = "Live")),
+        draft = List(subnav("abc", headerText = "Pending edit"))
+      )
+      val result = unpublish(config, "abc")
+      result.live should be(Nil)
+      result.draft.map(_.header.headerText) should be(List("Live"))
+    }
+
+    "does not affect other subnavs" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("abc"), subnav("xyz")),
+        draft = Nil
+      )
+      val result = unpublish(config, "abc")
+      result.live.map(_.id) should be(List("xyz"))
+      result.draft.map(_.id) should be(List("abc"))
+    }
+
+    "is a no-op when the id is not live" in {
+      val config = CustomSubnavConfig(live = Nil, draft = List(subnav("abc")))
+      unpublish(config, "abc") should be(config)
+    }
+  }
+
+  "delete" - {
+    "removes the id from both live and draft" in {
+      val config = CustomSubnavConfig(
+        live = List(subnav("abc"), subnav("xyz")),
+        draft = List(subnav("abc", headerText = "Edited"))
+      )
+      val result = delete(config, "abc")
+      result.live.map(_.id) should be(List("xyz"))
+      result.draft should be(Nil)
+    }
+
+    "is a no-op when the id is absent" in {
+      val config = CustomSubnavConfig(live = List(subnav("a")), draft = Nil)
+      delete(config, "missing") should be(config)
+    }
+  }
+}

--- a/test/services/CustomSubnavConfigFunctionsTest.scala
+++ b/test/services/CustomSubnavConfigFunctionsTest.scala
@@ -3,9 +3,12 @@ package services
 import com.gu.facia.client.models._
 import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
 
-class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
+class CustomSubnavConfigFunctionsTest
+    extends FreeSpec
+    with Matchers
+    with OptionValues {
 
   private val epoch = new DateTime(0)
 
@@ -82,7 +85,7 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
     "promotes a new draft subnav into live and removes it from draft" in {
       val config =
         CustomSubnavConfig(live = Nil, draft = List(subnav("abc")))
-      val result = publish(config, "abc")
+      val result = publish(config, "abc").value
       result.live.map(_.id) should be(List("abc"))
       result.draft should be(Nil)
     }
@@ -92,7 +95,7 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
         live = List(subnav("a"), subnav("b", headerText = "Old")),
         draft = List(subnav("b", headerText = "New"))
       )
-      val result = publish(config, "b")
+      val result = publish(config, "b").value
       result.live.map(_.id) should be(List("a", "b"))
       result.live.find(_.id == "b").map(_.header.headerText) should be(
         Some("New")
@@ -100,9 +103,9 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
       result.draft should be(Nil)
     }
 
-    "is a no-op when the id is not in draft" in {
+    "returns None when the id is not in draft" in {
       val config = CustomSubnavConfig(live = List(subnav("a")), draft = Nil)
-      publish(config, "missing") should be(config)
+      publish(config, "missing") should be(None)
     }
   }
 
@@ -112,9 +115,14 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
         live = List(subnav("a")),
         draft = List(subnav("a", headerText = "Edited"), subnav("b"))
       )
-      val result = discard(config, "a")
+      val result = discard(config, "a").value
       result.draft.map(_.id) should be(List("b"))
       result.live.map(_.id) should be(List("a"))
+    }
+
+    "returns None when the id has no draft entry" in {
+      val config = CustomSubnavConfig(live = List(subnav("a")), draft = Nil)
+      discard(config, "a") should be(None)
     }
   }
 
@@ -122,7 +130,7 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
     "moves a published subnav into draft and removes it from live" in {
       val config =
         CustomSubnavConfig(live = List(subnav("abc")), draft = Nil)
-      val result = unpublish(config, "abc")
+      val result = unpublish(config, "abc").value
       result.live should be(Nil)
       result.draft.map(_.id) should be(List("abc"))
     }
@@ -132,7 +140,7 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
         live = List(subnav("abc", headerText = "Live")),
         draft = List(subnav("abc", headerText = "Pending edit"))
       )
-      val result = unpublish(config, "abc")
+      val result = unpublish(config, "abc").value
       result.live should be(Nil)
       result.draft.map(_.header.headerText) should be(List("Live"))
     }
@@ -142,14 +150,14 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
         live = List(subnav("abc"), subnav("xyz")),
         draft = Nil
       )
-      val result = unpublish(config, "abc")
+      val result = unpublish(config, "abc").value
       result.live.map(_.id) should be(List("xyz"))
       result.draft.map(_.id) should be(List("abc"))
     }
 
-    "is a no-op when the id is not live" in {
+    "returns None when the id is not live" in {
       val config = CustomSubnavConfig(live = Nil, draft = List(subnav("abc")))
-      unpublish(config, "abc") should be(config)
+      unpublish(config, "abc") should be(None)
     }
   }
 
@@ -159,14 +167,14 @@ class CustomSubnavConfigFunctionsTest extends FreeSpec with Matchers {
         live = List(subnav("abc"), subnav("xyz")),
         draft = List(subnav("abc", headerText = "Edited"))
       )
-      val result = delete(config, "abc")
+      val result = delete(config, "abc").value
       result.live.map(_.id) should be(List("xyz"))
       result.draft should be(Nil)
     }
 
-    "is a no-op when the id is absent" in {
+    "returns None when the id is absent" in {
       val config = CustomSubnavConfig(live = List(subnav("a")), draft = Nil)
-      delete(config, "missing") should be(config)
+      delete(config, "missing") should be(None)
     }
   }
 }


### PR DESCRIPTION
Co-written with Claude AI

## What's changed?

Makes use of the latest facia scala client release (with the subnav client) and adds CRUD endpoints for the customsubnav.json file we'll store in S3. 

Per some inline documentation: S3 operations affect a single shared config document holding two parallel lists: `live` (rendered by platforms) and `draft` (unpublished versions edited in the fronts tool).

Routes:
  - `GET /custom-subnav` – return the whole config (`{ live, draft }`).
  - `PUT /custom-subnav/:id` – upsert a single subnav into `draft` (create or update the entry with that id).
  - `POST /custom-subnav/:id/publish` – promote a draft entry into `live`. 
  - `POST /custom-subnav/:id/discard` – drop a draft entry.
  - `POST /custom-subnav/:id/unpublish` – move a live entry back to `draft`.
  - `DELETE /custom-subnav/:id` – remove the id from both lists.

## Testing

Tested with the frontend PRs in the PR stack and successfully managed to create a custom subnav now stored in the code bucket in S3. 

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
