### PR TITLE
Refactor selectParentCollectionOfCard selector

### DIFF
--- a/fronts-client/src/bundles/__tests__/collectionsBundle.spec.ts
+++ b/fronts-client/src/bundles/__tests__/collectionsBundle.spec.ts
@@ -6,25 +6,56 @@ import {
 
 describe('collectionsBundle', () => {
 	describe('selectors', () => {
-		it('should select a parent collection given an cardId, if it exists', () => {
-			expect(
-				selectors.selectParentCollectionOfCard(
-					stateWithCollection,
-					'95e2bfc0-8999-4e6e-a359-19960967c1e0',
-				),
-			).toBe('exampleCollection');
-			expect(
-				selectors.selectParentCollectionOfCard(
-					stateWithCollectionAndSupporting,
-					'4c21ff2c-e2c5-4bac-ae14-24beb3f8d8b5',
-				),
-			).toBe('exampleCollection');
-			expect(
-				selectors.selectParentCollectionOfCard(
-					stateWithCollection,
-					'invalidId',
-				),
-			).toBe(null);
+		describe('selectParentCollectionOfCard', () => {
+			it('should select a parent collection given a cardId, if it exists', () => {
+				expect(
+					selectors.selectParentCollectionOfCard(
+						stateWithCollection,
+						'95e2bfc0-8999-4e6e-a359-19960967c1e0',
+					),
+				).toBe('exampleCollection');
+			});
+
+			it('should select a parent collection for a supporting cardId', () => {
+				expect(
+					selectors.selectParentCollectionOfCard(
+						stateWithCollectionAndSupporting,
+						'4c21ff2c-e2c5-4bac-ae14-24beb3f8d8b5',
+					),
+				).toBe('exampleCollection');
+			});
+
+			it('should return null when the cardId does not belong to any collection', () => {
+				expect(
+					selectors.selectParentCollectionOfCard(
+						stateWithCollection,
+						'invalidId',
+					),
+				).toBe(null);
+			});
+		});
+
+		describe('selectCardToCollectionMap', () => {
+			it('should map every card in a collection to its collection id, across stages', () => {
+				expect(
+					selectors.selectCardToCollectionMap(stateWithCollection),
+				).toEqual({
+					'95e2bfc0-8999-4e6e-a359-19960967c1e0': 'exampleCollection',
+					'4bc11359-bb3e-45e7-a0a9-86c0ee52653d': 'exampleCollection',
+					'12e1d70d-bad5-4c8d-b53c-cf38d01bc11d': 'exampleCollection',
+				});
+			});
+
+			it('should include supporting cards in the map', () => {
+				expect(
+					selectors.selectCardToCollectionMap(stateWithCollectionAndSupporting),
+				).toEqual({
+					'1269c42e-a341-4464-b206-a5731b92fa46': 'exampleCollection',
+					'322f0527-cf14-43c1-8520-e6732ab01297': 'exampleCollection',
+					'134c9d4f-b05c-43f4-be41-a605b6dccab9': 'exampleCollection',
+					'4c21ff2c-e2c5-4bac-ae14-24beb3f8d8b5': 'exampleCollection',
+				});
+			});
 		});
 	});
 });

--- a/fronts-client/src/bundles/collectionsBundle.ts
+++ b/fronts-client/src/bundles/collectionsBundle.ts
@@ -43,8 +43,6 @@ const getGroupIdsForCollection = (
  * and cards slices so the full tree is only traversed when one of them changes,
  * rather than on every `selectParentCollectionOfCard` call.
  *
- * A card can appear in more than one collection; we keep the first match to
- * preserve the previous selector's behaviour.
  */
 const selectCardToCollectionMap = createSelector(
 	(state: State) => state.collections.data,

--- a/fronts-client/src/bundles/collectionsBundle.ts
+++ b/fronts-client/src/bundles/collectionsBundle.ts
@@ -7,48 +7,71 @@ import { Collection } from 'types/Collection';
 import { State } from 'types/State';
 import { addPersistMetaToAction } from '../util/action';
 import set from 'lodash/fp/set';
+import { createSelector } from 'reselect';
 
 const collectionsEntityName = 'collections';
 
 const { actions, actionNames, reducer, selectors, initialState } =
 	createIndexedAsyncResourceBundle<Collection>(collectionsEntityName, {});
 
+const stages = ['live', 'draft', 'previously'] as const;
+
+/**
+ * All card ids that a group contributes: the group's own cards, plus any
+ * supporting cards nested under them.
+ */
+const getCardIdsForGroup = (
+	groupId: string,
+	groups: State['groups'],
+	cards: State['cards'],
+): string[] => {
+	const cardIds = groups[groupId]?.cards || [];
+	const supportingIds = cardIds.flatMap(
+		(cardId) => cards[cardId]?.meta?.supporting || [],
+	);
+	return [...cardIds, ...supportingIds];
+};
+
+/** All group ids belonging to a collection, across every stage. */
+const getGroupIdsForCollection = (
+	collection: State['collections']['data'][string],
+): string[] => stages.flatMap((stage) => collection[stage] || []);
+
+/**
+ * Build a reverse lookup of card id (including supporting card ids) to the id of
+ * the collection that contains it. This is memoised on the collections, groups
+ * and cards slices so the full tree is only traversed when one of them changes,
+ * rather than on every `selectParentCollectionOfCard` call.
+ *
+ * A card can appear in more than one collection; we keep the first match to
+ * preserve the previous selector's behaviour.
+ */
+const selectCardToCollectionMap = createSelector(
+	(state: State) => state.collections.data,
+	(state: State) => state.groups,
+	(state: State) => state.cards,
+	(collectionsData, groups, cards): Record<string, string> => {
+		const map: Record<string, string> = {};
+		for (const collectionId of Object.keys(collectionsData)) {
+			const groupIds = getGroupIdsForCollection(collectionsData[collectionId]);
+			const cardIds = groupIds.flatMap((groupId) =>
+				getCardIdsForGroup(groupId, groups, cards),
+			);
+			for (const cardId of cardIds) {
+				if (!(cardId in map)) {
+					map[cardId] = collectionId;
+				}
+			}
+		}
+		return map;
+	},
+);
+
 const collectionSelectors = {
 	...selectors,
-	selectParentCollectionOfCard: (
-		state: State,
-		cardId: string,
-	): string | null => {
-		const stages = ['live', 'draft', 'previously'] as const;
-		let collectionId: null | string = null;
-		Object.keys(state.collections.data).some((id) =>
-			stages.some((stage) => {
-				const groups = state.collections.data[id][stage] || [];
-
-				return groups.some((gId: string) => {
-					const cards = state.groups[gId].cards || [];
-					if (cards.indexOf(cardId) !== -1) {
-						collectionId = id;
-						return true;
-					}
-
-					return cards.some((afId: string) => {
-						if (
-							state.cards[afId] &&
-							state.cards[afId].meta &&
-							state.cards[afId].meta.supporting &&
-							state.cards[afId].meta.supporting!.indexOf(cardId) !== -1
-						) {
-							collectionId = id;
-							return true;
-						}
-						return false;
-					});
-				});
-			}),
-		);
-		return collectionId;
-	},
+	selectCardToCollectionMap,
+	selectParentCollectionOfCard: (state: State, cardId: string): string | null =>
+		selectCardToCollectionMap(state)[cardId] ?? null,
 };
 
 const SET_HIDDEN = 'SET_HIDDEN' as 'SET_HIDDEN';


### PR DESCRIPTION
## What's changed?
This PR memoises `selectParentCollectionOfCard` with a reverse index.

Previously, `selectParentCollectionOfCard` traversed the entire collections/groups/cards tree on every call. Since Reselect invokes input selectors whenever a selector is called, this traversal ran each time `selectFrontsWithCollection` was evaluated, as well as once per card in the `storeMiddleware` batch loop. This meant repeatedly scanning the entire tree, once for every card being processed.

This change introduces `selectCardToCollectionMap`, a memoised selector that builds a cardId -> collectionId lookup, including supporting cards. The map is rebuilt only when the collections, groups, or cards slices change.

`selectParentCollectionOfCard` can now find a card’s parent collection with a single map lookup., avoiding repeated full-tree scans and allowing downstream selector memoisation to be effective.

The existing first-match-wins behaviour is preserved, so the returned collection IDs remain unchanged. Optional-chaining guards have also been added when accessing groups and supporting cards, preventing a latent runtime error caused by dangling group IDs.

## Implementation notes
Initial pass of this refactor was done by Copilot 🤖 and then refined by me 👋

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
