### PR TITLE
Don't set `startDate` and `expiryDate` if test has been manually ended

### DIFF
--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -165,9 +165,12 @@ object FaciaApi {
 
   private def addTestDatesToTrail(trail: Trail, now: DateTime): Trail = {
     val updatedTests = trail.tests.map(_.map { test =>
-      val startDate = test.startDate.orElse(Some(now.getMillis))
-      val expiryDate = test.expiryDate.orElse(Some(now.plusDays(1).getMillis))
-      test.copy(startDate = startDate, expiryDate = expiryDate)
+      if (test.hasManuallyEndedOnThisTrail) test
+      else {
+        val startDate = test.startDate.orElse(Some(now.getMillis))
+        val expiryDate = test.expiryDate.orElse(Some(now.plusDays(1).getMillis))
+        test.copy(startDate = startDate, expiryDate = expiryDate)
+      }
     })
     trail.copy(tests = updatedTests)
   }

--- a/test/tools/FaciaApiTest.scala
+++ b/test/tools/FaciaApiTest.scala
@@ -1,6 +1,6 @@
 package tools
 
-import com.gu.facia.client.models.{CollectionJson, Trail}
+import com.gu.facia.client.models.{CollectionJson, Test, Trail}
 import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
@@ -60,6 +60,111 @@ class FaciaApiTest extends FreeSpec with Matchers {
       } should have(Symbol("length")(1))
     }
 
+  }
+
+  "set AB test start/expiry dates on publish" - {
+
+    def testFor(id: String, collectionJson: CollectionJson): Test =
+      collectionJson.live
+        .find(_.id == id)
+        .flatMap(_.tests)
+        .flatMap(_.headOption)
+        .getOrElse(fail(s"expected a test on trail <$id>"))
+
+    "sets dates on an active (not manually ended) test that has none" in {
+      val (identity, collectionJson) = scenarioWithTests
+      val newCollectionJson =
+        FaciaApi.preparePublishCollectionJson(identity)(collectionJson).get
+
+      val test = testFor("activeTestId", newCollectionJson)
+      test.startDate should be(Symbol("defined"))
+      test.expiryDate should be(Symbol("defined"))
+    }
+
+    "does NOT set dates on a manually ended test" in {
+      val (identity, collectionJson) = scenarioWithTests
+      val newCollectionJson =
+        FaciaApi.preparePublishCollectionJson(identity)(collectionJson).get
+
+      val test = testFor("endedTestId", newCollectionJson)
+      test.startDate should be(None)
+      test.expiryDate should be(None)
+    }
+
+    "does not overwrite existing dates on an active test" in {
+      val (identity, collectionJson) = scenarioWithTests
+      val newCollectionJson =
+        FaciaApi.preparePublishCollectionJson(identity)(collectionJson).get
+
+      val test = testFor("existingDatesTestId", newCollectionJson)
+      test.startDate should be(Some(1000L))
+      test.expiryDate should be(Some(2000L))
+    }
+  }
+
+  private def makeTest(
+      hasManuallyEndedOnThisTrail: Boolean,
+      startDate: Option[Long] = None,
+      expiryDate: Option[Long] = None
+  ): Test = Test(
+    testUuid = "uuid",
+    variantMeta = Nil,
+    startDate = startDate,
+    expiryDate = expiryDate,
+    createdByName = "Test Author",
+    createdByEmail = "author@email.com",
+    frontsThisTestCanRunOn = Nil,
+    hasManuallyEndedOnThisTrail = hasManuallyEndedOnThisTrail,
+    manuallyEndedOnThisTrailByName = None,
+    manuallyEndedOnThisTrailByEmail = None
+  )
+
+  private def scenarioWithTests: (User, CollectionJson) = {
+    val identity = User("John", "Duffell", "email@email.com", None)
+    val draft = List(
+      Trail(
+        "activeTestId",
+        0,
+        Some(""),
+        None,
+        Some(List(makeTest(hasManuallyEndedOnThisTrail = false)))
+      ),
+      Trail(
+        "endedTestId",
+        0,
+        Some(""),
+        None,
+        Some(List(makeTest(hasManuallyEndedOnThisTrail = true)))
+      ),
+      Trail(
+        "existingDatesTestId",
+        0,
+        Some(""),
+        None,
+        Some(
+          List(
+            makeTest(
+              hasManuallyEndedOnThisTrail = false,
+              startDate = Some(1000L),
+              expiryDate = Some(2000L)
+            )
+          )
+        )
+      )
+    )
+    val collectionJson = CollectionJson(
+      Nil,
+      Some(draft),
+      None,
+      new DateTime(0),
+      "oldUpdatedBy",
+      "oldUpdatedEmail",
+      None,
+      None,
+      None,
+      None
+    )
+    (identity, collectionJson)
   }
 
   private def scenarioOneLiveAnotherDraft: (User, CollectionJson) = {


### PR DESCRIPTION
## What's changed?

When a container is published, `addTestDatesToTrail` sets `startDate`/`expiryDate` for every AB test that didn't include them, including tests that had been manually ended. This gave stopped tests a live-looking date window which is probably harmless but confusing.

This PR fixes that bug and adds a test.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
