### PR TITLE
Test toggle re-enable logic

### DIFF
--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -443,5 +443,49 @@ describe('CardForm transform functions', () => {
 				{ id: 'B', meta: { headline: undefined } },
 			]);
 		});
+
+		it('should create a new test with a different UUID when the toggle is re-enabled after a test was manually ended', () => {
+			const existingTest = {
+				testUuid: 'old-test-uuid',
+				variantMeta: [
+					{ id: 'A' as const, meta: { headline: 'Old A' } },
+					{ id: 'B' as const, meta: { headline: 'Old B' } },
+				],
+				createdByName: 'Someone',
+				createdByEmail: 'someone@example.com',
+				hasManuallyEndedOnThisTrail: true,
+			};
+			const stateWithTest = {
+				...initialState,
+				cards: {
+					...initialState.cards,
+					exampleId: {
+						...initialState.cards.exampleId,
+						tests: [existingTest],
+					},
+				},
+			};
+			const values = {
+				abTestEnabled: true,
+				headlineA: 'Headline variant A',
+				headlineB: 'Headline variant B',
+			};
+			const state = createStateWithChangedFormFields(
+				stateWithTest,
+				'exampleId',
+				values,
+			);
+			const test = getCardTestFromFormValues(state, 'exampleId', {
+				...formValues,
+				...values,
+			});
+			expect(test.testUuid).toBeDefined();
+			expect(test.testUuid).not.toEqual('old-test-uuid');
+			expect(test.hasManuallyEndedOnThisTrail).toBe(false);
+			expect(test.variantMeta).toEqual([
+				{ id: 'A', meta: { headline: 'Headline variant A' } },
+				{ id: 'B', meta: { headline: 'Headline variant B' } },
+			]);
+		});
 	});
 });

--- a/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
+++ b/fronts-client/src/components/FrontsEdit/__tests__/CardForm.spec.ts
@@ -479,10 +479,10 @@ describe('CardForm transform functions', () => {
 				...formValues,
 				...values,
 			});
-			expect(test.testUuid).toBeDefined();
-			expect(test.testUuid).not.toEqual('old-test-uuid');
-			expect(test.hasManuallyEndedOnThisTrail).toBe(false);
-			expect(test.variantMeta).toEqual([
+			expect(test?.testUuid).toBeDefined();
+			expect(test?.testUuid).not.toEqual('old-test-uuid');
+			expect(test?.hasManuallyEndedOnThisTrail).toBe(false);
+			expect(test?.variantMeta).toEqual([
 				{ id: 'A', meta: { headline: 'Headline variant A' } },
 				{ id: 'B', meta: { headline: 'Headline variant B' } },
 			]);


### PR DESCRIPTION
## What's changed?

Improves test coverage to ensure that when the headline test toggle is re-enabled after a test has ended, `getCardTestFromFormValues` should create a new test with a unique `testUuid`.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
