### PR TITLE
Clean up Headline A field behaviour

### DIFF
--- a/fronts-client/src/selectors/__tests__/shared.spec.ts
+++ b/fronts-client/src/selectors/__tests__/shared.spec.ts
@@ -387,7 +387,7 @@ describe('Shared selectors', () => {
 				publishedBy: 'A. N. Author',
 				uuid: 'af1',
 				headline: 'card-headline',
-				headlineA: 'card-headline',
+				headlineA: undefined,
 				headlineB: undefined,
 				thumbnail: undefined,
 				trailText: 'card-trailText',

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -157,7 +157,14 @@ const createSelectArticleFromCard = () =>
 				...omit(card, 'meta'),
 				...articleMeta,
 				headline: headlineField,
-				// TODO: this is currently broken because the test doesn't exist when you first hit the toggle
+				/**
+				 * Tests (and headline variant fields) are only persisted to the card
+				 * once the card is saved.
+				 *
+				 * So, even though headlineA is set on the form level when the AB test
+				 * switch is toggled on, it won't persist to the card level until the
+				 * card is saved. This is expected behaviour.
+				 **/
 				headlineA: activeOrDraftTest ? headlineFieldVariantA : undefined,
 				headlineB: activeOrDraftTest ? headlineFieldVariantB : undefined,
 				abTestEnabled: !!activeOrDraftTest,

--- a/fronts-client/src/selectors/shared.ts
+++ b/fronts-client/src/selectors/shared.ts
@@ -157,11 +157,8 @@ const createSelectArticleFromCard = () =>
 				...omit(card, 'meta'),
 				...articleMeta,
 				headline: headlineField,
-				// if headlineA is not present, populate it with the headline field
 				// TODO: this is currently broken because the test doesn't exist when you first hit the toggle
-				headlineA: activeOrDraftTest
-					? headlineFieldVariantA || headlineField
-					: undefined,
+				headlineA: activeOrDraftTest ? headlineFieldVariantA : undefined,
 				headlineB: activeOrDraftTest ? headlineFieldVariantB : undefined,
 				abTestEnabled: !!activeOrDraftTest,
 				trailText:


### PR DESCRIPTION
## What's changed?
Addresses a TODO and removes the old fallback behaviour now the headlineA field is explicitly seeded by handleAbTestToggle:

```
const handleAbTestToggle: EventWithDataHandler<React.ChangeEvent<any>> = (
			_event: unknown,
			abTestEnabled?: boolean,
		) => {
			// set variant A with the card's current headline when the test is enabled
			if (abTestEnabled) {
				change('headlineA', headline);
			}
		};
```