### PR TITLE
Bump to latest pan-domain-auth-client for grace period

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -13,7 +13,6 @@ import scala.jdk.CollectionConverters._
 import scala.language.reflectiveCalls
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest
 import com.amazonaws.services.rds.AmazonRDSClientBuilder
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest
 import software.amazon.awssdk.auth.credentials.{
@@ -21,6 +20,8 @@ import software.amazon.awssdk.auth.credentials.{
   AwsCredentialsProviderChain => NewAwsCredentialsProviderChain,
   ProfileCredentialsProvider => NewProfileCredentialsProvider
 }
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
 
 import java.nio.charset.StandardCharsets
 
@@ -192,10 +193,10 @@ class ApplicationConfiguration(
       .withCredentials(cmsFrontsAccountCredentials)
       .withRegion(region)
       .build()
-    lazy val s3Client = AmazonS3ClientBuilder
-      .standard()
-      .withCredentials(cmsFrontsAccountCredentials)
-      .withRegion(region)
+    lazy val s3Client = S3Client
+      .builder()
+      .region(Region.of(region))
+      .credentialsProvider(newStyleCmsFrontsAccountCredentials)
       .build()
   }
 

--- a/app/controllers/BaseFaciaController.scala
+++ b/app/controllers/BaseFaciaController.scala
@@ -36,7 +36,7 @@ abstract class BaseFaciaControllerComponents(context: Context)
     PanDomainAuthSettingsRefresher(
       domain = config.pandomain.domain,
       system = config.pandomain.service,
-      S3BucketLoader.forAwsSdkV1(
+      S3BucketLoader.forAwsSdkV2(
         config.aws.s3Client,
         "pan-domain-auth-settings"
       )

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
   "com.gu" %% "fapi-client-play30" % "37.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
-  "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "21.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),
   "com.github.blemale" %% "scaffeine" % "4.1.0" % "compile",
   "com.gu" %% "thrift-serializer" % "4.0.2",


### PR DESCRIPTION
## What's changed?

Bump to latest pan-domain-auth-client to benefit from a relatively recent default grace period of 24 hours for API requests where the Google re-auth flow isn't available

## Implementation notes

This version no longer supports v1 of the AWS S3 Client, so this changes the client supplied

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
