### PR TITLE
End AB test when a card is moved to a front it can't run on

### DIFF
--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -31,7 +31,13 @@ import { PosSpec } from 'lib/dnd';
 import { removeClipboardCard } from './Clipboard';
 import { thunkInsertClipboardCard } from './ClipboardThunks';
 import { capGroupSiblings } from 'actions/Groups';
-import { selectCollectionCap } from 'selectors/configSelectors';
+import {
+	selectCollectionCap,
+	selectUserFullName,
+	selectUserEmail,
+} from 'selectors/configSelectors';
+import { selectFrontIdsWithCollectionId } from 'selectors/frontsSelectors';
+import { findActiveOrDraftTest } from 'util/abTests';
 import { getImageMetaFromValidationResponse } from 'util/form';
 import { ValidationResponse } from 'util/validateImageSrc';
 import { MappableDropType } from 'util/collectionUtils';
@@ -377,6 +383,68 @@ export const mayResetVideoReplace = ({
 	}
 };
 
+/**
+ * AB tests are designed to run only on the front(s) they were created on
+ * (recorded in `frontsThisTestCanRunOn`). When a card carrying a running test
+ * is moved to a different front, we end the test on that trail by setting
+ * `hasManuallyEndedOnThisTrail` to true.
+ *
+ * The following movements keep a test running (and therefore return no actions):
+ * - moving a card around within a front it can run on
+ * - moving a card to the clipboard, then re-adding it to a front it can run on
+ *
+ * Moving a card to the clipboard (and leaving it there) requires no action -
+ * its absence from the front is enough to imply the test is no longer running.
+ */
+export const mayEndAbTest = ({
+	to,
+	card,
+	persistTo,
+	state,
+}: UpdateCardParams) => {
+	// We only end tests when a card lands on a front (via a collection).
+	// Moves to the clipboard should not end tests, as the card may be re-added.
+	if (persistTo !== 'collection' || to.type === 'clipboard') {
+		return;
+	}
+
+	const runningTest = findActiveOrDraftTest(card);
+	if (!runningTest) {
+		return;
+	}
+
+	const allowedFrontIds = runningTest.frontsThisTestCanRunOn ?? [];
+	// If we don't know which fronts the test is allowed to run on, we can't
+	// tell whether this is a different front, so leave the test untouched.
+	if (allowedFrontIds.length === 0) {
+		return;
+	}
+
+	// The fronts that host the collection the card is being moved into.
+	const destinationFrontIds = selectFrontIdsWithCollectionId(
+		state,
+		to.collectionId,
+	);
+	const isMovingToAllowedFront = destinationFrontIds.some((frontId) =>
+		allowedFrontIds.includes(frontId),
+	);
+	if (isMovingToAllowedFront) {
+		return;
+	}
+
+	return updateCard(
+		card.uuid,
+		{},
+		{ merge: true },
+		{
+			...runningTest,
+			hasManuallyEndedOnThisTrail: true,
+			manuallyEndedOnThisTrailByName: selectUserFullName(state),
+			manuallyEndedOnThisTrailByEmail: selectUserEmail(state) || '',
+		},
+	);
+};
+
 const insertCardWithCreate =
 	(
 		to: PosSpec,
@@ -528,6 +596,7 @@ const moveCard = (
 					mayResetImageReplace(actionParams),
 					mayResetImmersive(actionParams),
 					mayResetVideoReplace(actionParams),
+					mayEndAbTest(actionParams),
 				];
 
 				modifyCardActions.forEach((action) => {

--- a/fronts-client/src/components/FrontsEdit/__tests__/mayEndAbTests.spec.tsx
+++ b/fronts-client/src/components/FrontsEdit/__tests__/mayEndAbTests.spec.tsx
@@ -1,0 +1,157 @@
+import type { Card, Test } from 'types/Collection';
+
+import { mayEndAbTest } from '../../../actions/Cards';
+import { baseTo, baseFrom } from './fixtures/groups.fixture';
+
+const FUTURE = Date.now() + 100_000;
+const PAST = Date.now() - 100_000;
+
+const UK_COLLECTION = 'collection-uk';
+const US_COLLECTION = 'collection-us';
+
+const makeTest = (overrides: Partial<Test> = {}): Test => ({
+	testUuid: 'test-1',
+	variantMeta: [],
+	createdByName: 'Jane Doe',
+	createdByEmail: 'jane.doe@guardian.co.uk',
+	expiryDate: FUTURE,
+	frontsThisTestCanRunOn: ['uk'],
+	hasManuallyEndedOnThisTrail: false,
+	...overrides,
+});
+
+const makeCard = (...tests: Test[]): Card => ({
+	id: 'internal-code/page/15334368',
+	frontPublicationDate: 1741879217277,
+	meta: {},
+	uuid: 'card-1',
+	tests: tests.length ? tests : undefined,
+});
+
+// The test was created on the `uk` front, which hosts UK_COLLECTION.
+const state: any = {
+	fronts: {
+		frontsConfig: {
+			data: {
+				fronts: {
+					uk: { id: 'uk', collections: [UK_COLLECTION] },
+					us: { id: 'us', collections: [US_COLLECTION] },
+				},
+				collections: {},
+			},
+		},
+	},
+	config: {
+		firstName: 'John',
+		lastName: 'Smith',
+		email: 'john.smith@guardian.co.uk',
+	},
+};
+
+const toUkFront = { ...baseTo, collectionId: UK_COLLECTION };
+const toUsFront = { ...baseTo, collectionId: US_COLLECTION };
+
+describe('mayEndAbTest', () => {
+	it('ends a running test when a card is moved to a different front', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsFront,
+			card: makeCard(makeTest()),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result?.payload.id).toBe('card-1');
+		expect(result?.payload.test?.hasManuallyEndedOnThisTrail).toBe(true);
+		expect(result?.payload.test?.manuallyEndedOnThisTrailByName).toBe(
+			'John Smith',
+		);
+		expect(result?.payload.test?.manuallyEndedOnThisTrailByEmail).toBe(
+			'john.smith@guardian.co.uk',
+		);
+	});
+
+	it('keeps the test running when a card is moved around its own front', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUkFront,
+			card: makeCard(makeTest()),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('does not end a test when a card is moved to the clipboard', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: { ...baseTo, type: 'clipboard', collectionId: undefined },
+			card: makeCard(makeTest()),
+			persistTo: 'clipboard',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns no actions when the card has no tests', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsFront,
+			card: makeCard(),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('ignores tests that have already been ended on this trail', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsFront,
+			card: makeCard(makeTest({ hasManuallyEndedOnThisTrail: true })),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('ignores expired tests', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsFront,
+			card: makeCard(makeTest({ expiryDate: PAST })),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('leaves the test untouched when we cannot tell which fronts it is allowed to run on', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsFront,
+			card: makeCard(makeTest({ frontsThisTestCanRunOn: undefined })),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('ends a draft test (no expiry date yet) when moved to a different front', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsFront,
+			card: makeCard(makeTest({ expiryDate: undefined })),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result?.payload.test?.hasManuallyEndedOnThisTrail).toBe(true);
+	});
+});

--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -120,6 +120,12 @@ const getFrontsWithCollection = (
 	return frontsWithCollection.map((front) => front.id);
 };
 
+const selectFrontIdsWithCollectionId = (
+	state: State,
+	collectionId: string | undefined,
+): string[] =>
+	getFrontsWithCollection(collectionId ?? null, selectFrontsAsArray(state));
+
 const getCollections = (state: State): CollectionConfigMap =>
 	frontsConfigSelectors.selectAll(state).collections || {};
 
@@ -356,4 +362,5 @@ export {
 	selectUnlockedFrontCollections,
 	createSelectArticleVisibilityDetails,
 	selectFrontsWithCollection,
+	selectFrontIdsWithCollectionId,
 };

--- a/fronts-client/src/selectors/frontsSelectors.ts
+++ b/fronts-client/src/selectors/frontsSelectors.ts
@@ -108,7 +108,7 @@ const selectFrontsWithPriority = (
 	getFrontsByPriority(state)[priority] || defaultFrontsWithPriority;
 
 const getFrontsWithCollection = (
-	parentCollectionOfCard: string | null,
+	parentCollectionOfCard: string | null | undefined,
 	fronts: FrontConfig[],
 ): string[] => {
 	if (!parentCollectionOfCard) return [];
@@ -124,7 +124,7 @@ const selectFrontIdsWithCollectionId = (
 	state: State,
 	collectionId: string | undefined,
 ): string[] =>
-	getFrontsWithCollection(collectionId ?? null, selectFrontsAsArray(state));
+	getFrontsWithCollection(collectionId, selectFrontsAsArray(state));
 
 const getCollections = (state: State): CollectionConfigMap =>
 	frontsConfigSelectors.selectAll(state).collections || {};


### PR DESCRIPTION
## What's changed?

AB tests are configured to run only on the front(s) they were created on (recorded in `frontsThisTestCanRunOn`). Previously, moving a card containing a running test to a different front left the test running there. This PR adds a `mayEndAbTest` action that ends the test on that trail (setting `hasManuallyEndedOnThisTrail = true` and the acting user's name/email) whenever a card lands on a front whose ID isn't in `frontsThisTestCanRunOn`.

`mayEndAbTest` is run alongside the other `mayReset*` card-modification actions in `moveCard`. A new `selectFrontIdsWithCollectionId` selector resolves the destination collection to its host front IDs so we can compare against the test's allowed fronts.

Behaviour covered:

🟢 Moving a card to another front (e.g. US → UK) ends the test.
🟢 Moving a card around within its own front keeps it running.
🟢 Moving a card to the clipboard and re-adding it to an allowed front keeps it running (the clipboard move itself is a no-op).
🟢 Moving a card to the clipboard and not re-adding it ends it (its absence from the front implies the test no longer runs).

Tests with no `frontsThisTestCanRunOn`, already-ended tests, and expired tests are left untouched.

https://github.com/user-attachments/assets/a25b2e04-7cb7-426c-804c-2d21e04efef8

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
