### PR TITLE
Add error handling for headline tests

### DIFF
--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -48,7 +48,11 @@ import type { State } from 'types/State';
 import { cardSets, noOfOpenCollectionsOnFirstLoad } from 'constants/fronts';
 import { Stages, Collection, CardSets, Card } from 'types/Collection';
 import difference from 'lodash/difference';
-import { selectCardsInCollections } from 'selectors/collection';
+import {
+	selectCardsInCollections,
+	createSelectActiveAbTestHeadlineErrorsForCollection,
+} from 'selectors/collection';
+import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import {
 	editorOpenCollections,
 	editorCloseCollections,
@@ -518,6 +522,9 @@ function initialiseCollectionsForFront(
 	};
 }
 
+const selectActiveAbTestHeadlineErrorsForCollection =
+	createSelectActiveAbTestHeadlineErrorsForCollection();
+
 function publishCollection(
 	collectionId: string,
 	frontId: string,
@@ -525,6 +532,19 @@ function publishCollection(
 	events.collectionPublished(frontId, collectionId);
 
 	return (dispatch: Dispatch, getState: () => State) => {
+		const state = getState();
+
+		// Safety net: never publish a collection whose active headline A/B test
+		// has invalid variant headlines. The Launch button is also disabled in
+		// this case, but guard here in case that is bypassed.
+		if (
+			selectFeatureValue(state, 'headline-ab-testing') &&
+			selectActiveAbTestHeadlineErrorsForCollection(state, { collectionId })
+				.length > 0
+		) {
+			return Promise.resolve();
+		}
+
 		return publishCollectionApi(collectionId)
 			.then(() => {
 				const batchedActions = [

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import type { State } from 'types/State';
+import FlatUl from 'components/layout/FlatUl';
+import {
+	AbTestHeadlineError,
+	createSelectActiveAbTestHeadlineErrorsForCollection,
+} from 'selectors/collection';
+import { createCardId } from '../../card/Card';
+import styled from 'styled-components';
+
+interface ContainerProps {
+	collectionId: string;
+}
+
+interface ComponentProps extends ContainerProps {
+	abTestHeadlineErrors: AbTestHeadlineError[];
+}
+
+const ErrorLi = styled.li`
+	& + & {
+		margin-top: 10px;
+	}
+`;
+
+const errorMessage = (error: AbTestHeadlineError['error']): string =>
+	error === 'duplicate'
+		? 'headline variants A and B are the same'
+		: 'headline variants A and B must both be set';
+
+const AbTestHeadlineWarning = ({ abTestHeadlineErrors }: ComponentProps) => (
+	<div>
+		<strong>
+			This collection cannot be launched because of an active headline test:
+		</strong>
+		<FlatUl>
+			{abTestHeadlineErrors.map(({ cardId, title, error }) => (
+				<ErrorLi key={cardId}>
+					<a
+						href={`#${cardId}`}
+						onClick={() => {
+							const id = createCardId(cardId);
+							const element = document.getElementById(id);
+							if (element) {
+								element.scrollIntoView({
+									behavior: 'smooth',
+									inline: 'start',
+									block: 'end',
+								});
+							}
+						}}
+					>
+						{title || 'No title'}
+					</a>
+					{`: ${errorMessage(error)}`}
+				</ErrorLi>
+			))}
+		</FlatUl>
+	</div>
+);
+
+const mapStateToProps = () => {
+	const selectActiveAbTestHeadlineErrorsForCollection =
+		createSelectActiveAbTestHeadlineErrorsForCollection();
+	return (state: State, { collectionId }: ContainerProps) => ({
+		abTestHeadlineErrors: selectActiveAbTestHeadlineErrorsForCollection(state, {
+			collectionId,
+		}),
+	});
+};
+
+export default connect(mapStateToProps)(AbTestHeadlineWarning);

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
@@ -31,7 +31,8 @@ const errorMessage = (error: AbTestHeadlineError['error']): string =>
 const AbTestHeadlineWarning = ({ abTestHeadlineErrors }: ComponentProps) => (
 	<div>
 		<strong>
-			This collection cannot be launched because of an active headline test:
+			This collection cannot be launched because of an incomplete active
+			headline test:
 		</strong>
 		<FlatUl>
 			{abTestHeadlineErrors.map(({ cardId, title, error }) => (

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -309,11 +309,12 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											<OpenFormsWarning collectionId={id} frontId={frontId} />
 										</OpenFormsWarningContainer>
 									)}
-									{hasAbTestHeadlineErrors && (
-										<OpenFormsWarningContainer>
-											<AbTestHeadlineWarning collectionId={id} />
-										</OpenFormsWarningContainer>
-									)}
+									{hasAbTestHeadlineErrors &&
+										this.state.showOpenFormsWarning && (
+											<OpenFormsWarningContainer>
+												<AbTestHeadlineWarning collectionId={id} />
+											</OpenFormsWarningContainer>
+										)}
 									<EditModeVisibility visibleMode="fronts">
 										<Button
 											size="l"

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -43,6 +43,9 @@ import EditModeVisibility from 'components/util/EditModeVisibility';
 import { fetchPrefill } from 'bundles/capiFeedBundle';
 import LoadingGif from 'images/icons/loading.gif';
 import OpenFormsWarning from './OpenFormsWarning';
+import AbTestHeadlineWarning from './AbTestHeadlineWarning';
+import { createSelectActiveAbTestHeadlineErrorsForCollection } from 'selectors/collection';
+import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import { selectors as editionsIssueSelectors } from '../../../bundles/editionsIssueBundle';
 import { moveFrontCollection } from '../../../actions/Editions';
 
@@ -77,6 +80,7 @@ type CollectionProps = CollectionPropsBeforeState & {
 	isCollectionLocked: boolean;
 	isOpen: boolean;
 	hasOpenForms: boolean;
+	hasAbTestHeadlineErrors: boolean;
 	hasContent: boolean;
 	hasMultipleFrontsOpen: boolean;
 	onChangeOpenState: (id: string, isOpen: boolean) => void;
@@ -220,6 +224,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 			targetedRegions,
 			hasContent,
 			hasOpenForms,
+			hasAbTestHeadlineErrors,
 			isFeast,
 		} = this.props;
 
@@ -304,6 +309,11 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											<OpenFormsWarning collectionId={id} frontId={frontId} />
 										</OpenFormsWarningContainer>
 									)}
+									{hasAbTestHeadlineErrors && (
+										<OpenFormsWarningContainer>
+											<AbTestHeadlineWarning collectionId={id} />
+										</OpenFormsWarningContainer>
+									)}
 									<EditModeVisibility visibleMode="fronts">
 										<Button
 											size="l"
@@ -319,7 +329,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											priority="primary"
 											onClick={() => this.startPublish(id, frontId)}
 											tabIndex={-1}
-											disabled={isLaunching}
+											disabled={isLaunching || hasAbTestHeadlineErrors}
 											data-testid="collection-launch-button"
 										>
 											{isLaunching ? (
@@ -391,6 +401,8 @@ const createMapStateToProps = () => {
 	const selectEditWarning = createSelectCollectionEditWarning();
 	const selectPreviously = createSelectPreviouslyLiveArticlesInCollection();
 	const selectHasOpenForms = createSelectDoesCollectionHaveOpenForms();
+	const selectActiveAbTestHeadlineErrorsForCollection =
+		createSelectActiveAbTestHeadlineErrorsForCollection();
 	return (
 		state: State,
 		{
@@ -434,6 +446,10 @@ const createMapStateToProps = () => {
 		hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
 		hasContent: !!selectors.selectById(state, collectionId),
 		hasOpenForms: selectHasOpenForms(state, { collectionId, frontId }),
+		hasAbTestHeadlineErrors:
+			selectFeatureValue(state, 'headline-ab-testing') &&
+			selectActiveAbTestHeadlineErrorsForCollection(state, { collectionId })
+				.length > 0,
 		isFeast: editionsIssueSelectors.selectAll(state)?.platform === 'feast',
 	});
 };

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -132,18 +132,46 @@ const ClipboardFirstPublished = styled.div`
 	right: 0;
 `;
 
-const ABTestStatus = styled.div<{ useSecondaryTheme?: boolean }>`
-	background-color: ${({ useSecondaryTheme }) =>
-		useSecondaryTheme
-			? theme.base.colors.abTestSecondaryColor
-			: theme.base.colors.abTestActiveColor};
+type ABTestTheme = 'active' | 'secondary' | 'error';
+type ABTestPalette = {
+	background: string;
+	foreground: string;
+	border: string;
+};
+
+const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette => {
+	switch (abTestTheme) {
+		case 'error':
+			return {
+				background: theme.base.colors.abTestErrorBackgroundColor,
+				foreground: theme.base.colors.abTestErrorColor,
+				border: theme.base.colors.abTestErrorColor,
+			};
+		case 'secondary':
+			return {
+				background: theme.base.colors.abTestSecondaryColor,
+				foreground: theme.base.colors.abTestActiveColor,
+				border: theme.base.colors.abTestActiveColor,
+			};
+		case 'active':
+		default:
+			return {
+				background: theme.base.colors.abTestActiveColor,
+				foreground: 'white',
+				border: 'transparent',
+			};
+	}
+};
+
+const ABTestStatus = styled.div<{ abTestTheme: ABTestTheme }>`
+	background-color: ${({ abTestTheme }) =>
+		getABTestThemeColors(abTestTheme).background};
 	border-radius: 12px;
-	color: ${({ useSecondaryTheme }) =>
-		useSecondaryTheme ? theme.base.colors.abTestActiveColor : 'white'};
+	color: ${({ abTestTheme }) => getABTestThemeColors(abTestTheme).foreground};
 	border-width: 1px;
 	border-style: solid;
-	border-color: ${({ useSecondaryTheme }) =>
-		useSecondaryTheme ? theme.base.colors.abTestActiveColor : 'transparent'};
+	border-color: ${({ abTestTheme }) =>
+		getABTestThemeColors(abTestTheme).border};
 	font-weight: 700;
 	font-size: 12px;
 	padding: 4px 8px;
@@ -155,8 +183,8 @@ const ABTestStatus = styled.div<{ useSecondaryTheme?: boolean }>`
 	align-items: center;
 `;
 
-const EllipsisIconWrapper = styled.div`
-	border: 1px solid ${theme.base.colors.abTestActiveColor};
+const EllipsisIconWrapper = styled.div<{ color: string }>`
+	border: 1px solid ${({ color }) => color};
 	border-radius: 50%;
 	display: flex;
 	justify-content: center;
@@ -317,22 +345,45 @@ const articleBodyDefault = React.memo(
 			| 'Test set up incomplete'
 			| 'Ready to launch';
 
-		const determineABTestStatusMessage = (
+		type ABTestTheme = 'active' | 'secondary' | 'error';
+
+		type ABTestStatus = {
+			message: ABStatusMessage;
+			theme: ABTestTheme;
+			palette: ABTestPalette;
+		};
+		const determineABTestStatus = (
 			hasLiveAbTest: boolean | undefined,
 			abTestEnabled: boolean | undefined,
 			headlineTestError: AbTestHeadlineErrorType | null,
-		): ABStatusMessage | undefined => {
+		): ABTestStatus | undefined => {
 			if (hasLiveAbTest && abTestEnabled) {
-				return 'Test in progress';
+				return {
+					message: 'Test in progress',
+					theme: 'active',
+					palette: getABTestThemeColors('active'),
+				};
 			}
 			if (hasLiveAbTest && !abTestEnabled) {
-				return 'End test on launch';
+				return {
+					message: 'End test on launch',
+					theme: 'secondary',
+					palette: getABTestThemeColors('secondary'),
+				};
 			}
 			if (!hasLiveAbTest && abTestEnabled && headlineTestError) {
-				return 'Test set up incomplete';
+				return {
+					message: 'Test set up incomplete',
+					theme: 'error',
+					palette: getABTestThemeColors('error'),
+				};
 			}
 			if (!hasLiveAbTest && abTestEnabled && !headlineTestError) {
-				return 'Ready to launch';
+				return {
+					message: 'Ready to launch',
+					theme: 'secondary',
+					palette: getABTestThemeColors('secondary'),
+				};
 			}
 			return undefined;
 		};
@@ -373,13 +424,11 @@ const articleBodyDefault = React.memo(
 			setMainVideoPlatform(properties.platform);
 		}, [mainMediaVideoAtom, showMainVideo]);
 
-		const abTestStatusMessage = determineABTestStatusMessage(
+		const abTestStatus = determineABTestStatus(
 			hasLiveAbTest,
 			abTestEnabled,
 			headlineTestError,
 		);
-
-		const useSecondaryTheme = abTestStatusMessage !== 'Test in progress';
 
 		return (
 			<>
@@ -507,21 +556,17 @@ const articleBodyDefault = React.memo(
 						)}
 						{displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
 					</CardHeadingContainer>
-					{abTestStatusMessage && headlineABTestingIsEnabled && (
-						<ABTestStatus useSecondaryTheme={useSecondaryTheme}>
+					{abTestStatus && headlineABTestingIsEnabled && (
+						<ABTestStatus abTestTheme={abTestStatus.theme}>
 							<ConicalFlaskIcon
 								size={'xs'}
-								fill={
-									useSecondaryTheme
-										? theme.base.colors.abTestActiveColor
-										: 'white'
-								}
+								fill={abTestStatus.palette.foreground}
 							/>
-							{abTestStatusMessage}
-							{useSecondaryTheme && (
-								<EllipsisIconWrapper>
+							{abTestStatus.message}
+							{abTestStatus.theme === 'secondary' && (
+								<EllipsisIconWrapper color={abTestStatus.palette.foreground}>
 									<EllipsisIcon
-										fill={theme.base.colors.abTestActiveColor}
+										fill={abTestStatus.palette.foreground}
 										size={'xxs'}
 									/>
 								</EllipsisIconWrapper>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -59,6 +59,7 @@ import {
 	IntendedAudienceSignifier,
 	IntendedAudienceSignifierProps,
 } from '@guardian/stand/IntendedAudienceSignifier';
+import { AbTestHeadlineErrorType } from '../../../util/abTests';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
 	flex-shrink: 0;
@@ -226,6 +227,7 @@ interface ArticleBodyProps {
 	abTestEnabled?: boolean;
 	hasLiveAbTest?: boolean;
 	headlineABTestingIsEnabled?: boolean;
+	headlineTestError: AbTestHeadlineErrorType | null;
 }
 
 const articleBodyDefault = React.memo(
@@ -286,6 +288,7 @@ const articleBodyDefault = React.memo(
 		abTestEnabled,
 		hasLiveAbTest,
 		headlineABTestingIsEnabled,
+		headlineTestError,
 	}: ArticleBodyProps) => {
 		const displayByline = size === 'default' && showByline && byline;
 		const now = Date.now();
@@ -311,11 +314,13 @@ const articleBodyDefault = React.memo(
 		type ABStatusMessage =
 			| 'Test in progress'
 			| 'End test on launch'
+			| 'Test set up incomplete'
 			| 'Ready to launch';
 
 		const determineABTestStatusMessage = (
 			hasLiveAbTest: boolean | undefined,
 			abTestEnabled: boolean | undefined,
+			headlineTestError: AbTestHeadlineErrorType | null,
 		): ABStatusMessage | undefined => {
 			if (hasLiveAbTest && abTestEnabled) {
 				return 'Test in progress';
@@ -323,7 +328,10 @@ const articleBodyDefault = React.memo(
 			if (hasLiveAbTest && !abTestEnabled) {
 				return 'End test on launch';
 			}
-			if (!hasLiveAbTest && abTestEnabled) {
+			if (!hasLiveAbTest && abTestEnabled && headlineTestError) {
+				return 'Test set up incomplete';
+			}
+			if (!hasLiveAbTest && abTestEnabled && !headlineTestError) {
 				return 'Ready to launch';
 			}
 			return undefined;
@@ -368,6 +376,7 @@ const articleBodyDefault = React.memo(
 		const abTestStatusMessage = determineABTestStatusMessage(
 			hasLiveAbTest,
 			abTestEnabled,
+			headlineTestError,
 		);
 
 		const useSecondaryTheme = abTestStatusMessage !== 'Test in progress';

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -563,7 +563,7 @@ const articleBodyDefault = React.memo(
 								fill={abTestStatus.palette.foreground}
 							/>
 							{abTestStatus.message}
-							{abTestStatus.theme === 'secondary' && (
+							{abTestStatus.theme !== 'active' && (
 								<EllipsisIconWrapper color={abTestStatus.palette.foreground}>
 									<EllipsisIcon
 										fill={abTestStatus.palette.foreground}

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -33,6 +33,7 @@ import {
 	CinemagraphIcon,
 	ConicalFlaskIcon,
 	EllipsisIcon,
+	ExclamationIcon,
 	LoopIcon,
 	VideoIcon,
 	YoutubeIcon,
@@ -135,30 +136,34 @@ const ClipboardFirstPublished = styled.div`
 type ABTestTheme = 'active' | 'secondary' | 'error';
 type ABTestPalette = {
 	background: string;
-	foreground: string;
+	text: string;
 	border: string;
+	icon: string;
 };
 
 const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette => {
 	switch (abTestTheme) {
 		case 'error':
 			return {
-				background: theme.base.colors.abTestErrorBackgroundColor,
-				foreground: theme.base.colors.abTestErrorColor,
-				border: theme.base.colors.abTestErrorColor,
+				background: theme.abTest.errorPrimaryColor,
+				text: theme.abTest.errorTextColor,
+				border: theme.abTest.errorAccentColor,
+				icon: theme.abTest.errorAccentColor,
 			};
 		case 'secondary':
 			return {
-				background: theme.base.colors.abTestSecondaryColor,
-				foreground: theme.base.colors.abTestActiveColor,
-				border: theme.base.colors.abTestActiveColor,
+				background: theme.abTest.secondaryPrimaryColor,
+				text: theme.abTest.secondaryAccentColor,
+				border: theme.abTest.secondaryAccentColor,
+				icon: theme.abTest.secondaryAccentColor,
 			};
 		case 'active':
 		default:
 			return {
-				background: theme.base.colors.abTestActiveColor,
-				foreground: 'white',
-				border: 'transparent',
+				background: theme.abTest.activePrimaryColor,
+				text: theme.abTest.activeAccentColor,
+				border: theme.abTest.activeBorderColor,
+				icon: theme.abTest.activeAccentColor,
 			};
 	}
 };
@@ -167,7 +172,7 @@ const ABTestStatus = styled.div<{ abTestTheme: ABTestTheme }>`
 	background-color: ${({ abTestTheme }) =>
 		getABTestThemeColors(abTestTheme).background};
 	border-radius: 12px;
-	color: ${({ abTestTheme }) => getABTestThemeColors(abTestTheme).foreground};
+	color: ${({ abTestTheme }) => getABTestThemeColors(abTestTheme).text};
 	border-width: 1px;
 	border-style: solid;
 	border-color: ${({ abTestTheme }) =>
@@ -558,17 +563,19 @@ const articleBodyDefault = React.memo(
 					</CardHeadingContainer>
 					{abTestStatus && headlineABTestingIsEnabled && (
 						<ABTestStatus abTestTheme={abTestStatus.theme}>
-							<ConicalFlaskIcon
-								size={'xs'}
-								fill={abTestStatus.palette.foreground}
-							/>
+							{abTestStatus.theme === 'error' ? (
+								<ExclamationIcon fill={abTestStatus.palette.icon} size={'s'} />
+							) : (
+								<ConicalFlaskIcon
+									size={'xs'}
+									fill={abTestStatus.palette.icon}
+								/>
+							)}
+
 							{abTestStatus.message}
 							{abTestStatus.theme !== 'active' && (
-								<EllipsisIconWrapper color={abTestStatus.palette.foreground}>
-									<EllipsisIcon
-										fill={abTestStatus.palette.foreground}
-										size={'xxs'}
-									/>
+								<EllipsisIconWrapper color={abTestStatus.palette.icon}>
+									<EllipsisIcon fill={abTestStatus.palette.icon} size={'xxs'} />
 								</EllipsisIconWrapper>
 							)}
 						</ABTestStatus>

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -27,7 +27,11 @@ import { dragEventHasImageData } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
 import { getMainMediaVideoAtom } from '../../../util/externalArticle';
 import { intendedAudienceFromTags } from 'lib/capi/IntendedAudience';
-import { hasActiveAbTestOnCard } from '../../../util/abTests';
+import {
+	AbTestHeadlineErrorType,
+	getCurrentAbTestHeadlineError,
+	hasActiveAbTestOnCard,
+} from '../../../util/abTests';
 
 const ArticleBodyContainer = styled(CardBody)<{
 	pillarId: string | undefined;
@@ -71,6 +75,7 @@ interface ArticleComponentProps {
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
 	hasLiveAbTest?: boolean;
 	headlineABTestingIsEnabled?: boolean;
+	headlineTestError: AbTestHeadlineErrorType | null;
 }
 
 interface ComponentProps extends ArticleComponentProps {
@@ -124,6 +129,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 			otherCollectionsOnSameFrontThisCardIsOn,
 			hasLiveAbTest,
 			headlineABTestingIsEnabled,
+			headlineTestError,
 		} = this.props;
 
 		const getArticleData = () =>
@@ -199,6 +205,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 								}
 								hasLiveAbTest={hasLiveAbTest}
 								headlineABTestingIsEnabled={headlineABTestingIsEnabled}
+								headlineTestError={headlineTestError}
 							/>
 						</ArticleBodyContainer>
 					</DragIntentContainer>
@@ -222,6 +229,7 @@ const createMapStateToProps = () => {
 		featureFlagPageViewData: boolean;
 		hasLiveAbTest?: boolean;
 		headlineABTestingIsEnabled: boolean;
+		headlineTestError: AbTestHeadlineErrorType | null;
 	} => {
 		const article = selectArticle(state, props.id);
 		const card = selectCard(state, props.id);
@@ -232,6 +240,7 @@ const createMapStateToProps = () => {
 			props.collectionId,
 		);
 		const hasLiveAbTest = hasActiveAbTestOnCard(liveCard);
+		const headlineTestError = getCurrentAbTestHeadlineError(card);
 
 		return {
 			article,
@@ -245,6 +254,7 @@ const createMapStateToProps = () => {
 				state,
 				'headline-ab-testing',
 			),
+			headlineTestError: headlineTestError,
 		};
 	};
 };

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -559,6 +559,27 @@ const EllipsisIcon = ({
 	</svg>
 );
 
+// (!)
+const ExclamationIcon = ({
+	fill = theme.colors.blackDark,
+	size = 's',
+}: IconProps) => (
+	<svg
+		width={`${mapSize(size)}px`}
+		height={`${mapSize(size)}px`}
+		viewBox="0 0 11 11"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+			d="M5.5 0C8.53757 0 11 2.46243 11 5.5C11 8.53757 8.53757 11 5.5 11C2.46243 11 0 8.53757 0 5.5C0 2.46243 2.46243 0 5.5 0ZM4.78906 7.53906V8.99902H6.31934V7.53906H4.78906ZM4.68945 1.78906L4.92969 6.45898H6.15918L6.39941 1.78906H4.68945Z"
+			fill={fill}
+		/>
+	</svg>
+);
+
 export {
 	DownCaretIcon,
 	RubbishBinIcon,
@@ -587,4 +608,5 @@ export {
 	CinemagraphIcon,
 	ConicalFlaskIcon,
 	EllipsisIcon,
+	ExclamationIcon,
 };

--- a/fronts-client/src/components/inputs/CreateResizeableTextInput.tsx
+++ b/fronts-client/src/components/inputs/CreateResizeableTextInput.tsx
@@ -98,6 +98,7 @@ const createResizeableTextInput = (
 				input,
 				originalValue,
 				labelContent: LabelContent,
+				meta,
 				...rest
 			} = this.props;
 			return (
@@ -111,6 +112,7 @@ const createResizeableTextInput = (
 								</RewindButton>
 							)}
 							{LabelContent}
+							{meta?.warning && <span className="warning">{meta.warning}</span>}
 						</TextInputLabel>
 					)}
 					<InputComponentContainer>

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -7,6 +7,8 @@ import InputCheckboxToggleInline from './InputCheckboxToggleInline';
 import ConditionalField from './ConditionalField';
 import styled from 'styled-components';
 import pageConfig from '../../util/extractConfigFromPage';
+import { WarningIcon } from '../icons/Icons';
+import { theme } from '../../constants/theme';
 
 interface HeadlineInputProps {
 	abTestEnabled: boolean;
@@ -38,6 +40,38 @@ const HeadlineVariantContainer = styled('div')`
 	flex-direction: column;
 	gap: 6px;
 `;
+
+const HeadlineWarning = styled('span')`
+	margin-left: 8px;
+	font-size: 12px;
+	color: ${theme.base.colors.dangerColor};
+	display: flex;
+	align-items: center;
+	gap: 4px;
+`;
+
+const emptyHeadlineWarning = (value: string | undefined) => {
+	const isEmpty = (value ?? '').trim() === '';
+	return isEmpty ? (
+		<HeadlineWarning>
+			<WarningIcon fill={theme.base.colors.dangerColor} size={'s'} /> Add a
+			headline or turn the test off to save this container
+		</HeadlineWarning>
+	) : undefined;
+};
+
+const duplicateHeadlineWarning = (
+	value: string | undefined,
+	allValues: any,
+) => {
+	const isDuplicate = value && value.trim() === allValues.headlineA.trim();
+	return isDuplicate ? (
+		<HeadlineWarning>
+			<WarningIcon fill={theme.base.colors.dangerColor} size={'s'} /> Headline
+			is a duplicate, please change a headline
+		</HeadlineWarning>
+	) : undefined;
+};
 
 const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 	/**
@@ -91,6 +125,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						component={InputTextArea}
 						data-testid="edit-form-headline-a-field"
 						placeholder={props.capiHeadline}
+						warn={emptyHeadlineWarning}
 					/>
 					<ConditionalField
 						permittedFields={props.editableFields}
@@ -99,6 +134,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						rows="2"
 						component={InputTextArea}
 						data-testid="edit-form-headline-b-field"
+						warn={[emptyHeadlineWarning, duplicateHeadlineWarning]}
 					/>
 				</HeadlineVariantContainer>
 			) : (

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -14,6 +14,7 @@ const colors = {
 	blackDark: '#121212', // darkest
 	blackLight: '#333',
 	blue: '#3B82F6',
+	blueDark: '#1B67E2',
 	blueGrey: '#EEF2F6',
 	greyDark: '#444444',
 	greyMediumDark: '#515151',
@@ -72,10 +73,11 @@ const base = {
 		placeholderDark: colors.greyLight,
 		focusColor: colors.orange,
 		dangerColor: colors.red,
-		abTestActiveColor: colors.blue,
+		abTestActiveColor: colors.blueDark,
 		abTestSecondaryColor: colors.blueGrey,
 		abTestErrorColor: colors.orange,
 		abTestErrorBackgroundColor: colors.white,
+		abTestErrorForegroundColor: colors.blackDark,
 	},
 };
 

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -74,6 +74,8 @@ const base = {
 		dangerColor: colors.red,
 		abTestActiveColor: colors.blue,
 		abTestSecondaryColor: colors.blueGrey,
+		abTestErrorColor: colors.orange,
+		abTestErrorBackgroundColor: colors.white,
 	},
 };
 
@@ -136,6 +138,8 @@ const input = {
 	checkboxButtonBackgroundDisabled: '#E6E6E6',
 	abTestActiveColor: base.colors.abTestActiveColor,
 	abTestSecondaryColor: base.colors.abTestSecondaryColor,
+	abTestErrorColor: base.colors.abTestErrorColor,
+	abTestErrorBackgroundColor: base.colors.abTestErrorBackgroundColor,
 };
 
 const collection = {

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -73,11 +73,6 @@ const base = {
 		placeholderDark: colors.greyLight,
 		focusColor: colors.orange,
 		dangerColor: colors.red,
-		abTestActiveColor: colors.blueDark,
-		abTestSecondaryColor: colors.blueGrey,
-		abTestErrorColor: colors.orange,
-		abTestErrorBackgroundColor: colors.white,
-		abTestErrorForegroundColor: colors.blackDark,
 	},
 };
 
@@ -120,6 +115,17 @@ const button = {
 	backgroundColorHighlightFocused: base.colors.highlightColorFocused,
 };
 
+const abTest = {
+	activePrimaryColor: colors.blueDark,
+	activeAccentColor: colors.white,
+	activeBorderColor: 'transparent',
+	secondaryPrimaryColor: colors.blueGrey,
+	secondaryAccentColor: colors.blueDark,
+	errorPrimaryColor: colors.white,
+	errorTextColor: colors.blackDark,
+	errorAccentColor: colors.orange,
+};
+
 const input = {
 	height: '30px',
 	paddingY: '3px',
@@ -138,10 +144,8 @@ const input = {
 	placeholderText: base.colors.placeholderDark,
 	radioButtonBackgroundDisabled: '#E6E6E6',
 	checkboxButtonBackgroundDisabled: '#E6E6E6',
-	abTestActiveColor: base.colors.abTestActiveColor,
-	abTestSecondaryColor: base.colors.abTestSecondaryColor,
-	abTestErrorColor: base.colors.abTestErrorColor,
-	abTestErrorBackgroundColor: base.colors.abTestErrorBackgroundColor,
+	abTestActiveColor: abTest.activePrimaryColor,
+	abTestSecondaryColor: abTest.secondaryPrimaryColor,
 };
 
 const collection = {
@@ -193,6 +197,7 @@ export const theme = {
 	thumbnailImage,
 	thumbnailImageSquare,
 	thumbnailImagePortrait,
+	abTest,
 };
 
 export type Theme = typeof theme;

--- a/fronts-client/src/selectors/__tests__/collection.spec.ts
+++ b/fronts-client/src/selectors/__tests__/collection.spec.ts
@@ -1,8 +1,40 @@
 import {
 	selectCardsInCollections,
 	createSelectIsArticleInCollection,
+	createSelectActiveAbTestHeadlineErrorsForCollection,
 } from '../collection';
 import { stateWithCollection } from '../../fixtures/shared';
+import { Test } from '../../types/Collection';
+
+const FUTURE = Date.now() + 100_000;
+
+const makeActiveTest = (
+	headlineA: string | undefined,
+	headlineB: string | undefined,
+): Test => ({
+	testUuid: 'test-1',
+	expiryDate: FUTURE,
+	hasManuallyEndedOnThisTrail: false,
+	createdByName: 'Jane Doe',
+	createdByEmail: 'jane.doe@guardian.co.uk',
+	variantMeta: [
+		{ id: 'A', meta: { headline: headlineA } },
+		{ id: 'B', meta: { headline: headlineB } },
+	],
+});
+
+const DRAFT_CARD_A = '4bc11359-bb3e-45e7-a0a9-86c0ee52653d';
+const DRAFT_CARD_B = '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d';
+
+const stateWithTests = (
+	tests: Record<string, Test | undefined>,
+): typeof stateWithCollection => {
+	const state = JSON.parse(JSON.stringify(stateWithCollection));
+	Object.entries(tests).forEach(([cardId, test]) => {
+		state.cards[cardId].tests = test ? [test] : undefined;
+	});
+	return state;
+};
 
 describe('Collection selectors', () => {
 	describe('selectCardsInCollections', () => {
@@ -54,6 +86,54 @@ describe('Collection selectors', () => {
 					cardId: 'not-a-thing',
 				}),
 			).toEqual(false);
+		});
+	});
+	describe('createSelectActiveAbTestHeadlineErrorsForCollection', () => {
+		const selectErrors = createSelectActiveAbTestHeadlineErrorsForCollection();
+
+		it('returns no errors when no draft card has an invalid active test', () => {
+			expect(
+				selectErrors(stateWithCollection, {
+					collectionId: 'exampleCollectionTwo',
+				}),
+			).toEqual([]);
+		});
+
+		it('flags a draft card whose active test has duplicate headlines', () => {
+			const state = stateWithTests({
+				[DRAFT_CARD_A]: makeActiveTest('Same', 'Same'),
+			});
+			expect(
+				selectErrors(state, { collectionId: 'exampleCollectionTwo' }),
+			).toEqual([
+				expect.objectContaining({
+					cardId: DRAFT_CARD_A,
+					error: 'duplicate',
+				}),
+			]);
+		});
+
+		it('flags a draft card whose active test has incomplete headlines', () => {
+			const state = stateWithTests({
+				[DRAFT_CARD_B]: makeActiveTest('Headline A', undefined),
+			});
+			expect(
+				selectErrors(state, { collectionId: 'exampleCollectionTwo' }),
+			).toEqual([
+				expect.objectContaining({
+					cardId: DRAFT_CARD_B,
+					error: 'incomplete',
+				}),
+			]);
+		});
+
+		it('does not flag a draft card with a valid active test', () => {
+			const state = stateWithTests({
+				[DRAFT_CARD_A]: makeActiveTest('Headline A', 'Headline B'),
+			});
+			expect(
+				selectErrors(state, { collectionId: 'exampleCollectionTwo' }),
+			).toEqual([]);
 		});
 	});
 });

--- a/fronts-client/src/selectors/collection.ts
+++ b/fronts-client/src/selectors/collection.ts
@@ -9,7 +9,7 @@ import { selectCard } from '../selectors/shared';
 import { frontStages } from 'constants/fronts';
 import {
 	AbTestHeadlineErrorType,
-	getActiveAbTestHeadlineError,
+	getCurrentAbTestHeadlineError,
 } from 'util/abTests';
 
 const selectCardsInCollection = createSelectCardsInCollection();
@@ -69,7 +69,7 @@ export const createSelectActiveAbTestHeadlineErrorsForCollection = () => {
 			if (!card) {
 				return errors;
 			}
-			const error = getActiveAbTestHeadlineError(card);
+			const error = getCurrentAbTestHeadlineError(card);
 			if (!error) {
 				return errors;
 			}

--- a/fronts-client/src/selectors/collection.ts
+++ b/fronts-client/src/selectors/collection.ts
@@ -1,8 +1,16 @@
 import type { State } from 'types/State';
 import { Card, CardSets } from 'types/Collection';
-import { createSelectCardsInCollection } from './shared';
+import {
+	createSelectArticleFromCard,
+	createSelectCardsInCollection,
+} from './shared';
 import { createSelector } from 'reselect';
 import { selectCard } from '../selectors/shared';
+import { frontStages } from 'constants/fronts';
+import {
+	AbTestHeadlineErrorType,
+	getActiveAbTestHeadlineError,
+} from 'util/abTests';
 
 const selectCardsInCollection = createSelectCardsInCollection();
 
@@ -31,4 +39,47 @@ export const createSelectIsArticleInCollection = () => {
 		(_: State, { cardId: articleId }: { cardId: string }) => articleId,
 		(articleIds, articleId) => articleIds.indexOf(articleId) !== -1,
 	);
+};
+
+export interface AbTestHeadlineError {
+	cardId: string;
+	title: string | undefined;
+	error: AbTestHeadlineErrorType;
+}
+
+/**
+ * Return the offending card and the reason for each card in the
+ * collection's draft set that has an active headline A/B test
+ * with invalid variant headlines.
+ * An empty array means the collection can be launched.
+ */
+export const createSelectActiveAbTestHeadlineErrorsForCollection = () => {
+	const selectDraftCardIds = createSelectCardsInCollection();
+	const selectArticleFromCard = createSelectArticleFromCard();
+	return (
+		state: State,
+		{ collectionId }: { collectionId: string },
+	): AbTestHeadlineError[] => {
+		const cardIds = selectDraftCardIds(state, {
+			collectionId,
+			collectionSet: frontStages.draft,
+		});
+		return cardIds.reduce<AbTestHeadlineError[]>((errors, cardId) => {
+			const card = selectCard(state, cardId);
+			if (!card) {
+				return errors;
+			}
+			const error = getActiveAbTestHeadlineError(card);
+			if (!error) {
+				return errors;
+			}
+			const derivedArticle = selectArticleFromCard(state, cardId);
+			errors.push({
+				cardId,
+				title: derivedArticle?.headline || derivedArticle?.customKicker,
+				error,
+			});
+			return errors;
+		}, []);
+	};
 };

--- a/fronts-client/src/util/abTests.spec.ts
+++ b/fronts-client/src/util/abTests.spec.ts
@@ -1,5 +1,9 @@
 import { Card, Test } from '../types/Collection';
-import { hasActiveAbTestOnCard, findActiveOrDraftTest } from './abTests';
+import {
+	hasActiveAbTestOnCard,
+	findActiveOrDraftTest,
+	getCurrentAbTestHeadlineError,
+} from './abTests';
 
 const makeCard = (tests?: Test[]): Card =>
 	({ uuid: 'card-1', id: 'id-1', meta: {}, tests }) as Card;
@@ -12,6 +16,14 @@ const makeTest = (test: Partial<Test> = {}): Test => ({
 	hasManuallyEndedOnThisTrail: false,
 	...test,
 });
+
+const makeVariantMeta = (
+	headlineA: string | undefined,
+	headlineB: string | undefined,
+): Test['variantMeta'] => [
+	{ id: 'A', meta: { headline: headlineA } },
+	{ id: 'B', meta: { headline: headlineB } },
+];
 
 const FUTURE = Date.now() + 100_000;
 const PAST = Date.now() - 100_000;
@@ -74,6 +86,92 @@ describe('abTests utils', () => {
 				makeTest({ expiryDate: FUTURE, hasManuallyEndedOnThisTrail: true }),
 			]);
 			expect(findActiveOrDraftTest(card)).toBeUndefined();
+		});
+	});
+
+	describe('getActiveAbTestHeadlineError', () => {
+		it('returns null when the card has no active test', () => {
+			expect(getCurrentAbTestHeadlineError(makeCard())).toBeNull();
+		});
+
+		it('returns null for a draft (non-active) test with invalid headlines', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: undefined,
+					variantMeta: makeVariantMeta('same', 'same'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBeNull();
+		});
+
+		it('returns "duplicate" when both variant headlines are the same', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Same headline', 'Same headline'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('duplicate');
+		});
+
+		it('returns "incomplete" when variant A headline is missing', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta(undefined, 'Headline B'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns "incomplete" when variant B headline is empty', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Headline A', ''),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns "incomplete" when a variant headline is whitespace-only', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Headline A', '   '),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns "duplicate" when variant headlines differ only by surrounding whitespace', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Same ', ' Same'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('duplicate');
+		});
+
+		it('returns "incomplete" when both variant headlines are missing', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta(undefined, undefined),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns null when variant headlines are distinct and populated', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Headline A', 'Headline B'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBeNull();
 		});
 	});
 });

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -14,11 +14,41 @@ export const hasActiveAbTestOnCard = (card: Card | undefined) =>
 export const findActiveOrDraftTest = (card: Card) =>
 	card.tests?.find((test) => isActiveTest(test) || isDraftTest(test));
 
+export type AbTestHeadlineErrorType = 'duplicate' | 'incomplete';
+
+/**
+ * Validates the active headline A/B test (if any) on a card. Returns:
+ *  - 'incomplete' when either variant headline is missing/empty
+ *  - 'duplicate' when both variant headlines are identical
+ *  - null when there is no active test or the test is valid
+ */
+export const getActiveAbTestHeadlineError = (
+	card: Card,
+): AbTestHeadlineErrorType | null => {
+	const activeTest = card.tests?.find(isActiveTest);
+	if (!activeTest) {
+		return null;
+	}
+
+	const headlineA = getVariantHeadline(activeTest, 'A');
+	const headlineB = getVariantHeadline(activeTest, 'B');
+
+	if (!headlineA || !headlineB) {
+		return 'incomplete';
+	}
+
+	if (headlineA === headlineB) {
+		return 'duplicate';
+	}
+
+	return null;
+};
+
 // we can extend this in future to 'getVariantField'
 export const getVariantHeadline = (
 	test: Test | undefined,
 	variantId: VariantId,
-) => {
+): string | undefined => {
 	return test?.variantMeta.find((variant) => variant.id === variantId)?.meta
 		.headline;
 };

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -18,7 +18,8 @@ export type AbTestHeadlineErrorType = 'duplicate' | 'incomplete';
 
 /**
  * Validates the active headline A/B test (if any) on a card. Returns:
- *  - 'incomplete' when either variant headline is missing/empty
+ *  - 'incomplete' when either variant headline is missing, empty or
+ *    whitespace-only
  *  - 'duplicate' when both variant headlines are identical
  *  - null when there is no active test or the test is valid
  */
@@ -30,8 +31,8 @@ export const getActiveAbTestHeadlineError = (
 		return null;
 	}
 
-	const headlineA = getVariantHeadline(activeTest, 'A');
-	const headlineB = getVariantHeadline(activeTest, 'B');
+	const headlineA = getVariantHeadline(activeTest, 'A')?.trim();
+	const headlineB = getVariantHeadline(activeTest, 'B')?.trim();
 
 	if (!headlineA || !headlineB) {
 		return 'incomplete';

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -15,24 +15,24 @@ export const findActiveOrDraftTest = (card: Card) =>
 	card.tests?.find((test) => isActiveTest(test) || isDraftTest(test));
 
 export type AbTestHeadlineErrorType = 'duplicate' | 'incomplete';
-
 /**
- * Validates the active headline A/B test (if any) on a card. Returns:
+ * Validates the headline A/B test (if any) on a card. Returns:
  *  - 'incomplete' when either variant headline is missing, empty or
  *    whitespace-only
  *  - 'duplicate' when both variant headlines are identical
- *  - null when there is no active test or the test is valid
+ *  - null when there is no active or draft test or the test is valid
  */
-export const getActiveAbTestHeadlineError = (
+export const getCurrentAbTestHeadlineError = (
 	card: Card,
 ): AbTestHeadlineErrorType | null => {
-	const activeTest = card.tests?.find(isActiveTest);
-	if (!activeTest) {
+	const currentTest =
+		card.tests?.find(isActiveTest) || card.tests?.find(isDraftTest);
+	if (!currentTest) {
 		return null;
 	}
 
-	const headlineA = getVariantHeadline(activeTest, 'A')?.trim();
-	const headlineB = getVariantHeadline(activeTest, 'B')?.trim();
+	const headlineA = getVariantHeadline(currentTest, 'A')?.trim();
+	const headlineB = getVariantHeadline(currentTest, 'B')?.trim();
 
 	if (!headlineA || !headlineB) {
 		return 'incomplete';


### PR DESCRIPTION
## What's changed?
Adds error feedback when a headline test meets the following error criteria
1. Both headlines variants match
2. At least one headline is blank

If either condition is met, the collection cannot be launched and feedback is presented to the user in 3 ways:

1. on the minimised card with an incomplete pill
2. in the expanded view by headline B
3. on hover of the launch button 


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
