### PR TITLE
Prevent collection launch if test error exists

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import type { State } from 'types/State';
+import FlatUl from 'components/layout/FlatUl';
+import {
+	AbTestHeadlineError,
+	createSelectActiveAbTestHeadlineErrorsForCollection,
+} from 'selectors/collection';
+import { createCardId } from '../../card/Card';
+import styled from 'styled-components';
+
+interface ContainerProps {
+	collectionId: string;
+}
+
+interface ComponentProps extends ContainerProps {
+	abTestHeadlineErrors: AbTestHeadlineError[];
+}
+
+const ErrorLi = styled.li`
+	& + & {
+		margin-top: 10px;
+	}
+`;
+
+const errorMessage = (error: AbTestHeadlineError['error']): string =>
+	error === 'duplicate'
+		? 'headline variants A and B are the same'
+		: 'headline variants A and B must both be set';
+
+const AbTestHeadlineWarning = ({ abTestHeadlineErrors }: ComponentProps) => (
+	<div>
+		<strong>
+			This collection cannot be launched because of an active headline test:
+		</strong>
+		<FlatUl>
+			{abTestHeadlineErrors.map(({ cardId, title, error }) => (
+				<ErrorLi key={cardId}>
+					<a
+						href={`#${cardId}`}
+						onClick={() => {
+							const id = createCardId(cardId);
+							const element = document.getElementById(id);
+							if (element) {
+								element.scrollIntoView({
+									behavior: 'smooth',
+									inline: 'start',
+									block: 'end',
+								});
+							}
+						}}
+					>
+						{title || 'No title'}
+					</a>
+					{`: ${errorMessage(error)}`}
+				</ErrorLi>
+			))}
+		</FlatUl>
+	</div>
+);
+
+const mapStateToProps = () => {
+	const selectActiveAbTestHeadlineErrorsForCollection =
+		createSelectActiveAbTestHeadlineErrorsForCollection();
+	return (state: State, { collectionId }: ContainerProps) => ({
+		abTestHeadlineErrors: selectActiveAbTestHeadlineErrorsForCollection(state, {
+			collectionId,
+		}),
+	});
+};
+
+export default connect(mapStateToProps)(AbTestHeadlineWarning);

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
@@ -1,73 +1,34 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import type { State } from 'types/State';
-import FlatUl from 'components/layout/FlatUl';
 import {
 	AbTestHeadlineError,
 	createSelectActiveAbTestHeadlineErrorsForCollection,
 } from 'selectors/collection';
-import { createCardId } from '../../card/Card';
-import styled from 'styled-components';
+import CollectionWarningList from './CollectionWarningList';
 
 interface ContainerProps {
 	collectionId: string;
 }
-
-interface ComponentProps extends ContainerProps {
-	abTestHeadlineErrors: AbTestHeadlineError[];
-}
-
-const ErrorLi = styled.li`
-	& + & {
-		margin-top: 10px;
-	}
-`;
 
 const errorMessage = (error: AbTestHeadlineError['error']): string =>
 	error === 'duplicate'
 		? 'headline variants A and B are the same'
 		: 'headline variants A and B must both be set';
 
-const AbTestHeadlineWarning = ({ abTestHeadlineErrors }: ComponentProps) => (
-	<div>
-		<strong>
-			This collection cannot be launched because of an incomplete active
-			headline test:
-		</strong>
-		<FlatUl>
-			{abTestHeadlineErrors.map(({ cardId, title, error }) => (
-				<ErrorLi key={cardId}>
-					<a
-						href={`#${cardId}`}
-						onClick={() => {
-							const id = createCardId(cardId);
-							const element = document.getElementById(id);
-							if (element) {
-								element.scrollIntoView({
-									behavior: 'smooth',
-									inline: 'start',
-									block: 'end',
-								});
-							}
-						}}
-					>
-						{title || 'No title'}
-					</a>
-					{`: ${errorMessage(error)}`}
-				</ErrorLi>
-			))}
-		</FlatUl>
-	</div>
-);
-
 const mapStateToProps = () => {
 	const selectActiveAbTestHeadlineErrorsForCollection =
 		createSelectActiveAbTestHeadlineErrorsForCollection();
 	return (state: State, { collectionId }: ContainerProps) => ({
-		abTestHeadlineErrors: selectActiveAbTestHeadlineErrorsForCollection(state, {
+		heading:
+			'This collection cannot be launched because of an incomplete active headline test:',
+		items: selectActiveAbTestHeadlineErrorsForCollection(state, {
 			collectionId,
-		}),
+		}).map(({ cardId, title, error }) => ({
+			id: cardId,
+			title,
+			suffix: `: ${errorMessage(error)}`,
+		})),
 	});
 };
 
-export default connect(mapStateToProps)(AbTestHeadlineWarning);
+export default connect(mapStateToProps)(CollectionWarningList);

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
@@ -31,7 +31,8 @@ const errorMessage = (error: AbTestHeadlineError['error']): string =>
 const AbTestHeadlineWarning = ({ abTestHeadlineErrors }: ComponentProps) => (
 	<div>
 		<strong>
-			This collection cannot be launched because of an active headline test:
+			This collection cannot be launched because of an incomplete active
+			headline test:
 		</strong>
 		<FlatUl>
 			{abTestHeadlineErrors.map(({ cardId, title, error }) => (

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/AbTestHeadlineWarning.tsx
@@ -1,4 +1,5 @@
-import { connect } from 'react-redux';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import type { State } from 'types/State';
 import {
 	AbTestHeadlineError,
@@ -6,7 +7,7 @@ import {
 } from 'selectors/collection';
 import CollectionWarningList from './CollectionWarningList';
 
-interface ContainerProps {
+interface Props {
 	collectionId: string;
 }
 
@@ -15,20 +16,25 @@ const errorMessage = (error: AbTestHeadlineError['error']): string =>
 		? 'headline variants A and B are the same'
 		: 'headline variants A and B must both be set';
 
-const mapStateToProps = () => {
-	const selectActiveAbTestHeadlineErrorsForCollection =
-		createSelectActiveAbTestHeadlineErrorsForCollection();
-	return (state: State, { collectionId }: ContainerProps) => ({
-		heading:
-			'This collection cannot be launched because of an incomplete active headline test:',
-		items: selectActiveAbTestHeadlineErrorsForCollection(state, {
-			collectionId,
-		}).map(({ cardId, title, error }) => ({
-			id: cardId,
-			title,
-			suffix: `: ${errorMessage(error)}`,
-		})),
-	});
+const AbTestHeadlineWarning = ({ collectionId }: Props) => {
+	const selectActiveAbTestHeadlineErrorsForCollection = useMemo(
+		() => createSelectActiveAbTestHeadlineErrorsForCollection(),
+		[],
+	);
+	const items = useSelector((state: State) =>
+		selectActiveAbTestHeadlineErrorsForCollection(state, { collectionId }),
+	).map(({ cardId, title, error }) => ({
+		id: cardId,
+		title,
+		suffix: `: ${errorMessage(error)}`,
+	}));
+
+	return (
+		<CollectionWarningList
+			heading="This collection cannot be launched because of an incomplete active headline test:"
+			items={items}
+		/>
+	);
 };
 
-export default connect(mapStateToProps)(CollectionWarningList);
+export default AbTestHeadlineWarning;

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -101,7 +101,7 @@ type CollectionProps = CollectionPropsBeforeState & {
 };
 
 interface CollectionState {
-	showOpenFormsWarning: boolean;
+	showFormWarnings: boolean;
 	isPreviouslyOpen: boolean;
 	isLaunching: boolean;
 }
@@ -171,7 +171,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 	public state = {
 		isPreviouslyOpen: false,
 		isLaunching: false,
-		showOpenFormsWarning: false,
+		showFormWarnings: false,
 	};
 
 	// added to prevent setState call on unmounted component
@@ -301,20 +301,19 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 									)}
 								</EditModeVisibility>
 								<ActionButtonsContainer
-									onMouseEnter={this.showOpenFormsWarning}
-									onMouseLeave={this.hideOpenFormsWarning}
+									onMouseEnter={this.showFormWarnings}
+									onMouseLeave={this.hideFormWarnings}
 								>
-									{hasOpenForms && this.state.showOpenFormsWarning && (
+									{hasOpenForms && this.state.showFormWarnings && (
 										<OpenFormsWarningContainer>
 											<OpenFormsWarning collectionId={id} frontId={frontId} />
 										</OpenFormsWarningContainer>
 									)}
-									{hasAbTestHeadlineErrors &&
-										this.state.showOpenFormsWarning && (
-											<OpenFormsWarningContainer>
-												<AbTestHeadlineWarning collectionId={id} />
-											</OpenFormsWarningContainer>
-										)}
+									{hasAbTestHeadlineErrors && this.state.showFormWarnings && (
+										<OpenFormsWarningContainer>
+											<AbTestHeadlineWarning collectionId={id} />
+										</OpenFormsWarningContainer>
+									)}
 									<EditModeVisibility visibleMode="fronts">
 										<Button
 											size="l"
@@ -391,10 +390,8 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 		);
 	}
 
-	private showOpenFormsWarning = () =>
-		this.setState({ showOpenFormsWarning: true });
-	private hideOpenFormsWarning = () =>
-		this.setState({ showOpenFormsWarning: false });
+	private showFormWarnings = () => this.setState({ showFormWarnings: true });
+	private hideFormWarnings = () => this.setState({ showFormWarnings: false });
 }
 
 const createMapStateToProps = () => {

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -309,11 +309,12 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											<OpenFormsWarning collectionId={id} frontId={frontId} />
 										</OpenFormsWarningContainer>
 									)}
-									{hasAbTestHeadlineErrors && (
-										<OpenFormsWarningContainer>
-											<AbTestHeadlineWarning collectionId={id} />
-										</OpenFormsWarningContainer>
-									)}
+									{hasAbTestHeadlineErrors &&
+										this.state.showOpenFormsWarning && (
+											<OpenFormsWarningContainer>
+												<AbTestHeadlineWarning collectionId={id} />
+											</OpenFormsWarningContainer>
+										)}
 									<EditModeVisibility visibleMode="fronts">
 										<Button
 											size="l"

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -43,6 +43,9 @@ import EditModeVisibility from 'components/util/EditModeVisibility';
 import { fetchPrefill } from 'bundles/capiFeedBundle';
 import LoadingGif from 'images/icons/loading.gif';
 import OpenFormsWarning from './OpenFormsWarning';
+import AbTestHeadlineWarning from './AbTestHeadlineWarning';
+import { createSelectActiveAbTestHeadlineErrorsForCollection } from 'selectors/collection';
+import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 import { selectors as editionsIssueSelectors } from '../../../bundles/editionsIssueBundle';
 import { moveFrontCollection } from '../../../actions/Editions';
 
@@ -77,6 +80,7 @@ type CollectionProps = CollectionPropsBeforeState & {
 	isCollectionLocked: boolean;
 	isOpen: boolean;
 	hasOpenForms: boolean;
+	hasAbTestHeadlineErrors: boolean;
 	hasContent: boolean;
 	hasMultipleFrontsOpen: boolean;
 	onChangeOpenState: (id: string, isOpen: boolean) => void;
@@ -220,6 +224,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 			targetedRegions,
 			hasContent,
 			hasOpenForms,
+			hasAbTestHeadlineErrors,
 			isFeast,
 		} = this.props;
 
@@ -304,6 +309,11 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											<OpenFormsWarning collectionId={id} frontId={frontId} />
 										</OpenFormsWarningContainer>
 									)}
+									{hasAbTestHeadlineErrors && (
+										<OpenFormsWarningContainer>
+											<AbTestHeadlineWarning collectionId={id} />
+										</OpenFormsWarningContainer>
+									)}
 									<EditModeVisibility visibleMode="fronts">
 										<Button
 											size="l"
@@ -319,7 +329,7 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											priority="primary"
 											onClick={() => this.startPublish(id, frontId)}
 											tabIndex={-1}
-											disabled={isLaunching}
+											disabled={isLaunching || hasAbTestHeadlineErrors}
 											data-testid="collection-launch-button"
 										>
 											{isLaunching ? (
@@ -391,6 +401,8 @@ const createMapStateToProps = () => {
 	const selectEditWarning = createSelectCollectionEditWarning();
 	const selectPreviously = createSelectPreviouslyLiveArticlesInCollection();
 	const selectHasOpenForms = createSelectDoesCollectionHaveOpenForms();
+	const selectActiveAbTestHeadlineErrorsForCollection =
+		createSelectActiveAbTestHeadlineErrorsForCollection();
 	return (
 		state: State,
 		{
@@ -434,6 +446,10 @@ const createMapStateToProps = () => {
 		hasMultipleFrontsOpen: selectHasMultipleFrontsOpen(state, priority),
 		hasContent: !!selectors.selectById(state, collectionId),
 		hasOpenForms: selectHasOpenForms(state, { collectionId, frontId }),
+		hasAbTestHeadlineErrors:
+			selectFeatureValue(state, 'headline-ab-testing') &&
+			selectActiveAbTestHeadlineErrorsForCollection(state, { collectionId })
+				.length > 0,
 		isFeast: editionsIssueSelectors.selectAll(state)?.platform === 'feast',
 	});
 };

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/CollectionWarningList.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/CollectionWarningList.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import FlatUl from 'components/layout/FlatUl';
+import styled from 'styled-components';
+import { createCardId } from '../../card/Card';
+
+export interface CollectionWarningItem {
+	id: string;
+	title?: string;
+	suffix?: string;
+}
+
+interface Props {
+	heading: string;
+	items: CollectionWarningItem[];
+}
+
+const WarningLi = styled.li`
+	& + & {
+		margin-top: 10px;
+	}
+`;
+
+const scrollToCard = (id: string) => {
+	const element = document.getElementById(createCardId(id));
+	if (element) {
+		element.scrollIntoView({
+			behavior: 'smooth',
+			inline: 'start',
+			block: 'end',
+		});
+	}
+};
+
+const CollectionWarningList = ({ heading, items }: Props) => (
+	<div>
+		<strong>{heading}</strong>
+		<FlatUl>
+			{items.map(({ id, title, suffix }) => (
+				<WarningLi key={id}>
+					<a href={`#${id}`} onClick={() => scrollToCard(id)}>
+						{title || 'No title'}
+					</a>
+					{suffix}
+				</WarningLi>
+			))}
+		</FlatUl>
+	</div>
+);
+
+export default CollectionWarningList;

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
@@ -1,23 +1,29 @@
-import { connect } from 'react-redux';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import type { State } from 'types/State';
 import { createSelectOpenCardTitlesForCollection } from 'bundles/frontsUI';
 import CollectionWarningList from './CollectionWarningList';
 
-interface ContainerProps {
+interface Props {
 	collectionId: string;
 	frontId: string;
 }
 
-const mapStateToProps = () => {
-	const selectOpenCardTitlesForCollection =
-		createSelectOpenCardTitlesForCollection();
-	return (state: State, { collectionId, frontId }: ContainerProps) => ({
-		heading: 'There are open forms in this collection:',
-		items: selectOpenCardTitlesForCollection(state, {
-			collectionId,
-			frontId,
-		}).map(({ uuid, title }) => ({ id: uuid, title })),
-	});
+const OpenFormsWarning = ({ collectionId, frontId }: Props) => {
+	const selectOpenCardTitlesForCollection = useMemo(
+		() => createSelectOpenCardTitlesForCollection(),
+		[],
+	);
+	const items = useSelector((state: State) =>
+		selectOpenCardTitlesForCollection(state, { collectionId, frontId }),
+	).map(({ uuid, title }) => ({ id: uuid, title }));
+
+	return (
+		<CollectionWarningList
+			heading="There are open forms in this collection:"
+			items={items}
+		/>
+	);
 };
 
-export default connect(mapStateToProps)(CollectionWarningList);
+export default OpenFormsWarning;

--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/OpenFormsWarning.tsx
@@ -1,63 +1,23 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import type { State } from 'types/State';
-import FlatUl from 'components/layout/FlatUl';
 import { createSelectOpenCardTitlesForCollection } from 'bundles/frontsUI';
-import { createCardId } from '../../card/Card';
-import styled from 'styled-components';
+import CollectionWarningList from './CollectionWarningList';
 
 interface ContainerProps {
 	collectionId: string;
 	frontId: string;
 }
 
-interface ComponentProps extends ContainerProps {
-	openArticleTitles: Array<{ uuid: string; title?: string }>;
-}
-
-const OpenArticleLi = styled.li`
-	& + & {
-		margin-top: 10px;
-	}
-`;
-
-const OpenFormsWarning = ({ openArticleTitles }: ComponentProps) => (
-	<div>
-		<strong>There are open forms in this collection:</strong>
-		<FlatUl>
-			{openArticleTitles.map(({ uuid, title }) => (
-				<OpenArticleLi key={title}>
-					<a
-						href={`#${uuid}`}
-						onClick={() => {
-							const id = createCardId(uuid);
-							const element = document.getElementById(id);
-							if (element) {
-								element.scrollIntoView({
-									behavior: 'smooth',
-									inline: 'start',
-									block: 'end',
-								});
-							}
-						}}
-					>
-						{title || 'No title'}
-					</a>
-				</OpenArticleLi>
-			))}
-		</FlatUl>
-	</div>
-);
-
 const mapStateToProps = () => {
 	const selectOpenCardTitlesForCollection =
 		createSelectOpenCardTitlesForCollection();
 	return (state: State, { collectionId, frontId }: ContainerProps) => ({
-		openArticleTitles: selectOpenCardTitlesForCollection(state, {
+		heading: 'There are open forms in this collection:',
+		items: selectOpenCardTitlesForCollection(state, {
 			collectionId,
 			frontId,
-		}),
+		}).map(({ uuid, title }) => ({ id: uuid, title })),
 	});
 };
 
-export default connect(mapStateToProps)(OpenFormsWarning);
+export default connect(mapStateToProps)(CollectionWarningList);

--- a/fronts-client/src/fixtures/abTests.ts
+++ b/fronts-client/src/fixtures/abTests.ts
@@ -14,3 +14,11 @@ export const makeTest = (overrides: Partial<Test> = {}): Test => ({
 
 export const makeCard = (tests?: Test[]): Card =>
 	({ uuid: 'card-1', id: 'card-1', meta: {}, tests }) as Card;
+
+export const makeVariantMeta = (
+	headlineA?: string,
+	headlineB?: string,
+): Test['variantMeta'] => [
+	{ id: 'A', meta: { headline: headlineA } },
+	{ id: 'B', meta: { headline: headlineB } },
+];

--- a/fronts-client/src/selectors/collection.ts
+++ b/fronts-client/src/selectors/collection.ts
@@ -9,7 +9,7 @@ import { selectCard } from '../selectors/shared';
 import { frontStages } from 'constants/fronts';
 import {
 	AbTestHeadlineErrorType,
-	getActiveAbTestHeadlineError,
+	getCurrentAbTestHeadlineError,
 } from 'util/abTests';
 
 const selectCardsInCollection = createSelectCardsInCollection();
@@ -69,7 +69,7 @@ export const createSelectActiveAbTestHeadlineErrorsForCollection = () => {
 			if (!card) {
 				return errors;
 			}
-			const error = getActiveAbTestHeadlineError(card);
+			const error = getCurrentAbTestHeadlineError(card);
 			if (!error) {
 				return errors;
 			}

--- a/fronts-client/src/selectors/collection.ts
+++ b/fronts-client/src/selectors/collection.ts
@@ -1,8 +1,16 @@
 import type { State } from 'types/State';
 import { Card, CardSets } from 'types/Collection';
-import { createSelectCardsInCollection } from './shared';
+import {
+	createSelectArticleFromCard,
+	createSelectCardsInCollection,
+} from './shared';
 import { createSelector } from 'reselect';
 import { selectCard } from '../selectors/shared';
+import { frontStages } from 'constants/fronts';
+import {
+	AbTestHeadlineErrorType,
+	getActiveAbTestHeadlineError,
+} from 'util/abTests';
 
 const selectCardsInCollection = createSelectCardsInCollection();
 
@@ -31,4 +39,47 @@ export const createSelectIsArticleInCollection = () => {
 		(_: State, { cardId: articleId }: { cardId: string }) => articleId,
 		(articleIds, articleId) => articleIds.indexOf(articleId) !== -1,
 	);
+};
+
+export interface AbTestHeadlineError {
+	cardId: string;
+	title: string | undefined;
+	error: AbTestHeadlineErrorType;
+}
+
+/**
+ * Return the offending card and the reason for each card in the
+ * collection's draft set that has an active headline A/B test
+ * with invalid variant headlines.
+ * An empty array means the collection can be launched.
+ */
+export const createSelectActiveAbTestHeadlineErrorsForCollection = () => {
+	const selectDraftCardIds = createSelectCardsInCollection();
+	const selectArticleFromCard = createSelectArticleFromCard();
+	return (
+		state: State,
+		{ collectionId }: { collectionId: string },
+	): AbTestHeadlineError[] => {
+		const cardIds = selectDraftCardIds(state, {
+			collectionId,
+			collectionSet: frontStages.draft,
+		});
+		return cardIds.reduce<AbTestHeadlineError[]>((errors, cardId) => {
+			const card = selectCard(state, cardId);
+			if (!card) {
+				return errors;
+			}
+			const error = getActiveAbTestHeadlineError(card);
+			if (!error) {
+				return errors;
+			}
+			const derivedArticle = selectArticleFromCard(state, cardId);
+			errors.push({
+				cardId,
+				title: derivedArticle?.headline || derivedArticle?.customKicker,
+				error,
+			});
+			return errors;
+		}, []);
+	};
 };

--- a/fronts-client/src/util/abTests.spec.ts
+++ b/fronts-client/src/util/abTests.spec.ts
@@ -1,5 +1,15 @@
-import { hasActiveAbTestOnCard, findActiveOrDraftTest } from './abTests';
-import { FUTURE, PAST, makeCard, makeTest } from '../fixtures/abTests';
+import {
+	FUTURE,
+	makeCard,
+	makeTest,
+	makeVariantMeta,
+	PAST,
+} from '../fixtures/abTests';
+import {
+	hasActiveAbTestOnCard,
+	findActiveOrDraftTest,
+	getCurrentAbTestHeadlineError,
+} from './abTests';
 
 describe('abTests utils', () => {
 	describe('hasActiveAbTestOnCard', () => {
@@ -59,6 +69,82 @@ describe('abTests utils', () => {
 				makeTest({ expiryDate: FUTURE, hasManuallyEndedOnThisTrail: true }),
 			]);
 			expect(findActiveOrDraftTest(card)).toBeUndefined();
+		});
+	});
+
+	describe('getActiveAbTestHeadlineError', () => {
+		it('returns null when the card has no active test', () => {
+			expect(getCurrentAbTestHeadlineError(makeCard())).toBeNull();
+		});
+
+		it('returns "duplicate" when both variant headlines are the same', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Same headline', 'Same headline'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('duplicate');
+		});
+
+		it('returns "incomplete" when variant A headline is missing', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta(undefined, 'Headline B'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns "incomplete" when variant B headline is empty', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Headline A', ''),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns "incomplete" when a variant headline is whitespace-only', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Headline A', '   '),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns "duplicate" when variant headlines differ only by surrounding whitespace', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Same ', ' Same'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('duplicate');
+		});
+
+		it('returns "incomplete" when both variant headlines are missing', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta(undefined, undefined),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('incomplete');
+		});
+
+		it('returns null when variant headlines are distinct and populated', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('Headline A', 'Headline B'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBeNull();
 		});
 	});
 });

--- a/fronts-client/src/util/abTests.spec.ts
+++ b/fronts-client/src/util/abTests.spec.ts
@@ -87,6 +87,16 @@ describe('abTests utils', () => {
 			expect(getCurrentAbTestHeadlineError(card)).toBe('duplicate');
 		});
 
+		it('returns "duplicate" when both variant headlines are the same but cased differently', () => {
+			const card = makeCard([
+				makeTest({
+					expiryDate: FUTURE,
+					variantMeta: makeVariantMeta('SAME headline', 'Same headline'),
+				}),
+			]);
+			expect(getCurrentAbTestHeadlineError(card)).toBe('duplicate');
+		});
+
 		it('returns "incomplete" when variant A headline is missing', () => {
 			const card = makeCard([
 				makeTest({

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -14,11 +14,41 @@ export const hasActiveAbTestOnCard = (card: Card | undefined) =>
 export const findActiveOrDraftTest = (card: Card) =>
 	card.tests?.find((test) => isActiveTest(test) || isDraftTest(test));
 
+export type AbTestHeadlineErrorType = 'duplicate' | 'incomplete';
+
+/**
+ * Validates the active headline A/B test (if any) on a card. Returns:
+ *  - 'incomplete' when either variant headline is missing/empty
+ *  - 'duplicate' when both variant headlines are identical
+ *  - null when there is no active test or the test is valid
+ */
+export const getActiveAbTestHeadlineError = (
+	card: Card,
+): AbTestHeadlineErrorType | null => {
+	const activeTest = card.tests?.find(isActiveTest);
+	if (!activeTest) {
+		return null;
+	}
+
+	const headlineA = getVariantHeadline(activeTest, 'A');
+	const headlineB = getVariantHeadline(activeTest, 'B');
+
+	if (!headlineA || !headlineB) {
+		return 'incomplete';
+	}
+
+	if (headlineA === headlineB) {
+		return 'duplicate';
+	}
+
+	return null;
+};
+
 // we can extend this in future to 'getVariantField'
 export const getVariantHeadline = (
 	test: Test | undefined,
 	variantId: VariantId,
-) => {
+): string | undefined => {
 	return test?.variantMeta.find((variant) => variant.id === variantId)?.meta
 		.headline;
 };

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -18,7 +18,8 @@ export type AbTestHeadlineErrorType = 'duplicate' | 'incomplete';
 
 /**
  * Validates the active headline A/B test (if any) on a card. Returns:
- *  - 'incomplete' when either variant headline is missing/empty
+ *  - 'incomplete' when either variant headline is missing, empty or
+ *    whitespace-only
  *  - 'duplicate' when both variant headlines are identical
  *  - null when there is no active test or the test is valid
  */
@@ -30,8 +31,8 @@ export const getActiveAbTestHeadlineError = (
 		return null;
 	}
 
-	const headlineA = getVariantHeadline(activeTest, 'A');
-	const headlineB = getVariantHeadline(activeTest, 'B');
+	const headlineA = getVariantHeadline(activeTest, 'A')?.trim();
+	const headlineB = getVariantHeadline(activeTest, 'B')?.trim();
 
 	if (!headlineA || !headlineB) {
 		return 'incomplete';

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -31,8 +31,8 @@ export const getCurrentAbTestHeadlineError = (
 		return null;
 	}
 
-	const headlineA = getVariantHeadline(currentTest, 'A')?.trim();
-	const headlineB = getVariantHeadline(currentTest, 'B')?.trim();
+	const headlineA = getVariantHeadline(currentTest, 'A')?.toLowerCase().trim();
+	const headlineB = getVariantHeadline(currentTest, 'B')?.toLowerCase().trim();
 
 	if (!headlineA || !headlineB) {
 		return 'incomplete';

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -15,24 +15,24 @@ export const findActiveOrDraftTest = (card: Card) =>
 	card.tests?.find((test) => isActiveTest(test) || isDraftTest(test));
 
 export type AbTestHeadlineErrorType = 'duplicate' | 'incomplete';
-
 /**
- * Validates the active headline A/B test (if any) on a card. Returns:
+ * Validates the headline A/B test (if any) on a card. Returns:
  *  - 'incomplete' when either variant headline is missing, empty or
  *    whitespace-only
  *  - 'duplicate' when both variant headlines are identical
- *  - null when there is no active test or the test is valid
+ *  - null when there is no active or draft test or the test is valid
  */
-export const getActiveAbTestHeadlineError = (
+export const getCurrentAbTestHeadlineError = (
 	card: Card,
 ): AbTestHeadlineErrorType | null => {
-	const activeTest = card.tests?.find(isActiveTest);
-	if (!activeTest) {
+	const currentTest =
+		card.tests?.find(isActiveTest) || card.tests?.find(isDraftTest);
+	if (!currentTest) {
 		return null;
 	}
 
-	const headlineA = getVariantHeadline(activeTest, 'A')?.trim();
-	const headlineB = getVariantHeadline(activeTest, 'B')?.trim();
+	const headlineA = getVariantHeadline(currentTest, 'A')?.trim();
+	const headlineB = getVariantHeadline(currentTest, 'B')?.trim();
 
 	if (!headlineA || !headlineB) {
 		return 'incomplete';


### PR DESCRIPTION
## What's changed?
Prevents a user from launching a collection if there is an incomplete test saved on a card. 

A test is considered incomplete if it meets one of the following criteria:
1. Duplicate - both headline variants are matching
2. Incomplete - at least one headline is blank.

If one of these conditions are met, the launch collection button is disabled and a warning is displayed on hover.

This uses the same underlying component as the open form warning. To facilitate this, this PR refactors the openFormWarning to create a reusable presentational component that can be used with a thin wrapper for both OpenFormsWarning and ABTestHeadlineWarning. I've used this opportunity to modernise the syntax for these components whilst refactoring.

## Screenshot

<img width="1214" height="572" alt="Screenshot 2026-08-19 at 13 56 08" src="https://github.com/user-attachments/assets/011f0940-b154-449b-a06e-760e7e4e8cf3" />

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
