### PR TITLE
Add test warnings on card by headline fields

### DIFF
--- a/fronts-client/src/components/inputs/CreateResizeableTextInput.tsx
+++ b/fronts-client/src/components/inputs/CreateResizeableTextInput.tsx
@@ -5,8 +5,8 @@ import clamp from 'lodash/clamp';
 
 import InputLabel from './InputLabel';
 import InputContainer from './InputContainer';
-import { RewindIcon } from '../icons/Icons';
-import { styled } from 'constants/theme';
+import { RewindIcon, WarningIcon } from '../icons/Icons';
+import { styled, theme } from 'constants/theme';
 
 type Props = {
 	label?: string;
@@ -54,6 +54,15 @@ const InputComponentContainer = styled.div`
 	}
 `;
 
+const Warning = styled('span')`
+	margin-left: 8px;
+	font-size: 12px;
+	color: ${theme.base.colors.dangerColor};
+	display: flex;
+	align-items: center;
+	gap: 4px;
+`;
+
 const createResizeableTextInput = (
 	Component: React.ComponentType<any>,
 	type?: string,
@@ -98,6 +107,7 @@ const createResizeableTextInput = (
 				input,
 				originalValue,
 				labelContent: LabelContent,
+				meta,
 				...rest
 			} = this.props;
 			return (
@@ -111,6 +121,15 @@ const createResizeableTextInput = (
 								</RewindButton>
 							)}
 							{LabelContent}
+							{meta?.warning && (
+								<Warning>
+									<WarningIcon
+										fill={theme.base.colors.dangerColor}
+										size={'s'}
+									/>{' '}
+									{meta.warning}
+								</Warning>
+							)}
 						</TextInputLabel>
 					)}
 					<InputComponentContainer>

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -39,6 +39,20 @@ const HeadlineVariantContainer = styled('div')`
 	gap: 6px;
 `;
 
+const normaliseHeadline = (value?: string) => (value ?? '').trim();
+
+const warnIfEmpty = (value: string | undefined) => {
+	return normaliseHeadline(value) === '' ? 'Headline missing' : undefined;
+};
+const warnIfDuplicate = (
+	value: string | undefined,
+	allValues: { headlineA?: string },
+) => {
+	return normaliseHeadline(value) === normaliseHeadline(allValues.headlineA)
+		? 'Headline is duplicated'
+		: undefined;
+};
+
 const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 	/**
 	 * You may be thinking -- why on earth would we use the `headline` field to contain
@@ -58,13 +72,12 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 			(feature) => feature.key === 'headline-ab-testing',
 		);
 
+	const abTestFeatureEnabled = headlineABTestingFeatureSwitch?.enabled === true;
 	return (
 		<HeadlineInputContainer
-			abTestEnabled={
-				props.abTestEnabled && headlineABTestingFeatureSwitch?.enabled === true
-			}
+			abTestEnabled={props.abTestEnabled && abTestFeatureEnabled}
 		>
-			{props.cardId && headlineABTestingFeatureSwitch?.enabled === true && (
+			{props.cardId && abTestFeatureEnabled && (
 				<ABTestToggleContainer>
 					<Field
 						name="abTestEnabled"
@@ -80,8 +93,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 				</ABTestToggleContainer>
 			)}
 
-			{props.abTestEnabled &&
-			headlineABTestingFeatureSwitch?.enabled === true ? (
+			{props.abTestEnabled && abTestFeatureEnabled ? (
 				<HeadlineVariantContainer>
 					<ConditionalField
 						permittedFields={props.editableFields}
@@ -91,6 +103,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						component={InputTextArea}
 						data-testid="edit-form-headline-a-field"
 						placeholder={props.capiHeadline}
+						warn={warnIfEmpty}
 					/>
 					<ConditionalField
 						permittedFields={props.editableFields}
@@ -99,6 +112,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						rows="2"
 						component={InputTextArea}
 						data-testid="edit-form-headline-b-field"
+						warn={[warnIfEmpty, warnIfDuplicate]}
 					/>
 				</HeadlineVariantContainer>
 			) : (


### PR DESCRIPTION
## What's changed?
Adds inline, per-card validation warnings to the headline A/B test inputs, so editors get immediate feedback on the card itself (rather than only at collection-launch time). This uses the warn field from redux-form and is rendered via `CreateResizableTextInput`.

When a headline test is active on a card, the edit form now surfaces two warnings against the variant fields:
1. Incomplete variant - if Headline A or Headline B is blank: "Add a headline or turn the test off to save this container".
2. Duplicate variant - if Headline B matches Headline A: "Headline is a duplicate; please change it".

## Screenshots
1. Incomplete variant 
<img width="702" height="572" alt="Screenshot 2026-08-19 at 16 18 14" src="https://github.com/user-attachments/assets/bfed411f-74d1-4fee-a9cc-5e9742b45de9" />

2. Duplicate variant
<img width="702" height="572" alt="Screenshot 2026-08-19 at 16 18 20" src="https://github.com/user-attachments/assets/6900ff5f-ea6a-4051-9aa5-951e7da34b13" />


### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
