### PR TITLE
Guarantee a card only ever has one active AB test

### DIFF
--- a/fronts-client/src/components/FrontsEdit/__tests__/mayEndAbTests.spec.tsx
+++ b/fronts-client/src/components/FrontsEdit/__tests__/mayEndAbTests.spec.tsx
@@ -1,32 +1,23 @@
-import type { Card, Test } from 'types/Collection';
+import type { Test } from 'types/Collection';
 
 import { mayEndAbTest } from '../../../actions/Cards';
 import { baseTo, baseFrom } from './fixtures/groups.fixture';
-
-const FUTURE = Date.now() + 100_000;
-const PAST = Date.now() - 100_000;
+import {
+	FUTURE,
+	PAST,
+	makeCard,
+	makeTest as makeBaseTest,
+} from '../../../fixtures/abTests';
 
 const UK_COLLECTION = 'collection-uk';
 const US_COLLECTION = 'collection-us';
 
-const makeTest = (overrides: Partial<Test> = {}): Test => ({
-	testUuid: 'test-1',
-	variantMeta: [],
-	createdByName: 'Jane Doe',
-	createdByEmail: 'jane.doe@guardian.co.uk',
-	expiryDate: FUTURE,
-	frontsThisTestCanRunOn: ['uk'],
-	hasManuallyEndedOnThisTrail: false,
-	...overrides,
-});
-
-const makeCard = (...tests: Test[]): Card => ({
-	id: 'internal-code/page/15334368',
-	frontPublicationDate: 1741879217277,
-	meta: {},
-	uuid: 'card-1',
-	tests: tests.length ? tests : undefined,
-});
+const makeTest = (overrides: Partial<Test> = {}): Test =>
+	makeBaseTest({
+		expiryDate: FUTURE,
+		frontsThisTestCanRunOn: ['uk'],
+		...overrides,
+	});
 
 // The test was created on the `uk` front, which hosts UK_COLLECTION.
 const state: any = {
@@ -56,7 +47,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: toUsFront,
-			card: makeCard(makeTest()),
+			card: makeCard([makeTest()]),
 			persistTo: 'collection',
 			state,
 		});
@@ -75,7 +66,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: toUkFront,
-			card: makeCard(makeTest()),
+			card: makeCard([makeTest()]),
 			persistTo: 'collection',
 			state,
 		});
@@ -87,7 +78,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: { ...baseTo, type: 'clipboard', collectionId: undefined },
-			card: makeCard(makeTest()),
+			card: makeCard([makeTest()]),
 			persistTo: 'clipboard',
 			state,
 		});
@@ -111,7 +102,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: toUsFront,
-			card: makeCard(makeTest({ hasManuallyEndedOnThisTrail: true })),
+			card: makeCard([makeTest({ hasManuallyEndedOnThisTrail: true })]),
 			persistTo: 'collection',
 			state,
 		});
@@ -123,7 +114,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: toUsFront,
-			card: makeCard(makeTest({ expiryDate: PAST })),
+			card: makeCard([makeTest({ expiryDate: PAST })]),
 			persistTo: 'collection',
 			state,
 		});
@@ -135,7 +126,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: toUsFront,
-			card: makeCard(makeTest({ frontsThisTestCanRunOn: undefined })),
+			card: makeCard([makeTest({ frontsThisTestCanRunOn: undefined })]),
 			persistTo: 'collection',
 			state,
 		});
@@ -147,7 +138,7 @@ describe('mayEndAbTest', () => {
 		const result = mayEndAbTest({
 			from: baseFrom,
 			to: toUsFront,
-			card: makeCard(makeTest({ expiryDate: undefined })),
+			card: makeCard([makeTest({ expiryDate: undefined })]),
 			persistTo: 'collection',
 			state,
 		});

--- a/fronts-client/src/fixtures/abTests.ts
+++ b/fronts-client/src/fixtures/abTests.ts
@@ -1,0 +1,16 @@
+import type { Card, Test } from 'types/Collection';
+
+export const FUTURE = Date.now() + 100_000;
+export const PAST = Date.now() - 100_000;
+
+export const makeTest = (overrides: Partial<Test> = {}): Test => ({
+	testUuid: 'test-1',
+	variantMeta: [],
+	createdByName: 'Jane Doe',
+	createdByEmail: 'jane.doe@guardian.co.uk',
+	hasManuallyEndedOnThisTrail: false,
+	...overrides,
+});
+
+export const makeCard = (tests?: Test[]): Card =>
+	({ uuid: 'card-1', id: 'card-1', meta: {}, tests }) as Card;

--- a/fronts-client/src/util/abTests.spec.ts
+++ b/fronts-client/src/util/abTests.spec.ts
@@ -1,20 +1,5 @@
-import { Card, Test } from '../types/Collection';
 import { hasActiveAbTestOnCard, findActiveOrDraftTest } from './abTests';
-
-const makeCard = (tests?: Test[]): Card =>
-	({ uuid: 'card-1', id: 'id-1', meta: {}, tests }) as Card;
-
-const makeTest = (test: Partial<Test> = {}): Test => ({
-	testUuid: 'test-1',
-	variantMeta: [],
-	createdByName: 'Jane Doe',
-	createdByEmail: 'jane.doe@guardian.co.uk',
-	hasManuallyEndedOnThisTrail: false,
-	...test,
-});
-
-const FUTURE = Date.now() + 100_000;
-const PAST = Date.now() - 100_000;
+import { FUTURE, PAST, makeCard, makeTest } from '../fixtures/abTests';
 
 describe('abTests utils', () => {
 	describe('hasActiveAbTestOnCard', () => {

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -1,6 +1,6 @@
 import { Card, VariantId, Test } from '../types/Collection';
 
-const isActiveTest = (test: Test) =>
+export const isActiveTest = (test: Test) =>
 	!test.hasManuallyEndedOnThisTrail &&
 	!!test.expiryDate &&
 	test.expiryDate > Date.now();

--- a/fronts-client/src/util/form.spec.ts
+++ b/fronts-client/src/util/form.spec.ts
@@ -4,25 +4,11 @@ import { getCardTestFromFormValues, CardFormData } from './form';
 import cardsReducer from 'reducers/cardsReducer';
 import { updateCard } from 'actions/CardsCommon';
 import { isActiveTest } from './abTests';
+import { FUTURE, PAST, makeCard, makeTest } from '../fixtures/abTests';
 
 jest.mock('selectors/frontsSelectors', () => ({
 	selectFrontsWithCollection: () => [],
 }));
-
-const FUTURE = Date.now() + 100_000;
-const PAST = Date.now() - 100_000;
-
-const makeCard = (tests?: Test[]): Card =>
-	({ uuid: 'card-1', id: 'card-1', meta: {}, tests }) as Card;
-
-const makeTest = (test: Partial<Test> = {}): Test => ({
-	testUuid: 'test-1',
-	variantMeta: [],
-	createdByName: 'Jane Doe',
-	createdByEmail: 'jane.doe@guardian.co.uk',
-	hasManuallyEndedOnThisTrail: false,
-	...test,
-});
 
 const makeFormValues = (values: Partial<CardFormData> = {}): CardFormData =>
 	({

--- a/fronts-client/src/util/form.spec.ts
+++ b/fronts-client/src/util/form.spec.ts
@@ -1,0 +1,113 @@
+import type { State } from 'types/State';
+import { Card } from 'types/Collection';
+import { getCardTestFromFormValues, CardFormData } from './form';
+import cardsReducer from 'reducers/cardsReducer';
+import { updateCard } from 'actions/CardsCommon';
+import { isActiveTest } from './abTests';
+
+jest.mock('selectors/frontsSelectors', () => ({
+	selectFrontsWithCollection: () => [],
+}));
+
+const FUTURE = Date.now() + 100_000;
+const PAST = Date.now() - 100_000;
+
+const makeCard = (tests?: Test[]): Card =>
+	({ uuid: 'card-1', id: 'card-1', meta: {}, tests }) as Card;
+
+const makeTest = (test: Partial<Test> = {}): Test => ({
+	testUuid: 'test-1',
+	variantMeta: [],
+	createdByName: 'Jane Doe',
+	createdByEmail: 'jane.doe@guardian.co.uk',
+	hasManuallyEndedOnThisTrail: false,
+	...test,
+});
+
+const makeFormValues = (values: Partial<CardFormData> = {}): CardFormData =>
+	({
+		headlineA: 'Headline A',
+		headlineB: 'Headline B',
+		abTestEnabled: true,
+		...values,
+	}) as CardFormData;
+
+const countActiveTests = (card: Card) =>
+	(card.tests || []).filter(isActiveTest).length;
+
+// Runs the form values through `getCardTestFromFormValues` and the reducer, so
+// we assert on the tests actually persisted to the card, which mimics the real
+// save flow
+const saveTest = (card: Card, values: CardFormData): Card => {
+	const state = { cards: { [card.id]: card } } as unknown as State;
+	const test = getCardTestFromFormValues(state, card.id, values);
+	return cardsReducer(
+		state.cards,
+		updateCard(card.id, card.meta, undefined, test),
+	)[card.id];
+};
+
+describe('getCardTestFromFormValues', () => {
+	it('creates no test when there is none and AB testing is off', () => {
+		const saved = saveTest(
+			makeCard(),
+			makeFormValues({ abTestEnabled: false }),
+		);
+		expect(saved.tests).toBeUndefined();
+	});
+
+	it('creates a draft (not yet active) test when enabling AB testing on a fresh card', () => {
+		const saved = saveTest(makeCard(), makeFormValues());
+		expect(saved.tests).toHaveLength(1);
+		// New tests start as drafts (no expiry date), so nothing is active yet.
+		expect(saved.tests?.[0].expiryDate).toBeUndefined();
+		expect(countActiveTests(saved)).toBe(0);
+	});
+
+	it('updates the existing active test in place rather than adding a second', () => {
+		const existing = makeTest({ testUuid: 'existing', expiryDate: FUTURE });
+		const saved = saveTest(makeCard([existing]), makeFormValues());
+		// Same test (matched by uuid), so still exactly one active test.
+		expect(saved.tests).toHaveLength(1);
+		expect(saved.tests?.[0].testUuid).toBe('existing');
+		expect(countActiveTests(saved)).toBe(1);
+	});
+
+	it('ends the active test when AB testing is switched off', () => {
+		const existing = makeTest({ testUuid: 'existing', expiryDate: FUTURE });
+		const saved = saveTest(
+			makeCard([existing]),
+			makeFormValues({ abTestEnabled: false }),
+		);
+		expect(saved.tests).toHaveLength(1);
+		expect(saved.tests?.[0].hasManuallyEndedOnThisTrail).toBe(true);
+		expect(countActiveTests(saved)).toBe(0);
+	});
+
+	it('keeps exactly one active test when a card already has active and ended tests', () => {
+		const card = makeCard([
+			makeTest({ testUuid: 'active', expiryDate: FUTURE }),
+			makeTest({ testUuid: 'expired', expiryDate: PAST }),
+			makeTest({
+				testUuid: 'manually-ended',
+				expiryDate: FUTURE,
+				hasManuallyEndedOnThisTrail: true,
+			}),
+		]);
+		const saved = saveTest(card, makeFormValues());
+		// The active test is updated in place; the ended tests are untouched.
+		expect(saved.tests).toHaveLength(3);
+		expect(countActiveTests(saved)).toBe(1);
+	});
+
+	it('never has more than one active test across the test lifecycle', () => {
+		// Start from a card with an active test (as loaded from the server).
+		let card = makeCard([makeTest({ testUuid: 'live', expiryDate: FUTURE })]);
+		card = saveTest(card, makeFormValues({ headlineB: 'New Variant B' })); // edit it
+		expect(countActiveTests(card)).toBe(1);
+		card = saveTest(card, makeFormValues({ abTestEnabled: false })); // end it
+		expect(countActiveTests(card)).toBe(0);
+		card = saveTest(card, makeFormValues()); // start a fresh one (a draft)
+		expect(countActiveTests(card)).toBe(0);
+	});
+});


### PR DESCRIPTION
## What's changed?

DCR and the Data Lake assume a card has at most one active test. This PR confirms the Fronts Tool upholds that and adds regression coverage so it can't silently break in future.

After some investigation I was able to determine that it's impossible for a card to have more than one active test. Every test the tool creates is a draft (`getCardTestFromFormValues` never sets an `expiryDate`), so active tests only ever come from the server. On save, it reuses any existing active-or-draft test and updates it in place rather than adding a second, and `mayEndAbTest` only ends tests. So no tool action can ever increase the active test count.

To ensure this remains true in future, this PR introduces a new spec (`form.spec.ts`) which asserts the number of active tests stays <= 1 across enabling, editing, ending and re-enabling AB tests.

In the second commit I extracted some duplicated test setup logic into its own module. This is a matter of taste and I'm happy to be challenged on this.

## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
