### PR TITLE
Add "incomplete" ab test pill variant

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -126,9 +126,9 @@ const TestIndicator = styled(ButtonDefault)`
 	width: 18px;
 	&&:hover,
 	&&:active {
-		background: ${theme.base.colors.abTestActiveColor};
+		background: ${theme.abTest.activePrimaryColor};
 	}
-	background: ${theme.base.colors.abTestActiveColor};
+	background: ${theme.abTest.activePrimaryColor};
 `;
 
 const CollectionOverview = ({

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -126,9 +126,9 @@ const TestIndicator = styled(ButtonDefault)`
 	width: 18px;
 	&&:hover,
 	&&:active {
-		background: ${theme.abTest.activePrimaryColor};
+		background: ${theme.abTest.active.background};
 	}
-	background: ${theme.abTest.activePrimaryColor};
+	background: ${theme.abTest.active.background};
 `;
 
 const CollectionOverview = ({

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -132,18 +132,46 @@ const ClipboardFirstPublished = styled.div`
 	right: 0;
 `;
 
-const ABTestStatus = styled.div<{ useSecondaryTheme?: boolean }>`
-	background-color: ${({ useSecondaryTheme }) =>
-		useSecondaryTheme
-			? theme.base.colors.abTestSecondaryColor
-			: theme.base.colors.abTestActiveColor};
+type ABTestTheme = 'active' | 'secondary' | 'error';
+type ABTestPalette = {
+	background: string;
+	foreground: string;
+	border: string;
+};
+
+const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette => {
+	switch (abTestTheme) {
+		case 'error':
+			return {
+				background: theme.base.colors.abTestErrorBackgroundColor,
+				foreground: theme.base.colors.abTestErrorColor,
+				border: theme.base.colors.abTestErrorColor,
+			};
+		case 'secondary':
+			return {
+				background: theme.base.colors.abTestSecondaryColor,
+				foreground: theme.base.colors.abTestActiveColor,
+				border: theme.base.colors.abTestActiveColor,
+			};
+		case 'active':
+		default:
+			return {
+				background: theme.base.colors.abTestActiveColor,
+				foreground: 'white',
+				border: 'transparent',
+			};
+	}
+};
+
+const ABTestStatus = styled.div<{ abTestTheme: ABTestTheme }>`
+	background-color: ${({ abTestTheme }) =>
+		getABTestThemeColors(abTestTheme).background};
 	border-radius: 12px;
-	color: ${({ useSecondaryTheme }) =>
-		useSecondaryTheme ? theme.base.colors.abTestActiveColor : 'white'};
+	color: ${({ abTestTheme }) => getABTestThemeColors(abTestTheme).foreground};
 	border-width: 1px;
 	border-style: solid;
-	border-color: ${({ useSecondaryTheme }) =>
-		useSecondaryTheme ? theme.base.colors.abTestActiveColor : 'transparent'};
+	border-color: ${({ abTestTheme }) =>
+		getABTestThemeColors(abTestTheme).border};
 	font-weight: 700;
 	font-size: 12px;
 	padding: 4px 8px;
@@ -155,8 +183,8 @@ const ABTestStatus = styled.div<{ useSecondaryTheme?: boolean }>`
 	align-items: center;
 `;
 
-const EllipsisIconWrapper = styled.div`
-	border: 1px solid ${theme.base.colors.abTestActiveColor};
+const EllipsisIconWrapper = styled.div<{ color: string }>`
+	border: 1px solid ${({ color }) => color};
 	border-radius: 50%;
 	display: flex;
 	justify-content: center;
@@ -317,22 +345,45 @@ const articleBodyDefault = React.memo(
 			| 'Test set up incomplete'
 			| 'Ready to launch';
 
-		const determineABTestStatusMessage = (
+		type ABTestTheme = 'active' | 'secondary' | 'error';
+
+		type ABTestStatus = {
+			message: ABStatusMessage;
+			theme: ABTestTheme;
+			palette: ABTestPalette;
+		};
+		const determineABTestStatus = (
 			hasLiveAbTest: boolean | undefined,
 			abTestEnabled: boolean | undefined,
 			headlineTestError: AbTestHeadlineErrorType | null,
-		): ABStatusMessage | undefined => {
+		): ABTestStatus | undefined => {
 			if (hasLiveAbTest && abTestEnabled) {
-				return 'Test in progress';
+				return {
+					message: 'Test in progress',
+					theme: 'active',
+					palette: getABTestThemeColors('active'),
+				};
 			}
 			if (hasLiveAbTest && !abTestEnabled) {
-				return 'End test on launch';
+				return {
+					message: 'End test on launch',
+					theme: 'secondary',
+					palette: getABTestThemeColors('secondary'),
+				};
 			}
 			if (!hasLiveAbTest && abTestEnabled && headlineTestError) {
-				return 'Test set up incomplete';
+				return {
+					message: 'Test set up incomplete',
+					theme: 'error',
+					palette: getABTestThemeColors('error'),
+				};
 			}
 			if (!hasLiveAbTest && abTestEnabled && !headlineTestError) {
-				return 'Ready to launch';
+				return {
+					message: 'Ready to launch',
+					theme: 'secondary',
+					palette: getABTestThemeColors('secondary'),
+				};
 			}
 			return undefined;
 		};
@@ -373,13 +424,11 @@ const articleBodyDefault = React.memo(
 			setMainVideoPlatform(properties.platform);
 		}, [mainMediaVideoAtom, showMainVideo]);
 
-		const abTestStatusMessage = determineABTestStatusMessage(
+		const abTestStatus = determineABTestStatus(
 			hasLiveAbTest,
 			abTestEnabled,
 			headlineTestError,
 		);
-
-		const useSecondaryTheme = abTestStatusMessage !== 'Test in progress';
 
 		return (
 			<>
@@ -507,21 +556,17 @@ const articleBodyDefault = React.memo(
 						)}
 						{displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
 					</CardHeadingContainer>
-					{abTestStatusMessage && headlineABTestingIsEnabled && (
-						<ABTestStatus useSecondaryTheme={useSecondaryTheme}>
+					{abTestStatus && headlineABTestingIsEnabled && (
+						<ABTestStatus abTestTheme={abTestStatus.theme}>
 							<ConicalFlaskIcon
 								size={'xs'}
-								fill={
-									useSecondaryTheme
-										? theme.base.colors.abTestActiveColor
-										: 'white'
-								}
+								fill={abTestStatus.palette.foreground}
 							/>
-							{abTestStatusMessage}
-							{useSecondaryTheme && (
-								<EllipsisIconWrapper>
+							{abTestStatus.message}
+							{abTestStatus.theme === 'secondary' && (
+								<EllipsisIconWrapper color={abTestStatus.palette.foreground}>
 									<EllipsisIcon
-										fill={theme.base.colors.abTestActiveColor}
+										fill={abTestStatus.palette.foreground}
 										size={'xxs'}
 									/>
 								</EllipsisIconWrapper>

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -68,7 +68,7 @@ type ABStatusMessage =
 	| 'Test set up incomplete'
 	| 'Ready to launch';
 
-type ABTestTheme = 'active' | 'secondary' | 'error';
+type ABTestTheme = 'active' | 'draft' | 'error';
 
 type ABTestPalette = {
 	background: string;
@@ -153,32 +153,8 @@ const ClipboardFirstPublished = styled.div`
 	right: 0;
 `;
 
-const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette => {
-	switch (abTestTheme) {
-		case 'error':
-			return {
-				background: theme.abTest.errorPrimaryColor,
-				text: theme.abTest.errorTextColor,
-				border: theme.abTest.errorAccentColor,
-				icon: theme.abTest.errorAccentColor,
-			};
-		case 'secondary':
-			return {
-				background: theme.abTest.secondaryPrimaryColor,
-				text: theme.abTest.secondaryAccentColor,
-				border: theme.abTest.secondaryAccentColor,
-				icon: theme.abTest.secondaryAccentColor,
-			};
-		case 'active':
-		default:
-			return {
-				background: theme.abTest.activePrimaryColor,
-				text: theme.abTest.activeAccentColor,
-				border: theme.abTest.activeBorderColor,
-				icon: theme.abTest.activeAccentColor,
-			};
-	}
-};
+const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette =>
+	theme.abTest[abTestTheme];
 
 const ABTestStatus = styled.div<{ abTestTheme: ABTestTheme }>`
 	background-color: ${({ abTestTheme }) =>
@@ -371,8 +347,8 @@ const articleBodyDefault = React.memo(
 			if (hasLiveAbTest && !abTestEnabled) {
 				return {
 					message: 'End test on launch',
-					theme: 'secondary',
-					palette: getABTestThemeColors('secondary'),
+					theme: 'draft',
+					palette: getABTestThemeColors('draft'),
 				};
 			}
 			if (!hasLiveAbTest && abTestEnabled && headlineTestError) {
@@ -385,8 +361,8 @@ const articleBodyDefault = React.memo(
 			if (!hasLiveAbTest && abTestEnabled && !headlineTestError) {
 				return {
 					message: 'Ready to launch',
-					theme: 'secondary',
-					palette: getABTestThemeColors('secondary'),
+					theme: 'draft',
+					palette: getABTestThemeColors('draft'),
 				};
 			}
 			return undefined;

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -62,6 +62,26 @@ import {
 } from '@guardian/stand/IntendedAudienceSignifier';
 import { AbTestHeadlineErrorType } from '../../../util/abTests';
 
+type ABStatusMessage =
+	| 'Test in progress'
+	| 'End test on launch'
+	| 'Test set up incomplete'
+	| 'Ready to launch';
+
+type ABTestTheme = 'active' | 'secondary' | 'error';
+
+type ABTestPalette = {
+	background: string;
+	text: string;
+	border: string;
+	icon: string;
+};
+type ABTestStatus = {
+	message: ABStatusMessage;
+	theme: ABTestTheme;
+	palette: ABTestPalette;
+};
+
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
 	flex-shrink: 0;
 	width: 83px;
@@ -132,14 +152,6 @@ const ClipboardFirstPublished = styled.div`
 	bottom: 0;
 	right: 0;
 `;
-
-type ABTestTheme = 'active' | 'secondary' | 'error';
-type ABTestPalette = {
-	background: string;
-	text: string;
-	border: string;
-	icon: string;
-};
 
 const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette => {
 	switch (abTestTheme) {
@@ -260,7 +272,7 @@ interface ArticleBodyProps {
 	abTestEnabled?: boolean;
 	hasLiveAbTest?: boolean;
 	headlineABTestingIsEnabled?: boolean;
-	headlineTestError: AbTestHeadlineErrorType | null;
+	headlineTestError?: AbTestHeadlineErrorType | null;
 }
 
 const articleBodyDefault = React.memo(
@@ -344,23 +356,10 @@ const articleBodyDefault = React.memo(
 			imageCriteria.heightAspectRatio ===
 				portraitCardImageCriteria.heightAspectRatio;
 
-		type ABStatusMessage =
-			| 'Test in progress'
-			| 'End test on launch'
-			| 'Test set up incomplete'
-			| 'Ready to launch';
-
-		type ABTestTheme = 'active' | 'secondary' | 'error';
-
-		type ABTestStatus = {
-			message: ABStatusMessage;
-			theme: ABTestTheme;
-			palette: ABTestPalette;
-		};
 		const determineABTestStatus = (
 			hasLiveAbTest: boolean | undefined,
 			abTestEnabled: boolean | undefined,
-			headlineTestError: AbTestHeadlineErrorType | null,
+			headlineTestError: AbTestHeadlineErrorType | null | undefined,
 		): ABTestStatus | undefined => {
 			if (hasLiveAbTest && abTestEnabled) {
 				return {

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -59,6 +59,7 @@ import {
 	IntendedAudienceSignifier,
 	IntendedAudienceSignifierProps,
 } from '@guardian/stand/IntendedAudienceSignifier';
+import { AbTestHeadlineErrorType } from '../../../util/abTests';
 
 const ThumbnailPlaceholder = styled(BasePlaceholder)`
 	flex-shrink: 0;
@@ -226,6 +227,7 @@ interface ArticleBodyProps {
 	abTestEnabled?: boolean;
 	hasLiveAbTest?: boolean;
 	headlineABTestingIsEnabled?: boolean;
+	headlineTestError: AbTestHeadlineErrorType | null;
 }
 
 const articleBodyDefault = React.memo(
@@ -286,6 +288,7 @@ const articleBodyDefault = React.memo(
 		abTestEnabled,
 		hasLiveAbTest,
 		headlineABTestingIsEnabled,
+		headlineTestError,
 	}: ArticleBodyProps) => {
 		const displayByline = size === 'default' && showByline && byline;
 		const now = Date.now();
@@ -311,11 +314,13 @@ const articleBodyDefault = React.memo(
 		type ABStatusMessage =
 			| 'Test in progress'
 			| 'End test on launch'
+			| 'Test set up incomplete'
 			| 'Ready to launch';
 
 		const determineABTestStatusMessage = (
 			hasLiveAbTest: boolean | undefined,
 			abTestEnabled: boolean | undefined,
+			headlineTestError: AbTestHeadlineErrorType | null,
 		): ABStatusMessage | undefined => {
 			if (hasLiveAbTest && abTestEnabled) {
 				return 'Test in progress';
@@ -323,7 +328,10 @@ const articleBodyDefault = React.memo(
 			if (hasLiveAbTest && !abTestEnabled) {
 				return 'End test on launch';
 			}
-			if (!hasLiveAbTest && abTestEnabled) {
+			if (!hasLiveAbTest && abTestEnabled && headlineTestError) {
+				return 'Test set up incomplete';
+			}
+			if (!hasLiveAbTest && abTestEnabled && !headlineTestError) {
 				return 'Ready to launch';
 			}
 			return undefined;
@@ -368,6 +376,7 @@ const articleBodyDefault = React.memo(
 		const abTestStatusMessage = determineABTestStatusMessage(
 			hasLiveAbTest,
 			abTestEnabled,
+			headlineTestError,
 		);
 
 		const useSecondaryTheme = abTestStatusMessage !== 'Test in progress';

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -563,7 +563,7 @@ const articleBodyDefault = React.memo(
 								fill={abTestStatus.palette.foreground}
 							/>
 							{abTestStatus.message}
-							{abTestStatus.theme === 'secondary' && (
+							{abTestStatus.theme !== 'active' && (
 								<EllipsisIconWrapper color={abTestStatus.palette.foreground}>
 									<EllipsisIcon
 										fill={abTestStatus.palette.foreground}

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -33,6 +33,7 @@ import {
 	CinemagraphIcon,
 	ConicalFlaskIcon,
 	EllipsisIcon,
+	ExclamationIcon,
 	LoopIcon,
 	VideoIcon,
 	YoutubeIcon,
@@ -135,30 +136,34 @@ const ClipboardFirstPublished = styled.div`
 type ABTestTheme = 'active' | 'secondary' | 'error';
 type ABTestPalette = {
 	background: string;
-	foreground: string;
+	text: string;
 	border: string;
+	icon: string;
 };
 
 const getABTestThemeColors = (abTestTheme: ABTestTheme): ABTestPalette => {
 	switch (abTestTheme) {
 		case 'error':
 			return {
-				background: theme.base.colors.abTestErrorBackgroundColor,
-				foreground: theme.base.colors.abTestErrorColor,
-				border: theme.base.colors.abTestErrorColor,
+				background: theme.abTest.errorPrimaryColor,
+				text: theme.abTest.errorTextColor,
+				border: theme.abTest.errorAccentColor,
+				icon: theme.abTest.errorAccentColor,
 			};
 		case 'secondary':
 			return {
-				background: theme.base.colors.abTestSecondaryColor,
-				foreground: theme.base.colors.abTestActiveColor,
-				border: theme.base.colors.abTestActiveColor,
+				background: theme.abTest.secondaryPrimaryColor,
+				text: theme.abTest.secondaryAccentColor,
+				border: theme.abTest.secondaryAccentColor,
+				icon: theme.abTest.secondaryAccentColor,
 			};
 		case 'active':
 		default:
 			return {
-				background: theme.base.colors.abTestActiveColor,
-				foreground: 'white',
-				border: 'transparent',
+				background: theme.abTest.activePrimaryColor,
+				text: theme.abTest.activeAccentColor,
+				border: theme.abTest.activeBorderColor,
+				icon: theme.abTest.activeAccentColor,
 			};
 	}
 };
@@ -167,7 +172,7 @@ const ABTestStatus = styled.div<{ abTestTheme: ABTestTheme }>`
 	background-color: ${({ abTestTheme }) =>
 		getABTestThemeColors(abTestTheme).background};
 	border-radius: 12px;
-	color: ${({ abTestTheme }) => getABTestThemeColors(abTestTheme).foreground};
+	color: ${({ abTestTheme }) => getABTestThemeColors(abTestTheme).text};
 	border-width: 1px;
 	border-style: solid;
 	border-color: ${({ abTestTheme }) =>
@@ -558,17 +563,19 @@ const articleBodyDefault = React.memo(
 					</CardHeadingContainer>
 					{abTestStatus && headlineABTestingIsEnabled && (
 						<ABTestStatus abTestTheme={abTestStatus.theme}>
-							<ConicalFlaskIcon
-								size={'xs'}
-								fill={abTestStatus.palette.foreground}
-							/>
+							{abTestStatus.theme === 'error' ? (
+								<ExclamationIcon fill={abTestStatus.palette.icon} size={'s'} />
+							) : (
+								<ConicalFlaskIcon
+									size={'xs'}
+									fill={abTestStatus.palette.icon}
+								/>
+							)}
+
 							{abTestStatus.message}
 							{abTestStatus.theme !== 'active' && (
-								<EllipsisIconWrapper color={abTestStatus.palette.foreground}>
-									<EllipsisIcon
-										fill={abTestStatus.palette.foreground}
-										size={'xxs'}
-									/>
+								<EllipsisIconWrapper color={abTestStatus.palette.icon}>
+									<EllipsisIcon fill={abTestStatus.palette.icon} size={'xxs'} />
 								</EllipsisIconWrapper>
 							)}
 						</ABTestStatus>

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -27,7 +27,11 @@ import { dragEventHasImageData } from 'util/validateImageSrc';
 import { Criteria } from 'types/Grid';
 import { getMainMediaVideoAtom } from '../../../util/externalArticle';
 import { intendedAudienceFromTags } from 'lib/capi/IntendedAudience';
-import { hasActiveAbTestOnCard } from '../../../util/abTests';
+import {
+	AbTestHeadlineErrorType,
+	getCurrentAbTestHeadlineError,
+	hasActiveAbTestOnCard,
+} from '../../../util/abTests';
 
 const ArticleBodyContainer = styled(CardBody)<{
 	pillarId: string | undefined;
@@ -71,6 +75,7 @@ interface ArticleComponentProps {
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
 	hasLiveAbTest?: boolean;
 	headlineABTestingIsEnabled?: boolean;
+	headlineTestError: AbTestHeadlineErrorType | null;
 }
 
 interface ComponentProps extends ArticleComponentProps {
@@ -124,6 +129,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 			otherCollectionsOnSameFrontThisCardIsOn,
 			hasLiveAbTest,
 			headlineABTestingIsEnabled,
+			headlineTestError,
 		} = this.props;
 
 		const getArticleData = () =>
@@ -199,6 +205,7 @@ class ArticleCard extends React.Component<ComponentProps, ComponentState> {
 								}
 								hasLiveAbTest={hasLiveAbTest}
 								headlineABTestingIsEnabled={headlineABTestingIsEnabled}
+								headlineTestError={headlineTestError}
 							/>
 						</ArticleBodyContainer>
 					</DragIntentContainer>
@@ -222,6 +229,7 @@ const createMapStateToProps = () => {
 		featureFlagPageViewData: boolean;
 		hasLiveAbTest?: boolean;
 		headlineABTestingIsEnabled: boolean;
+		headlineTestError: AbTestHeadlineErrorType | null;
 	} => {
 		const article = selectArticle(state, props.id);
 		const card = selectCard(state, props.id);
@@ -232,6 +240,7 @@ const createMapStateToProps = () => {
 			props.collectionId,
 		);
 		const hasLiveAbTest = hasActiveAbTestOnCard(liveCard);
+		const headlineTestError = getCurrentAbTestHeadlineError(card);
 
 		return {
 			article,
@@ -245,6 +254,7 @@ const createMapStateToProps = () => {
 				state,
 				'headline-ab-testing',
 			),
+			headlineTestError: headlineTestError,
 		};
 	};
 };

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -75,7 +75,7 @@ interface ArticleComponentProps {
 	otherCollectionsOnSameFrontThisCardIsOn?: OtherCollectionsOnSameFrontThisCardIsOn;
 	hasLiveAbTest?: boolean;
 	headlineABTestingIsEnabled?: boolean;
-	headlineTestError: AbTestHeadlineErrorType | null;
+	headlineTestError?: AbTestHeadlineErrorType | null;
 }
 
 interface ComponentProps extends ArticleComponentProps {

--- a/fronts-client/src/components/icons/Icons.tsx
+++ b/fronts-client/src/components/icons/Icons.tsx
@@ -559,6 +559,27 @@ const EllipsisIcon = ({
 	</svg>
 );
 
+// (!)
+const ExclamationIcon = ({
+	fill = theme.colors.blackDark,
+	size = 's',
+}: IconProps) => (
+	<svg
+		width={`${mapSize(size)}px`}
+		height={`${mapSize(size)}px`}
+		viewBox="0 0 11 11"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+			d="M5.5 0C8.53757 0 11 2.46243 11 5.5C11 8.53757 8.53757 11 5.5 11C2.46243 11 0 8.53757 0 5.5C0 2.46243 2.46243 0 5.5 0ZM4.78906 7.53906V8.99902H6.31934V7.53906H4.78906ZM4.68945 1.78906L4.92969 6.45898H6.15918L6.39941 1.78906H4.68945Z"
+			fill={fill}
+		/>
+	</svg>
+);
+
 export {
 	DownCaretIcon,
 	RubbishBinIcon,
@@ -587,4 +608,5 @@ export {
 	CinemagraphIcon,
 	ConicalFlaskIcon,
 	EllipsisIcon,
+	ExclamationIcon,
 };

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -7,6 +7,7 @@ import InputCheckboxToggleInline from './InputCheckboxToggleInline';
 import ConditionalField from './ConditionalField';
 import styled from 'styled-components';
 import pageConfig from '../../util/extractConfigFromPage';
+import { normaliseHeadline } from '../../util/abTests';
 
 interface HeadlineInputProps {
 	abTestEnabled: boolean;
@@ -38,8 +39,6 @@ const HeadlineVariantContainer = styled('div')`
 	flex-direction: column;
 	gap: 6px;
 `;
-
-const normaliseHeadline = (value?: string) => (value ?? '').trim();
 
 const warnIfEmpty = (value: string | undefined) => {
 	return normaliseHeadline(value) === '' ? 'Headline missing' : undefined;

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -19,7 +19,7 @@ interface HeadlineInputProps {
 
 const HeadlineInputContainer = styled('div')<{ abTestEnabled: boolean }>`
 	background-color: ${({ abTestEnabled, theme }) =>
-		abTestEnabled ? theme.input.abTestSecondaryColor : 'transparent'};
+		abTestEnabled ? theme.abTest.draft.background : 'transparent'};
 	border-radius: 4px;
 	padding: ${({ abTestEnabled }) =>
 		abTestEnabled ? '4px 14px 12px' : '4px 0px 0px'};

--- a/fronts-client/src/components/inputs/InputCheckboxToggleInline.tsx
+++ b/fronts-client/src/components/inputs/InputCheckboxToggleInline.tsx
@@ -28,7 +28,7 @@ const Label = styled(InputLabel)<{
 }>`
 	color: ${({ useABTestStyling, activeABTest, theme }) =>
 		useABTestStyling && activeABTest
-			? theme.input.abTestActiveColor
+			? theme.abTest.active.background
 			: theme.input.colorLabel};
 	line-height: 15px;
 	flex: 1;
@@ -84,13 +84,13 @@ const Checkbox = styled.input<{ useABTestStyling?: boolean }>`
 	:checked + ${CheckboxLabel} {
 		background-color: ${({ useABTestStyling }) =>
 			useABTestStyling
-				? theme.input.abTestActiveColor
+				? theme.abTest.active.background
 				: theme.input.checkboxColorActive};
 	}
 	&:checked + ${CheckboxLabel}, &:checked + ${CheckboxLabel}:before {
 		border-color: ${({ useABTestStyling }) =>
 			useABTestStyling
-				? theme.input.abTestActiveColor
+				? theme.abTest.active.background
 				: theme.input.checkboxColorActive};
 		right: 0px;
 	}
@@ -147,7 +147,7 @@ export default ({
 							size={'xs'}
 							fill={
 								activeABTest
-									? theme.input.abTestActiveColor
+									? theme.abTest.active.background
 									: theme.input.colorLabel
 							}
 						/>

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -14,6 +14,7 @@ const colors = {
 	blackDark: '#121212', // darkest
 	blackLight: '#333',
 	blue: '#3B82F6',
+	blueDark: '#1B67E2',
 	blueGrey: '#EEF2F6',
 	greyDark: '#444444',
 	greyMediumDark: '#515151',
@@ -72,10 +73,11 @@ const base = {
 		placeholderDark: colors.greyLight,
 		focusColor: colors.orange,
 		dangerColor: colors.red,
-		abTestActiveColor: colors.blue,
+		abTestActiveColor: colors.blueDark,
 		abTestSecondaryColor: colors.blueGrey,
 		abTestErrorColor: colors.orange,
 		abTestErrorBackgroundColor: colors.white,
+		abTestErrorForegroundColor: colors.blackDark,
 	},
 };
 

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -116,14 +116,24 @@ const button = {
 };
 
 const abTest = {
-	activePrimaryColor: colors.blueDark,
-	activeAccentColor: colors.white,
-	activeBorderColor: 'transparent',
-	secondaryPrimaryColor: colors.blueGrey,
-	secondaryAccentColor: colors.blueDark,
-	errorPrimaryColor: colors.white,
-	errorTextColor: colors.blackDark,
-	errorAccentColor: colors.orange,
+	active: {
+		background: colors.blueDark,
+		text: colors.white,
+		border: 'transparent',
+		icon: colors.white,
+	},
+	draft: {
+		background: colors.blueGrey,
+		text: colors.blueDark,
+		border: colors.blueDark,
+		icon: colors.blueDark,
+	},
+	error: {
+		background: colors.white,
+		text: colors.blackDark,
+		border: colors.orange,
+		icon: colors.orange,
+	},
 };
 
 const input = {
@@ -144,8 +154,6 @@ const input = {
 	placeholderText: base.colors.placeholderDark,
 	radioButtonBackgroundDisabled: '#E6E6E6',
 	checkboxButtonBackgroundDisabled: '#E6E6E6',
-	abTestActiveColor: abTest.activePrimaryColor,
-	abTestSecondaryColor: abTest.secondaryPrimaryColor,
 };
 
 const collection = {

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -74,6 +74,8 @@ const base = {
 		dangerColor: colors.red,
 		abTestActiveColor: colors.blue,
 		abTestSecondaryColor: colors.blueGrey,
+		abTestErrorColor: colors.orange,
+		abTestErrorBackgroundColor: colors.white,
 	},
 };
 
@@ -136,6 +138,8 @@ const input = {
 	checkboxButtonBackgroundDisabled: '#E6E6E6',
 	abTestActiveColor: base.colors.abTestActiveColor,
 	abTestSecondaryColor: base.colors.abTestSecondaryColor,
+	abTestErrorColor: base.colors.abTestErrorColor,
+	abTestErrorBackgroundColor: base.colors.abTestErrorBackgroundColor,
 };
 
 const collection = {

--- a/fronts-client/src/constants/theme.ts
+++ b/fronts-client/src/constants/theme.ts
@@ -73,11 +73,6 @@ const base = {
 		placeholderDark: colors.greyLight,
 		focusColor: colors.orange,
 		dangerColor: colors.red,
-		abTestActiveColor: colors.blueDark,
-		abTestSecondaryColor: colors.blueGrey,
-		abTestErrorColor: colors.orange,
-		abTestErrorBackgroundColor: colors.white,
-		abTestErrorForegroundColor: colors.blackDark,
 	},
 };
 
@@ -120,6 +115,17 @@ const button = {
 	backgroundColorHighlightFocused: base.colors.highlightColorFocused,
 };
 
+const abTest = {
+	activePrimaryColor: colors.blueDark,
+	activeAccentColor: colors.white,
+	activeBorderColor: 'transparent',
+	secondaryPrimaryColor: colors.blueGrey,
+	secondaryAccentColor: colors.blueDark,
+	errorPrimaryColor: colors.white,
+	errorTextColor: colors.blackDark,
+	errorAccentColor: colors.orange,
+};
+
 const input = {
 	height: '30px',
 	paddingY: '3px',
@@ -138,10 +144,8 @@ const input = {
 	placeholderText: base.colors.placeholderDark,
 	radioButtonBackgroundDisabled: '#E6E6E6',
 	checkboxButtonBackgroundDisabled: '#E6E6E6',
-	abTestActiveColor: base.colors.abTestActiveColor,
-	abTestSecondaryColor: base.colors.abTestSecondaryColor,
-	abTestErrorColor: base.colors.abTestErrorColor,
-	abTestErrorBackgroundColor: base.colors.abTestErrorBackgroundColor,
+	abTestActiveColor: abTest.activePrimaryColor,
+	abTestSecondaryColor: abTest.secondaryPrimaryColor,
 };
 
 const collection = {
@@ -193,6 +197,7 @@ export const theme = {
 	thumbnailImage,
 	thumbnailImageSquare,
 	thumbnailImagePortrait,
+	abTest,
 };
 
 export type Theme = typeof theme;

--- a/fronts-client/src/selectors/__tests__/collection.spec.ts
+++ b/fronts-client/src/selectors/__tests__/collection.spec.ts
@@ -1,8 +1,33 @@
 import {
 	selectCardsInCollections,
 	createSelectIsArticleInCollection,
+	createSelectActiveAbTestHeadlineErrorsForCollection,
 } from '../collection';
 import { stateWithCollection } from '../../fixtures/shared';
+import { Test } from '../../types/Collection';
+import { FUTURE, makeTest, makeVariantMeta } from '../../fixtures/abTests';
+
+const makeActiveTest = (
+	headlineA: string | undefined,
+	headlineB: string | undefined,
+): Test =>
+	makeTest({
+		expiryDate: FUTURE,
+		variantMeta: makeVariantMeta(headlineA, headlineB),
+	});
+
+const DRAFT_CARD_A = '4bc11359-bb3e-45e7-a0a9-86c0ee52653d';
+const DRAFT_CARD_B = '12e1d70d-bad5-4c8d-b53c-cf38d01bc11d';
+
+const stateWithTests = (
+	tests: Record<string, Test | undefined>,
+): typeof stateWithCollection => {
+	const state = JSON.parse(JSON.stringify(stateWithCollection));
+	Object.entries(tests).forEach(([cardId, test]) => {
+		state.cards[cardId].tests = test ? [test] : undefined;
+	});
+	return state;
+};
 
 describe('Collection selectors', () => {
 	describe('selectCardsInCollections', () => {
@@ -54,6 +79,54 @@ describe('Collection selectors', () => {
 					cardId: 'not-a-thing',
 				}),
 			).toEqual(false);
+		});
+	});
+	describe('createSelectActiveAbTestHeadlineErrorsForCollection', () => {
+		const selectErrors = createSelectActiveAbTestHeadlineErrorsForCollection();
+
+		it('returns no errors when no draft card has an invalid active test', () => {
+			expect(
+				selectErrors(stateWithCollection, {
+					collectionId: 'exampleCollectionTwo',
+				}),
+			).toEqual([]);
+		});
+
+		it('flags a draft card whose active test has duplicate headlines', () => {
+			const state = stateWithTests({
+				[DRAFT_CARD_A]: makeActiveTest('Same', 'Same'),
+			});
+			expect(
+				selectErrors(state, { collectionId: 'exampleCollectionTwo' }),
+			).toEqual([
+				expect.objectContaining({
+					cardId: DRAFT_CARD_A,
+					error: 'duplicate',
+				}),
+			]);
+		});
+
+		it('flags a draft card whose active test has incomplete headlines', () => {
+			const state = stateWithTests({
+				[DRAFT_CARD_B]: makeActiveTest('Headline A', undefined),
+			});
+			expect(
+				selectErrors(state, { collectionId: 'exampleCollectionTwo' }),
+			).toEqual([
+				expect.objectContaining({
+					cardId: DRAFT_CARD_B,
+					error: 'incomplete',
+				}),
+			]);
+		});
+
+		it('does not flag a draft card with a valid active test', () => {
+			const state = stateWithTests({
+				[DRAFT_CARD_A]: makeActiveTest('Headline A', 'Headline B'),
+			});
+			expect(
+				selectErrors(state, { collectionId: 'exampleCollectionTwo' }),
+			).toEqual([]);
 		});
 	});
 });

--- a/fronts-client/src/util/abTests.ts
+++ b/fronts-client/src/util/abTests.ts
@@ -31,8 +31,8 @@ export const getCurrentAbTestHeadlineError = (
 		return null;
 	}
 
-	const headlineA = getVariantHeadline(currentTest, 'A')?.toLowerCase().trim();
-	const headlineB = getVariantHeadline(currentTest, 'B')?.toLowerCase().trim();
+	const headlineA = normaliseHeadline(getVariantHeadline(currentTest, 'A'));
+	const headlineB = normaliseHeadline(getVariantHeadline(currentTest, 'B'));
 
 	if (!headlineA || !headlineB) {
 		return 'incomplete';
@@ -53,3 +53,6 @@ export const getVariantHeadline = (
 	return test?.variantMeta.find((variant) => variant.id === variantId)?.meta
 		.headline;
 };
+
+export const normaliseHeadline = (value?: string) =>
+	value?.toLowerCase().trim();


### PR DESCRIPTION
## What's changed?
Adds a third ab test pill variant for when a test is incomplete. 

A test is incomplete when either of the following criteria is met:
1. either headline is blank
2. both headlines are matching

Previously, we handled two pills and themes. In adding a third, I have refactored the way that themes and ab test status is managed. Theme, palette and message are now coupled together in one `ABTestStatus` object depending on the current state of the ab test. Similarly, colours used in the pill have been coupled together in an `ABTestPalette` object

Additionally this PR also introduces a new exclamation icon svg and colour palette, both of which are used in the new `incomplete` pill


## Screenshot
<img width="702" height="944" alt="Screenshot 2026-08-19 at 16 25 07" src="https://github.com/user-attachments/assets/1aa7403f-7b14-4496-9d43-a79ab1cdbfe4" />


### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
