### PR TITLE
Disable text input on launched test

### DIFF
--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -15,9 +15,11 @@ import {
 	createSelectArticleFromCard,
 	selectExternalArticleFromCard,
 	selectArticleTag,
+	selectCard,
 } from 'selectors/shared';
 import { createSelectFormFieldsForCard } from 'selectors/formSelectors';
 import { emptyObject } from 'util/selectorUtils';
+import { hasActiveAbTestOnCard } from 'util/abTests';
 import {
 	CardMeta,
 	ArticleTag,
@@ -559,6 +561,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			pristine,
 			showByline,
 			abTestEnabled,
+			hasActiveABTest,
 			headline,
 			editableFields = [],
 			showKickerTag,
@@ -722,6 +725,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 						{shouldRenderField('headline', editableFields) && (
 							<HeadlineInput
 								abTestEnabled={abTestEnabled}
+								hasActiveABTest={hasActiveABTest}
 								capiHeadline={articleCapiFieldValues.headline}
 								cardId={this.props.cardId}
 								editableFields={editableFields}
@@ -1279,6 +1283,7 @@ interface ContainerProps {
 	pickedKicker: string | undefined;
 	showByline: boolean;
 	abTestEnabled: boolean;
+	hasActiveABTest: boolean;
 	headline: string;
 	editableFields?: string[];
 	showKickerTag: boolean;
@@ -1361,6 +1366,7 @@ const createMapStateToProps = () => {
 			replaceVideoUri: valueSelector(state, 'replaceVideoUri'),
 			showByline: valueSelector(state, 'showByline'),
 			abTestEnabled: valueSelector(state, 'abTestEnabled'),
+			hasActiveABTest: hasActiveAbTestOnCard(selectCard(state, cardId)),
 			headline: valueSelector(state, 'headline'),
 			showKickerTag: valueSelector(state, 'showKickerTag'),
 			showKickerSection: valueSelector(state, 'showKickerSection'),

--- a/fronts-client/src/components/form/__tests__/ArticleMetaForm.spec.tsx
+++ b/fronts-client/src/components/form/__tests__/ArticleMetaForm.spec.tsx
@@ -5,7 +5,15 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from 'constants/theme';
 import configureStore from 'util/configureStore';
 import { state as initialState } from 'fixtures/initialState';
+import { Test, VariantMeta } from 'types/Collection';
+import { State } from 'types/State';
 import ArticleMetaForm from '../ArticleMetaForm';
+import { FUTURE, makeTest } from '../../../fixtures/abTests';
+
+const variantMeta: VariantMeta[] = [
+	{ id: 'A', meta: { headline: 'Headline A variant' } },
+	{ id: 'B', meta: { headline: 'Headline B variant' } },
+];
 
 // TODO: Remove when no longer gated behind feature switch
 jest.mock('util/extractConfigFromPage', () => {
@@ -23,10 +31,42 @@ jest.mock('util/extractConfigFromPage', () => {
 
 afterEach(cleanup);
 
+const cardId = 'exampleId';
+
+const getStateWithTestOnExampleCard = (test: Test): State => ({
+	...initialState,
+	cards: {
+		...initialState.cards,
+		[cardId]: {
+			...initialState.cards[cardId],
+			tests: [test],
+		},
+	},
+});
+
+const renderForm = (state: State) => {
+	const store = configureStore(state);
+	return {
+		store,
+		...render(
+			<Provider store={store}>
+				<ThemeProvider theme={theme}>
+					<ArticleMetaForm
+						cardId={cardId}
+						form={cardId}
+						frontId="frontId"
+						onSave={jest.fn()}
+						onCancel={jest.fn()}
+					/>
+				</ThemeProvider>
+			</Provider>,
+		),
+	};
+};
+
 describe('ArticleMetaForm - headline AB testing', () => {
 	it('copies the card headline into headlineA when the AB test toggle is switched on', () => {
 		const store = configureStore(initialState);
-		const cardId = 'exampleId';
 
 		const { getByTestId } = render(
 			<Provider store={store}>
@@ -60,5 +100,45 @@ describe('ArticleMetaForm - headline AB testing', () => {
 			'edit-form-headline-a-field',
 		) as HTMLTextAreaElement;
 		expect(headlineAField.value).toBe('Bill Shorten');
+	});
+
+	it('disables the Headline A & Headline B input when the card has an active launched test', () => {
+		const launchedTest = makeTest({
+			variantMeta,
+			expiryDate: FUTURE,
+		});
+
+		const { getByTestId } = renderForm(
+			getStateWithTestOnExampleCard(launchedTest),
+		);
+
+		const headlineAField = getByTestId(
+			'edit-form-headline-a-field',
+		) as HTMLTextAreaElement;
+		const headlineBField = getByTestId(
+			'edit-form-headline-b-field',
+		) as HTMLTextAreaElement;
+
+		expect(headlineAField.disabled).toBe(true);
+		expect(headlineBField.disabled).toBe(true);
+	});
+
+	it('does not disable the Headline A & Headline B input when the card only has a draft test', () => {
+		// A draft test has no expiryDate, so it is not considered launched
+		const draftTest = makeTest({ variantMeta });
+
+		const { getByTestId } = renderForm(
+			getStateWithTestOnExampleCard(draftTest),
+		);
+
+		const headlineAField = getByTestId(
+			'edit-form-headline-a-field',
+		) as HTMLTextAreaElement;
+		const headlineBField = getByTestId(
+			'edit-form-headline-b-field',
+		) as HTMLTextAreaElement;
+
+		expect(headlineAField.disabled).toBe(false);
+		expect(headlineBField.disabled).toBe(false);
 	});
 });

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -10,6 +10,7 @@ import pageConfig from '../../util/extractConfigFromPage';
 
 interface HeadlineInputProps {
 	abTestEnabled: boolean;
+	hasActiveABTest: boolean;
 	capiHeadline: string;
 	cardId: string;
 	editableFields: string[];
@@ -91,6 +92,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						component={InputTextArea}
 						data-testid="edit-form-headline-a-field"
 						placeholder={props.capiHeadline}
+						disabled={props.hasActiveABTest}
 					/>
 					<ConditionalField
 						permittedFields={props.editableFields}
@@ -99,6 +101,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 						rows="2"
 						component={InputTextArea}
 						data-testid="edit-form-headline-b-field"
+						disabled={props.hasActiveABTest}
 					/>
 				</HeadlineVariantContainer>
 			) : (


### PR DESCRIPTION
## What's changed?
Prevents edits to the test headline fields if they are from an active ab test. `Active` means a test that has been saved and launched. 

This is to prevent users editing variant fields mid test and invalidating the test results. 

## Screengrab

https://github.com/user-attachments/assets/66c46f45-831a-4eed-b3d0-78e3f0a1500c


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
