### PR TITLE
Set manuallyEndedOnThisTrailDate when a test is manually ended

### DIFF
--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -166,11 +166,9 @@ object FaciaApi {
   private def addTestDatesToTrail(trail: Trail, now: DateTime): Trail = {
     val updatedTests = trail.tests.map(_.map { test =>
       if (test.hasManuallyEndedOnThisTrail) {
-        test.manuallyEndedOnThisTrailDate match {
-          case Some(endedDate) => test
-          case _ =>
-            test.copy(manuallyEndedOnThisTrailDate = Some(now.getMillis))
-        }
+        test.copy(manuallyEndedOnThisTrailDate =
+          test.manuallyEndedOnThisTrailDate.orElse(Some(now.getMillis))
+        )
       } else {
         val startDate = test.startDate.orElse(Some(now.getMillis))
         val expiryDate = test.expiryDate.orElse(Some(now.plusDays(1).getMillis))

--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -165,8 +165,13 @@ object FaciaApi {
 
   private def addTestDatesToTrail(trail: Trail, now: DateTime): Trail = {
     val updatedTests = trail.tests.map(_.map { test =>
-      if (test.hasManuallyEndedOnThisTrail) test
-      else {
+      if (test.hasManuallyEndedOnThisTrail) {
+        test.manuallyEndedOnThisTrailDate match {
+          case Some(endedDate) => test
+          case _ =>
+            test.copy(manuallyEndedOnThisTrailDate = Some(now.getMillis))
+        }
+      } else {
         val startDate = test.startDate.orElse(Some(now.getMillis))
         val expiryDate = test.expiryDate.orElse(Some(now.plusDays(1).getMillis))
         test.copy(startDate = startDate, expiryDate = expiryDate)

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "37.0.0",
+  "com.gu" %% "fapi-client-play30" % "38.0.0-PREVIEW.eiadd-manually-ended-date.2026-08-21T1150.d5613722",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "21.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "38.0.0-PREVIEW.eiadd-manually-ended-date.2026-08-21T1150.d5613722",
+  "com.gu" %% "fapi-client-play30" % "38.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "21.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/test/tools/FaciaApiTest.scala
+++ b/test/tools/FaciaApiTest.scala
@@ -116,7 +116,8 @@ class FaciaApiTest extends FreeSpec with Matchers {
     frontsThisTestCanRunOn = Nil,
     hasManuallyEndedOnThisTrail = hasManuallyEndedOnThisTrail,
     manuallyEndedOnThisTrailByName = None,
-    manuallyEndedOnThisTrailByEmail = None
+    manuallyEndedOnThisTrailByEmail = None,
+    manuallyEndedOnThisTrailDate = None
   )
 
   private def scenarioWithTests: (User, CollectionJson) = {


### PR DESCRIPTION
## What's changed?
Bumps the model to bring in the `manuallyEndedOnThisTrailDate` field, and sets a value for that field when a test is manually ended on a card, and the card is launched.


<img width="540" height="424" alt="Screenshot 2026-08-21 at 16 21 58" src="https://github.com/user-attachments/assets/eead26c2-7d37-49c1-95a0-b3a4d084657f" />
