### PR TITLE
Add Ophan banner to in progess tests

### DIFF
--- a/fronts-client/src/components/OphanBanner.tsx
+++ b/fronts-client/src/components/OphanBanner.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import styled from 'styled-components';
+import { ConicalFlaskIcon } from './icons/Icons';
+import { theme } from 'constants/theme';
+import url from '../constants/url';
+
+const OphanBannerContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+	background: ${({ theme }) => theme.abTest.active.background};
+	color: ${({ theme }) => theme.abTest.active.text};
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	padding: 10px 18px;
+	margin: 10px -14px -12px -14px;
+	font-size: 14px;
+`;
+
+const OphanBannerTitle = styled.span`
+	font-weight: 600;
+`;
+
+const OphanBannerLink = styled.a`
+	color: ${({ theme }) => theme.abTest.active.text};
+`;
+
+const OphanBanner = () => {
+	return (
+		<OphanBannerContainer role="status">
+			<ConicalFlaskIcon size="xs" fill={theme.abTest.active.icon} />
+			<OphanBannerTitle>Headline Test In Progress:</OphanBannerTitle>
+			<span>
+				View results in{' '}
+				<OphanBannerLink
+					href={url.ophan}
+					target="_blank"
+					rel="noreferrer noopener"
+					aria-label="View results in Ophan (opens in a new tab)"
+				>
+					Ophan
+				</OphanBannerLink>
+			</span>
+		</OphanBannerContainer>
+	);
+};
+
+export { OphanBanner };

--- a/fronts-client/src/components/OphanBanner.tsx
+++ b/fronts-client/src/components/OphanBanner.tsx
@@ -31,7 +31,7 @@ const OphanBanner = () => {
 	return (
 		<OphanBannerContainer role="status">
 			<ConicalFlaskIcon size="xs" fill={theme.abTest.active.icon} />
-			<OphanBannerTitle>Headline Test In Progress:</OphanBannerTitle>
+			<OphanBannerTitle>Headline Test In Progress :</OphanBannerTitle>
 			<span>
 				View results in{' '}
 				<OphanBannerLink

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -8,6 +8,8 @@ import ConditionalField from './ConditionalField';
 import styled from 'styled-components';
 import pageConfig from '../../util/extractConfigFromPage';
 import { normaliseHeadline } from '../../util/abTests';
+import { ConicalFlaskIcon } from '../icons/Icons';
+import url from '../../constants/url';
 
 interface HeadlineInputProps {
 	abTestEnabled: boolean;
@@ -39,6 +41,27 @@ const HeadlineVariantContainer = styled('div')`
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
+`;
+
+const OphanBannerContainer = styled('div')`
+	display: flex;
+	background: ${({ theme }) => theme.abTest.active.background};
+	color: ${({ theme }) => theme.abTest.active.text};
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	padding: 10px 18px;
+	margin: 10px -14px -12px -14px;
+	font-size: 14px;
+`;
+
+const OphanBannerTitle = styled('span')`
+	font-weight: 600;
+`;
+const OphanBannerLink = styled('a')`
+	color: ${({ theme }) => theme.abTest.active.text};
 `;
 
 const warnIfEmpty = (value: string | undefined) => {
@@ -128,6 +151,18 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 					data-testid="edit-form-headline-field"
 				/>
 			)}
+			<OphanBannerContainer>
+				<ConicalFlaskIcon size={'xs'} fill={'white'} />{' '}
+				<OphanBannerTitle>Headline Test In Progress :</OphanBannerTitle> View
+				results in{' '}
+				<OphanBannerLink
+					href={url.ophan}
+					target="_blank"
+					rel="noreferrer noopener"
+				>
+					Ophan
+				</OphanBannerLink>
+			</OphanBannerContainer>
 		</HeadlineInputContainer>
 	);
 };

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -129,7 +129,9 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 					data-testid="edit-form-headline-field"
 				/>
 			)}
-			{props.abTestEnabled && props.hasActiveABTest && <OphanBanner />}
+			{abTestFeatureEnabled && props.abTestEnabled && props.hasActiveABTest && (
+				<OphanBanner />
+			)}
 		</HeadlineInputContainer>
 	);
 };

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -129,7 +129,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 					data-testid="edit-form-headline-field"
 				/>
 			)}
-			<OphanBanner />
+			{props.abTestEnabled && props.hasActiveABTest && <OphanBanner />}
 		</HeadlineInputContainer>
 	);
 };

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -5,11 +5,10 @@ import { RichTextInput } from './RichTextInput';
 import InputTextArea from './InputTextArea';
 import InputCheckboxToggleInline from './InputCheckboxToggleInline';
 import ConditionalField from './ConditionalField';
+import { OphanBanner } from '../OphanBanner';
 import styled from 'styled-components';
 import pageConfig from '../../util/extractConfigFromPage';
 import { normaliseHeadline } from '../../util/abTests';
-import { ConicalFlaskIcon } from '../icons/Icons';
-import url from '../../constants/url';
 
 interface HeadlineInputProps {
 	abTestEnabled: boolean;
@@ -41,27 +40,6 @@ const HeadlineVariantContainer = styled('div')`
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
-`;
-
-const OphanBannerContainer = styled('div')`
-	display: flex;
-	background: ${({ theme }) => theme.abTest.active.background};
-	color: ${({ theme }) => theme.abTest.active.text};
-	flex-direction: row;
-	align-items: center;
-	gap: 6px;
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
-	padding: 10px 18px;
-	margin: 10px -14px -12px -14px;
-	font-size: 14px;
-`;
-
-const OphanBannerTitle = styled('span')`
-	font-weight: 600;
-`;
-const OphanBannerLink = styled('a')`
-	color: ${({ theme }) => theme.abTest.active.text};
 `;
 
 const warnIfEmpty = (value: string | undefined) => {
@@ -151,18 +129,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 					data-testid="edit-form-headline-field"
 				/>
 			)}
-			<OphanBannerContainer>
-				<ConicalFlaskIcon size={'xs'} fill={'white'} />{' '}
-				<OphanBannerTitle>Headline Test In Progress :</OphanBannerTitle> View
-				results in{' '}
-				<OphanBannerLink
-					href={url.ophan}
-					target="_blank"
-					rel="noreferrer noopener"
-				>
-					Ophan
-				</OphanBannerLink>
-			</OphanBannerContainer>
+			<OphanBanner />
 		</HeadlineInputContainer>
 	);
 };

--- a/fronts-client/src/constants/url.ts
+++ b/fronts-client/src/constants/url.ts
@@ -45,4 +45,6 @@ export default {
 	liveUrlPROD: 'https://www.theguardian.com/',
 	emailLiveUrlCODE,
 	emailLiveUrlPROD,
+	//TODO: update to the correct url
+	ophan: 'https://dashboard.ophan.co.uk/',
 };


### PR DESCRIPTION
## What's changed?
Adds an Ophan click through link in a banner at the bottom of editorial tests that are in progress. This will provide a quick way for users to view current test results. 

NB: this link currently goes to ` https://dashboard.ophan.co.uk/` as the Ophan Editorial AB test dashboard is currently being built. Once the editorial ab test dashboard is ready, the link should be updated to direct users to this dashboard instead.

## Screenshot
<img width="1048" height="1090" alt="Screenshot 2026-08-24 at 18 13 58" src="https://github.com/user-attachments/assets/3cd04632-461e-4aca-bb00-a1d6ef9c8b4b" />

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
