### PR TITLE
Lift front restriction so AB headline tests can run on all fronts

### DIFF
--- a/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionComponents/Collection.tsx
@@ -233,8 +233,6 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 
 		const groupIds = groups.map((group) => group.uuid);
 
-		const isUSNetworkFront = frontId === 'us';
-
 		return (
 			<>
 				<CollectionDisplay
@@ -310,13 +308,11 @@ class Collection extends React.Component<CollectionProps, CollectionState> {
 											<OpenFormsWarning collectionId={id} frontId={frontId} />
 										</OpenFormsWarningContainer>
 									)}
-									{hasAbTestHeadlineErrors &&
-										isUSNetworkFront &&
-										this.state.showFormWarnings && (
-											<OpenFormsWarningContainer>
-												<AbTestHeadlineWarning collectionId={id} />
-											</OpenFormsWarningContainer>
-										)}
+									{hasAbTestHeadlineErrors && this.state.showFormWarnings && (
+										<OpenFormsWarningContainer>
+											<AbTestHeadlineWarning collectionId={id} />
+										</OpenFormsWarningContainer>
+									)}
 									<EditModeVisibility visibleMode="fronts">
 										<Button
 											size="l"

--- a/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
+++ b/fronts-client/src/components/FrontsEdit/CollectionOverview.tsx
@@ -138,14 +138,8 @@ const CollectionOverview = ({
 	isSelected,
 	hasOpenForms,
 	liveAndDraftCards,
-}: FrontCollectionOverviewProps) => {
-	/*
-	 * Initial rollout of Editorial AB testing will be limited to the US front only.
-	 * Removal of this front restriction will be covered by https://github.com/guardian/frontend/issues/29129
-	 */
-	const isUSNetworkFront = frontId === 'us';
-
-	return collection ? (
+}: FrontCollectionOverviewProps) =>
+	collection ? (
 		<Container
 			onClick={(e: React.MouseEvent) => {
 				e.preventDefault();
@@ -201,9 +195,7 @@ const CollectionOverview = ({
 							</StatusWarning>
 						</EditModeVisibility>
 					) : null)}
-				{liveAndDraftCards.some(
-					(card) => hasActiveAbTestOnCard(card) && isUSNetworkFront,
-				) && (
+				{liveAndDraftCards.some((card) => hasActiveAbTestOnCard(card)) && (
 					<EditModeVisibility visibleMode="fronts">
 						<TestIndicator priority="primary" size="s" title="Active tests">
 							<ConicalFlaskIcon size={'xxs'} fill={'white'} />
@@ -213,7 +205,7 @@ const CollectionOverview = ({
 			</TextContainerRight>
 		</Container>
 	) : null;
-};
+
 const mapStateToProps = () => {
 	const selectCollection = createSelectCollection();
 	const selectCardsInCollection = createSelectCardsInCollection();

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -408,14 +408,6 @@ const articleBodyDefault = React.memo(
 			headlineTestError,
 		);
 
-		/*
-		 * Initial rollout of Editorial AB testing will be limited to the US front only.
-		 * Removal of this front restriction will be covered by https://github.com/guardian/frontend/issues/29129
-		 */
-		const isUSNetworkFront = frontId === 'us';
-
-		const shouldShowAbTestStatus = !!abTestStatus && isUSNetworkFront;
-
 		return (
 			<>
 				{showMeta && (
@@ -542,7 +534,7 @@ const articleBodyDefault = React.memo(
 						)}
 						{displayByline && <ArticleBodyByline>{byline}</ArticleBodyByline>}
 					</CardHeadingContainer>
-					{shouldShowAbTestStatus && (
+					{!!abTestStatus && (
 						<ABTestStatus abTestTheme={abTestStatus.theme}>
 							{abTestStatus.theme === 'error' ? (
 								<ExclamationIcon fill={abTestStatus.palette.icon} size={'s'} />

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -731,7 +731,6 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								editableFields={editableFields}
 								snapType={this.props.snapType}
 								onAbTestToggle={handleAbTestToggle}
-								frontId={this.props.frontId}
 							/>
 						)}
 						<CheckboxFieldsContainer

--- a/fronts-client/src/components/form/__tests__/ArticleMetaForm.spec.tsx
+++ b/fronts-client/src/components/form/__tests__/ArticleMetaForm.spec.tsx
@@ -40,7 +40,7 @@ const renderForm = (state: State) => {
 					<ArticleMetaForm
 						cardId={cardId}
 						form={cardId}
-						frontId="us"
+						frontId="frontId"
 						onSave={jest.fn()}
 						onCancel={jest.fn()}
 					/>
@@ -60,7 +60,7 @@ describe('ArticleMetaForm - headline AB testing', () => {
 					<ArticleMetaForm
 						cardId={cardId}
 						form={cardId}
-						frontId="us"
+						frontId="frontId"
 						onSave={jest.fn()}
 						onCancel={jest.fn()}
 					/>

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -17,7 +17,6 @@ interface HeadlineInputProps {
 	editableFields: string[];
 	snapType: string | undefined;
 	onAbTestToggle?: EventWithDataHandler<React.ChangeEvent<any>>;
-	frontId: string;
 }
 
 const HeadlineInputContainer = styled('div')<{ abTestEnabled: boolean }>`
@@ -68,16 +67,9 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 
 	const getInputId = (cardId: string, label: string) => `${cardId}-${label}`;
 
-	/*
-	 * Initial rollout of Editorial AB testing will be limited to the US front only.
-	 * Removal of this front restriction will be covered by https://github.com/guardian/frontend/issues/29129
-	 */
-	const isUSNetworkFront = props.frontId === 'us';
 	return (
-		<HeadlineInputContainer
-			abTestEnabled={props.abTestEnabled && isUSNetworkFront}
-		>
-			{props.cardId && isUSNetworkFront && (
+		<HeadlineInputContainer abTestEnabled={props.abTestEnabled}>
+			{props.cardId && (
 				<ABTestToggleContainer>
 					<Field
 						name="abTestEnabled"
@@ -93,7 +85,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 				</ABTestToggleContainer>
 			)}
 
-			{props.abTestEnabled && isUSNetworkFront ? (
+			{props.abTestEnabled ? (
 				<HeadlineVariantContainer>
 					<ConditionalField
 						permittedFields={props.editableFields}
@@ -128,9 +120,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 					data-testid="edit-form-headline-field"
 				/>
 			)}
-			{isUSNetworkFront && props.abTestEnabled && props.hasActiveABTest && (
-				<OphanBanner />
-			)}
+			{props.abTestEnabled && props.hasActiveABTest && <OphanBanner />}
 		</HeadlineInputContainer>
 	);
 };


### PR DESCRIPTION
## What's changed?
Effectively reverts #2059. To be rolled out after we have (successfully) tested on the US front.