### PR TITLE
GuCDK migration phase 2: run GuEc2App alongside the legacy ELB

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,17 +1,25 @@
-import "source-map-support/register";
-import { GuRoot } from "@guardian/cdk/lib/constructs/root";
-import { FaciaTool } from "../lib/facia-tool";
+import 'source-map-support/register';
+import { GuRoot } from '@guardian/cdk/lib/constructs/root';
+import { FaciaTool } from '../lib/facia-tool';
 
 const app = new GuRoot();
-new FaciaTool(app, "FaciaTool-euwest-1-CODE", {
-  stack: "cms-fronts",
-  stage: "CODE",
-  env: { region: "eu-west-1" },
-  cloudFormationStackName: "facia-CODE",
+new FaciaTool(app, 'FaciaTool-euwest-1-CODE', {
+	stack: 'cms-fronts',
+	stage: 'CODE',
+	env: { region: 'eu-west-1' },
+	cloudFormationStackName: 'facia-CODE',
+	domainName: 'fronts.code.dev-gutools.co.uk',
+	instanceType: 't4g.small',
+	minimumInstances: 1,
+	maximumInstances: 2,
 });
-new FaciaTool(app, "FaciaTool-euwest-1-PROD", {
-  stack: "cms-fronts",
-  stage: "PROD",
-  env: { region: "eu-west-1" },
-  cloudFormationStackName: "facia-PROD",
+new FaciaTool(app, 'FaciaTool-euwest-1-PROD', {
+	stack: 'cms-fronts',
+	stage: 'PROD',
+	env: { region: 'eu-west-1' },
+	cloudFormationStackName: 'facia-PROD',
+	domainName: 'fronts.gutools.co.uk',
+	instanceType: 't4g.medium',
+	minimumInstances: 3,
+	maximumInstances: 6,
 });

--- a/cdk/lib/__snapshots__/facia-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/facia-tool.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`The FaciaTool stack matches the snapshot 1`] = `
+exports[`The FaciaTool stack matches the CODE snapshot 1`] = `
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
@@ -53,7 +53,42 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
     },
   },
   "Metadata": {
-    "gu:cdk:constructs": [],
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuEc2App",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuSsmSshPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
+      "GuSecurityGroup",
+    ],
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
@@ -88,6 +123,15 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
         "Ref": "FrontsUpdateSNSTopic",
       },
     },
+    "LoadBalancerFaciatoolDnsName": {
+      "Description": "DNS entry for LoadBalancerFaciatool",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerFaciatool65BDBE55",
+          "DNSName",
+        ],
+      },
+    },
     "StorageConsumerRole": {
       "Description": "Role to be assumed for cross account access to the bucket",
       "Value": {
@@ -99,6 +143,15 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
     "AMI": {
       "Description": "ID of the machine image for this service (ami)",
       "Type": "String",
+    },
+    "AMIFaciatool": {
+      "Description": "Amazon Machine Image ID for the app facia-tool. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "AvailabilityZones": {
       "Default": "eu-west-1a,eu-west-1b,eu-west-1c",
@@ -132,6 +185,11 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
     "DBSecurityGroupIdNewVPC": {
       "Type": "String",
     },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "ELKKinesisStreamArn": {
       "Description": "Arn of the kinesis stream for logging to ELK (logs.gutools)",
       "Type": "String",
@@ -149,6 +207,11 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
       "Default": "arn:aws:iam::642631414762:role/CmsFrontsRole-FaciaToolRole-1U44IWRZDIWAX",
       "Description": "Frontend Role to assume for cross account policies",
       "Type": "String",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "MobileAPIAccountID": {
       "Description": "AWS account ID of MAPI",
@@ -230,7 +293,7 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
         "VpcId": {
@@ -275,6 +338,187 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "AssumeCapiPreviewRolePolicyBDA58B0F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiPreviewRole",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AssumeCapiPreviewRolePolicyBDA58B0F",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AssumeFrontendRolePolicy61B2F894": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "FrontendRoleToAssume",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AssumeFrontendRolePolicy61B2F894",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupFaciatoolASG65C5AF0A": {
+      "Properties": {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "cmsfrontsCODEfaciatoolB7C60B51",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "cmsfrontsCODEfaciatoolB7C60B51",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "MaxSize": "2",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+          },
+        ],
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "gu:riffraff:new-asg",
+            "PropagateAtLaunch": true,
+            "Value": "true",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "CODE",
+          },
+          {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "facia-tool.service",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupFaciatool7B903AE5",
+          },
+        ],
+        "VPCZoneIdentifier": [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              2,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "CertificateFaciatool53F3F73A": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "fronts.code.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Name",
+            "Value": "FaciaTool-euwest-1-CODE/CertificateFaciatool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
     "CloudwatchPolicy": {
       "Properties": {
         "PolicyDocument": {
@@ -300,6 +544,31 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudwatchPolicyFEF3FFD1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:PutMetricData",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudwatchPolicyFEF3FFD1",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "CrossAccountPolicy": {
       "Properties": {
         "PolicyDocument": {
@@ -318,6 +587,141 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
         "Roles": [
           {
             "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DatabaseAccessSecurityGroupFaciatool6BB0DD52": {
+      "Properties": {
+        "GroupDescription": "Allows facia-tool instances to reach the fronts Postgres database",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "DatabaseAccessSecurityGroupFaciatoolfromFaciaTooleuwest1CODELoadBalancerFaciatoolSecurityGroupE5425EB9900039B43F5B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DatabaseAccessSecurityGroupFaciatooltoFaciaTooleuwest1CODEDatabaseSecurityGroupA6CFB9F95432465AF237": {
+      "Properties": {
+        "Description": "Postgres",
+        "DestinationSecurityGroupId": {
+          "Ref": "DBSecurityGroupIdNewVPC",
+        },
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "DatabaseSecurityGroupfromFaciaTooleuwest1CODEDatabaseAccessSecurityGroupFaciatool7F8C6F7D543228013B35": {
+      "Properties": {
+        "Description": "Postgres",
+        "FromPort": 5432,
+        "GroupId": {
+          "Ref": "DBSecurityGroupIdNewVPC",
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DescribeDatabasesPolicyC25545E8": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "rds:DescribeDBInstances",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DescribeDatabasesPolicyC25545E8",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
           },
         ],
       },
@@ -544,7 +948,7 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -637,6 +1041,68 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "EditionsBucketsPolicy20C5B98E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::published-editions-",
+                      {
+                        "Fn::FindInMap": [
+                          "StageMap",
+                          "CODE",
+                          "LowerCaseStage",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::preview-editions-",
+                      {
+                        "Fn::FindInMap": [
+                          "StageMap",
+                          "CODE",
+                          "LowerCaseStage",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EditionsBucketsPolicy20C5B98E",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "FaciaAutoscalingGroupNewVPC": {
       "Properties": {
         "AvailabilityZones": {
@@ -697,11 +1163,6 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
             "Value": "guardian/facia-tool",
           },
           {
-            "Key": "gu:riffraff:new-asg",
-            "PropagateAtLaunch": true,
-            "Value": "1",
-          },
-          {
             "Key": "LogKinesisStreamName",
             "PropagateAtLaunch": true,
             "Value": {
@@ -716,7 +1177,7 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
           {
             "Key": "Stage",
             "PropagateAtLaunch": true,
-            "Value": "TEST",
+            "Value": "CODE",
           },
           {
             "Key": "SystemdUnit",
@@ -808,7 +1269,7 @@ exports[`The FaciaTool stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -1002,7 +1463,7 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -1025,7 +1486,7 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -1102,7 +1563,7 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -1158,11 +1619,399 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
       "Type": "AWS::DynamoDB::Table",
+    },
+    "GetDistributablePolicyFaciatool090C933A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/cms-fronts/CODE/facia-tool/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyFaciatool090C933A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupFaciatoolC5C70906": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupFaciatoolfromFaciaTooleuwest1CODELoadBalancerFaciatoolSecurityGroupE5425EB9900006EF6D55": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupFaciatoolC5C70906",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleFaciatoolBF15D06F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ListenerFaciatool63715AFF": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateFaciatool53F3F73A",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupFaciatool7B903AE5",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerFaciatool65BDBE55",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerFaciatool65BDBE55": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/CODE/cms-fronts/facia-tool",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerFaciatoolSecurityGroupF59B8036",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Ref": "PublicSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Ref": "PublicSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              2,
+              {
+                "Ref": "PublicSubnets",
+              },
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerFaciatoolSecurityGroupF59B8036": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB FaciaTooleuwest1CODELoadBalancerFaciatoolE2C6B7C9",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerFaciatoolSecurityGrouptoFaciaTooleuwest1CODECapiEndpointSecurityGroup274185A890001592DFE9": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Ref": "CapiEndpointSsmKeyNewVPC",
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerFaciatoolSecurityGrouptoFaciaTooleuwest1CODEDatabaseAccessSecurityGroupFaciatool7F8C6F7D90008CADD2CE": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerFaciatoolSecurityGrouptoFaciaTooleuwest1CODEGuHttpsEgressSecurityGroupFaciatoolFBAECB429000B19F0091": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupFaciatoolC5C70906",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "LoadBalancerSecurityGroupNewVPC": {
       "Properties": {
@@ -1196,7 +2045,7 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
         "VpcId": {
@@ -1270,6 +2119,130 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
       },
       "Type": "AWS::IAM::Policy",
     },
+    "PanDomainPolicyB981546E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::pan-domain-auth-settings/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PanDomainPolicyB981546E",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStorePolicy28E552F7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/facia-tool/cms-fronts/CODE/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ParameterStorePolicy28E552F7",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreReadFaciatool2FF13129": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/cms-fronts/facia-tool",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/cms-fronts/facia-tool/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "PermissionsPolicy": {
       "Properties": {
         "PolicyDocument": {
@@ -1289,6 +2262,183 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
         "Roles": [
           {
             "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PermissionsPolicy9C13C9BA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::permissions-cache/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PermissionsPolicy9C13C9BA",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PressedFrontsStatusPolicy1CB40C45": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":dynamodb:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    {
+                      "Fn::FindInMap": [
+                        "CrossResources",
+                        "CODE",
+                        "FrontPressedTable",
+                      ],
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PressedFrontsStatusPolicy1CB40C45",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PrivateConfigPolicyA17A0455": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::facia-private/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PrivateConfigPolicyA17A0455",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PublishEventsQueuePolicy27DED7B2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":sqs:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":publish-events-CODE",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishEventsQueuePolicy27DED7B2",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PublishTopicPolicy4E651CDF": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "FrontsUpdateSNSTopic",
+                },
+                {
+                  "Ref": "FeastPublicationTopic",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishTopicPolicy4E651CDF",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
           },
         ],
       },
@@ -1518,6 +2668,63 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
       },
       "Type": "AWS::IAM::ManagedPolicy",
     },
+    "SendEmailPolicyE4FDC241": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ses:SendEmail",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SendEmailPolicyE4FDC241",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "StaticCloudFrontDnsRecord": {
       "Properties": {
         "Name": {
@@ -1634,7 +2841,7 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -1685,6 +2892,58 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Ref": "StorageConsumerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "StorageBucketPolicy8A3F0568": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::facia-tool-store/CODE/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::facia-tool-store",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "StorageBucketPolicy8A3F0568",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
           },
         ],
       },
@@ -1820,7 +3079,7 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "CODE",
           },
         ],
       },
@@ -1848,6 +3107,3734 @@ dpkg -i /home/facia-tool/facia-tool.all.deb
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "SwitchesPolicyDD0F07D1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SwitchboardBucket",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SwitchesPolicyDD0F07D1",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupFaciatool7B903AE5": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/_healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UserDataTablePolicyFAA099C3": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Scan",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":dynamodb:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    {
+                      "Ref": "FrontsUserDataDynamoTable",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "UserDataTablePolicyFAA099C3",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "cmsfrontsCODEfaciatoolB7C60B51": {
+      "DependsOn": [
+        "InstanceRoleFaciatoolBF15D06F",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cmsfrontsCODEfaciatoolProfileB8F7FB2E",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMIFaciatool",
+          },
+          "InstanceType": "t4g.small",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
+          },
+          "Monitoring": {
+            "Enabled": false,
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupFaciatoolC5C70906",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+                "GroupId",
+              ],
+            },
+            {
+              "Ref": "CapiEndpointSsmKeyNewVPC",
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "facia-tool",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/facia-tool",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "FaciaTool-euwest-1-CODE/cms-fronts-CODE-facia-tool",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "cms-fronts",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "CODE",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "facia-tool",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/facia-tool",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "FaciaTool-euwest-1-CODE/cms-fronts-CODE-facia-tool",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "cms-fronts",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "CODE",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+groupadd --force --system facia-tool
+useradd --system --gid facia-tool --home-dir /home/facia-tool --create-home --shell /usr/sbin/nologin facia-tool || true
+mkdir -p /etc/gu
+aws s3 cp s3://facia-private/facia-tool.application.secrets.CODE.conf /etc/gu/facia-tool.application.secrets.conf --region eu-west-1
+chown facia-tool /etc/gu/facia-tool.application.secrets.conf
+chmod 400 /etc/gu/facia-tool.application.secrets.conf
+cat > /etc/gu/facia-tool.properties <<'EOF'
+STAGE=CODE
+STS_ROLE=",
+                  {
+                    "Ref": "FrontendRoleToAssume",
+                  },
+                  "
+FRONT_PRESSED_TABLE=",
+                  {
+                    "Fn::FindInMap": [
+                      "CrossResources",
+                      "CODE",
+                      "FrontPressedTable",
+                    ],
+                  },
+                  "
+USER_DATA_TABLE=",
+                  {
+                    "Ref": "UserDataTablePrefix",
+                  },
+                  "-CODE
+EOF
+aws s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/cms-fronts/CODE/facia-tool/facia-tool_1.0_all.deb /home/facia-tool/facia-tool.all.deb --region eu-west-1
+dpkg -i /home/facia-tool/facia-tool.all.deb",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "facia-tool",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/facia-tool",
+              },
+              {
+                "Key": "Name",
+                "Value": "FaciaTool-euwest-1-CODE/cms-fronts-CODE-facia-tool",
+              },
+              {
+                "Key": "Stack",
+                "Value": "cms-fronts",
+              },
+              {
+                "Key": "Stage",
+                "Value": "CODE",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "cmsfrontsCODEfaciatoolProfileB8F7FB2E": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+  },
+}
+`;
+
+exports[`The FaciaTool stack matches the PROD snapshot 1`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "IsCode": {
+      "Fn::Equals": [
+        {
+          "Ref": "Stage",
+        },
+        "CODE",
+      ],
+    },
+  },
+  "Description": "Facia Tool Service",
+  "Mappings": {
+    "CrossResources": {
+      "CODE": {
+        "FrontPressedTable": "front-pressed-lambda-CODE-DynamoDBTable-1CY26GZDUP0OU",
+      },
+      "PROD": {
+        "FrontPressedTable": "front-pressed-lambda-PROD-DynamoDBTable-M03VC0RYBQ1W",
+      },
+    },
+    "StageMap": {
+      "CODE": {
+        "CloudFrontAliases": [
+          "fronts.code.dev-gutools.co.uk",
+        ],
+        "DesiredCapacity": 1,
+        "InstanceType": "t4g.small",
+        "LowerCaseStage": "code",
+        "MaxSize": 2,
+        "MinSize": 1,
+        "StaticCloudFrontAliases": [
+          "fronts-static.code.dev-gutools.co.uk",
+        ],
+      },
+      "PROD": {
+        "CloudFrontAliases": [
+          "fronts.gutools.co.uk",
+        ],
+        "DesiredCapacity": 3,
+        "InstanceType": "t4g.medium",
+        "LowerCaseStage": "prod",
+        "MaxSize": 6,
+        "MinSize": 3,
+        "StaticCloudFrontAliases": [
+          "fronts-static.gutools.co.uk",
+        ],
+      },
+    },
+  },
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuAllowPolicy",
+      "GuEc2App",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuSsmSshPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
+      "GuSecurityGroup",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "FaciaLoadBalancerDNS": {
+      "Description": "Load balancer DNS",
+      "Value": {
+        "Fn::GetAtt": [
+          "FaciaLoadBalancerNewVPC",
+          "DNSName",
+        ],
+      },
+    },
+    "FeastPublicationSNSTopic": {
+      "Description": "ARN of the SNS topic",
+      "Export": {
+        "Name": {
+          "Fn::Sub": "\${AWS::StackName}-FeastPublicationSNSTopicARN",
+        },
+      },
+      "Value": {
+        "Ref": "FeastPublicationTopic",
+      },
+    },
+    "FrontsUpdateSNSTopicARN": {
+      "Description": "ARN of the SNS topic",
+      "Export": {
+        "Name": {
+          "Fn::Sub": "\${AWS::StackName}-FrontsUpdateSNSTopicARN",
+        },
+      },
+      "Value": {
+        "Ref": "FrontsUpdateSNSTopic",
+      },
+    },
+    "LoadBalancerFaciatoolDnsName": {
+      "Description": "DNS entry for LoadBalancerFaciatool",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerFaciatool65BDBE55",
+          "DNSName",
+        ],
+      },
+    },
+    "StorageConsumerRole": {
+      "Description": "Role to be assumed for cross account access to the bucket",
+      "Value": {
+        "Ref": "StorageConsumerRole",
+      },
+    },
+  },
+  "Parameters": {
+    "AMI": {
+      "Description": "ID of the machine image for this service (ami)",
+      "Type": "String",
+    },
+    "AMIFaciatool": {
+      "Description": "Amazon Machine Image ID for the app facia-tool. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "AvailabilityZones": {
+      "Default": "eu-west-1a,eu-west-1b,eu-west-1c",
+      "Description": "The availability zone where instances are allowed to run",
+      "Type": "List<AWS::EC2::AvailabilityZone::Name>",
+    },
+    "CapiEndpointSsmKeyNewVPC": {
+      "Default": "/newvpc/endpoint/capi/PROD",
+      "Description": "SSM key containing security group of the CAPI endpoint",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "CapiPreviewRole": {
+      "Description": "ARN of the CAPI preview role",
+      "Type": "String",
+    },
+    "CertificateArn": {
+      "Description": "ARN of the x509 certificate for this service",
+      "Type": "String",
+    },
+    "CloudFrontCertificateArn": {
+      "Description": "x509 certificate ARN for CloudFront - must be in us-east-1",
+      "Type": "String",
+    },
+    "ContentAPIAccountID": {
+      "Description": "AWS account ID of CAPI",
+      "Type": "String",
+    },
+    "DBSecurityGroupId": {
+      "Type": "String",
+    },
+    "DBSecurityGroupIdNewVPC": {
+      "Type": "String",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "ELKKinesisStreamArn": {
+      "Description": "Arn of the kinesis stream for logging to ELK (logs.gutools)",
+      "Type": "String",
+    },
+    "ELKKinesisStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "Elk logging stream name",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "FrontendAccountID": {
+      "Description": "AWS account ID of frontend",
+      "Type": "String",
+    },
+    "FrontendRoleToAssume": {
+      "Default": "arn:aws:iam::642631414762:role/CmsFrontsRole-FaciaToolRole-1U44IWRZDIWAX",
+      "Description": "Frontend Role to assume for cross account policies",
+      "Type": "String",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "MobileAPIAccountID": {
+      "Description": "AWS account ID of MAPI",
+      "Type": "String",
+    },
+    "MobileAPITeamcityAccountID": {
+      "Description": "AWS account ID of MAPI - used for CI",
+      "Type": "String",
+    },
+    "OphanAccountID": {
+      "Description": "AWS account ID of Ophan",
+      "Type": "String",
+    },
+    "PrivateSubnets": {
+      "Description": "The private subnets of the new VPC for the autoscaling group",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "PublicSubnets": {
+      "Description": "The public subnets of the new VPC for the loadbalancer",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "Stage": {
+      "AllowedValues": [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "PROD",
+      "Description": "Environment name",
+      "Type": "String",
+    },
+    "StaticBucketName": {
+      "Description": "Bucket containing static files",
+      "Type": "String",
+    },
+    "SupportAccountID": {
+      "Description": "AWS account ID of Support",
+      "Type": "String",
+    },
+    "SwitchboardBucket": {
+      "Default": "arn:aws:s3:::facia-switches/*",
+      "Description": "Bucket where switchboard writes switches status",
+      "Type": "String",
+    },
+    "UserDataTablePrefix": {
+      "Default": "fronts-user-data-table",
+      "Type": "String",
+    },
+    "VpcId": {
+      "Description": "The new VPC we look to migrate to",
+      "Type": "AWS::EC2::VPC::Id",
+    },
+  },
+  "Resources": {
+    "AppServerSecurityGroupNewVPC": {
+      "Properties": {
+        "GroupDescription": "Application servers",
+        "SecurityGroupIngress": [
+          {
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": {
+              "Ref": "LoadBalancerSecurityGroupNewVPC",
+            },
+            "ToPort": 9000,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "AppToNewDBEgressNewVPC": {
+      "Properties": {
+        "DestinationSecurityGroupId": {
+          "Ref": "DBSecurityGroupIdNewVPC",
+        },
+        "FromPort": 5432,
+        "GroupId": {
+          "Ref": "AppServerSecurityGroupNewVPC",
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "AssumeCapiPreviewRolePolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiPreviewRole",
+              },
+            },
+          ],
+        },
+        "PolicyName": "assume-capi-preview-role",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AssumeCapiPreviewRolePolicyBDA58B0F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiPreviewRole",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AssumeCapiPreviewRolePolicyBDA58B0F",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AssumeFrontendRolePolicy61B2F894": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "FrontendRoleToAssume",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AssumeFrontendRolePolicy61B2F894",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupFaciatoolASG65C5AF0A": {
+      "Properties": {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "cmsfrontsPRODfaciatool6792D81A",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "cmsfrontsPRODfaciatool6792D81A",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "MaxSize": "6",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+          },
+        ],
+        "MinSize": "3",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "gu:riffraff:new-asg",
+            "PropagateAtLaunch": true,
+            "Value": "true",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "PROD",
+          },
+          {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "facia-tool.service",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupFaciatool7B903AE5",
+          },
+        ],
+        "VPCZoneIdentifier": [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              2,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "CertificateFaciatool53F3F73A": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "fronts.gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Name",
+            "Value": "FaciaTool-euwest-1-PROD/CertificateFaciatool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudwatchPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:PutMetricData",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudwatchPolicy",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudwatchPolicyFEF3FFD1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:PutMetricData",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudwatchPolicyFEF3FFD1",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "FrontendRoleToAssume",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountPolicy",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DatabaseAccessSecurityGroupFaciatool6BB0DD52": {
+      "Properties": {
+        "GroupDescription": "Allows facia-tool instances to reach the fronts Postgres database",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "DatabaseAccessSecurityGroupFaciatoolfromFaciaTooleuwest1PRODLoadBalancerFaciatoolSecurityGroupF9A9E849900083FE8ADC": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DatabaseAccessSecurityGroupFaciatooltoFaciaTooleuwest1PRODDatabaseSecurityGroupAC33F525543270A003A5": {
+      "Properties": {
+        "Description": "Postgres",
+        "DestinationSecurityGroupId": {
+          "Ref": "DBSecurityGroupIdNewVPC",
+        },
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "DatabaseSecurityGroupfromFaciaTooleuwest1PRODDatabaseAccessSecurityGroupFaciatoolBC9C5918543223C46354": {
+      "Properties": {
+        "Description": "Postgres",
+        "FromPort": 5432,
+        "GroupId": {
+          "Ref": "DBSecurityGroupIdNewVPC",
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DescribeDatabasesPolicyC25545E8": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "rds:DescribeDBInstances",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DescribeDatabasesPolicyC25545E8",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DistributionInstanceProfile": {
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "DistributionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::ImportValue": {
+              "Fn::Sub": "guardian-ec2-for-ssm-GuardianEC2ForSSMPolicy",
+            },
+          },
+        ],
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "ssm:GetParameter",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/facia-tool/cms-fronts/\${Stage}/*",
+                  },
+                },
+                {
+                  "Action": "kms:Decrypt",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+            },
+            "PolicyName": "getparameters",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:aws:sqs:\${Region}:\${Account}:publish-events-\${Stage}",
+                        {
+                          "Account": {
+                            "Ref": "AWS::AccountId",
+                          },
+                          "Region": {
+                            "Ref": "AWS::Region",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Action": [
+                    "s3:GetObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3:::facia-dist/*",
+                    "arn:aws:s3:::facia-private/*",
+                  ],
+                },
+                {
+                  "Action": [
+                    "dynamodb:GetItem",
+                    "dynamodb:Query",
+                    "dynamodb:PutItem",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:Scan",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:aws:dynamodb:\${Region}:\${Account}:table/\${Table}",
+                        {
+                          "Account": {
+                            "Ref": "AWS::AccountId",
+                          },
+                          "Region": {
+                            "Ref": "AWS::Region",
+                          },
+                          "Table": {
+                            "Ref": "FrontsUserDataDynamoTable",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Action": [
+                    "ses:SendEmail",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    "*",
+                  ],
+                },
+                {
+                  "Action": [
+                    "ec2:DescribeTags",
+                    "ec2:DescribeInstances",
+                    "autoscaling:DescribeAutoScalingGroups",
+                    "autoscaling:DescribeAutoScalingInstances",
+                    "rds:DescribeDBInstances",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "s3:PutObject",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:aws:s3:::published-editions-\${LowerCaseStage}/*",
+                        {
+                          "LowerCaseStage": {
+                            "Fn::FindInMap": [
+                              "StageMap",
+                              {
+                                "Ref": "Stage",
+                              },
+                              "LowerCaseStage",
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      "Fn::Sub": [
+                        "arn:aws:s3:::preview-editions-\${LowerCaseStage}/*",
+                        {
+                          "LowerCaseStage": {
+                            "Fn::FindInMap": [
+                              "StageMap",
+                              {
+                                "Ref": "Stage",
+                              },
+                              "LowerCaseStage",
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "root",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "sns:Publish",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "FrontsUpdateSNSTopic",
+                  },
+                  "Sid": "AllowPublishToMyTopic",
+                },
+                {
+                  "Action": "sns:Publish",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "FeastPublicationTopic",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "publishTopic",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DnsRecord": {
+      "Properties": {
+        "Name": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::FindInMap": [
+                "StageMap",
+                {
+                  "Ref": "Stage",
+                },
+                "CloudFrontAliases",
+              ],
+            },
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::GetAtt": "FaciaCloudfront.DomainName",
+                },
+                ".",
+              ],
+            ],
+          },
+        ],
+        "Stage": {
+          "Ref": "Stage",
+        },
+        "TTL": 900,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "DynamoPressStatus": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/",
+                      {
+                        "Fn::FindInMap": [
+                          "CrossResources",
+                          {
+                            "Ref": "Stage",
+                          },
+                          "FrontPressedTable",
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoPressStatus",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "EditionsBucketsPolicy20C5B98E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::published-editions-",
+                      {
+                        "Fn::FindInMap": [
+                          "StageMap",
+                          "PROD",
+                          "LowerCaseStage",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::preview-editions-",
+                      {
+                        "Fn::FindInMap": [
+                          "StageMap",
+                          "PROD",
+                          "LowerCaseStage",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EditionsBucketsPolicy20C5B98E",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "FaciaAutoscalingGroupNewVPC": {
+      "Properties": {
+        "AvailabilityZones": {
+          "Ref": "AvailabilityZones",
+        },
+        "Cooldown": "180",
+        "DesiredCapacity": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "DesiredCapacity",
+          ],
+        },
+        "HealthCheckGracePeriod": 200,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": {
+          "Ref": "FaciaLaunchConfigNewVPC",
+        },
+        "LoadBalancerNames": [
+          {
+            "Ref": "FaciaLoadBalancerNewVPC",
+          },
+        ],
+        "MaxSize": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "MaxSize",
+          ],
+        },
+        "MinSize": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "MinSize",
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "ELKKinesisStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "PROD",
+          },
+          {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "facia-tool.service",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "PrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "FaciaCloudfront": {
+      "Properties": {
+        "DistributionConfig": {
+          "Aliases": {
+            "Fn::FindInMap": [
+              "StageMap",
+              {
+                "Ref": "Stage",
+              },
+              "CloudFrontAliases",
+            ],
+          },
+          "DefaultCacheBehavior": {
+            "AllowedMethods": [
+              "DELETE",
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PUT",
+            ],
+            "Compress": true,
+            "ForwardedValues": {
+              "Cookies": {
+                "Forward": "all",
+              },
+              "Headers": [
+                "*",
+              ],
+              "QueryString": true,
+            },
+            "TargetOriginId": "facia-tool",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "v2",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": [
+            {
+              "CustomOriginConfig": {
+                "HTTPSPort": 443,
+                "OriginProtocolPolicy": "https-only",
+              },
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "FaciaLoadBalancerNewVPC",
+                  "DNSName",
+                ],
+              },
+              "Id": "facia-tool",
+            },
+          ],
+          "PriceClass": "PriceClass_All",
+          "ViewerCertificate": {
+            "AcmCertificateArn": {
+              "Ref": "CloudFrontCertificateArn",
+            },
+            "MinimumProtocolVersion": "TLSv1.2_2021",
+            "SslSupportMethod": "sni-only",
+          },
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "FaciaLaunchConfigNewVPC": {
+      "Metadata": {
+        "AWS::CloudFormation::Authentication": {
+          "distributionAuthentication": {
+            "buckets": [
+              "facia-dist",
+            ],
+            "roleName": {
+              "Ref": "DistributionRole",
+            },
+            "type": "S3",
+          },
+        },
+        "AWS::CloudFormation::Init": {
+          "config": {
+            "files": {
+              "/etc/gu/facia-tool.application.secrets.conf": {
+                "authentication": "distributionAuthentication",
+                "mode": "000400",
+                "owner": "facia-tool",
+                "source": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "https://s3-eu-west-1.amazonaws.com/facia-private/facia-tool.application.secrets.\${Stage}.conf",
+                      },
+                    ],
+                  ],
+                },
+              },
+              "/etc/gu/facia-tool.properties": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "STAGE=",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "
+",
+                      "STS_ROLE=",
+                      {
+                        "Ref": "FrontendRoleToAssume",
+                      },
+                      "
+",
+                      "FRONT_PRESSED_TABLE=",
+                      {
+                        "Fn::FindInMap": [
+                          "CrossResources",
+                          {
+                            "Ref": "Stage",
+                          },
+                          "FrontPressedTable",
+                        ],
+                      },
+                      "
+",
+                      "USER_DATA_TABLE=",
+                      {
+                        "Fn::Sub": "\${UserDataTablePrefix}-\${Stage}",
+                      },
+                      "
+",
+                    ],
+                  ],
+                },
+              },
+              "/home/facia-tool/facia-tool.all.deb": {
+                "authentication": "distributionAuthentication",
+                "source": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "https://s3-eu-west-1.amazonaws.com/facia-dist/cms-fronts/",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "/facia-tool/facia-tool_1.0_all.deb",
+                    ],
+                  ],
+                },
+              },
+            },
+            "users": {
+              "facia-tool": {
+                "homeDir": "/home/facia-tool",
+              },
+            },
+          },
+        },
+      },
+      "Properties": {
+        "IamInstanceProfile": {
+          "Ref": "DistributionInstanceProfile",
+        },
+        "ImageId": {
+          "Ref": "AMI",
+        },
+        "InstanceType": {
+          "Fn::FindInMap": [
+            "StageMap",
+            {
+              "Ref": "Stage",
+            },
+            "InstanceType",
+          ],
+        },
+        "MetadataOptions": {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": "AppServerSecurityGroupNewVPC.GroupId",
+          },
+          {
+            "Ref": "CapiEndpointSsmKeyNewVPC",
+          },
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Sub": "#!/bin/bash -ev
+cfn-init -s \${AWS::StackId} -r FaciaLaunchConfigNewVPC --region \${AWS::Region} || error_exit 'Failed to run cfn-init'
+dpkg -i /home/facia-tool/facia-tool.all.deb
+",
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "FaciaLoadBalancerNewVPC": {
+      "Properties": {
+        "CrossZone": true,
+        "HealthCheck": {
+          "HealthyThreshold": "2",
+          "Interval": "60",
+          "Target": "HTTP:9000/_healthcheck",
+          "Timeout": "5",
+          "UnhealthyThreshold": "10",
+        },
+        "Listeners": [
+          {
+            "InstancePort": "9000",
+            "LoadBalancerPort": "80",
+            "Protocol": "HTTP",
+          },
+          {
+            "InstancePort": "9000",
+            "InstanceProtocol": "HTTP",
+            "LoadBalancerPort": "443",
+            "Protocol": "HTTPS",
+            "SSLCertificateId": {
+              "Ref": "CertificateArn",
+            },
+          },
+        ],
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerSecurityGroupNewVPC",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "PublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+    },
+    "FeastPublicationTopic": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "FrontsUpdateSNSPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Subscribe",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "MobileAPIAccountID",
+                },
+              },
+              "Resource": {
+                "Ref": "FrontsUpdateSNSTopic",
+              },
+              "Sid": "MobileAccount",
+            },
+            {
+              "Action": "sns:Subscribe",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "FrontendAccountID",
+                },
+              },
+              "Resource": {
+                "Ref": "FrontsUpdateSNSTopic",
+              },
+              "Sid": "FrontendAccount",
+            },
+            {
+              "Action": "sns:Subscribe",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Ref": "OphanAccountID",
+                },
+              },
+              "Resource": {
+                "Ref": "FrontsUpdateSNSTopic",
+              },
+              "Sid": "OphanAccount",
+            },
+          ],
+        },
+        "Topics": [
+          {
+            "Ref": "FrontsUpdateSNSTopic",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::TopicPolicy",
+    },
+    "FrontsUpdateSNSTopic": {
+      "Properties": {
+        "DisplayName": "SNS Topic for fronts updates (both draft & live)",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "FrontsUserDataDynamoTable": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "email",
+            "AttributeType": "S",
+          },
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "email",
+            "KeyType": "HASH",
+          },
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5,
+        },
+        "TableName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "UserDataTablePrefix",
+              },
+              {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+    },
+    "GetDistributablePolicyFaciatool090C933A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/cms-fronts/PROD/facia-tool/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyFaciatool090C933A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupFaciatoolC5C70906": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupFaciatoolfromFaciaTooleuwest1PRODLoadBalancerFaciatoolSecurityGroupF9A9E849900080BA368F": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupFaciatoolC5C70906",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleFaciatoolBF15D06F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ListenerFaciatool63715AFF": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateFaciatool53F3F73A",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupFaciatool7B903AE5",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerFaciatool65BDBE55",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerFaciatool65BDBE55": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/PROD/cms-fronts/facia-tool",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerFaciatoolSecurityGroupF59B8036",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Ref": "PublicSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Ref": "PublicSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              2,
+              {
+                "Ref": "PublicSubnets",
+              },
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerFaciatoolSecurityGroupF59B8036": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB FaciaTooleuwest1PRODLoadBalancerFaciatoolE684BF89",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerFaciatoolSecurityGrouptoFaciaTooleuwest1PRODCapiEndpointSecurityGroup1E0AFCC09000BF4CF4B2": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Ref": "CapiEndpointSsmKeyNewVPC",
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerFaciatoolSecurityGrouptoFaciaTooleuwest1PRODDatabaseAccessSecurityGroupFaciatoolBC9C59189000E96F8A24": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerFaciatoolSecurityGrouptoFaciaTooleuwest1PRODGuHttpsEgressSecurityGroupFaciatoolC8AD4465900053694EFF": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupFaciatoolC5C70906",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerFaciatoolSecurityGroupF59B8036",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerSecurityGroupNewVPC": {
+      "Properties": {
+        "GroupDescription": "Facia application load balancer",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LogServerPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:PutRecord",
+                "kinesis:PutRecords",
+                "kinesis:DescribeStream",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "ELKKinesisStreamArn",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogServerPolicy",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "NewDBToAppIngressNewVPC": {
+      "Properties": {
+        "FromPort": 5432,
+        "GroupId": {
+          "Ref": "DBSecurityGroupIdNewVPC",
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "AppServerSecurityGroupNewVPC",
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "PanDomainPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:s3:::pan-domain-auth-settings/*",
+              ],
+            },
+          ],
+        },
+        "PolicyName": "PanDomainPolicy",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PanDomainPolicyB981546E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::pan-domain-auth-settings/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PanDomainPolicyB981546E",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStorePolicy28E552F7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/facia-tool/cms-fronts/PROD/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ParameterStorePolicy28E552F7",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreReadFaciatool2FF13129": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/cms-fronts/facia-tool",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/cms-fronts/facia-tool/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PermissionsPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:s3:::permissions-cache/*",
+              ],
+            },
+          ],
+        },
+        "PolicyName": "PermissionsPolicy",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PermissionsPolicy9C13C9BA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::permissions-cache/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PermissionsPolicy9C13C9BA",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PressedFrontsStatusPolicy1CB40C45": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":dynamodb:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    {
+                      "Fn::FindInMap": [
+                        "CrossResources",
+                        "PROD",
+                        "FrontPressedTable",
+                      ],
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PressedFrontsStatusPolicy1CB40C45",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PrivateConfigPolicyA17A0455": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::facia-private/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PrivateConfigPolicyA17A0455",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PublishEventsQueuePolicy27DED7B2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":sqs:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":publish-events-PROD",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishEventsQueuePolicy27DED7B2",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PublishTopicPolicy4E651CDF": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "FrontsUpdateSNSTopic",
+                },
+                {
+                  "Ref": "FeastPublicationTopic",
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PublishTopicPolicy4E651CDF",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "RunFaciaToolLocally": {
+      "Condition": "IsCode",
+      "Properties": {
+        "Description": "Policy used for running fronts-tool locally",
+        "Path": {
+          "Fn::Sub": "/developer-policy/guardian/facia-tool/cms-fronts/\${Stage}/run-fronts-tool-locally/",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/facia-tool/cms-fronts/\${Stage}/*",
+              },
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:kms:\${AWS::Region}:\${AWS::AccountId}:key/alias/aws/ssm",
+                },
+              ],
+            },
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:sqs:\${AWS::Region}:\${AWS::AccountId}:publish-events-\${Stage}",
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:s3:::facia-dist/\${Stage}/*",
+                },
+                {
+                  "Fn::Sub": "arn:aws:s3:::facia-private/facia-tool.application.secrets.local.conf",
+                },
+                {
+                  "Fn::Sub": "arn:aws:s3:::facia-private/facia-tool.local.properties",
+                },
+              ],
+            },
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Scan",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:dynamodb:\${AWS::Region}:\${AWS::AccountId}:table/\${FrontsUserDataDynamoTable}",
+                },
+              ],
+            },
+            {
+              "Action": [
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "rds:DescribeDBInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "s3:PutObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:aws:s3:::published-editions-\${LowerCaseStage}/*",
+                    {
+                      "LowerCaseStage": {
+                        "Fn::FindInMap": [
+                          "StageMap",
+                          {
+                            "Ref": "Stage",
+                          },
+                          "LowerCaseStage",
+                        ],
+                      },
+                    },
+                  ],
+                },
+                {
+                  "Fn::Sub": [
+                    "arn:aws:s3:::preview-editions-\${LowerCaseStage}/*",
+                    {
+                      "LowerCaseStage": {
+                        "Fn::FindInMap": [
+                          "StageMap",
+                          {
+                            "Ref": "Stage",
+                          },
+                          "LowerCaseStage",
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "FrontsUpdateSNSTopic",
+              },
+              "Sid": "AllowPublishToMyTopic",
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "FeastPublicationTopic",
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:s3:::facia-tool-store/\${Stage}/*",
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:ListBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:s3:::facia-tool-store",
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:s3:::pan-domain-auth-settings/local.dev-gutools.co.uk.settings",
+                "arn:aws:s3:::pan-domain-auth-settings/local.dev-gutools.co.uk.settings.public",
+                "arn:aws:s3:::pan-domain-auth-settings/*.p12",
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:s3:::permissions-cache/\${Stage}/*",
+                },
+              ],
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiPreviewRole",
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SwitchboardBucket",
+              },
+            },
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:aws:dynamodb:\${AWS::Region}:\${AWS::AccountId}:table/\${Table}",
+                    {
+                      "Table": {
+                        "Fn::FindInMap": [
+                          "CrossResources",
+                          {
+                            "Ref": "Stage",
+                          },
+                          "FrontPressedTable",
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "SendEmailPolicyE4FDC241": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ses:SendEmail",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SendEmailPolicyE4FDC241",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "StaticCloudFrontDnsRecord": {
+      "Properties": {
+        "Name": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::FindInMap": [
+                "StageMap",
+                {
+                  "Ref": "Stage",
+                },
+                "StaticCloudFrontAliases",
+              ],
+            },
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::GetAtt": "StaticCloudfront.DomainName",
+                },
+                ".",
+              ],
+            ],
+          },
+        ],
+        "Stage": {
+          "Ref": "Stage",
+        },
+        "TTL": 900,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "StaticCloudfront": {
+      "Properties": {
+        "DistributionConfig": {
+          "Aliases": {
+            "Fn::FindInMap": [
+              "StageMap",
+              {
+                "Ref": "Stage",
+              },
+              "StaticCloudFrontAliases",
+            ],
+          },
+          "DefaultCacheBehavior": {
+            "Compress": true,
+            "ForwardedValues": {
+              "QueryString": false,
+            },
+            "TargetOriginId": "static-facia-tool",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": [
+            {
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "StaticBucketName",
+                    },
+                    ".s3.amazonaws.com",
+                  ],
+                ],
+              },
+              "Id": "static-facia-tool",
+              "OriginPath": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "/",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "/static-facia-tool",
+                  ],
+                ],
+              },
+              "S3OriginConfig": {
+                "OriginAccessIdentity": "",
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_All",
+          "ViewerCertificate": {
+            "AcmCertificateArn": {
+              "Ref": "CloudFrontCertificateArn",
+            },
+            "MinimumProtocolVersion": "TLSv1.2_2021",
+            "SslSupportMethod": "sni-only",
+          },
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "StorageBucket": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::facia-tool-store/",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:ListBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:s3:::facia-tool-store",
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "StorageBucket",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+          {
+            "Ref": "StorageConsumerRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "StorageBucketPolicy8A3F0568": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::facia-tool-store/PROD/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::facia-tool-store",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "StorageBucketPolicy8A3F0568",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "StorageConsumerRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "FrontendAccountID",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "MobileAPIAccountID",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "MobileAPITeamcityAccountID",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "OphanAccountID",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "ContentAPIAccountID",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "SupportAccountID",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SwitchesPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SwitchboardBucket",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SwitchesPolicy",
+        "Roles": [
+          {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SwitchesPolicyDD0F07D1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SwitchboardBucket",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SwitchesPolicyDD0F07D1",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupFaciatool7B903AE5": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/_healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "facia-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/facia-tool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "cms-fronts",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UserDataTablePolicyFAA099C3": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Scan",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":dynamodb:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    {
+                      "Ref": "FrontsUserDataDynamoTable",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "UserDataTablePolicyFAA099C3",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "cmsfrontsPRODfaciatool6792D81A": {
+      "DependsOn": [
+        "InstanceRoleFaciatoolBF15D06F",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cmsfrontsPRODfaciatoolProfileA9E732FC",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMIFaciatool",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
+          },
+          "Monitoring": {
+            "Enabled": false,
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupFaciatoolC5C70906",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "DatabaseAccessSecurityGroupFaciatool6BB0DD52",
+                "GroupId",
+              ],
+            },
+            {
+              "Ref": "CapiEndpointSsmKeyNewVPC",
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "facia-tool",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/facia-tool",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "FaciaTool-euwest-1-PROD/cms-fronts-PROD-facia-tool",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "cms-fronts",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "facia-tool",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/facia-tool",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "FaciaTool-euwest-1-PROD/cms-fronts-PROD-facia-tool",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "cms-fronts",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+groupadd --force --system facia-tool
+useradd --system --gid facia-tool --home-dir /home/facia-tool --create-home --shell /usr/sbin/nologin facia-tool || true
+mkdir -p /etc/gu
+aws s3 cp s3://facia-private/facia-tool.application.secrets.PROD.conf /etc/gu/facia-tool.application.secrets.conf --region eu-west-1
+chown facia-tool /etc/gu/facia-tool.application.secrets.conf
+chmod 400 /etc/gu/facia-tool.application.secrets.conf
+cat > /etc/gu/facia-tool.properties <<'EOF'
+STAGE=PROD
+STS_ROLE=",
+                  {
+                    "Ref": "FrontendRoleToAssume",
+                  },
+                  "
+FRONT_PRESSED_TABLE=",
+                  {
+                    "Fn::FindInMap": [
+                      "CrossResources",
+                      "PROD",
+                      "FrontPressedTable",
+                    ],
+                  },
+                  "
+USER_DATA_TABLE=",
+                  {
+                    "Ref": "UserDataTablePrefix",
+                  },
+                  "-PROD
+EOF
+aws s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/cms-fronts/PROD/facia-tool/facia-tool_1.0_all.deb /home/facia-tool/facia-tool.all.deb --region eu-west-1
+dpkg -i /home/facia-tool/facia-tool.all.deb",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "facia-tool",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/facia-tool",
+              },
+              {
+                "Key": "Name",
+                "Value": "FaciaTool-euwest-1-PROD/cms-fronts-PROD-facia-tool",
+              },
+              {
+                "Key": "Stack",
+                "Value": "cms-fronts",
+              },
+              {
+                "Key": "Stage",
+                "Value": "PROD",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "cmsfrontsPRODfaciatoolProfileA9E732FC": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFaciatoolBF15D06F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/cdk/lib/facia-tool.test.ts
+++ b/cdk/lib/facia-tool.test.ts
@@ -1,12 +1,35 @@
-import { App } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
-import { FaciaTool } from "./facia-tool";
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { FaciaTool } from './facia-tool';
 
-describe("The FaciaTool stack", () => {
-  it("matches the snapshot", () => {
-    const app = new App();
-    const stack = new FaciaTool(app, "FaciaTool", { stack: "cms-fronts", stage: "TEST" });
-    const template = Template.fromStack(stack);
-    expect(template.toJSON()).toMatchSnapshot();
-  });
+describe('The FaciaTool stack', () => {
+	it('matches the CODE snapshot', () => {
+		const app = new App();
+		const stack = new FaciaTool(app, 'FaciaTool-euwest-1-CODE', {
+			stack: 'cms-fronts',
+			stage: 'CODE',
+			env: { region: 'eu-west-1' },
+			domainName: 'fronts.code.dev-gutools.co.uk',
+			instanceType: 't4g.small',
+			minimumInstances: 1,
+			maximumInstances: 2,
+		});
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
+
+	it('matches the PROD snapshot', () => {
+		const app = new App();
+		const stack = new FaciaTool(app, 'FaciaTool-euwest-1-PROD', {
+			stack: 'cms-fronts',
+			stage: 'PROD',
+			env: { region: 'eu-west-1' },
+			domainName: 'fronts.gutools.co.uk',
+			instanceType: 't4g.medium',
+			minimumInstances: 3,
+			maximumInstances: 6,
+		});
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
 });

--- a/cdk/lib/facia-tool.ts
+++ b/cdk/lib/facia-tool.ts
@@ -1,15 +1,348 @@
-import { join } from "path";
-import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuStack } from "@guardian/cdk/lib/constructs/core";
-import type { App } from "aws-cdk-lib";
-import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
+import { join } from 'path';
+import { GuEc2App } from '@guardian/cdk';
+import { AccessScope } from '@guardian/cdk/lib/constants';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import {
+	GuDistributionBucketParameter,
+	GuStack,
+} from '@guardian/cdk/lib/constructs/core';
+import { GuSecurityGroup, GuVpc } from '@guardian/cdk/lib/constructs/ec2';
+import { GuAllowPolicy, GuPolicy } from '@guardian/cdk/lib/constructs/iam';
+import type { App } from 'aws-cdk-lib';
+import { Fn, Tags } from 'aws-cdk-lib';
+import type { ISubnet } from 'aws-cdk-lib/aws-ec2';
+import {
+	InstanceType,
+	Port,
+	SecurityGroup,
+	UserData,
+} from 'aws-cdk-lib/aws-ec2';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
+
+const app = 'facia-tool';
+const applicationPort = 9000;
+
+export interface FaciaToolProps extends GuStackProps {
+	/** Must match the `Host` header CloudFront forwards to the origin. */
+	domainName: string;
+	instanceType: string;
+	minimumInstances: number;
+	maximumInstances: number;
+}
 
 export class FaciaTool extends GuStack {
-  constructor(scope: App, id: string, props: GuStackProps) {
-    super(scope, id, props);
-    const yamlTemplateFilePath = join(__dirname, "../..", "cloudformation/facia-tool.cfn.yaml");
-    new CfnInclude(this, "YamlTemplate", {
-      templateFile: yamlTemplateFilePath,
-    });
-  }
+	constructor(scope: App, id: string, props: FaciaToolProps) {
+		super(scope, id, props);
+
+		const yamlTemplateFilePath = join(
+			__dirname,
+			'../..',
+			'cloudformation/facia-tool.cfn.yaml',
+		);
+		const cfnInclude = new CfnInclude(this, 'YamlTemplate', {
+			templateFile: yamlTemplateFilePath,
+		});
+
+		const parameter = (name: string) =>
+			cfnInclude.getParameter(name).valueAsString;
+		const subnets = (name: string): ISubnet[] => {
+			const subnetIds = cfnInclude.getParameter(name).valueAsList;
+			return GuVpc.subnets(
+				this,
+				[0, 1, 2].map((index) => Fn.select(index, subnetIds)),
+			);
+		};
+
+		const vpc = GuVpc.fromId(this, 'Vpc', { vpcId: parameter('VpcId') });
+
+		const frontendRoleToAssume = parameter('FrontendRoleToAssume');
+		const frontPressedTable = Fn.findInMap(
+			'CrossResources',
+			this.stage,
+			'FrontPressedTable',
+		);
+		const lowerCaseStage = Fn.findInMap(
+			'StageMap',
+			this.stage,
+			'LowerCaseStage',
+		);
+		const userDataTable = `${parameter('UserDataTablePrefix')}-${this.stage}`;
+
+		const ec2App = new GuEc2App(this, {
+			app,
+			access: { scope: AccessScope.PUBLIC },
+			applicationPort,
+			instanceType: new InstanceType(props.instanceType),
+			monitoringConfiguration: { noMonitoring: true },
+			applicationLogging: { enabled: true },
+			instanceMetricGranularity: '5Minute',
+			imageRecipe: 'editorial-tools-jammy-java11',
+			userData: this.buildUserData({
+				frontendRoleToAssume,
+				frontPressedTable,
+				userDataTable,
+			}),
+			certificateProps: { domainName: props.domainName },
+			scaling: {
+				minimumInstances: props.minimumInstances,
+				maximumInstances: props.maximumInstances,
+			},
+			healthcheck: { path: '/_healthcheck' },
+			additionalPolicies: this.applicationPolicies({
+				frontendRoleToAssume,
+				frontPressedTable,
+				lowerCaseStage,
+				userDataTableArn: cfnInclude.getResource('FrontsUserDataDynamoTable')
+					.ref,
+				frontsUpdateTopicArn: cfnInclude.getResource('FrontsUpdateSNSTopic')
+					.ref,
+				feastPublicationTopicArn: cfnInclude.getResource(
+					'FeastPublicationTopic',
+				).ref,
+				capiPreviewRole: parameter('CapiPreviewRole'),
+				switchboardBucket: parameter('SwitchboardBucket'),
+			}),
+			vpc,
+			privateSubnets: subnets('PrivateSubnets'),
+			publicSubnets: subnets('PublicSubnets'),
+		});
+
+		// Tells Riff-Raff which of the two ASGs is the new one while the migration is in progress.
+		Tags.of(ec2App.autoScalingGroup).add('gu:riffraff:new-asg', 'true');
+
+		const databaseSecurityGroup = SecurityGroup.fromSecurityGroupId(
+			this,
+			'DatabaseSecurityGroup',
+			parameter('DBSecurityGroupIdNewVPC'),
+			{ mutable: true },
+		);
+
+		// A dedicated group, so the Postgres rule is never replayed onto the shared CAPI endpoint group.
+		const databaseAccessSecurityGroup = new GuSecurityGroup(
+			this,
+			'DatabaseAccessSecurityGroup',
+			{
+				app,
+				vpc,
+				description:
+					'Allows facia-tool instances to reach the fronts Postgres database',
+				allowAllOutbound: false,
+			},
+		);
+		databaseAccessSecurityGroup.connections.allowTo(
+			databaseSecurityGroup,
+			Port.tcp(5432),
+			'Postgres',
+		);
+
+		const capiEndpointSecurityGroup = SecurityGroup.fromSecurityGroupId(
+			this,
+			'CapiEndpointSecurityGroup',
+			parameter('CapiEndpointSsmKeyNewVPC'),
+			{ mutable: false },
+		);
+
+		ec2App.autoScalingGroup.instanceLaunchTemplate.connections.addSecurityGroup(
+			databaseAccessSecurityGroup,
+			capiEndpointSecurityGroup,
+		);
+	}
+
+	private buildUserData({
+		frontendRoleToAssume,
+		frontPressedTable,
+		userDataTable,
+	}: {
+		frontendRoleToAssume: string;
+		frontPressedTable: string;
+		userDataTable: string;
+	}): UserData {
+		const distributionBucket =
+			GuDistributionBucketParameter.getInstance(this).valueAsString;
+		const userData = UserData.forLinux({ shebang: '#!/bin/bash -ev' });
+
+		// Installing the .deb starts the service, so the user and its config must be in place first.
+		userData.addCommands(
+			`groupadd --force --system ${app}`,
+			`useradd --system --gid ${app} --home-dir /home/${app} --create-home --shell /usr/sbin/nologin ${app} || true`,
+			`mkdir -p /etc/gu`,
+			`aws s3 cp s3://facia-private/${app}.application.secrets.${this.stage}.conf /etc/gu/${app}.application.secrets.conf --region ${this.region}`,
+			`chown ${app} /etc/gu/${app}.application.secrets.conf`,
+			`chmod 400 /etc/gu/${app}.application.secrets.conf`,
+			`cat > /etc/gu/${app}.properties <<'EOF'
+STAGE=${this.stage}
+STS_ROLE=${frontendRoleToAssume}
+FRONT_PRESSED_TABLE=${frontPressedTable}
+USER_DATA_TABLE=${userDataTable}
+EOF`,
+			`aws s3 cp s3://${distributionBucket}/${this.stack}/${this.stage}/${app}/${app}_1.0_all.deb /home/${app}/${app}.all.deb --region ${this.region}`,
+			`dpkg -i /home/${app}/${app}.all.deb`,
+		);
+
+		return userData;
+	}
+
+	private applicationPolicies({
+		frontendRoleToAssume,
+		frontPressedTable,
+		lowerCaseStage,
+		userDataTableArn,
+		frontsUpdateTopicArn,
+		feastPublicationTopicArn,
+		capiPreviewRole,
+		switchboardBucket,
+	}: {
+		frontendRoleToAssume: string;
+		frontPressedTable: string;
+		lowerCaseStage: string;
+		userDataTableArn: string;
+		frontsUpdateTopicArn: string;
+		feastPublicationTopicArn: string;
+		capiPreviewRole: string;
+		switchboardBucket: string;
+	}): GuPolicy[] {
+		const bucketArn = (bucketName: string, key?: string) =>
+			this.formatArn({
+				service: 's3',
+				region: '',
+				account: '',
+				resource: bucketName,
+				resourceName: key,
+			});
+
+		const dynamoTableArn = (tableName: string) =>
+			this.formatArn({
+				service: 'dynamodb',
+				resource: 'table',
+				resourceName: tableName,
+			});
+
+		return [
+			new GuPolicy(this, 'ParameterStorePolicy', {
+				statements: [
+					new PolicyStatement({
+						effect: Effect.ALLOW,
+						actions: ['ssm:GetParameter'],
+						resources: [
+							this.formatArn({
+								service: 'ssm',
+								resource: 'parameter',
+								resourceName: `${app}/${this.stack}/${this.stage}/*`,
+							}),
+						],
+					}),
+					new PolicyStatement({
+						effect: Effect.ALLOW,
+						actions: ['kms:Decrypt'],
+						resources: ['*'],
+					}),
+				],
+			}),
+
+			new GuAllowPolicy(this, 'PrivateConfigPolicy', {
+				actions: ['s3:GetObject'],
+				resources: [bucketArn('facia-private', '*')],
+			}),
+
+			new GuAllowPolicy(this, 'PublishEventsQueuePolicy', {
+				actions: ['sqs:ReceiveMessage', 'sqs:DeleteMessage'],
+				resources: [
+					this.formatArn({
+						service: 'sqs',
+						resource: `publish-events-${this.stage}`,
+					}),
+				],
+			}),
+
+			new GuAllowPolicy(this, 'UserDataTablePolicy', {
+				actions: [
+					'dynamodb:GetItem',
+					'dynamodb:Query',
+					'dynamodb:PutItem',
+					'dynamodb:UpdateItem',
+					'dynamodb:Scan',
+				],
+				resources: [dynamoTableArn(userDataTableArn)],
+			}),
+
+			new GuAllowPolicy(this, 'PressedFrontsStatusPolicy', {
+				actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+				resources: [dynamoTableArn(frontPressedTable)],
+			}),
+
+			new GuAllowPolicy(this, 'SendEmailPolicy', {
+				actions: ['ses:SendEmail'],
+				resources: ['*'],
+			}),
+
+			// The one Describe permission GuDescribeEC2Policy does not already grant.
+			new GuAllowPolicy(this, 'DescribeDatabasesPolicy', {
+				actions: ['rds:DescribeDBInstances'],
+				resources: ['*'],
+			}),
+
+			new GuAllowPolicy(this, 'EditionsBucketsPolicy', {
+				actions: ['s3:PutObject'],
+				resources: [
+					bucketArn(`published-editions-${lowerCaseStage}`, '*'),
+					bucketArn(`preview-editions-${lowerCaseStage}`, '*'),
+				],
+			}),
+
+			new GuAllowPolicy(this, 'PublishTopicPolicy', {
+				actions: ['sns:Publish'],
+				resources: [frontsUpdateTopicArn, feastPublicationTopicArn],
+			}),
+
+			new GuPolicy(this, 'StorageBucketPolicy', {
+				statements: [
+					new PolicyStatement({
+						effect: Effect.ALLOW,
+						actions: ['s3:GetObject', 's3:PutObject', 's3:PutObjectAcl'],
+						resources: [bucketArn('facia-tool-store', `${this.stage}/*`)],
+					}),
+					new PolicyStatement({
+						effect: Effect.ALLOW,
+						actions: ['s3:ListBucket'],
+						resources: [bucketArn('facia-tool-store')],
+					}),
+				],
+			}),
+
+			new GuAllowPolicy(this, 'PanDomainPolicy', {
+				actions: ['s3:GetObject'],
+				resources: [bucketArn('pan-domain-auth-settings', '*')],
+			}),
+
+			new GuAllowPolicy(this, 'PermissionsPolicy', {
+				actions: ['s3:GetObject'],
+				resources: [bucketArn('permissions-cache', '*')],
+			}),
+
+			new GuAllowPolicy(this, 'SwitchesPolicy', {
+				actions: ['s3:GetObject'],
+				resources: [switchboardBucket],
+			}),
+
+			new GuAllowPolicy(this, 'CloudwatchPolicy', {
+				actions: [
+					'cloudwatch:GetMetricStatistics',
+					'cloudwatch:ListMetrics',
+					'cloudwatch:PutMetricData',
+				],
+				resources: ['*'],
+			}),
+
+			new GuAllowPolicy(this, 'AssumeFrontendRolePolicy', {
+				actions: ['sts:AssumeRole'],
+				resources: [frontendRoleToAssume],
+			}),
+
+			new GuAllowPolicy(this, 'AssumeCapiPreviewRolePolicy', {
+				actions: ['sts:AssumeRole'],
+				resources: [capiPreviewRole],
+			}),
+		];
+	}
 }

--- a/cloudformation/facia-tool.cfn.yaml
+++ b/cloudformation/facia-tool.cfn.yaml
@@ -710,9 +710,6 @@ Resources:
         - Key: SystemdUnit
           Value: facia-tool.service
           PropagateAtLaunch: 'true'
-        - Key: "gu:riffraff:new-asg"
-          Value: 1
-          PropagateAtLaunch: 'true'
   FaciaLaunchConfigNewVPC:
     Type: AWS::AutoScaling::LaunchConfiguration
     Metadata:

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -89,6 +89,7 @@ CloudFront `FaciaCloudfront` + `StaticCloudfront`, `DnsRecord` +
   platform-repo facia deployer + orphaned template removed; `access.ts` permission
   removed.
 - [x] **Phase 2** — `GuEc2App` (ALB) in parallel with legacy ELB (dual-stack).
+  PR [#2061](https://github.com/guardian/facia-tool/pull/2061).
   Done: `GuEc2App` in [cdk/lib/facia-tool.ts](cdk/lib/facia-tool.ts) with per-stage
   `domainName`/`instanceType`/`minimumInstances`/`maximumInstances` supplied from
   [cdk/bin/cdk.ts](cdk/bin/cdk.ts); network + KMS/DB/CAPI params reused from the

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -80,15 +80,14 @@ CloudFront `FaciaCloudfront` + `StaticCloudfront`, `DnsRecord` +
 
 ## Phases
 
-- [x] **Phase 1 (implemented locally)** — wrap template with GuCDK via
+- [x] **Phase 1** — wrap template with GuCDK via
   `CfnInclude` (verified **tags-only** `cdk diff` vs live `facia-CODE`). Done:
   template at `cloudformation/facia-tool.cfn.yaml`; `cdk/` scaffolded; per-stage
   `cloudFormationStackName` = `facia-CODE`/`facia-PROD`; `cdk/.nvmrc` node 24;
   service-repo CI builds+synths CDK and uploads templates; `riff-raff.yaml` now a
   `cloud-formation` deploy (`cfn-facia-tool`) with `autoscaling` depending on it;
   platform-repo facia deployer + orphaned template removed; `access.ts` permission
-  removed. **Pending user action:** create branches/commits in each repo, push,
-  open the 3 PRs in merge order, deploy CODE then PROD.
+  removed.
 - [ ] **Phase 2** — `GuEc2App` (ALB) in parallel with legacy ELB (dual-stack);
   remove leftover `gu:riffraff:new-asg` from legacy ASG; `asgMigrationInProgress`.
 - [ ] **Phase 3** — repoint CloudFront origin ELB → ALB (revertible).

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -88,12 +88,55 @@ CloudFront `FaciaCloudfront` + `StaticCloudfront`, `DnsRecord` +
   `cloud-formation` deploy (`cfn-facia-tool`) with `autoscaling` depending on it;
   platform-repo facia deployer + orphaned template removed; `access.ts` permission
   removed.
-- [ ] **Phase 2** — `GuEc2App` (ALB) in parallel with legacy ELB (dual-stack);
-  remove leftover `gu:riffraff:new-asg` from legacy ASG; `asgMigrationInProgress`.
+- [x] **Phase 2** — `GuEc2App` (ALB) in parallel with legacy ELB (dual-stack).
+  Done: `GuEc2App` in [cdk/lib/facia-tool.ts](cdk/lib/facia-tool.ts) with per-stage
+  `domainName`/`instanceType`/`minimumInstances`/`maximumInstances` supplied from
+  [cdk/bin/cdk.ts](cdk/bin/cdk.ts); network + KMS/DB/CAPI params reused from the
+  wrapped template via `getParameter`; leftover `gu:riffraff:new-asg` removed from
+  the legacy ASG and added to the new one; `riff-raff.yaml` switched to
+  `amiParametersToTags` (`AMI` + `AMIFaciatool`) with
+  `asgMigrationInProgress: true`. CODE + PROD `cdk diff` verified purely additive
+  apart from the intended legacy-ASG tag removal.
 - [ ] **Phase 3** — repoint CloudFront origin ELB → ALB (revertible).
 - [ ] **Phase 4** — delete legacy compute (ELB/ASG/LC/SGs/role); template keeps
   the non-compute resources (mixed stack end-state `CDK(cfn.yaml) -> cfn.json`).
 - [ ] **Phase 5** — follow-ups: CloudFront into GuCDK, alarms, stateful resources.
+
+## Phase 2 decisions
+
+- `imageRecipe` kept verbatim as the legacy `editorial-tools-jammy-java11`.
+- Certificate: a new per-stage `GuCertificate` for the CloudFront alias domain
+  (`fronts.gutools.co.uk` / `fronts.code.dev-gutools.co.uk`) — that is the `Host`
+  header CloudFront forwards to the origin. Validation records are created
+  automatically; no manual DNS step.
+- `GuUserData` not used: the app reads config from `/etc/gu/`, and the private
+  config lives in `facia-private` (not the distribution bucket). Raw
+  `UserData.forLinux()` replicates the legacy `cfn-init` order — user + config
+  first, `.deb` install last (installing it starts the service).
+- IAM: one policy per concern. Deliberately **not** ported (already granted by
+  `GuInstanceRole`): ec2/autoscaling `Describe*`, Kinesis log shipping, artifact
+  bucket `s3:GetObject`, SSM/SSH. `rds:DescribeDBInstances` **is** ported. The
+  legacy SSM path (`/facia-tool/cms-fronts/<stage>/*`) differs from GuCDK's
+  (`/<stage>/cms-fronts/facia-tool/*`) so both are present.
+- Postgres access uses a **dedicated** `DatabaseAccessSecurityGroup` rather than
+  the ASG's own connections, so the 5432 rule can't be replayed onto the shared
+  CAPI endpoint group. Instance SG count is 3 (well under the limit of 5).
+- Benign diff artefacts: ALB SG egress on 9000 to the DB-access and CAPI endpoint
+  groups (connections-model side effect; the LB never uses them), and a cfn-lint
+  `W9007` "duplicate Subnets" false positive (the three `Fn::Select` indices are
+  distinct).
+
+## Phase 2 deploy notes
+
+- This is a **new-ASG ("dangerous") deploy**. Riff-Raff rotates both ASGs because
+  of `asgMigrationInProgress`.
+- Synthesized template is ~58KiB, above CloudFormation's 51,200-byte inline
+  limit; Riff-Raff uploads templates that size to S3 automatically.
+- Smoke-test via the new ALB DNS name (stack output `LoadBalancerFaciatoolDnsName`)
+  sending the real `Host` header, e.g.
+  `curl -sk -H 'Host: fronts.code.dev-gutools.co.uk' https://<alb-dns>/_healthcheck`.
+- The new instance SG allows egress on 443 only (GuCDK default) versus the legacy
+  allow-all. Confirm no outbound dependency on another port during the soak.
 
 ## Node / tooling
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,13 +14,20 @@ deployments:
         PROD: FaciaTool-euwest-1-PROD.template.json
       cloudFormationStackName: facia
       prependStackToCloudFormationStackName: false
-      amiParameter: AMI
-      amiTags:
-        Recipe: editorial-tools-jammy-java11
-        AmigoStage: PROD
-        BuiltBy: amigo
+      amiParametersToTags:
+        AMI:
+          Recipe: editorial-tools-jammy-java11
+          AmigoStage: PROD
+          BuiltBy: amigo
+        AMIFaciatool:
+          Recipe: editorial-tools-jammy-java11
+          AmigoStage: PROD
+          BuiltBy: amigo
       amiEncrypted: true
   facia-tool:
     type: autoscaling
+    parameters:
+      # Dual-stack migration: rotate both the legacy ASG and the new (GuEc2App) one.
+      asgMigrationInProgress: true
     dependencies:
         - cfn-facia-tool


### PR DESCRIPTION
> [!NOTE] 
> This PR was opened by Claude Opus 5 using cloudformation-to-gucdk-migration@7fe540d31beb7ee7bc0c7793b4add833ee0275d1 but I have reviewed the output

## What's changed?

Phase 2 of the [CloudFormation → GuCDK migration](https://github.com/guardian/cdk/blob/main/docs/migration-guide.md): a `GuEc2App` (ALB + ASG) is introduced **in parallel** with the legacy classic ELB, so the two run side by side in the same `facia-CODE` / `facia-PROD` stacks.

**No traffic moves in this PR.** CloudFront still points at the legacy ELB; repointing the origin at the new ALB is phase 3 and is independently revertible.

Follows on from #2045 (phase 1 — wrapping the template in `CfnInclude`), which is deployed to PROD. The living plan is in [`plans/cloudformation-to-cdk-migration.md`](plans/cloudformation-to-cdk-migration.md).

Also in this PR:

- The leftover `gu:riffraff:new-asg` tag is removed from the **legacy** ASG (it was a stale marker from an earlier migration) and added to the **new** ASG, which is what the tag is for.
- `riff-raff.yaml` gains `asgMigrationInProgress: true` so Riff-Raff rotates both ASGs instead of failing on finding two, and switches from `amiParameter` to `amiParametersToTags` so both `AMI` (legacy launch config) and `AMIFaciatool` (new launch template) are resolved at deploy time.

## Implementation notes

**Everything already in the wrapped template is referenced, not retyped.** The VPC, subnets, DB and CAPI security groups, `FrontendRoleToAssume`, `CapiPreviewRole`, `SwitchboardBucket` and `UserDataTablePrefix` all come from `cfnInclude.getParameter(...)`; the DynamoDB table names come from the existing `CrossResources` / `StageMap` mappings via `Fn.findInMap`. Reusing the network parameters also avoids GuCDK's generated `VpcId` / `PrivateSubnets` / `PublicSubnets` parameters clashing with the template's own.

Per-stage values (`domainName`, `instanceType`, min/max instances) live in `bin/cdk.ts` next to the existing per-stage `cloudFormationStackName`, rather than in a stage lookup inside the stack class.

**`GuUserData` isn't usable here**, so the user data is a raw `UserData.forLinux()` replicating the legacy `cfn-init` faithfully: `GuUserData` writes config to `/etc/<app>/` but this app reads `/etc/gu/`, and the private config lives in `facia-private`, not the distribution bucket. Order matters — the user and its config are created *before* the `.deb` is installed, because installing it starts the service.

**IAM is one policy per concern**, named for what it grants, rather than the legacy catch-all `root` policy. Deliberately *not* ported, because `GuInstanceRole` already grants them: ec2/autoscaling `Describe*`, Kinesis log shipping, artifact-bucket `s3:GetObject`, and SSM/SSH. `rds:DescribeDBInstances` *is* ported, since `GuDescribeEC2Policy` doesn't cover it. Note the legacy Parameter Store path (`/facia-tool/cms-fronts/<stage>/*`) differs from GuCDK's convention (`/<stage>/cms-fronts/facia-tool/*`), so both are present.

**Postgres access uses a dedicated security group** rather than the ASG's own `connections`. `Connections` replays its rules onto any group added to it later, so granting DB access via the ASG's connections — which also carries the shared CAPI endpoint group — would have opened the database to everything in that shared group. The CAPI endpoint group is imported with `mutable: false` so no rules are written into it. Instances end up in 3 security groups, comfortably under the limit of 5.

**A brand-new per-stage `GuCertificate`** is created for the domain CloudFront forwards as the `Host` header (`fronts.gutools.co.uk` / `fronts.code.dev-gutools.co.uk`), rather than reusing the legacy ELB's certificate ARN via an escape hatch. Validation records are created automatically, so there's no manual DNS step.

`imageRecipe` is the legacy recipe verbatim (`editorial-tools-jammy-java11`) — no recipe change is needed for this migration.

### Reviewing the diff

`cdk diff` against both live stacks is **purely additive**, apart from the intended `gu:riffraff:new-asg` tag removal from the legacy ASG. Two things in the diff that look odd but are expected:

- The ALB security group gets egress on 9000 to the DB-access and CAPI endpoint groups. That's a side effect of CDK's connections model; the load balancer never uses it.
- `cfn-lint` warns `W9007` "Array property 'Subnets' contains duplicate values" on the new ALB. It's a false positive — the three entries are `Fn::Select` of index 0, 1 and 2.

### Deploying

This creates a new ASG, so it's a **"dangerous" (new-ASG) Riff-Raff deploy**. CODE first, then PROD.

Smoke-test through the new ALB before phase 3, sending the real `Host` header (the ALB DNS name is the `LoadBalancerFaciatoolDnsName` stack output):

```
curl -sk -H 'Host: fronts.code.dev-gutools.co.uk' https://<alb-dns-name>/_healthcheck
```

One thing worth watching during the soak: the new instance security group allows **egress on 443 only** (the GuCDK default), where the legacy one allowed all outbound. Postgres (5432) is covered by the dedicated group and DNS isn't subject to security group rules, but if the app has an outbound dependency on some other port it would show up here.

The synthesized template is ~58KiB, over CloudFormation's 51,200-byte inline limit; Riff-Raff uploads templates that size to S3 automatically.

## Checklist

### General
- [x] 🤖 Relevant tests added — snapshot tests now cover both CODE and PROD
- [x] ✅ CI checks / tests run locally — `npm run lint`, `npm test`, `npm run synth` and `cdk diff` (CODE + PROD) all green
- [ ] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors) — n/a, infrastructure only
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work) — n/a, infrastructure only
- [x] 📷 Screenshots / GIFs of relevant UI changes included — n/a, infrastructure only
