### PR TITLE
Fix test status display on clipboard cards

### DIFF
--- a/fronts-client/src/components/OphanBanner.tsx
+++ b/fronts-client/src/components/OphanBanner.tsx
@@ -36,6 +36,7 @@ const OphanBannerLink = styled.a`
 `;
 
 interface OphanBannerProps {
+	isClipboard: boolean;
 	isTestLive: boolean;
 }
 
@@ -47,9 +48,11 @@ const OphanBanner = ({ ...props }: OphanBannerProps) => {
 			</FixedSizeIcon>
 			<OphanBannerText>
 				<OphanBannerTitle>
-					{props.isTestLive
-						? 'Headline test in progress: '
-						: 'Test ready to launch: '}
+					{props.isClipboard
+						? 'Test staged: '
+						: props.isTestLive
+							? 'Headline test in progress: '
+							: 'Test ready to launch: '}
 				</OphanBannerTitle>
 				view results {!props.isTestLive && 'from other cards with this test'} in{' '}
 				<OphanBannerLink

--- a/fronts-client/src/components/card/article/ArticleBody.tsx
+++ b/fronts-client/src/components/card/article/ArticleBody.tsx
@@ -7,7 +7,7 @@ import BasePlaceholder from '../../BasePlaceholder';
 import { getPillarColor } from 'util/getPillarColor';
 import CardMetaContainer from '../CardMetaContainer';
 import CardContent from '../CardContent';
-import { notLiveLabels, liveBlogTones } from 'constants/fronts';
+import { notLiveLabels, liveBlogTones, clipboardId } from 'constants/fronts';
 import TextPlaceholder from 'components/TextPlaceholder';
 import { ThumbnailSmall, ThumbnailCutout } from 'components/image/Thumbnail';
 import CardMetaHeading from '../CardMetaHeading';
@@ -66,7 +66,8 @@ type ABStatusMessage =
 	| 'Test in progress'
 	| 'End test on launch'
 	| 'Test set up incomplete'
-	| 'Ready to launch';
+	| 'Ready to launch'
+	| 'Test staged';
 
 type ABTestTheme = 'active' | 'draft' | 'error';
 
@@ -336,7 +337,15 @@ const articleBodyDefault = React.memo(
 			hasLiveAbTest: boolean | undefined,
 			abTestEnabled: boolean | undefined,
 			headlineTestError: AbTestHeadlineErrorType | null | undefined,
+			frontId: string,
 		): ABTestStatus | undefined => {
+			if (frontId === clipboardId && abTestEnabled) {
+				return {
+					message: 'Test staged',
+					theme: 'draft',
+					palette: getABTestThemeColors('draft'),
+				};
+			}
 			if (hasLiveAbTest && abTestEnabled) {
 				return {
 					message: 'Test in progress',
@@ -408,6 +417,7 @@ const articleBodyDefault = React.memo(
 			hasLiveAbTest,
 			abTestEnabled,
 			headlineTestError,
+			frontId,
 		);
 
 		return (

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -32,6 +32,7 @@ import {
 	getCurrentAbTestHeadlineError,
 	hasActiveAbTestOnCard,
 } from '../../../util/abTests';
+import { clipboardId } from 'constants/fronts';
 
 const ArticleBodyContainer = styled(CardBody)<{
 	pillarId: string | undefined;
@@ -239,7 +240,11 @@ const createMapStateToProps = () => {
 			card.id,
 			props.collectionId,
 		);
-		const hasLiveAbTest = hasActiveAbTestOnCard(liveCard);
+		// cards on the clipboard will have an undefined liveCard, because the clipboard collection won't exist
+		// on live collections. Just use the card itself here so that test status displays as expected
+		const hasLiveAbTest = hasActiveAbTestOnCard(
+			props.frontId === clipboardId ? card : liveCard,
+		);
 		const headlineTestError = getCurrentAbTestHeadlineError(card);
 
 		return {

--- a/fronts-client/src/components/card/article/ArticleCard.tsx
+++ b/fronts-client/src/components/card/article/ArticleCard.tsx
@@ -32,7 +32,6 @@ import {
 	getCurrentAbTestHeadlineError,
 	hasActiveAbTestOnCard,
 } from '../../../util/abTests';
-import { clipboardId } from 'constants/fronts';
 
 const ArticleBodyContainer = styled(CardBody)<{
 	pillarId: string | undefined;
@@ -240,11 +239,7 @@ const createMapStateToProps = () => {
 			card.id,
 			props.collectionId,
 		);
-		// cards on the clipboard will have an undefined liveCard, because the clipboard collection won't exist
-		// on live collections. Just use the card itself here so that test status displays as expected
-		const hasLiveAbTest = hasActiveAbTestOnCard(
-			props.frontId === clipboardId ? card : liveCard,
-		);
+		const hasLiveAbTest = hasActiveAbTestOnCard(liveCard);
 		const headlineTestError = getCurrentAbTestHeadlineError(card);
 
 		return {

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -95,6 +95,7 @@ import type { Atom, AtomResponse } from '../../types/Capi';
 import Tooltip from '../modals/Tooltip';
 import { isAtom } from '../../util/atom';
 import { HeadlineInput } from 'components/inputs/HeadlineInput';
+import { clipboardId } from 'constants/fronts';
 
 interface ComponentProps extends ContainerProps {
 	articleExists: boolean;
@@ -734,6 +735,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 								editableFields={editableFields}
 								snapType={this.props.snapType}
 								onAbTestToggle={handleAbTestToggle}
+								isClipboard={frontId === clipboardId}
 							/>
 						)}
 						<CheckboxFieldsContainer

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -19,6 +19,7 @@ interface HeadlineInputProps {
 	editableFields: string[];
 	snapType: string | undefined;
 	onAbTestToggle?: EventWithDataHandler<React.ChangeEvent<any>>;
+	isClipboard: boolean;
 }
 
 const HeadlineInputContainer = styled('div')<{ abTestEnabled: boolean }>`
@@ -131,7 +132,10 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 				/>
 			)}
 			{abTestFeatureEnabled && props.abTestEnabled && props.hasActiveABTest && (
-				<OphanBanner isTestLive={props.hasActiveABTestOnLiveCard} />
+				<OphanBanner
+					isClipboard={props.isClipboard}
+					isTestLive={props.hasActiveABTestOnLiveCard}
+				/>
 			)}
 		</HeadlineInputContainer>
 	);


### PR DESCRIPTION
## What's changed?
This PR handles the status message of tests on cards on the clipboard explicitly, instead of relying on the fallback of `Ready to launch`. `Ready to launch` isn't necessarily inaccurate, but in future if we made changes to this, having the clipboard messaging handled explicitly helps to make sure that this edge case is considered. It also makes what's going on a bit clearer to future developers. 

Currently, when moving a card with an active test to the clipboard, the test status shows `Ready to launch`. This is because the `selectLiveCardForGivenCardId` selector looks for the current collection ID in the live collections to find the live version of the card. The clipboard doesn't exist on the live collections, so no live card ID is returned. This means the code finds no active AB test.

This PR updates that logic to check for tests on the current card if it is on the clipboard, instead of using the `liveCard`, which will be undefined. This then shows the current test status for the clipboard card.

| Before | After |
| ------ | ------ |
| <img width="197" height="154" alt="Screenshot 2026-09-08 at 17 40 41" src="https://github.com/user-attachments/assets/189432cf-d40a-4dc5-a481-cc25cb3bf3de" /> | <img width="191" height="151" alt="Screenshot 2026-09-08 at 17 38 14" src="https://github.com/user-attachments/assets/9cf63124-9006-4589-83f4-2c72aea5bc20" /> |





