### PR TITLE
Add support for A/B tests in sublinks

### DIFF
--- a/app/tools/FaciaApiIO.scala
+++ b/app/tools/FaciaApiIO.scala
@@ -1,6 +1,13 @@
 package tools
 
-import com.gu.facia.client.models.{CollectionJson, ConfigJson, Trail}
+import com.gu.facia.client.models.{
+  CollectionJson,
+  ConfigJson,
+  SupportingItem,
+  Test,
+  Trail,
+  TrailMetaData
+}
 import com.gu.pandomainauth.model.User
 import frontsapi.model.CollectionJsonFunctions
 import org.joda.time.DateTime
@@ -163,8 +170,11 @@ object FaciaApi {
     collectionJson.copy(draft = Some(draftsWithNewDate))
   }
 
-  private def addTestDatesToTrail(trail: Trail, now: DateTime): Trail = {
-    val updatedTests = trail.tests.map(_.map { test =>
+  private def addTestDates(
+      tests: Option[List[Test]],
+      now: DateTime
+  ): Option[List[Test]] =
+    tests.map(_.map { test =>
       if (test.hasManuallyEndedOnThisTrail) {
         test.copy(manuallyEndedOnThisTrailDate =
           test.manuallyEndedOnThisTrailDate.orElse(Some(now.getMillis))
@@ -175,7 +185,31 @@ object FaciaApi {
         test.copy(startDate = startDate, expiryDate = expiryDate)
       }
     })
-    trail.copy(tests = updatedTests)
+
+  private def addTestDatesToSupportingItem(
+      item: SupportingItem,
+      now: DateTime
+  ): SupportingItem =
+    item.copy(tests = addTestDates(item.tests, now))
+
+  private def addTestDatesToTrail(trail: Trail, now: DateTime): Trail = {
+    val updatedTests = addTestDates(trail.tests, now)
+
+    // Sublinks (supporting items) can carry their own tests, so we also need to
+    // set dates on those
+    val updatedMeta = trail.meta.map { meta =>
+      meta.supporting match {
+        case None => meta
+        case Some(supporting) =>
+          val updatedSupporting =
+            supporting.map(item => addTestDatesToSupportingItem(item, now))
+          TrailMetaData(
+            meta.json + ("supporting" -> Json.toJson(updatedSupporting))
+          )
+      }
+    }
+
+    trail.copy(tests = updatedTests, meta = updatedMeta)
   }
 
   def addTestDatesToTrails(

--- a/fronts-client/src/actions/Cards.ts
+++ b/fronts-client/src/actions/Cards.ts
@@ -391,6 +391,7 @@ export const mayResetVideoReplace = ({
  *
  * The following movements keep a test running (and therefore return no actions):
  * - moving a card around within a front it can run on
+ * - moving a card between a trail and a sublink on a front it can run on
  * - moving a card to the clipboard, then re-adding it to a front it can run on
  *
  * Moving a card to the clipboard (and leaving it there) requires no action -

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -214,6 +214,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 													<CardLevel
 														isUneditable={isUneditable}
 														cardId={card.uuid}
+														collectionId={id}
 														groupName={group.name ? group.name : ''}
 														groupIds={groupIds}
 														groups={groups}

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -233,6 +233,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 															return (
 																<Card
 																	frontId={frontId}
+																	collectionId={id}
 																	uuid={supporting.uuid}
 																	parentId={card.uuid}
 																	canShowPageViewData={false}

--- a/fronts-client/src/components/FrontsEdit/__tests__/mayEndAbTests.spec.tsx
+++ b/fronts-client/src/components/FrontsEdit/__tests__/mayEndAbTests.spec.tsx
@@ -42,6 +42,19 @@ const state: any = {
 const toUkFront = { ...baseTo, collectionId: UK_COLLECTION };
 const toUsFront = { ...baseTo, collectionId: US_COLLECTION };
 
+const toUkSublink = {
+	...baseTo,
+	type: 'card',
+	id: 'parent-uk',
+	collectionId: UK_COLLECTION,
+};
+const toUsSublink = {
+	...baseTo,
+	type: 'card',
+	id: 'parent-us',
+	collectionId: US_COLLECTION,
+};
+
 describe('mayEndAbTest', () => {
 	it('ends a running test when a card is moved to a different front', () => {
 		const result = mayEndAbTest({
@@ -72,6 +85,31 @@ describe('mayEndAbTest', () => {
 		});
 
 		expect(result).toBeUndefined();
+	});
+
+	it('keeps the test running when a card is moved into a sublink on its own front', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUkSublink,
+			card: makeCard([makeTest()]),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('ends a running test when a card is moved into a sublink on a different front', () => {
+		const result = mayEndAbTest({
+			from: baseFrom,
+			to: toUsSublink,
+			card: makeCard([makeTest()]),
+			persistTo: 'collection',
+			state,
+		});
+
+		expect(result?.payload.id).toBe('card-1');
+		expect(result?.payload.test?.hasManuallyEndedOnThisTrail).toBe(true);
 	});
 
 	it('does not end a test when a card is moved to the clipboard', () => {

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -20,6 +20,7 @@ interface OuterProps {
 	isUneditable?: boolean;
 	dropMessage?: string;
 	cardTypeAllowList?: CardTypes[];
+	collectionId?: string;
 	groupName?: string;
 	groupIds?: string[];
 	groups?: Group[];
@@ -52,6 +53,7 @@ const CardLevel = ({
 	isUneditable,
 	dropMessage,
 	cardTypeAllowList,
+	collectionId,
 	groupName,
 	groupIds,
 	groups,
@@ -60,6 +62,7 @@ const CardLevel = ({
 		arr={supporting || []}
 		parentType="card"
 		parentId={cardId}
+		collectionId={collectionId}
 		groupName={groupName}
 		groupIds={groupIds}
 		groupsData={groups}

--- a/test/tools/FaciaApiTest.scala
+++ b/test/tools/FaciaApiTest.scala
@@ -1,9 +1,16 @@
 package tools
 
-import com.gu.facia.client.models.{CollectionJson, Test, Trail}
+import com.gu.facia.client.models.{
+  CollectionJson,
+  SupportingItem,
+  Test,
+  Trail,
+  TrailMetaData
+}
 import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
+import play.api.libs.json.Json
 
 class FaciaApiTest extends FreeSpec with Matchers {
 
@@ -102,6 +109,61 @@ class FaciaApiTest extends FreeSpec with Matchers {
     }
   }
 
+  "set AB test start/expiry dates on sublinks (supporting items) on publish" - {
+
+    def sublinkTestFor(
+        trailId: String,
+        sublinkId: String,
+        collectionJson: CollectionJson
+    ): Test =
+      collectionJson.live
+        .find(_.id == trailId)
+        .flatMap(_.meta)
+        .flatMap(_.supporting)
+        .flatMap(_.find(_.id == sublinkId))
+        .flatMap(_.tests)
+        .flatMap(_.headOption)
+        .getOrElse(
+          fail(s"expected a test on sublink <$sublinkId> of trail <$trailId>")
+        )
+
+    "sets dates on an active (not manually ended) test that has none" in {
+      val (identity, collectionJson) = scenarioWithSublinkTests
+      val newCollectionJson =
+        FaciaApi.preparePublishCollectionJson(identity)(collectionJson).get
+
+      val test =
+        sublinkTestFor("trailWithSublinks", "activeSublinkTestId", newCollectionJson)
+      test.startDate should be(Symbol("defined"))
+      test.expiryDate should be(Symbol("defined"))
+    }
+
+    "does NOT set dates on a manually ended test" in {
+      val (identity, collectionJson) = scenarioWithSublinkTests
+      val newCollectionJson =
+        FaciaApi.preparePublishCollectionJson(identity)(collectionJson).get
+
+      val test =
+        sublinkTestFor("trailWithSublinks", "endedSublinkTestId", newCollectionJson)
+      test.startDate should be(None)
+      test.expiryDate should be(None)
+    }
+
+    "does not overwrite existing dates on an active test" in {
+      val (identity, collectionJson) = scenarioWithSublinkTests
+      val newCollectionJson =
+        FaciaApi.preparePublishCollectionJson(identity)(collectionJson).get
+
+      val test = sublinkTestFor(
+        "trailWithSublinks",
+        "existingDatesSublinkTestId",
+        newCollectionJson
+      )
+      test.startDate should be(Some(1000L))
+      test.expiryDate should be(Some(2000L))
+    }
+  }
+
   private def makeTest(
       hasManuallyEndedOnThisTrail: Boolean,
       startDate: Option[Long] = None,
@@ -144,6 +206,67 @@ class FaciaApiTest extends FreeSpec with Matchers {
         None,
         Some(
           List(
+            makeTest(
+              hasManuallyEndedOnThisTrail = false,
+              startDate = Some(1000L),
+              expiryDate = Some(2000L)
+            )
+          )
+        )
+      )
+    )
+    val collectionJson = CollectionJson(
+      Nil,
+      Some(draft),
+      None,
+      new DateTime(0),
+      "oldUpdatedBy",
+      "oldUpdatedEmail",
+      None,
+      None,
+      None,
+      None
+    )
+    (identity, collectionJson)
+  }
+
+  private def makeSublink(id: String, test: Test): SupportingItem =
+    SupportingItem(
+      id = id,
+      frontPublicationDate = None,
+      publishedBy = None,
+      meta = None,
+      tests = Some(List(test))
+    )
+
+  private def trailWithSublinks(
+      id: String,
+      sublinks: List[SupportingItem]
+  ): Trail =
+    Trail(
+      id,
+      0,
+      Some(""),
+      Some(TrailMetaData(Map("supporting" -> Json.toJson(sublinks)))),
+      None
+    )
+
+  private def scenarioWithSublinkTests: (User, CollectionJson) = {
+    val identity = User("John", "Duffell", "email@email.com", None)
+    val draft = List(
+      trailWithSublinks(
+        "trailWithSublinks",
+        List(
+          makeSublink(
+            "activeSublinkTestId",
+            makeTest(hasManuallyEndedOnThisTrail = false)
+          ),
+          makeSublink(
+            "endedSublinkTestId",
+            makeTest(hasManuallyEndedOnThisTrail = true)
+          ),
+          makeSublink(
+            "existingDatesSublinkTestId",
             makeTest(
               hasManuallyEndedOnThisTrail = false,
               startDate = Some(1000L),


### PR DESCRIPTION
## What's changed?

This PR fixes 2 bugs to support AB tests on sublinks (also known as supporting items), mirroring how they already behave on trails.

### Fix 1

https://github.com/guardian/facia-tool/pull/2063/changes/c5c728a5ddd2ae7204142dd281943efebafd9617 fixes a bug where moving a card carrying a running A/B test into (or out of) a sublink on the test's own front would wrongly end the test. Previously, sublink drops built a `PosSpec` without a `collectionId`, so `mayEndAbTest` couldn't resolve the destination front and assumed the card had moved elsewhere. Setting `collectionId` in `CardLevel` fixes the issue.

#### Before

https://github.com/user-attachments/assets/ac649619-a04b-4dd7-8973-d683e9d8848a

#### After

https://github.com/user-attachments/assets/c0f05730-ea58-43c6-8573-f36235f4c280

### Fix 2

https://github.com/guardian/facia-tool/pull/2063/changes/0bc31bd9df8fb0be2eb2550ea2ead74b20270027 fixes a bug where `startDate`/`expiryDate` weren't being set on publish. This in turn meant they displayed the wrong label ("Ready to publish" instead of "Test in progress"). `addTestDatesToTrail` now recurses into a trail's `meta.supporting` and sets these properties for tests on sublinks. It uses a shared `addTestDates` helper so trails and sublinks apply the same rules.

#### Before

https://github.com/user-attachments/assets/a9306a19-2834-432b-8236-9037c612b62b

#### After

https://github.com/user-attachments/assets/e2726a9c-3cc2-44f8-b635-72af9cf7d0b9

## Implementation notes

The tests were written by copilot and manually reviewed.

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
