### PR TITLE
GuCDK migration phase 3: serve CloudFront from the new ALB

### DIFF
--- a/cdk/lib/__snapshots__/facia-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/facia-tool.test.ts.snap
@@ -1238,7 +1238,7 @@ exports[`The FaciaTool stack matches the CODE snapshot 1`] = `
               },
               "DomainName": {
                 "Fn::GetAtt": [
-                  "FaciaLoadBalancerNewVPC",
+                  "LoadBalancerFaciatool65BDBE55",
                   "DNSName",
                 ],
               },
@@ -4658,7 +4658,7 @@ exports[`The FaciaTool stack matches the PROD snapshot 1`] = `
               },
               "DomainName": {
                 "Fn::GetAtt": [
-                  "FaciaLoadBalancerNewVPC",
+                  "LoadBalancerFaciatool65BDBE55",
                   "DNSName",
                 ],
               },

--- a/cdk/lib/facia-tool.ts
+++ b/cdk/lib/facia-tool.ts
@@ -111,6 +111,15 @@ export class FaciaTool extends GuStack {
 		// Tells Riff-Raff which of the two ASGs is the new one while the migration is in progress.
 		Tags.of(ec2App.autoScalingGroup).add('gu:riffraff:new-asg', 'true');
 
+		// Traffic cutover: serve CloudFront from the new ALB instead of the legacy ELB.
+		// Reverting this override is the rollback.
+		cfnInclude
+			.getResource('FaciaCloudfront')
+			.addPropertyOverride(
+				'DistributionConfig.Origins.0.DomainName',
+				ec2App.loadBalancer.loadBalancerDnsName,
+			);
+
 		const databaseSecurityGroup = SecurityGroup.fromSecurityGroupId(
 			this,
 			'DatabaseSecurityGroup',

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -98,7 +98,11 @@ CloudFront `FaciaCloudfront` + `StaticCloudfront`, `DnsRecord` +
   `amiParametersToTags` (`AMI` + `AMIFaciatool`) with
   `asgMigrationInProgress: true`. CODE + PROD `cdk diff` verified purely additive
   apart from the intended legacy-ASG tag removal.
-- [ ] **Phase 3** — repoint CloudFront origin ELB → ALB (revertible).
+- [ ] **Phase 3** — repoint CloudFront origin ELB → ALB (revertible). Code done:
+  a single `addPropertyOverride` on the included `FaciaCloudfront` resource sets
+  `DistributionConfig.Origins.0.DomainName` to the new ALB. `cdk diff` against
+  both live stacks shows **only** that one property change. Awaiting CODE then
+  PROD deploy + soak.
 - [ ] **Phase 4** — delete legacy compute (ELB/ASG/LC/SGs/role); template keeps
   the non-compute resources (mixed stack end-state `CDK(cfn.yaml) -> cfn.json`).
 - [ ] **Phase 5** — follow-ups: CloudFront into GuCDK, alarms, stateful resources.
@@ -138,6 +142,37 @@ CloudFront `FaciaCloudfront` + `StaticCloudfront`, `DnsRecord` +
   `curl -sk -H 'Host: fronts.code.dev-gutools.co.uk' https://<alb-dns>/_healthcheck`.
 - The new instance SG allows egress on 443 only (GuCDK default) versus the legacy
   allow-all. Confirm no outbound dependency on another port during the soak.
+
+## Phase 3 decisions
+
+- The distribution stays in the wrapped template; CDK only overrides the origin
+  domain via `cfnInclude.getResource('FaciaCloudfront').addPropertyOverride(...)`.
+  Nothing else about CloudFront (aliases, cache behaviour, viewer certificate) or
+  its DNS records changes, so the blast radius is one property.
+- **Rollback = revert that override and redeploy** (the legacy ELB and ASG are
+  still running untouched throughout Phase 3).
+- Origin id `facia-tool` and `TargetOriginId` are unchanged, so the cache
+  behaviour keeps pointing at the same origin entry.
+- CloudFront forwards all headers (`ForwardedValues.Headers: ["*"]`), so it
+  reaches the origin with `Host: fronts[.code.dev]-gutools.co.uk` and
+  `OriginProtocolPolicy: https-only`. The Phase 2 `GuCertificate` covers exactly
+  that name — verified with a real SNI/hostname-validated request.
+
+### Pre-cutover verification (done)
+
+- Phase 2 is deployed to both stages; new ALB target groups healthy (CODE 1
+  instance, PROD 3).
+- Smoke tests against the new ALBs with the real `Host` header:
+  `/_healthcheck` → 200, `/` → 303 (pan-domain auth redirect), in both stages,
+  with full TLS verification via `curl --resolve`.
+
+### Cutover steps
+
+1. Deploy CODE, confirm `fronts.code.dev-gutools.co.uk` works end-to-end
+   (auth + core flows), and check the CODE ALB metrics show the traffic.
+2. Deploy PROD, repeat.
+3. Soak. CloudFront origin changes propagate in minutes; rollback is a revert.
+4. Only once the old ELBs show **0 requests** does Phase 4 delete them.
 
 ## Node / tooling
 

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -98,7 +98,8 @@ CloudFront `FaciaCloudfront` + `StaticCloudfront`, `DnsRecord` +
   `amiParametersToTags` (`AMI` + `AMIFaciatool`) with
   `asgMigrationInProgress: true`. CODE + PROD `cdk diff` verified purely additive
   apart from the intended legacy-ASG tag removal.
-- [ ] **Phase 3** — repoint CloudFront origin ELB → ALB (revertible). Code done:
+- [ ] **Phase 3** — repoint CloudFront origin ELB → ALB (revertible).
+  PR [#2064](https://github.com/guardian/facia-tool/pull/2064). Code done:
   a single `addPropertyOverride` on the included `FaciaCloudfront` resource sets
   `DistributionConfig.Origins.0.DomainName` to the new ALB. `cdk diff` against
   both live stacks shows **only** that one property change. Awaiting CODE then


### PR DESCRIPTION
> [!NOTE] 
> This PR was opened by Claude Opus 5 using cloudformation-to-gucdk-migration@7fe540d31beb7ee7bc0c7793b4add833ee0275d1 but I have reviewed the output

## What's changed?

Phase 3 of the [CloudFormation → GuCDK migration](https://github.com/guardian/facia-tool/blob/main/plans/cloudformation-to-cdk-migration.md): **switch live traffic from the legacy classic ELB to the ALB** that [#2061](https://github.com/guardian/facia-tool/pull/2061) stood up alongside it.

facia-tool is fronted by a CloudFront distribution whose origin is the ELB, so the traffic switch is simply repointing that origin — there is no DNS change:

```ts
cfnInclude
  .getResource('FaciaCloudfront')
  .addPropertyOverride(
    'DistributionConfig.Origins.0.DomainName',
    ec2App.loadBalancer.loadBalancerDnsName,
  );
```

`cdk diff` against **both** live stacks is that one property, and nothing else:

```
Stack FaciaTool-euwest-1-PROD (facia-PROD)
Resources
[~] AWS::CloudFront::Distribution YamlTemplate/FaciaCloudfront FaciaCloudfront
 └─ [~] DistributionConfig
     └─ [~] .Origins:
         └─ @@ -6,7 +6,7 @@
            [ ] "DomainName": {
            [ ]   "Fn::GetAtt": [
            [-]     "FaciaLoadBalancerNewVPC",
            [+]     "LoadBalancerFaciatool65BDBE55",
            [ ]     "DNSName"
```

## Implementation notes

**Rollback is reverting this PR.** The legacy ELB, ASG and launch config all keep running untouched through Phase 3 — this changes only where CloudFront sends requests. Origin changes propagate in minutes. Phase 4 deletes the legacy compute, and only once CloudWatch shows the old ELBs at 0 requests.

**The distribution stays in the wrapped template.** CDK overrides one property rather than adopting CloudFront, so aliases, cache behaviour, the viewer certificate and the `Guardian::DNS::RecordSet` records are all untouched. Moving the distribution into GuCDK proper is a Phase 5 follow-up, deliberately not part of the cutover.

**Origin id is unchanged** (`facia-tool`), so `TargetOriginId` on the cache behaviour still resolves to the same origin entry.

**TLS to the origin.** The distribution uses `OriginProtocolPolicy: https-only` and forwards all headers (`ForwardedValues.Headers: ["*"]`), so it reaches the origin with the viewer's `Host` header. The per-stage `GuCertificate` added in Phase 2 covers exactly that name, which I verified with a hostname-validated request rather than trusting `-k`:

```
$ curl --resolve "fronts.gutools.co.uk:443:<alb-ip>" https://fronts.gutools.co.uk/_healthcheck
PROD verified TLS: 200
```

### Pre-cutover verification

- Phase 2 is deployed to both stages; new ALB target groups healthy (CODE 1 instance, PROD 3).
- Smoke tests against both new ALBs with the real `Host` header: `/_healthcheck` → 200, `/` → 303 (pan-domain auth redirect).
- Lint, CODE + PROD snapshots and synth green.

### Deploy order

1. Deploy **CODE**, confirm `fronts.code.dev-gutools.co.uk` end-to-end (auth + core flows) and that the CODE ALB metrics show the traffic.
2. Deploy **PROD**, repeat on `fronts.gutools.co.uk`.
3. Soak before starting Phase 4.

## Checklist

### General
- [x] 🤖 Relevant tests added — snapshot tests updated for both stages
- [x] ✅ CI checks / tests run locally — lint, test, synth, plus `cdk diff` vs both live stacks
- [ ] 🔍 Checked on CODE — to do at deploy

### Client
- [x] 🚫 No obvious console errors on the client — no client changes
- [x] 🎛️ No regressions with existing user interactions — no client changes
- [x] 📷 Screenshots / GIFs of relevant UI changes included — n/a, infrastructure only
