### PR TITLE
Show different Ophan banner message if test is active but not live

### DIFF
--- a/fronts-client/src/components/OphanBanner.tsx
+++ b/fronts-client/src/components/OphanBanner.tsx
@@ -19,6 +19,14 @@ const OphanBannerContainer = styled.div`
 	font-size: 14px;
 `;
 
+const FixedSizeIcon = styled.span`
+	flex: none;
+`;
+
+const OphanBannerText = styled.p`
+	margin: 0;
+`;
+
 const OphanBannerTitle = styled.span`
 	font-weight: 600;
 `;
@@ -34,23 +42,25 @@ interface OphanBannerProps {
 const OphanBanner = ({ ...props }: OphanBannerProps) => {
 	return (
 		<OphanBannerContainer role="status">
-			<ConicalFlaskIcon size="xs" fill={theme.abTest.active.icon} />
-			<OphanBannerTitle>
-				{props.isTestLive
-					? 'Headline test in progress:'
-					: 'Test ready to launch:'}
-			</OphanBannerTitle>
-			<span>
-				View results {!props.isTestLive && 'from other cards with this test'} in{' '}
+			<FixedSizeIcon>
+				<ConicalFlaskIcon size="xs" fill={theme.abTest.active.icon} />
+			</FixedSizeIcon>
+			<OphanBannerText>
+				<OphanBannerTitle>
+					{props.isTestLive
+						? 'Headline test in progress: '
+						: 'Test ready to launch: '}
+				</OphanBannerTitle>
+				view results {!props.isTestLive && 'from other cards with this test'} in{' '}
 				<OphanBannerLink
 					href={url.ophan}
 					target="_blank"
 					rel="noreferrer noopener"
-					aria-label="View results in Ophan (opens in a new tab)"
+					aria-label="view results in Ophan (opens in a new tab)"
 				>
 					Ophan
 				</OphanBannerLink>
-			</span>
+			</OphanBannerText>
 		</OphanBannerContainer>
 	);
 };

--- a/fronts-client/src/components/OphanBanner.tsx
+++ b/fronts-client/src/components/OphanBanner.tsx
@@ -27,13 +27,21 @@ const OphanBannerLink = styled.a`
 	color: ${({ theme }) => theme.abTest.active.text};
 `;
 
-const OphanBanner = () => {
+interface OphanBannerProps {
+	isTestLive: boolean;
+}
+
+const OphanBanner = ({ ...props }: OphanBannerProps) => {
 	return (
 		<OphanBannerContainer role="status">
 			<ConicalFlaskIcon size="xs" fill={theme.abTest.active.icon} />
-			<OphanBannerTitle>Headline Test In Progress :</OphanBannerTitle>
+			<OphanBannerTitle>
+				{props.isTestLive
+					? 'Headline test in progress:'
+					: 'Test ready to launch on this card:'}
+			</OphanBannerTitle>
 			<span>
-				View results in{' '}
+				View results {!props.isTestLive && 'from other cards with this test'} in{' '}
 				<OphanBannerLink
 					href={url.ophan}
 					target="_blank"

--- a/fronts-client/src/components/OphanBanner.tsx
+++ b/fronts-client/src/components/OphanBanner.tsx
@@ -38,7 +38,7 @@ const OphanBanner = ({ ...props }: OphanBannerProps) => {
 			<OphanBannerTitle>
 				{props.isTestLive
 					? 'Headline test in progress:'
-					: 'Test ready to launch on this card:'}
+					: 'Test ready to launch:'}
 			</OphanBannerTitle>
 			<span>
 				View results {!props.isTestLive && 'from other cards with this test'} in{' '}

--- a/fronts-client/src/components/form/ArticleMetaForm.tsx
+++ b/fronts-client/src/components/form/ArticleMetaForm.tsx
@@ -16,6 +16,7 @@ import {
 	selectExternalArticleFromCard,
 	selectArticleTag,
 	selectCard,
+	createSelectLiveCardForGivenCardId,
 } from 'selectors/shared';
 import { createSelectFormFieldsForCard } from 'selectors/formSelectors';
 import { emptyObject } from 'util/selectorUtils';
@@ -562,6 +563,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 			showByline,
 			abTestEnabled,
 			hasActiveABTest,
+			hasActiveABTestOnLiveCard,
 			headline,
 			editableFields = [],
 			showKickerTag,
@@ -726,6 +728,7 @@ class FormComponent extends React.Component<Props, FormComponentState> {
 							<HeadlineInput
 								abTestEnabled={abTestEnabled}
 								hasActiveABTest={hasActiveABTest}
+								hasActiveABTestOnLiveCard={hasActiveABTestOnLiveCard}
 								capiHeadline={articleCapiFieldValues.headline}
 								cardId={this.props.cardId}
 								editableFields={editableFields}
@@ -1284,6 +1287,7 @@ interface ContainerProps {
 	showByline: boolean;
 	abTestEnabled: boolean;
 	hasActiveABTest: boolean;
+	hasActiveABTestOnLiveCard: boolean;
 	headline: string;
 	editableFields?: string[];
 	showKickerTag: boolean;
@@ -1320,6 +1324,8 @@ const formContainer: React.SFC<ContainerProps & InterfaceProps> = (props) => (
 const createMapStateToProps = () => {
 	const selectArticle = createSelectArticleFromCard();
 	const selectFormFields = createSelectFormFieldsForCard();
+	const selectLiveCardForGivenCardId = createSelectLiveCardForGivenCardId();
+
 	return (state: State, { cardId, isSupporting = false }: InterfaceProps) => {
 		const externalArticle = selectExternalArticleFromCard(state, cardId);
 		const valueSelector = formValueSelector(cardId);
@@ -1340,6 +1346,12 @@ const createMapStateToProps = () => {
 
 		const isEmailFronts = selectV2SubPath(state) === '/email';
 		const collectionId = (parentCollection && parentCollection.id) || null;
+
+		const liveCard = selectLiveCardForGivenCardId(
+			state,
+			article?.id ?? '',
+			collectionId ?? undefined,
+		);
 
 		return {
 			articleExists: !!article,
@@ -1367,6 +1379,7 @@ const createMapStateToProps = () => {
 			showByline: valueSelector(state, 'showByline'),
 			abTestEnabled: valueSelector(state, 'abTestEnabled'),
 			hasActiveABTest: hasActiveAbTestOnCard(selectCard(state, cardId)),
+			hasActiveABTestOnLiveCard: hasActiveAbTestOnCard(liveCard),
 			headline: valueSelector(state, 'headline'),
 			showKickerTag: valueSelector(state, 'showKickerTag'),
 			showKickerSection: valueSelector(state, 'showKickerSection'),

--- a/fronts-client/src/components/inputs/HeadlineInput.tsx
+++ b/fronts-client/src/components/inputs/HeadlineInput.tsx
@@ -13,6 +13,7 @@ import { normaliseHeadline } from '../../util/abTests';
 interface HeadlineInputProps {
 	abTestEnabled: boolean;
 	hasActiveABTest: boolean;
+	hasActiveABTestOnLiveCard: boolean;
 	capiHeadline: string;
 	cardId: string;
 	editableFields: string[];
@@ -130,7 +131,7 @@ const HeadlineInput = ({ ...props }: HeadlineInputProps) => {
 				/>
 			)}
 			{abTestFeatureEnabled && props.abTestEnabled && props.hasActiveABTest && (
-				<OphanBanner />
+				<OphanBanner isTestLive={props.hasActiveABTestOnLiveCard} />
 			)}
 		</HeadlineInputContainer>
 	);


### PR DESCRIPTION
## What's changed?
Solves an issued flagged by @Fweddi [here](https://github.com/guardian/facia-tool/pull/2062#issuecomment-5506876952).

Currently, if a card with a test is moved to the clipboard, and then added to a different container on the front, there is a mismatch between the status indicator of 'Ready to launch' and the message in the Ophan banner which suggests the test is already live on that card. This is beacuse the Ophan banner is only looking at whether a card has an active test, not whether that test is actually live on that specific card. This PR changes the message in the Ophan banner depending on whether or not the test is launched on that card, to be more specific about the state the card test is currently in. This should help reduce confusion.

### Before

https://github.com/user-attachments/assets/069f595a-be55-4dd9-95f1-1bfb8cc6140f

### After

https://github.com/user-attachments/assets/a0bf5781-24fa-4e96-afbd-b4520ac5c76e

