### PR TITLE
Custom subnavs: Style nav bar and list of subnavs

### DIFF
--- a/fronts-client/README.md
+++ b/fronts-client/README.md
@@ -44,7 +44,7 @@ Fronts-Client is a ReactRedux Javascript application hooking into the existing F
 You'll need to understand the Redux concepts of Thunks and Selectors.
 
 | Uses                                                       | For                                                                                                     | Config                                                                              |
-|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [React](https://jestjs.io/docs/en/getting-started.html)    | Components                                                                                              |                                                                                     |
 | [Redux](https://redux.js.org/)                             | State management                                                                                        |                                                                                     |
 | [Redux Thunk](https://github.com/reduxjs/redux-thunk)      | Redux Thunk middleware allows you to write action creators that return a function instead of an action. |                                                                                     |
@@ -58,17 +58,19 @@ You'll need to understand the Redux concepts of Thunks and Selectors.
 | [Raven](https://github.com/getsentry/sentry-javascript)    | Sentry error reporting                                                                                  |                                                                                     |
 | [Panda Session](https://github.com/guardian/panda-session) | Pan Domain (cross-gutools) session management                                                           |                                                                                     |
 
+Increasingly, we are trying to use the Guardian [Stand component library](https://github.com/guardian/stand).
+
 ## Building and Compiling
 
 | Uses                            | For                 | Config                           |
-|---------------------------------|---------------------|----------------------------------|
+| ------------------------------- | ------------------- | -------------------------------- |
 | [Yarn](https://yarnpkg.com/en/) | Yarning             | [package.json](package.json)     |
 | [Vite](https://vitejs.dev/)     | Bundle your assests | [vite.config.js](vite.config.ts) |
 
 ## Testing
 
 | Uses                                                                         | For                                                   | Config                           |
-|------------------------------------------------------------------------------|-------------------------------------------------------|----------------------------------|
+| ---------------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------- |
 | [Jest](https://jestjs.io/docs/en/getting-started.html)                       | Testing library                                       | [jest.config.js](jest.config.js) |
 | [react-testing-library](https://github.com/kentcdodds/react-testing-library) | JavaScript Testing utilities for React Components     |                                  |
 | [React Test Renderer](https://reactjs.org/docs/test-renderer.html)           | Render Components to JSON (e.g for Jest Snapshotting) |                                  |
@@ -99,6 +101,7 @@ Calling the helper like `select('clipboard', 'drop-zone')` will create a TestCaf
 It's also encouraged to abstract these selectors (and their strings) into one place where possible so that they are easier to refactor if they need to change in future.
 
 ## Linting
+
 For the time being we're being pretty aggressive regarding linting / style
 (vite will fail the build). If this proves to get in the way of people's
 workflow then we can discuss / remove as needs be. To lint manually run:
@@ -114,7 +117,7 @@ yarn lint-fix
 ```
 
 | Uses                                             | For                                  | Config                         |
-|--------------------------------------------------|--------------------------------------|--------------------------------|
+| ------------------------------------------------ | ------------------------------------ | ------------------------------ |
 | [Prettier](https://github.com/prettier/prettier) | Anti-bikeshed Auto syntax formatting | [.prettierrc](.prettierrc)     |
 | [.editorconfig](https://editorconfig.org/)       | Standard Editor formatting           | [.editorconfig](.editorconfig) |
 
@@ -123,15 +126,16 @@ It’s recommended to [set your editor up to run Prettier](https://prettier.io/d
 There is also a file [.git-blame-ignore-revs](../.git-blame-ignore-revs) in this repository which contains refs of formatting commits, in order to exclude them from `git blame` using gitʼs `blame.ignoreRevsFile` config option. (For convenience, the [dev setup script](../scripts/setup.sh) sets this value for you.)
 
 ## Typescript
+
 We are using Typescript for typing in Fronts-Client.
 
 ## File Structure
 
 - Components, Actions, Reducers and Selectors are top level.
-    - The [App component](src/components/App.tsx) is the application entry point
-    - All reducers are combined in the [Root Reducer](src/reducers/rootReducer.ts) as per standard convention
+  - The [App component](src/components/App.tsx) is the application entry point
+  - All reducers are combined in the [Root Reducer](src/reducers/rootReducer.ts) as per standard convention
 - `bundles`
-    - A bundle exports a reducer and all of the related things a reducer needs to function in an app - selectors, actions and action names. It's a bit like an index.ts for a single redux module. This is especially useful when you're generating the actions, reducer and selectors rather than writing them manually, for example with the `createAsyncResourceBundle` utility in shared/util. This is one way of storing Redux code and is [explained here](https://reduxbundler.com/).
+  - A bundle exports a reducer and all of the related things a reducer needs to function in an app - selectors, actions and action names. It's a bit like an index.ts for a single redux module. This is especially useful when you're generating the actions, reducer and selectors rather than writing them manually, for example with the `createAsyncResourceBundle` utility in shared/util. This is one way of storing Redux code and is [explained here](https://reduxbundler.com/).
 - `constants` store high-level application constants such as theme styles and image paths
 - `services` contains the modules for requests to APIs such as CAPI and FaciaAPI
 - `lib` contains modules designed to be reusable such as the Drag N' Drop (dnd) module
@@ -153,9 +157,9 @@ There are a few areas that we'd like to address in the medium to long term for t
 There are plenty of inconsistencies with the way we name things. This is a little manifesto for cleaning some of them up.
 
 - We confuse terminology for actions, selectors and API calls -- terms like `get`, `select` and `fetch` are easily confused, and prefixes and suffixes are used interchangably, when they're used at all. For precision's sake, we should rely on the following -
- - Actions should be prefixed with `action`.
- - Selectors be prefixed with `select`. Selector factories should use `createSelect`
- - Service functions that make HTTP calls should be prefixed with `fetch`. Thunks that use these functions can make that clear with the prefix `actionFetch` where it's appropriate.
+- Actions should be prefixed with `action`.
+- Selectors be prefixed with `select`. Selector factories should use `createSelect`
+- Service functions that make HTTP calls should be prefixed with `fetch`. Thunks that use these functions can make that clear with the prefix `actionFetch` where it's appropriate.
 
 ### Persistent UUIDs
 
@@ -187,5 +191,3 @@ We already handle all of our persistence calls for collections in one place -- t
 At the moment, we normalise on the client. This introduces a degree of complexity to the client-side code that, although well encapsulated, seems an unnecessary concern for the client domain -- better to have the server pass data in an ideal format and handle the details of modelling for the persistence domain.
 
 In normalising on the server, we have an additional advantage -- if the persistence model changes, for example if in the future we move to an RDS to store collection data, we can swap out the models without disturbing the client, avoiding concerns with overlapping versions etc.
-
-

--- a/fronts-client/package.json
+++ b/fronts-client/package.json
@@ -94,6 +94,7 @@
 		"raven": "^2.5.0",
 		"raven-js": "^3.24.1",
 		"react": "17",
+		"react-aria-components": "1.20.0",
 		"react-beautiful-dnd": "^11.0.5",
 		"react-dates": "^21.8.0",
 		"react-dom": "^16.13.0",

--- a/fronts-client/package.json
+++ b/fronts-client/package.json
@@ -56,7 +56,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
 		"@emotion/react": "^11.14.0",
-		"@guardian/stand": "0.0.50",
+		"@guardian/stand": "0.0.73",
 		"@types/lodash": "^4.14.117",
 		"@types/lodash.throttle": "^4.1.4",
 		"@types/mousetrap": "^1.6.1",

--- a/fronts-client/src/components/Subnav/SubnavListView.tsx
+++ b/fronts-client/src/components/Subnav/SubnavListView.tsx
@@ -4,32 +4,19 @@ import format from 'date-fns/format';
 import { Grid, Item } from '@guardian/stand/Grid';
 import { Typography } from '@guardian/stand/Typography';
 import { Button } from '@guardian/stand/Button';
-import { theme } from 'constants/theme';
-import ButtonDefault from 'components/inputs/ButtonDefault';
-import { SubnavStatusActions, SubnavStatusTags } from './SubnavStatusActions';
-import { RunAction, SubnavListEntry } from './helpers';
 import {
-	List,
-	ListHeader,
-	ListItem,
-	ListItemActions,
-	ListItemMeta,
-	ListItemTitle,
-	Message,
-	Panel,
-	PanelEntryBody,
-	PanelEntryRow,
-	PanelEntryStatus,
-	PanelList,
-	PanelListItem,
-	PanelThumb,
-	PanelThumbButton,
-	PanelTitleButton,
-	PanelTopBar,
-	PanelTopBarMeta,
-	SubnavContainer,
-	SubnavContainerHeading,
-} from './styles';
+	Table,
+	TableBody,
+	TableCell,
+	TableColumnHeader,
+	TableHeader,
+	TableRow,
+} from '@guardian/stand/Table';
+import { Badge } from '@guardian/stand/Badge';
+import { Link } from '@guardian/stand/Link';
+import { theme } from 'constants/theme';
+import { RunAction, SubnavListEntry } from './helpers';
+import { Panel, PanelThumb } from './styles';
 
 interface SubnavListViewProps {
 	entries: SubnavListEntry[];
@@ -55,24 +42,47 @@ const panelsGridTheme = {
 	},
 };
 
+// Three columns at desktop; collapses to a single stacked column below `lg`.
+const tableColumns = {
+	sm: 'minmax(0, 1fr)',
+	lg: 'minmax(0, 2.4fr) minmax(96px, 1fr) auto',
+};
+
+const subnavCellStyles = css`
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	min-width: 0;
+`;
+
+const thumbLinkStyles = css`
+	flex: 0 0 auto;
+	line-height: 0;
+`;
+
+const subnavTextStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: '2px',
+	minWidth: 0,
+};
+
+const titleLinkStyles = css`
+	text-decoration: underline;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+`;
+
+const metaStyles = css`
+	color: ${theme.base.colors.textMuted};
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+`;
+
 const mutedText = css`
 	color: ${theme.base.colors.textMuted};
-`;
-
-const entryTitleStyle = css`
-	display: block;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-`;
-
-const entryMetaStyle = css`
-	display: block;
-	margin-top: 4px;
-	color: ${theme.base.colors.textMuted};
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
 `;
 
 const emptyStyle = css`
@@ -81,8 +91,41 @@ const emptyStyle = css`
 	color: ${theme.base.colors.textMuted};
 `;
 
+const badgeGroupStyle: React.CSSProperties = {
+	display: 'inline-flex',
+	gap: '6px',
+	flexWrap: 'wrap',
+};
+
+const createHeaderCellStyle: React.CSSProperties = {
+	display: 'flex',
+	justifyContent: 'flex-end',
+	width: '100%',
+};
+
 const formatUpdated = (lastUpdated: number) =>
 	format(lastUpdated, 'ddd D MMM YYYY');
+
+const StatusBadges = ({
+	hasLive,
+	hasDraft,
+}: {
+	hasLive: boolean;
+	hasDraft: boolean;
+}) => (
+	<span style={badgeGroupStyle}>
+		{hasLive && (
+			<Badge color="green" size="sm" weight="light">
+				Live
+			</Badge>
+		)}
+		{hasDraft && (
+			<Badge color="orange" size="sm" weight="light">
+				{hasLive ? 'Draft changes' : 'New draft'}
+			</Badge>
+		)}
+	</span>
+);
 
 const SubnavListPanel = ({
 	status,
@@ -94,102 +137,115 @@ const SubnavListPanel = ({
 	entries: SubnavListEntry[];
 	onEdit: (id: string) => void;
 	onCreate?: () => void;
-}) => (
-	<Panel>
-		<PanelTopBar>
-			<Typography element="h2" variant="headingSm">
-				{status === 'live' ? 'Launched subnavs' : 'Draft subnavs'}
-			</Typography>
-			<PanelTopBarMeta>
-				<Typography
-					element="span"
-					variant="labelFormSm"
-					cssOverrides={mutedText}
+}) => {
+	const heading = status === 'live' ? 'Launched subnavs' : 'Draft subnavs';
+	const emptyMessage =
+		status === 'live' ? 'No launched subnavs yet.' : 'No draft subnavs yet.';
+	return (
+		<Panel>
+			<Table aria-label={heading} columns={tableColumns} headerVisibleFrom="lg">
+				<TableHeader>
+					<TableColumnHeader isRowHeader>
+						<Typography element="h2" variant="headingSm">
+							{heading}
+						</Typography>
+					</TableColumnHeader>
+					<TableColumnHeader>Last updated</TableColumnHeader>
+					<TableColumnHeader>
+						{status === 'draft'
+							? onCreate && (
+									<span style={createHeaderCellStyle}>
+										<Button
+											variant="tertiary"
+											size="sm"
+											icon="+"
+											onPress={onCreate}
+										>
+											Create new
+										</Button>
+									</span>
+								)
+							: 'Status'}
+					</TableColumnHeader>
+				</TableHeader>
+				<TableBody
+					renderEmptyState={() => (
+						<Typography element="p" variant="bodySm" cssOverrides={emptyStyle}>
+							{emptyMessage}
+						</Typography>
+					)}
 				>
-					Last updated
-				</Typography>
-				{status === 'draft' && onCreate && (
-					<Button variant="tertiary" size="sm" icon="+" onPress={onCreate}>
-						Create new
-					</Button>
-				)}
-			</PanelTopBarMeta>
-		</PanelTopBar>
-		{entries.length === 0 ? (
-			<Typography element="p" variant="bodySm" cssOverrides={emptyStyle}>
-				{status === 'live'
-					? 'No launched subnavs yet.'
-					: 'No draft subnavs yet.'}
-			</Typography>
-		) : (
-			<PanelList>
-				{entries.map(({ id, subnav, hasLive, hasDraft }) => {
-					const imageSrc = subnav.images?.[0]?.imageSrc;
-					const meta = [
-						...subnav.links.map((link) => link.linkText),
-						...subnav.pages.map((page) => page.path),
-					]
-						.filter(Boolean)
-						.join(' · ');
-					const title = subnav.header.headerText || 'Untitled subnav';
-					return (
-						<PanelListItem key={id}>
-							{imageSrc && (
-								<PanelThumbButton
-									type="button"
-									onClick={() => onEdit(id)}
-									aria-label={`Edit ${title}`}
+					{entries.map(({ id, subnav, hasLive, hasDraft }) => {
+						const imageSrc = subnav.images?.[0]?.imageSrc;
+						const title = subnav.header.headerText || 'Untitled subnav';
+						const meta = [
+							...subnav.links.map((link) => link.linkText),
+							...subnav.pages.map((page) => page.path),
+						]
+							.filter(Boolean)
+							.join(' · ');
+						return (
+							<TableRow key={id} id={id}>
+								<TableCell
+									gridColumn={{ lg: '1' }}
+									cssOverrides={subnavCellStyles}
 								>
-									<PanelThumb url={imageSrc} />
-								</PanelThumbButton>
-							)}
-							<PanelEntryBody>
-								<PanelEntryRow>
-									<PanelTitleButton type="button" onClick={() => onEdit(id)}>
-										<Typography
-											element="span"
-											variant="bodyBoldSm"
-											cssOverrides={entryTitleStyle}
+									{imageSrc && (
+										<Link
+											onPress={() => onEdit(id)}
+											aria-label={`Edit ${title}`}
+											cssOverrides={thumbLinkStyles}
+										>
+											<PanelThumb url={imageSrc} />
+										</Link>
+									)}
+									<span style={subnavTextStyle}>
+										<Link
+											onPress={() => onEdit(id)}
+											typography="bodyBoldSm"
+											cssOverrides={titleLinkStyles}
 										>
 											{title}
-										</Typography>
-									</PanelTitleButton>
-									<Typography
-										element="span"
-										variant="metaMd"
-										cssOverrides={mutedText}
-									>
-										{formatUpdated(subnav.lastUpdated)}
-									</Typography>
-									<PanelEntryStatus>
-										<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
-									</PanelEntryStatus>
-								</PanelEntryRow>
-								{meta && (
-									<Typography
-										element="p"
-										variant="bodySm"
-										cssOverrides={entryMetaStyle}
-									>
-										{meta}
-									</Typography>
+										</Link>
+										{meta && (
+											<Typography
+												element="span"
+												variant="bodySm"
+												cssOverrides={metaStyles}
+											>
+												{meta}
+											</Typography>
+										)}
+									</span>
+								</TableCell>
+								<TableCell
+									compactLabel="Last updated: "
+									gridColumn={{ lg: '2' }}
+									cssOverrides={mutedText}
+								>
+									{formatUpdated(subnav.lastUpdated)}
+								</TableCell>
+								{status === 'live' ? (
+									<TableCell compactLabel="Status: " gridColumn={{ lg: '3' }}>
+										<StatusBadges hasLive={hasLive} hasDraft={hasDraft} />
+									</TableCell>
+								) : (
+									<TableCell gridColumn={{ lg: '3' }}>{null}</TableCell>
 								)}
-							</PanelEntryBody>
-						</PanelListItem>
-					);
-				})}
-			</PanelList>
-		)}
-	</Panel>
-);
+							</TableRow>
+						);
+					})}
+				</TableBody>
+			</Table>
+		</Panel>
+	);
+};
 
 export const SubnavListView = ({
 	entries,
 	isLoading,
-	pendingActionId,
 	onCreate,
 	onEdit,
-	runAction,
 }: SubnavListViewProps) => {
 	const draftEntries = entries.filter((entry) => entry.hasDraft);
 
@@ -199,90 +255,30 @@ export const SubnavListView = ({
 
 	return (
 		<>
-			{/*<SubnavContainer> <SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
-
-				<ListHeader>
-					<ButtonDefault type="button" priority="primary" onClick={onCreate}>
-						+ Create new subnav
-					</ButtonDefault>
-				</ListHeader>
-
-				{isLoading ? (
-					<Message>Loading…</Message>
-				) : entries.length === 0 ? (
-					<Message>No custom subnavs yet. Create one to get started.</Message>
-				) : (
-					<List>
-						{entries.map(({ id, subnav, hasLive, hasDraft }) => {
-							const isBusy = pendingActionId === id;
-							return (
-								<ListItem key={id}>
-									<div>
-										<ListItemTitle>
-											{subnav.header.headerText || 'Untitled subnav'}
-											<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
-										</ListItemTitle>
-										<ListItemMeta>
-											{subnav.pages.length} page
-											{subnav.pages.length === 1 ? '' : 's'} ·{' '}
-											{subnav.links.length} link
-											{subnav.links.length === 1 ? '' : 's'}
-										</ListItemMeta>
-									</div>
-									<ListItemActions>
-										<ButtonDefault
-											type="button"
-											size="s"
-											disabled={isBusy}
-											onClick={() => onEdit(id)}
-										>
-											Edit
-										</ButtonDefault>
-										<SubnavStatusActions
-											id={id}
-											hasLive={hasLive}
-											hasDraft={hasDraft}
-											isBusy={isBusy}
-											runAction={runAction}
-										/>
-									</ListItemActions>
-								</ListItem>
-							);
-						})}
-					</List>
-				)}
-								</SubnavContainer>
-
-				 */}
-			<div
-				style={{
-					paddingTop: '80px',
-				}}
-			></div>
-			<Grid theme={panelsGridTheme}>
-				<Item>
-					<SubnavListPanel
-						status="draft"
-						entries={draftEntries}
-						onEdit={onEdit}
-						onCreate={onCreate}
-					/>
-				</Item>
-				<Item>
-					<SubnavListPanel
-						status="live"
-						entries={publishedEntries}
-						onEdit={onEdit}
-					/>
-				</Item>
-			</Grid>{' '}
-			{/*
-			<div style={{ paddingTop: '82px' }}>
+			<div style={{ paddingTop: '80px' }} />
+			{isLoading ? (
+				<Typography element="p" variant="bodySm" cssOverrides={emptyStyle}>
+					Loading…
+				</Typography>
+			) : (
 				<Grid theme={panelsGridTheme}>
-					<Item>test</Item>
-					<Item>test</Item>
+					<Item>
+						<SubnavListPanel
+							status="draft"
+							entries={draftEntries}
+							onEdit={onEdit}
+							onCreate={onCreate}
+						/>
+					</Item>
+					<Item>
+						<SubnavListPanel
+							status="live"
+							entries={publishedEntries}
+							onEdit={onEdit}
+						/>
+					</Item>
 				</Grid>
-			</div> */}
+			)}
 		</>
 	);
 };

--- a/fronts-client/src/components/Subnav/SubnavListView.tsx
+++ b/fronts-client/src/components/Subnav/SubnavListView.tsx
@@ -43,7 +43,7 @@ const panelsGridTheme = {
 
 const tableColumns = {
 	sm: 'minmax(0, 1fr)',
-	lg: 'minmax(0, 2.4fr) minmax(96px, 1fr) auto',
+	lg: 'minmax(0, 2.4fr) 130px 135px',
 };
 
 const subnavCellStyles = css`

--- a/fronts-client/src/components/Subnav/SubnavListView.tsx
+++ b/fronts-client/src/components/Subnav/SubnavListView.tsx
@@ -27,7 +27,6 @@ interface SubnavListViewProps {
 	runAction: RunAction;
 }
 
-// Two panels side by side, each capped at 40% of the page width (2 of 5 columns).
 const panelsGridTheme = {
 	shared: {
 		direction: 'row',
@@ -42,7 +41,6 @@ const panelsGridTheme = {
 	},
 };
 
-// Three columns at desktop; collapses to a single stacked column below `lg`.
 const tableColumns = {
 	sm: 'minmax(0, 1fr)',
 	lg: 'minmax(0, 2.4fr) minmax(96px, 1fr) auto',
@@ -103,6 +101,12 @@ const createHeaderCellStyle: React.CSSProperties = {
 	width: '100%',
 };
 
+const tableHeaderStyles = css`
+	& > tr {
+		align-items: center;
+	}
+`;
+
 const formatUpdated = (lastUpdated: number) =>
 	format(lastUpdated, 'ddd D MMM YYYY');
 
@@ -144,7 +148,7 @@ const SubnavListPanel = ({
 	return (
 		<Panel>
 			<Table aria-label={heading} columns={tableColumns} headerVisibleFrom="lg">
-				<TableHeader>
+				<TableHeader cssOverrides={tableHeaderStyles}>
 					<TableColumnHeader isRowHeader>
 						<Typography element="h2" variant="headingSm">
 							{heading}
@@ -158,7 +162,7 @@ const SubnavListPanel = ({
 										<Button
 											variant="tertiary"
 											size="sm"
-											icon="+"
+											icon="add"
 											onPress={onCreate}
 										>
 											Create new

--- a/fronts-client/src/components/Subnav/SubnavListView.tsx
+++ b/fronts-client/src/components/Subnav/SubnavListView.tsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import { css } from '@emotion/react';
+import format from 'date-fns/format';
+import { Grid, Item } from '@guardian/stand/Grid';
+import { Typography } from '@guardian/stand/Typography';
+import { Button } from '@guardian/stand/Button';
+import { theme } from 'constants/theme';
 import ButtonDefault from 'components/inputs/ButtonDefault';
 import { SubnavStatusActions, SubnavStatusTags } from './SubnavStatusActions';
 import { RunAction, SubnavListEntry } from './helpers';
@@ -10,6 +16,17 @@ import {
 	ListItemMeta,
 	ListItemTitle,
 	Message,
+	Panel,
+	PanelEntryBody,
+	PanelEntryRow,
+	PanelEntryStatus,
+	PanelList,
+	PanelListItem,
+	PanelThumb,
+	PanelThumbButton,
+	PanelTitleButton,
+	PanelTopBar,
+	PanelTopBarMeta,
 	SubnavContainer,
 	SubnavContainerHeading,
 } from './styles';
@@ -23,6 +40,149 @@ interface SubnavListViewProps {
 	runAction: RunAction;
 }
 
+// Two panels side by side, each capped at 40% of the page width (2 of 5 columns).
+const panelsGridTheme = {
+	shared: {
+		direction: 'row',
+		wrap: 'nowrap',
+		justifyContent: 'center',
+		alignItems: 'flex-start',
+	},
+	lg: {
+		columns: 2,
+		gap: '12px',
+		padding: '60px',
+	},
+};
+
+const mutedText = css`
+	color: ${theme.base.colors.textMuted};
+`;
+
+const entryTitleStyle = css`
+	display: block;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+`;
+
+const entryMetaStyle = css`
+	display: block;
+	margin-top: 4px;
+	color: ${theme.base.colors.textMuted};
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+`;
+
+const emptyStyle = css`
+	display: block;
+	padding: 12px;
+	color: ${theme.base.colors.textMuted};
+`;
+
+const formatUpdated = (lastUpdated: number) =>
+	format(lastUpdated, 'ddd D MMM YYYY');
+
+const SubnavListPanel = ({
+	status,
+	entries,
+	onEdit,
+	onCreate,
+}: {
+	status: 'live' | 'draft';
+	entries: SubnavListEntry[];
+	onEdit: (id: string) => void;
+	onCreate?: () => void;
+}) => (
+	<Panel>
+		<PanelTopBar>
+			<Typography element="h2" variant="headingSm">
+				{status === 'live' ? 'Launched subnavs' : 'Draft subnavs'}
+			</Typography>
+			<PanelTopBarMeta>
+				<Typography
+					element="span"
+					variant="labelFormSm"
+					cssOverrides={mutedText}
+				>
+					Last updated
+				</Typography>
+				{status === 'draft' && onCreate && (
+					<Button variant="tertiary" size="sm" icon="+" onPress={onCreate}>
+						Create new
+					</Button>
+				)}
+			</PanelTopBarMeta>
+		</PanelTopBar>
+		{entries.length === 0 ? (
+			<Typography element="p" variant="bodySm" cssOverrides={emptyStyle}>
+				{status === 'live'
+					? 'No launched subnavs yet.'
+					: 'No draft subnavs yet.'}
+			</Typography>
+		) : (
+			<PanelList>
+				{entries.map(({ id, subnav, hasLive, hasDraft }) => {
+					const imageSrc = subnav.images?.[0]?.imageSrc;
+					const meta = [
+						...subnav.links.map((link) => link.linkText),
+						...subnav.pages.map((page) => page.path),
+					]
+						.filter(Boolean)
+						.join(' · ');
+					const title = subnav.header.headerText || 'Untitled subnav';
+					return (
+						<PanelListItem key={id}>
+							{imageSrc && (
+								<PanelThumbButton
+									type="button"
+									onClick={() => onEdit(id)}
+									aria-label={`Edit ${title}`}
+								>
+									<PanelThumb url={imageSrc} />
+								</PanelThumbButton>
+							)}
+							<PanelEntryBody>
+								<PanelEntryRow>
+									<PanelTitleButton type="button" onClick={() => onEdit(id)}>
+										<Typography
+											element="span"
+											variant="bodyBoldSm"
+											cssOverrides={entryTitleStyle}
+										>
+											{title}
+										</Typography>
+									</PanelTitleButton>
+									<Typography
+										element="span"
+										variant="metaMd"
+										cssOverrides={mutedText}
+									>
+										{formatUpdated(subnav.lastUpdated)}
+									</Typography>
+									<PanelEntryStatus>
+										<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
+									</PanelEntryStatus>
+								</PanelEntryRow>
+								{meta && (
+									<Typography
+										element="p"
+										variant="bodySm"
+										cssOverrides={entryMetaStyle}
+									>
+										{meta}
+									</Typography>
+								)}
+							</PanelEntryBody>
+						</PanelListItem>
+					);
+				})}
+			</PanelList>
+		)}
+	</Panel>
+);
+
 export const SubnavListView = ({
 	entries,
 	isLoading,
@@ -30,59 +190,99 @@ export const SubnavListView = ({
 	onCreate,
 	onEdit,
 	runAction,
-}: SubnavListViewProps) => (
-	<SubnavContainer>
-		<SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
+}: SubnavListViewProps) => {
+	const draftEntries = entries.filter((entry) => entry.hasDraft);
 
-		<ListHeader>
-			<ButtonDefault type="button" priority="primary" onClick={onCreate}>
-				+ Create new subnav
-			</ButtonDefault>
-		</ListHeader>
+	const publishedEntries = entries.filter(
+		(entry) => entry.hasLive && !entry.hasDraft,
+	);
 
-		{isLoading ? (
-			<Message>Loading…</Message>
-		) : entries.length === 0 ? (
-			<Message>No custom subnavs yet. Create one to get started.</Message>
-		) : (
-			<List>
-				{entries.map(({ id, subnav, hasLive, hasDraft }) => {
-					const isBusy = pendingActionId === id;
-					return (
-						<ListItem key={id}>
-							<div>
-								<ListItemTitle>
-									{subnav.header.headerText || 'Untitled subnav'}
-									<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
-								</ListItemTitle>
-								<ListItemMeta>
-									{subnav.pages.length} page
-									{subnav.pages.length === 1 ? '' : 's'} · {subnav.links.length}{' '}
-									link
-									{subnav.links.length === 1 ? '' : 's'}
-								</ListItemMeta>
-							</div>
-							<ListItemActions>
-								<ButtonDefault
-									type="button"
-									size="s"
-									disabled={isBusy}
-									onClick={() => onEdit(id)}
-								>
-									Edit
-								</ButtonDefault>
-								<SubnavStatusActions
-									id={id}
-									hasLive={hasLive}
-									hasDraft={hasDraft}
-									isBusy={isBusy}
-									runAction={runAction}
-								/>
-							</ListItemActions>
-						</ListItem>
-					);
-				})}
-			</List>
-		)}
-	</SubnavContainer>
-);
+	return (
+		<>
+			{/*<SubnavContainer> <SubnavContainerHeading>Custom subnavs</SubnavContainerHeading>
+
+				<ListHeader>
+					<ButtonDefault type="button" priority="primary" onClick={onCreate}>
+						+ Create new subnav
+					</ButtonDefault>
+				</ListHeader>
+
+				{isLoading ? (
+					<Message>Loading…</Message>
+				) : entries.length === 0 ? (
+					<Message>No custom subnavs yet. Create one to get started.</Message>
+				) : (
+					<List>
+						{entries.map(({ id, subnav, hasLive, hasDraft }) => {
+							const isBusy = pendingActionId === id;
+							return (
+								<ListItem key={id}>
+									<div>
+										<ListItemTitle>
+											{subnav.header.headerText || 'Untitled subnav'}
+											<SubnavStatusTags hasLive={hasLive} hasDraft={hasDraft} />
+										</ListItemTitle>
+										<ListItemMeta>
+											{subnav.pages.length} page
+											{subnav.pages.length === 1 ? '' : 's'} ·{' '}
+											{subnav.links.length} link
+											{subnav.links.length === 1 ? '' : 's'}
+										</ListItemMeta>
+									</div>
+									<ListItemActions>
+										<ButtonDefault
+											type="button"
+											size="s"
+											disabled={isBusy}
+											onClick={() => onEdit(id)}
+										>
+											Edit
+										</ButtonDefault>
+										<SubnavStatusActions
+											id={id}
+											hasLive={hasLive}
+											hasDraft={hasDraft}
+											isBusy={isBusy}
+											runAction={runAction}
+										/>
+									</ListItemActions>
+								</ListItem>
+							);
+						})}
+					</List>
+				)}
+								</SubnavContainer>
+
+				 */}
+			<div
+				style={{
+					paddingTop: '80px',
+				}}
+			></div>
+			<Grid theme={panelsGridTheme}>
+				<Item>
+					<SubnavListPanel
+						status="draft"
+						entries={draftEntries}
+						onEdit={onEdit}
+						onCreate={onCreate}
+					/>
+				</Item>
+				<Item>
+					<SubnavListPanel
+						status="live"
+						entries={publishedEntries}
+						onEdit={onEdit}
+					/>
+				</Item>
+			</Grid>{' '}
+			{/*
+			<div style={{ paddingTop: '82px' }}>
+				<Grid theme={panelsGridTheme}>
+					<Item>test</Item>
+					<Item>test</Item>
+				</Grid>
+			</div> */}
+		</>
+	);
+};

--- a/fronts-client/src/components/Subnav/index.tsx
+++ b/fronts-client/src/components/Subnav/index.tsx
@@ -111,37 +111,39 @@ const SubnavSection = () => {
 	const entries = subnavConfig ? toListEntries(subnavConfig) : [];
 
 	return (
-		<Switch>
-			<Route {...subnavRoutes.createProps}>
-				<SubnavFormView
-					heading="Create custom subnav"
-					onSave={handleCreate}
-					onCancel={goToList}
-					saving={isSaving}
-				/>
-			</Route>
-			<Route {...subnavRoutes.editProps}>
-				<SubnavEditRoute
-					config={subnavConfig}
-					isLoading={isLoading}
-					pendingActionId={pendingActionId}
-					runAction={runAction}
-					onSave={handleSave}
-					onCancel={goToList}
-					saving={isSaving}
-				/>
-			</Route>
-			<Route {...subnavRoutes.listProps}>
-				<SubnavListView
-					entries={entries}
-					isLoading={isLoading}
-					pendingActionId={pendingActionId}
-					onCreate={() => history.push(subnavRoutes.create)}
-					onEdit={(id) => history.push(subnavRoutes.edit(id))}
-					runAction={runAction}
-				/>
-			</Route>
-		</Switch>
+		<>
+			<Switch>
+				<Route {...subnavRoutes.createProps}>
+					<SubnavFormView
+						heading="Create custom subnav"
+						onSave={handleCreate}
+						onCancel={goToList}
+						saving={isSaving}
+					/>
+				</Route>
+				<Route {...subnavRoutes.editProps}>
+					<SubnavEditRoute
+						config={subnavConfig}
+						isLoading={isLoading}
+						pendingActionId={pendingActionId}
+						runAction={runAction}
+						onSave={handleSave}
+						onCancel={goToList}
+						saving={isSaving}
+					/>
+				</Route>
+				<Route {...subnavRoutes.listProps}>
+					<SubnavListView
+						entries={entries}
+						isLoading={isLoading}
+						pendingActionId={pendingActionId}
+						onCreate={() => history.push(subnavRoutes.create)}
+						onEdit={(id) => history.push(subnavRoutes.edit(id))}
+						runAction={runAction}
+					/>
+				</Route>
+			</Switch>
+		</>
 	);
 };
 

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -44,43 +44,6 @@ export const BackButton = styled.button`
  * List
  */
 
-export const ListHeader = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 16px;
-`;
-
-export const List = styled.ul`
-	list-style: none;
-	margin: 0;
-	padding: 0;
-`;
-
-export const ListItem = styled.li`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 12px 16px;
-	margin-bottom: 8px;
-	background-color: ${({ theme }) => theme.base.colors.backgroundColorLight};
-	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
-	border-radius: 4px;
-`;
-
-export const ListItemTitle = styled.span`
-	font-size: 15px;
-	font-weight: 500;
-	color: ${({ theme }) => theme.base.colors.textDark};
-`;
-
-export const ListItemMeta = styled.span`
-	display: block;
-	font-size: 12px;
-	color: ${({ theme }) => theme.base.colors.textMuted};
-`;
-
 export const ListItemActions = styled.div`
 	display: flex;
 	flex-wrap: wrap;
@@ -113,49 +76,11 @@ export const StatusTag = styled.span<{ draft?: boolean }>`
 		draft ? theme.base.colors.brandColor : '#AED2A6'};
 `;
 
-/**
- * Side-by-side draft / live panels
- */
-
 export const Panel = styled.section`
 	height: 100%;
-	/* width: 50%; */
 	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
 	border-radius: 4px;
 	overflow: hidden;
-`;
-
-export const PanelTopBar = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 8px 12px;
-	background-color: ${({ theme }) => theme.base.colors.formBackground};
-	border-bottom: 1px solid ${({ theme }) => theme.base.colors.borderColor};
-`;
-
-export const PanelTopBarMeta = styled.div`
-	display: flex;
-	align-items: center;
-	gap: 12px;
-`;
-
-export const PanelList = styled.ul`
-	list-style: none;
-	margin: 0;
-	padding: 0;
-`;
-
-export const PanelListItem = styled.li`
-	display: flex;
-	gap: 12px;
-	padding: 12px;
-	border-bottom: 1px solid ${({ theme }) => theme.base.colors.borderColor};
-
-	&:last-child {
-		border-bottom: none;
-	}
 `;
 
 export const PanelThumb = styled.div<{ url: string }>`
@@ -167,45 +92,6 @@ export const PanelThumb = styled.div<{ url: string }>`
 	background-image: url(${({ url }) => url});
 	background-size: cover;
 	background-position: center;
-`;
-
-export const PanelThumbButton = styled.button`
-	flex: 0 0 auto;
-	display: block;
-	padding: 0;
-	border: none;
-	border-radius: 3px;
-	background: none;
-	line-height: 0;
-	cursor: pointer;
-`;
-
-export const PanelTitleButton = styled.button`
-	flex: 1;
-	min-width: 0;
-	display: block;
-	padding: 0;
-	border: none;
-	background: none;
-	color: inherit;
-	text-align: left;
-	text-decoration: underline;
-	cursor: pointer;
-`;
-
-export const PanelEntryBody = styled.div`
-	flex: 1;
-	min-width: 0;
-`;
-
-export const PanelEntryRow = styled.div`
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
-`;
-
-export const PanelEntryStatus = styled.div`
-	flex: 0 0 auto;
 `;
 
 /**

--- a/fronts-client/src/components/Subnav/styles.ts
+++ b/fronts-client/src/components/Subnav/styles.ts
@@ -107,9 +107,105 @@ export const StatusTag = styled.span<{ draft?: boolean }>`
 	padding: 2px 6px;
 	margin-left: 8px;
 	border-radius: 3px;
-	color: ${({ theme }) => theme.base.colors.textLight};
+	color: ${({ theme, draft }) =>
+		draft ? theme.base.colors.textLight : theme.base.colors.textDark};
 	background-color: ${({ theme, draft }) =>
-		draft ? theme.base.colors.brandColor : theme.base.colors.button};
+		draft ? theme.base.colors.brandColor : '#AED2A6'};
+`;
+
+/**
+ * Side-by-side draft / live panels
+ */
+
+export const Panel = styled.section`
+	height: 100%;
+	/* width: 50%; */
+	border: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+	border-radius: 4px;
+	overflow: hidden;
+`;
+
+export const PanelTopBar = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 8px 12px;
+	background-color: ${({ theme }) => theme.base.colors.formBackground};
+	border-bottom: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+`;
+
+export const PanelTopBarMeta = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 12px;
+`;
+
+export const PanelList = styled.ul`
+	list-style: none;
+	margin: 0;
+	padding: 0;
+`;
+
+export const PanelListItem = styled.li`
+	display: flex;
+	gap: 12px;
+	padding: 12px;
+	border-bottom: 1px solid ${({ theme }) => theme.base.colors.borderColor};
+
+	&:last-child {
+		border-bottom: none;
+	}
+`;
+
+export const PanelThumb = styled.div<{ url: string }>`
+	flex: 0 0 auto;
+	width: 40px;
+	height: 40px;
+	border-radius: 3px;
+	background-color: ${({ theme }) => theme.base.colors.backgroundColorFocused};
+	background-image: url(${({ url }) => url});
+	background-size: cover;
+	background-position: center;
+`;
+
+export const PanelThumbButton = styled.button`
+	flex: 0 0 auto;
+	display: block;
+	padding: 0;
+	border: none;
+	border-radius: 3px;
+	background: none;
+	line-height: 0;
+	cursor: pointer;
+`;
+
+export const PanelTitleButton = styled.button`
+	flex: 1;
+	min-width: 0;
+	display: block;
+	padding: 0;
+	border: none;
+	background: none;
+	color: inherit;
+	text-align: left;
+	text-decoration: underline;
+	cursor: pointer;
+`;
+
+export const PanelEntryBody = styled.div`
+	flex: 1;
+	min-width: 0;
+`;
+
+export const PanelEntryRow = styled.div`
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+`;
+
+export const PanelEntryStatus = styled.div`
+	flex: 0 0 auto;
 `;
 
 /**

--- a/fronts-client/src/components/layout/SectionHeaderWithLogo.tsx
+++ b/fronts-client/src/components/layout/SectionHeaderWithLogo.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import { css } from '@emotion/react';
 import { styled, theme } from 'constants/theme';
 import { SectionHeaderUnpadded } from './SectionHeader';
 import { Link } from 'react-router-dom';
+import { useRouteMatch } from 'react-router';
+import { subnavRoutes } from 'routes/routes';
+import {
+	TopBar,
+	TopBarContainerLeft,
+	TopBarNavigation,
+} from '@guardian/stand/TopBar';
+import { TopBarToolName } from '@guardian/stand/TopBar';
 
 const SectionHeader = styled(SectionHeaderUnpadded)`
 	display: flex;
@@ -18,6 +27,10 @@ const LogoTypeContainer = styled(Link)`
 	text-decoration: none;
 `;
 
+const customNaviStyles = css`
+	height: 60px;
+`;
+
 export default ({
 	children,
 	includeBorder,
@@ -26,9 +39,25 @@ export default ({
 	children?: React.ReactNode;
 	includeBorder?: boolean;
 	greyHeader?: boolean;
-}) => (
-	<SectionHeader greyHeader={greyHeader} includeBorder={includeBorder}>
-		<LogoTypeContainer to="/">F</LogoTypeContainer>
-		{children}
-	</SectionHeader>
-);
+}) => {
+	const isSubnavPath = useRouteMatch(subnavRoutes.sectionProps);
+	return (
+		<SectionHeader greyHeader={greyHeader} includeBorder={includeBorder}>
+			<LogoTypeContainer to="/">F</LogoTypeContainer>
+			{isSubnavPath && (
+				<TopBar cssOverrides={customNaviStyles}>
+					<TopBarToolName
+						name="Navi"
+						favicon={{ letter: 'N' }}
+						href="/v2/subnavs"
+					></TopBarToolName>
+					<TopBarContainerLeft>
+						<TopBarNavigation text="All subnavs" href="/v2/subnavs" />
+						<TopBarNavigation text="Create subnav" href="/v2/subnavs/new" />
+					</TopBarContainerLeft>
+				</TopBar>
+			)}
+			{children}
+		</SectionHeader>
+	);
+};

--- a/fronts-client/src/index.tsx
+++ b/fronts-client/src/index.tsx
@@ -1,6 +1,9 @@
 // For development mode with Vite
 import 'vite/modulepreload-polyfill';
 
+// Material Symbols font used by @guardian/stand icons
+import '@guardian/stand/fonts/MaterialSymbolsOutlined.css';
+
 import './util/tti';
 import React from 'react';
 import { render } from 'react-dom';

--- a/fronts-client/yarn.lock
+++ b/fronts-client/yarn.lock
@@ -1408,10 +1408,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-8.0.1.tgz#3c7ce5f6b2d35fe19540a7c5b70807aec619bb1a"
   integrity sha512-mELIji0FezEj5YTyHkylB6VNeCN1+/jsHW/iZ0RItDMn/GjU6gbaPP5D2m+BZwrTYNrxYhCoFqCE/ObkEghtdg==
 
-"@guardian/stand@0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.50.tgz#2bef626b4742e26b953b5d4aa8867bbf65f47832"
-  integrity sha512-Ngilr3LbIKP5/Q7U7jZ0uejyMAQ1jHrd4SY7/AcaKHljISmvUreYejXm7h234LSmRLf/EbDYjmhmd0DLmEbuvQ==
+"@guardian/stand@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.73.tgz#847fd6187ce017350606099d99bf7aa669d78ed4"
+  integrity sha512-Mqjja5TkEmpoZQDAYrz4Yg8pyeGZI1T0bZ1JkXKxQgjTnkC2WUW2IXFTK4udZBgDhAEVpUhWklWGaf/AWzOTeQ==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"

--- a/fronts-client/yarn.lock
+++ b/fronts-client/yarn.lock
@@ -1432,6 +1432,27 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@internationalized/date@^3.12.3":
+  version "3.12.3"
+  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.12.3.tgz#e11d14dbf12bf45057dd5996bac77f7c2f89ff9c"
+  integrity sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/number@^3.6.7":
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.6.7.tgz#5a0a8fa413b5f8679a59dcf37e2a74dc508b8371"
+  integrity sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/string@^3.2.10":
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/@internationalized/string/-/string-3.2.10.tgz#c38bd59a69509a41bf7422f1b2fc3af7468e4322"
+  integrity sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1737,6 +1758,11 @@
     unbzip2-stream "^1.4.3"
     yargs "^17.7.2"
 
+"@react-types/shared@^3.36.1":
+  version "3.36.1"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.36.1.tgz#edb8081e3872ae68a4eb4a65e62233d0754ec186"
+  integrity sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==
+
 "@rollup/rollup-android-arm-eabi@4.32.0":
   version "4.32.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz#42a8e897c7b656adb4edebda3a8b83a57526452f"
@@ -1929,6 +1955,13 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
+
+"@swc/helpers@^0.5.0":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.23.tgz#19287d0d86d962b111376039a50c792902c9a86a"
+  integrity sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==
+  dependencies:
+    tslib "^2.8.0"
 
 "@swc/types@^0.1.17":
   version "0.1.17"
@@ -2665,6 +2698,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
+  dependencies:
+    tslib "^2.0.0"
+
 aria-query@^5.0.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
@@ -3281,6 +3321,11 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -7340,6 +7385,34 @@ raw-body@2.5.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-aria-components@1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/react-aria-components/-/react-aria-components-1.20.0.tgz#19a6ae1d0f6fcbf4a4e7747476a76921497af09e"
+  integrity sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==
+  dependencies:
+    "@internationalized/date" "^3.12.3"
+    "@internationalized/string" "^3.2.10"
+    "@react-types/shared" "^3.36.1"
+    "@swc/helpers" "^0.5.0"
+    client-only "^0.0.1"
+    react-aria "3.51.0"
+    react-stately "3.49.0"
+
+react-aria@3.51.0:
+  version "3.51.0"
+  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.51.0.tgz#b8129df769eda51a0f92d256fddcc105badf6ed7"
+  integrity sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==
+  dependencies:
+    "@internationalized/date" "^3.12.3"
+    "@internationalized/number" "^3.6.7"
+    "@internationalized/string" "^3.2.10"
+    "@react-types/shared" "^3.36.1"
+    "@swc/helpers" "^0.5.0"
+    aria-hidden "^1.2.3"
+    clsx "^2.0.0"
+    react-stately "3.49.0"
+    use-sync-external-store "^1.6.0"
+
 react-beautiful-dnd@^11.0.5:
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-11.0.5.tgz#16b1dbd4d6493de0cb3f842cad57c7e9e1ff5fe7"
@@ -7518,6 +7591,18 @@ react-smooth@^4.0.0:
     fast-equals "^5.0.1"
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
+
+react-stately@3.49.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/react-stately/-/react-stately-3.49.0.tgz#bc7fda7d0245e2a1239a8f0451950b27639d0e17"
+  integrity sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==
+  dependencies:
+    "@internationalized/date" "^3.12.3"
+    "@internationalized/number" "^3.6.7"
+    "@internationalized/string" "^3.2.10"
+    "@react-types/shared" "^3.36.1"
+    "@swc/helpers" "^0.5.0"
+    use-sync-external-store "^1.6.0"
 
 react-test-renderer@^16.13.0:
   version "16.14.0"
@@ -8816,7 +8901,7 @@ tsconfck@^3.0.3:
   resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.4.tgz#de01a15334962e2feb526824339b51be26712229"
   integrity sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==
 
-tslib@^2.0.0, tslib@^2.0.1:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -9063,6 +9148,11 @@ use-sync-external-store@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
   integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 utf8-byte-length@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
## What's changed?

Based on the figma designs [here](https://www.figma.com/design/BCMCuoXOVGQx3FFrUE3d4s/Event-kit-Missions?node-id=233-1745&p=f&t=XVLACZbNHGrle9Hc-0) (though with a couple of tweaked bits/adjustments, e.g. with the standard fronts tool icon in the top bar), also ran by Abo first. 

This just adds the top bar navigation and styles the initial page showing a list of draft and launched subnavs. Makes use of the stand component library.

Font adjustments come in a subsequent PR, as well as the create/edit page. 

## Screenshot

<img width="1444" height="294" alt="image" src="https://github.com/user-attachments/assets/f75b8a9c-8a0e-4eff-bbdd-d77beec52484" />


## Checklist

### General
- [ ] 🤖 Relevant tests added
- [ ] ✅ CI checks / tests run locally
- [ ] 🔍 Checked on CODE

### Client
- [ ] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [ ] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [ ] 📷 Screenshots / GIFs of relevant UI changes included
