### PR TITLE
Support event graphic

### DIFF
--- a/app/model/FeatureSwitches.scala
+++ b/app/model/FeatureSwitches.scala
@@ -33,11 +33,19 @@ object HeadlineABTesting
       enabled = false
     )
 
+object EventGraphics
+    extends FeatureSwitch(
+      key = "event-graphics",
+      title = "Enable event graphics (e.g. election trackers) in the feed",
+      enabled = false
+    )
+
 object FeatureSwitches {
   val all: List[FeatureSwitch] = List(
     ObscureFeed,
     PageViewDataVisualisation,
-    HeadlineABTesting
+    HeadlineABTesting,
+    EventGraphics
   )
 
   def updateFeatureSwitchesForUser(

--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,8 @@ TwirlKeys.templateImports ++= Seq(
 routesImport += "model.editions._"
 
 val awsVersion = "1.12.470"
-val capiModelsVersion = "46.0.0"
-val capiClientVersion = "47.0.0"
+val capiModelsVersion = "50.0.0"
+val capiClientVersion = "49.0.0"
 val json4sVersion = "4.0.3"
 val circeVersion = "0.14.10"
 val awsSdkVersion = "2.49.6"
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "content-api-client-aws" % "0.7.6",
   "com.gu" %% "content-api-client-default" % capiClientVersion,
   "com.gu" %% "editorial-permissions-client" % "3.0.0",
-  "com.gu" %% "fapi-client-play30" % "38.0.0",
+  "com.gu" %% "fapi-client-play30" % "40.0.0",
   "com.gu" %% "mobile-notifications-api-models" % "4.0.0",
   "com.gu" %% "pan-domain-auth-play_3-0" % "21.0.0",
   "org.scanamo" %% "scanamo" % "1.1.1" exclude ("org.scala-lang.modules", "scala-java8-compat_2.13"),

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -319,7 +319,7 @@ function updateCollection(
 const fetchArticles =
 	(articleIds: string[]): ThunkResult<Promise<void>> =>
 	async (dispatch, getState) => {
-		// Neither snaps nor event graphics exist in CAPI, so asking for them would
+		// Neither snaps nor event graphics exist in CAPI, so requesting them would
 		// only produce spurious "not returned by CAPI" errors.
 		const idsToFetch = articleIds.filter(
 			(id) => !id.match(/^snap/) && !isEventGraphicId(id),

--- a/fronts-client/src/actions/Collections.ts
+++ b/fronts-client/src/actions/Collections.ts
@@ -46,6 +46,7 @@ import { Dispatch, ThunkResult } from 'types/Store';
 import type { Action } from 'types/Action';
 import type { State } from 'types/State';
 import { cardSets, noOfOpenCollectionsOnFirstLoad } from 'constants/fronts';
+import { isEventGraphicId } from 'constants/eventGraphics';
 import { Stages, Collection, CardSets, Card } from 'types/Collection';
 import difference from 'lodash/difference';
 import { selectCardsInCollections } from 'selectors/collection';
@@ -318,16 +319,18 @@ function updateCollection(
 const fetchArticles =
 	(articleIds: string[]): ThunkResult<Promise<void>> =>
 	async (dispatch, getState) => {
-		const uniqueArticleIdsWithoutSnaps = articleIds.filter(
-			(id) => !id.match(/^snap/),
+		// Neither snaps nor event graphics exist in CAPI, so asking for them would
+		// only produce spurious "not returned by CAPI" errors.
+		const idsToFetch = articleIds.filter(
+			(id) => !id.match(/^snap/) && !isEventGraphicId(id),
 		);
 
-		if (!uniqueArticleIdsWithoutSnaps.length) {
+		if (!idsToFetch.length) {
 			return;
 		}
-		dispatch(externalArticleActions.fetchStart(uniqueArticleIdsWithoutSnaps));
+		dispatch(externalArticleActions.fetchStart(idsToFetch));
 		try {
-			const articles = await getArticlesBatched(uniqueArticleIdsWithoutSnaps);
+			const articles = await getArticlesBatched(idsToFetch);
 			const freshArticles = articles.filter((article) =>
 				selectIsExternalArticleStale(
 					getState(),
@@ -340,7 +343,7 @@ const fetchArticles =
 				dispatch(externalArticleActions.fetchSuccess(freshArticles));
 			}
 			const remainingArticles = difference(
-				uniqueArticleIdsWithoutSnaps,
+				idsToFetch,
 				articles.map((_) => _.id),
 			);
 			if (remainingArticles.length) {

--- a/fronts-client/src/actions/__tests__/Collections.spec.ts
+++ b/fronts-client/src/actions/__tests__/Collections.spec.ts
@@ -407,6 +407,29 @@ describe('Collection actions', () => {
 				externalArticleActions.fetchStart(['internal-code/page/5029528']),
 			);
 		});
+		it('should remove event graphics', async () => {
+			fetchMock.once('begin:/api/preview/internal-code/page/5029528', {
+				response: { results: [capiArticle] },
+			});
+			await store.dispatch(
+				fetchArticles([
+					'internal-code/page/5029528',
+					'event-graphic/election-tracker/us-midterm-2026',
+				]) as any,
+			);
+			const actions = store.getActions();
+			expect(actions[0]).toEqual(
+				externalArticleActions.fetchStart(['internal-code/page/5029528']),
+			);
+		});
+		it('should not issue a request when only event graphics are given', async () => {
+			await store.dispatch(
+				fetchArticles([
+					'event-graphic/election-tracker/us-midterm-2026',
+				]) as any,
+			);
+			expect(store.getActions()).toEqual([]);
+		});
 		it("should dispatch errors when the CAPI result count doesn't match the requested articles", async () => {
 			fetchMock.once('begin:/api/preview/search', {
 				response: { results: [capiArticle] },

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -17,13 +17,10 @@ import { addImageToCard, removeCard as removeCardAction } from 'actions/Cards';
 import { resetFocusState } from 'bundles/focusBundle';
 import { connect } from 'react-redux';
 import type { State } from 'types/State';
-import {
-	createSelectArticleVisibilityDetails,
-	selectCollectionType,
-} from 'selectors/frontsSelectors';
+import { createSelectArticleVisibilityDetails } from 'selectors/frontsSelectors';
 import FocusWrapper from 'components/FocusWrapper';
 import { CardTypes, CardTypesMap } from 'constants/cardTypes';
-import { isEventGraphicId, isEventGraphicSlot } from 'constants/eventGraphics';
+import { isEventGraphicId } from 'constants/eventGraphics';
 import { updateCardWithPersist as updateCardAction } from 'actions/Cards';
 import { ValidationResponse } from '../../util/validateImageSrc';
 import { bindActionCreators } from 'redux';
@@ -126,7 +123,6 @@ interface ConnectedCollectionContextProps extends CollectionContextProps {
 	cardsWhichAreAlsoOnOtherCollectionsOnSameFront?: CardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap;
 	updateCard: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
-	collectionType?: string;
 }
 
 class CollectionContext extends React.Component<ConnectedCollectionContextProps> {
@@ -150,7 +146,6 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			cardsWhichAreAlsoOnOtherCollectionsOnSameFront,
 			updateCard,
 			addImageToCard,
-			collectionType,
 		} = this.props;
 
 		return (
@@ -183,11 +178,6 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}
-								cardTypeDenyList={
-									isEventGraphicSlot(collectionType, group.id)
-										? undefined
-										: [CardTypesMap.EVENT_GRAPHIC]
-								}
 							>
 								{(card, getAfNodeProps) => {
 									const otherCollectionsOnSameFrontThisCardIsOn =
@@ -327,7 +317,6 @@ const createMapStateToProps = () => {
 			lastDesktopArticle: articleVisibilityDetails.desktop,
 			lastMobileArticle: articleVisibilityDetails.mobile,
 			cardsWhichAreAlsoOnOtherCollectionsOnSameFront,
-			collectionType: selectCollectionType(state, props.id),
 		};
 	};
 };

--- a/fronts-client/src/components/FrontsEdit/Collection.tsx
+++ b/fronts-client/src/components/FrontsEdit/Collection.tsx
@@ -17,9 +17,13 @@ import { addImageToCard, removeCard as removeCardAction } from 'actions/Cards';
 import { resetFocusState } from 'bundles/focusBundle';
 import { connect } from 'react-redux';
 import type { State } from 'types/State';
-import { createSelectArticleVisibilityDetails } from 'selectors/frontsSelectors';
+import {
+	createSelectArticleVisibilityDetails,
+	selectCollectionType,
+} from 'selectors/frontsSelectors';
 import FocusWrapper from 'components/FocusWrapper';
-import { CardTypes } from 'constants/cardTypes';
+import { CardTypes, CardTypesMap } from 'constants/cardTypes';
+import { isEventGraphicId, isEventGraphicSlot } from 'constants/eventGraphics';
 import { updateCardWithPersist as updateCardAction } from 'actions/Cards';
 import { ValidationResponse } from '../../util/validateImageSrc';
 import { bindActionCreators } from 'redux';
@@ -122,6 +126,7 @@ interface ConnectedCollectionContextProps extends CollectionContextProps {
 	cardsWhichAreAlsoOnOtherCollectionsOnSameFront?: CardsWhichAreAlsoOnOtherCollectionsOnSameFrontMap;
 	updateCard: (id: string, meta: CardMeta) => void;
 	addImageToCard: (uuid: string, imageData: ValidationResponse) => void;
+	collectionType?: string;
 }
 
 class CollectionContext extends React.Component<ConnectedCollectionContextProps> {
@@ -145,6 +150,7 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 			cardsWhichAreAlsoOnOtherCollectionsOnSameFront,
 			updateCard,
 			addImageToCard,
+			collectionType,
 		} = this.props;
 
 		return (
@@ -177,6 +183,11 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 								onMove={handleMove}
 								onDrop={handleInsert}
 								cardIds={group.cards}
+								cardTypeDenyList={
+									isEventGraphicSlot(collectionType, group.id)
+										? undefined
+										: [CardTypesMap.EVENT_GRAPHIC]
+								}
 							>
 								{(card, getAfNodeProps) => {
 									const otherCollectionsOnSameFrontThisCardIsOn =
@@ -220,10 +231,8 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 														groups={groups}
 														onMove={handleMove}
 														onDrop={handleInsert}
-														cardTypeAllowList={this.getPermittedCardTypes(
-															card.cardType,
-														)}
-														dropMessage={this.getDropMessage(card.cardType)}
+														cardTypeAllowList={this.getPermittedCardTypes(card)}
+														dropMessage={this.getDropMessage(card)}
 													>
 														{(supporting, getSupportingProps) => {
 															const otherCollectionsOnSameFrontThisSublinkIsOn =
@@ -280,13 +289,21 @@ class CollectionContext extends React.Component<ConnectedCollectionContextProps>
 		);
 	}
 
-	private getPermittedCardTypes = (
-		cardType?: CardTypes,
-	): CardTypes[] | undefined =>
-		cardType === 'feast-collection' ? ['recipe'] : undefined; // Todo: Chef also to be checked?
+	private getPermittedCardTypes = (card: TCard): CardTypes[] | undefined => {
+		if (card.cardType === CardTypesMap.FEAST_COLLECTION) {
+			return ['recipe']; // Todo: Chef also to be checked?
+		}
+		// An event graphic can't have sublinks.
+		if (isEventGraphicId(card.id)) {
+			return [];
+		}
+		return undefined;
+	};
 
-	private getDropMessage = (cardType?: CardTypes) =>
-		cardType === 'feast-collection' ? 'Place recipe here' : 'Sublink';
+	private getDropMessage = (card: TCard) =>
+		card.cardType === CardTypesMap.FEAST_COLLECTION
+			? 'Place recipe here'
+			: 'Sublink';
 }
 
 const createMapStateToProps = () => {
@@ -310,6 +327,7 @@ const createMapStateToProps = () => {
 			lastDesktopArticle: articleVisibilityDetails.desktop,
 			lastMobileArticle: articleVisibilityDetails.mobile,
 			cardsWhichAreAlsoOnOtherCollectionsOnSameFront,
+			collectionType: selectCollectionType(state, props.id),
 		};
 	};
 };

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -60,6 +60,7 @@ import { RecipeCard } from 'components/card/recipe/RecipeCard';
 import { ChefCard } from 'components/card/chef/ChefCard';
 import { ChefMetaForm } from '../form/ChefMetaForm';
 import { FeastCollectionCard } from './feastCollection/FeastCollectionCard';
+import { EventGraphicCard } from './eventGraphic/EventGraphicCard';
 import { FeastCollectionMetaForm } from 'components/form/FeastCollectionMetaForm';
 import { selectCollectionType } from 'selectors/frontsSelectors';
 import { Criteria } from 'types/Grid';
@@ -310,6 +311,22 @@ class Card extends React.Component<CardContainerProps> {
 								: this.state.showCardSublinks && children}
 						</>
 					);
+				case CardTypesMap.EVENT_GRAPHIC:
+					return (
+						<EventGraphicCard
+							frontId={frontId}
+							collectionId={collectionId}
+							id={uuid}
+							isUneditable={isUneditable}
+							{...getNodeProps()}
+							onDelete={this.onDelete}
+							onAddToClipboard={this.handleAddToClipboard}
+							/* No onClick here - there are no editable fields */
+							size={size}
+							textSize={textSize}
+							showMeta={showMeta}
+						/>
+					);
 				default:
 					return (
 						<p>
@@ -369,7 +386,10 @@ class Card extends React.Component<CardContainerProps> {
 			}
 		};
 
-		const supportsForm = type !== 'recipe';
+		// Neither recipes nor event graphics have editable fields, so there is no
+		// form to open when they are selected.
+		const supportsForm =
+			type !== CardTypesMap.RECIPE && type !== CardTypesMap.EVENT_GRAPHIC;
 		const shouldDisplayForm = isSelected && supportsForm;
 
 		return (

--- a/fronts-client/src/components/card/Card.tsx
+++ b/fronts-client/src/components/card/Card.tsx
@@ -386,8 +386,7 @@ class Card extends React.Component<CardContainerProps> {
 			}
 		};
 
-		// Neither recipes nor event graphics have editable fields, so there is no
-		// form to open when they are selected.
+		// Recipes and event graphics have no editable fields, so no form to open.
 		const supportsForm =
 			type !== CardTypesMap.RECIPE && type !== CardTypesMap.EVENT_GRAPHIC;
 		const shouldDisplayForm = isSelected && supportsForm;

--- a/fronts-client/src/components/card/__tests__/EventGraphicCard.spec.tsx
+++ b/fronts-client/src/components/card/__tests__/EventGraphicCard.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, cleanup } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import { ThemeProvider } from 'styled-components';
+import 'jest-styled-components';
+import configureStore from 'util/configureStore';
+import { theme } from '../../../constants/theme';
+import { EventGraphicCard } from '../eventGraphic/EventGraphicCard';
+import { eventGraphics } from 'constants/eventGraphics';
+
+const [eventGraphic] = eventGraphics;
+
+const cardFixture = {
+	id: eventGraphic.id,
+	uuid: 'a3b1c1e0-0f3a-4f1a-9c4e-0e6a6a0b3c11',
+	frontPublicationDate: 1,
+	meta: {},
+};
+
+const unknownCardFixture = {
+	id: 'event-graphic/some-graphic-we-no-longer-know-about',
+	uuid: 'b3b1c1e0-0f3a-4f1a-9c4e-0e6a6a0b3c22',
+	frontPublicationDate: 1,
+	meta: {},
+};
+
+const renderCard = (card: typeof cardFixture) => {
+	const store = configureStore({
+		feed: {},
+		cards: { [card.uuid]: card },
+	} as never);
+
+	return render(
+		<Provider store={store}>
+			<ThemeProvider theme={theme}>
+				<EventGraphicCard
+					id={card.uuid}
+					frontId="front"
+					onDelete={jest.fn()}
+					onAddToClipboard={jest.fn()}
+				/>
+			</ThemeProvider>
+		</Provider>,
+	);
+};
+
+describe('EventGraphicCard', () => {
+	afterEach(cleanup);
+
+	it('should render the title of the event graphic', () => {
+		const { getByTestId } = renderCard(cardFixture);
+		expect(getByTestId('headline').textContent).toBe(eventGraphic.title);
+	});
+
+	it('should label the card as an event graphic', () => {
+		const { getByText } = renderCard(cardFixture);
+		expect(getByText('Event graphic')).toBeTruthy();
+	});
+
+	it('should fall back to the id when the event graphic is unknown', () => {
+		const { getByTestId } = renderCard(unknownCardFixture);
+		expect(getByTestId('headline').textContent).toBe(unknownCardFixture.id);
+	});
+});

--- a/fronts-client/src/components/card/__tests__/EventGraphicCard.spec.tsx
+++ b/fronts-client/src/components/card/__tests__/EventGraphicCard.spec.tsx
@@ -52,9 +52,9 @@ describe('EventGraphicCard', () => {
 		expect(getByTestId('headline').textContent).toBe(eventGraphic.title);
 	});
 
-	it('should label the card as an event graphic', () => {
+	it('should label the card as an Election Tracker', () => {
 		const { getByText } = renderCard(cardFixture);
-		expect(getByText('Event graphic')).toBeTruthy();
+		expect(getByText('Election Tracker')).toBeTruthy();
 	});
 
 	it('should fall back to the id when the event graphic is unknown', () => {

--- a/fronts-client/src/components/card/eventGraphic/EventGraphicCard.tsx
+++ b/fronts-client/src/components/card/eventGraphic/EventGraphicCard.tsx
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux';
 import { Card, CardSizes } from 'types/Collection';
 import { State } from 'types/State';
 import { selectCard } from 'selectors/shared';
-import { getEventGraphicTitle } from 'constants/eventGraphics';
+import {
+	eventGraphicKind,
+	getEventGraphicTitle,
+} from 'constants/eventGraphics';
 import CardContainer from '../CardContainer';
 import CardBody from '../CardBody';
 import CardContent from '../CardContent';
@@ -55,7 +58,7 @@ export const EventGraphicCard = ({
 			<CardBody data-testid="event-graphic" size={size} fade={fade}>
 				{showMeta && (
 					<CardMetaContainer size={size}>
-						<CardMetaHeading>Event graphic</CardMetaHeading>
+						<CardMetaHeading>{eventGraphicKind(card.id)}</CardMetaHeading>
 					</CardMetaContainer>
 				)}
 				<CardContent textSize={textSize}>

--- a/fronts-client/src/components/card/eventGraphic/EventGraphicCard.tsx
+++ b/fronts-client/src/components/card/eventGraphic/EventGraphicCard.tsx
@@ -42,8 +42,7 @@ export const EventGraphicCard = ({
 	onDelete,
 	onAddToClipboard,
 	showMeta = true,
-	// These are part of the common card interface but aren't needed here, so
-	// they're kept out of the props spread onto the container.
+	// Part of the common card interface, but unused here: kept out of the spread.
 	collectionId,
 	frontId,
 	isUneditable,

--- a/fronts-client/src/components/card/eventGraphic/EventGraphicCard.tsx
+++ b/fronts-client/src/components/card/eventGraphic/EventGraphicCard.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Card, CardSizes } from 'types/Collection';
+import { State } from 'types/State';
+import { selectCard } from 'selectors/shared';
+import { getEventGraphicTitle } from 'constants/eventGraphics';
+import CardContainer from '../CardContainer';
+import CardBody from '../CardBody';
+import CardContent from '../CardContent';
+import CardHeading from '../CardHeading';
+import CardHeadingContainer from '../CardHeadingContainer';
+import CardMetaContainer from '../CardMetaContainer';
+import CardMetaHeading from '../CardMetaHeading';
+import { HoverActionsAreaOverlay } from 'components/CollectionHoverItems';
+import { HoverActionsButtonWrapper } from 'components/inputs/HoverActionButtonWrapper';
+import {
+	HoverAddToClipboardButton,
+	HoverDeleteButton,
+} from 'components/inputs/HoverActionButtons';
+
+interface Props {
+	onDragStart?: (d: React.DragEvent<HTMLElement>) => void;
+	onDrop?: (d: React.DragEvent<HTMLElement>) => void;
+	onDelete: () => void;
+	onAddToClipboard: () => void;
+	id: string;
+	collectionId?: string;
+	frontId: string;
+	draggable?: boolean;
+	size?: CardSizes;
+	textSize?: CardSizes;
+	fade?: boolean;
+	isUneditable?: boolean;
+	showMeta?: boolean;
+}
+
+export const EventGraphicCard = ({
+	id,
+	fade,
+	size = 'default',
+	textSize = 'default',
+	onDelete,
+	onAddToClipboard,
+	showMeta = true,
+	// These are part of the common card interface but aren't needed here, so
+	// they're kept out of the props spread onto the container.
+	collectionId,
+	frontId,
+	isUneditable,
+	...rest
+}: Props) => {
+	const card = useSelector<State, Card>((state) => selectCard(state, id));
+
+	return (
+		<CardContainer {...rest}>
+			<CardBody data-testid="event-graphic" size={size} fade={fade}>
+				{showMeta && (
+					<CardMetaContainer size={size}>
+						<CardMetaHeading>Event graphic</CardMetaHeading>
+					</CardMetaContainer>
+				)}
+				<CardContent textSize={textSize}>
+					<CardHeadingContainer size={size}>
+						<CardHeading data-testid="headline">
+							{getEventGraphicTitle(card.id)}
+						</CardHeading>
+					</CardHeadingContainer>
+				</CardContent>
+				<HoverActionsAreaOverlay data-testid="hover-overlay">
+					<HoverActionsButtonWrapper
+						toolTipPosition={'top'}
+						toolTipAlign={'right'}
+						urlPath={undefined}
+						renderButtons={(props) => (
+							<>
+								<HoverAddToClipboardButton
+									onAddToClipboard={onAddToClipboard}
+									hoverText="Clipboard"
+									{...props}
+								/>
+								<HoverDeleteButton
+									hoverText="Delete"
+									onDelete={onDelete}
+									{...props}
+								/>
+							</>
+						)}
+					/>
+				</HoverActionsAreaOverlay>
+			</CardBody>
+		</CardContainer>
+	);
+};

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -10,7 +10,13 @@ import DropZone, {
 import { createSelectSupportingArticles } from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
 import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
-import { CardTypes } from 'constants/cardTypes';
+import { CardTypes, CardTypesMap } from 'constants/cardTypes';
+
+/**
+ * Event graphics are placed as cards in their own right; they are never
+ * sublinks of another card.
+ */
+const sublinkCardTypeDenyList: CardTypes[] = [CardTypesMap.EVENT_GRAPHIC];
 
 interface OuterProps {
 	cardId: string;
@@ -70,6 +76,7 @@ const CardLevel = ({
 		onDrop={onDrop}
 		canDrop={!isUneditable}
 		cardTypeAllowList={cardTypeAllowList}
+		cardTypeDenyList={sublinkCardTypeDenyList}
 		renderDrop={
 			isUneditable
 				? undefined

--- a/fronts-client/src/components/clipboard/CardLevel.tsx
+++ b/fronts-client/src/components/clipboard/CardLevel.tsx
@@ -12,10 +12,7 @@ import { theme, styled } from 'constants/theme';
 import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
 import { CardTypes, CardTypesMap } from 'constants/cardTypes';
 
-/**
- * Event graphics are placed as cards in their own right; they are never
- * sublinks of another card.
- */
+/** Event graphics are placed as cards in their own right, never as sublinks. */
 const sublinkCardTypeDenyList: CardTypes[] = [CardTypesMap.EVENT_GRAPHIC];
 
 interface OuterProps {

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -10,6 +10,7 @@ import {
 } from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
 import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
+import { CardTypes } from 'constants/cardTypes';
 import { createShallowEqualResultSelector } from 'util/selectorUtils';
 
 interface OuterProps {
@@ -24,6 +25,7 @@ interface OuterProps {
 	groupIds: string[];
 	groupMaxItems?: number;
 	groups?: Group[];
+	cardTypeDenyList?: CardTypes[];
 }
 
 interface InnerProps {
@@ -75,6 +77,7 @@ const GroupLevel = ({
 	groupIds,
 	groupMaxItems,
 	groupsWithCardsData,
+	cardTypeDenyList,
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
@@ -85,6 +88,7 @@ const GroupLevel = ({
 		groupIds={groupIds}
 		groupMaxItems={groupMaxItems}
 		groupsData={groupsWithCardsData}
+		cardTypeDenyList={cardTypeDenyList}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/clipboard/GroupLevel.tsx
+++ b/fronts-client/src/components/clipboard/GroupLevel.tsx
@@ -10,7 +10,6 @@ import {
 } from 'selectors/shared';
 import { theme, styled } from 'constants/theme';
 import { CardTypeLevel } from 'lib/dnd/CardTypeLevel';
-import { CardTypes } from 'constants/cardTypes';
 import { createShallowEqualResultSelector } from 'util/selectorUtils';
 
 interface OuterProps {
@@ -25,7 +24,6 @@ interface OuterProps {
 	groupIds: string[];
 	groupMaxItems?: number;
 	groups?: Group[];
-	cardTypeDenyList?: CardTypes[];
 }
 
 interface InnerProps {
@@ -77,7 +75,6 @@ const GroupLevel = ({
 	groupIds,
 	groupMaxItems,
 	groupsWithCardsData,
-	cardTypeDenyList,
 }: Props) => (
 	<CardTypeLevel
 		arr={cards}
@@ -88,7 +85,6 @@ const GroupLevel = ({
 		groupIds={groupIds}
 		groupMaxItems={groupMaxItems}
 		groupsData={groupsWithCardsData}
-		cardTypeDenyList={cardTypeDenyList}
 		onMove={onMove}
 		onDrop={onDrop}
 		canDrop={!isUneditable}

--- a/fronts-client/src/components/feed/EventGraphicFeedItem.tsx
+++ b/fronts-client/src/components/feed/EventGraphicFeedItem.tsx
@@ -37,7 +37,7 @@ export const EventGraphicFeedItem = ({ eventGraphic }: Props) => {
 				CardTypesMap.EVENT_GRAPHIC,
 				eventGraphic,
 			)}
-			// An event graphic has no page of its own to view.
+			// No page of its own to view.
 			showViewButton={false}
 			metaContent={
 				<>

--- a/fronts-client/src/components/feed/EventGraphicFeedItem.tsx
+++ b/fronts-client/src/components/feed/EventGraphicFeedItem.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { CardTypesMap } from 'constants/cardTypes';
+import { EventGraphic } from 'constants/eventGraphics';
+import { handleDragStartForCard } from 'util/dragAndDrop';
+import { insertCardWithCreate } from 'actions/Cards';
+import { FeedItem } from './FeedItem';
+import { ContentInfo, ContentExtra } from './ContentInfo';
+
+interface Props {
+	eventGraphic: EventGraphic;
+}
+
+export const EventGraphicFeedItem = ({ eventGraphic }: Props) => {
+	const dispatch = useDispatch();
+
+	const onAddToClipboard = useCallback(() => {
+		dispatch<any>(
+			insertCardWithCreate(
+				{ type: 'clipboard', id: 'clipboard', index: 0 },
+				{ type: 'EVENT_GRAPHIC', data: eventGraphic },
+				'clipboard',
+			),
+		);
+	}, [dispatch, eventGraphic]);
+
+	return (
+		<FeedItem
+			id={eventGraphic.id}
+			type={CardTypesMap.EVENT_GRAPHIC}
+			title={eventGraphic.title}
+			hasVideo={false}
+			isLive={false}
+			urlPath={eventGraphic.id}
+			onAddToClipboard={onAddToClipboard}
+			handleDragStart={handleDragStartForCard(
+				CardTypesMap.EVENT_GRAPHIC,
+				eventGraphic,
+			)}
+			// An event graphic has no page of its own to view.
+			showViewButton={false}
+			metaContent={
+				<>
+					<ContentInfo>Event graphic</ContentInfo>
+					{eventGraphic.description && (
+						<ContentExtra>{eventGraphic.description}</ContentExtra>
+					)}
+				</>
+			}
+		/>
+	);
+};

--- a/fronts-client/src/components/feed/EventGraphicFeedItem.tsx
+++ b/fronts-client/src/components/feed/EventGraphicFeedItem.tsx
@@ -5,7 +5,7 @@ import { EventGraphic } from 'constants/eventGraphics';
 import { handleDragStartForCard } from 'util/dragAndDrop';
 import { insertCardWithCreate } from 'actions/Cards';
 import { FeedItem } from './FeedItem';
-import { ContentInfo, ContentExtra } from './ContentInfo';
+import { ContentInfo } from './ContentInfo';
 
 interface Props {
 	eventGraphic: EventGraphic;
@@ -41,10 +41,7 @@ export const EventGraphicFeedItem = ({ eventGraphic }: Props) => {
 			showViewButton={false}
 			metaContent={
 				<>
-					<ContentInfo>Event graphic</ContentInfo>
-					{eventGraphic.description && (
-						<ContentExtra>{eventGraphic.description}</ContentExtra>
-					)}
+					<ContentInfo>{eventGraphic.kind}</ContentInfo>
 				</>
 			}
 		/>

--- a/fronts-client/src/components/feed/EventGraphicsSearchContainer.tsx
+++ b/fronts-client/src/components/feed/EventGraphicsSearchContainer.tsx
@@ -1,0 +1,83 @@
+import ClipboardHeader from 'components/ClipboardHeader';
+import TextInput from 'components/inputs/TextInput';
+import { styled } from 'constants/theme';
+import React, { useMemo, useState } from 'react';
+import { eventGraphics } from 'constants/eventGraphics';
+import ScrollContainer from '../ScrollContainer';
+import { EventGraphicFeedItem } from './EventGraphicFeedItem';
+
+const InputContainer = styled.div`
+	margin-bottom: 10px;
+	display: flex;
+	justify-content: space-between;
+`;
+
+const TextInputContainer = styled.div`
+	flex-grow: 2;
+`;
+
+const ResultsContainer = styled.div`
+	margin-right: 10px;
+`;
+
+const FeedsContainerWrapper = styled.div`
+	height: 100%;
+	min-height: 0;
+`;
+
+const NoResults = styled.div`
+	margin: 4px;
+`;
+
+/**
+ * Event graphics come from a hard-coded list rather than a search service, so
+ * this container filters that list in memory -- there is no redux state and no
+ * request to make.
+ */
+export const EventGraphicsSearchContainer = () => {
+	const [searchText, setSearchText] = useState('');
+
+	const results = useMemo(() => {
+		const query = searchText.trim().toLowerCase();
+		if (!query) {
+			return eventGraphics;
+		}
+		return eventGraphics.filter(({ title, description, id }) =>
+			[title, description, id].some((field) =>
+				field?.toLowerCase().includes(query),
+			),
+		);
+	}, [searchText]);
+
+	return (
+		<React.Fragment>
+			<InputContainer>
+				<TextInputContainer>
+					<TextInput
+						placeholder="Search event graphics"
+						displaySearchIcon
+						onChange={(event) => setSearchText(event.target.value)}
+						value={searchText}
+					/>
+				</TextInputContainer>
+				<ClipboardHeader />
+			</InputContainer>
+			<FeedsContainerWrapper>
+				<ScrollContainer fixed={<h3>Results</h3>}>
+					<ResultsContainer>
+						{results.length ? (
+							results.map((eventGraphic) => (
+								<EventGraphicFeedItem
+									key={eventGraphic.id}
+									eventGraphic={eventGraphic}
+								/>
+							))
+						) : (
+							<NoResults>No results found</NoResults>
+						)}
+					</ResultsContainer>
+				</ScrollContainer>
+			</FeedsContainerWrapper>
+		</React.Fragment>
+	);
+};

--- a/fronts-client/src/components/feed/EventGraphicsSearchContainer.tsx
+++ b/fronts-client/src/components/feed/EventGraphicsSearchContainer.tsx
@@ -31,8 +31,7 @@ const NoResults = styled.div`
 
 /**
  * Event graphics come from a hard-coded list rather than a search service, so
- * this container filters that list in memory -- there is no redux state and no
- * request to make.
+ * filtering happens in memory: no redux state, no request.
  */
 export const EventGraphicsSearchContainer = () => {
 	const [searchText, setSearchText] = useState('');

--- a/fronts-client/src/components/feed/EventGraphicsSearchContainer.tsx
+++ b/fronts-client/src/components/feed/EventGraphicsSearchContainer.tsx
@@ -41,10 +41,8 @@ export const EventGraphicsSearchContainer = () => {
 		if (!query) {
 			return eventGraphics;
 		}
-		return eventGraphics.filter(({ title, description, id }) =>
-			[title, description, id].some((field) =>
-				field?.toLowerCase().includes(query),
-			),
+		return eventGraphics.filter(({ title, kind, id }) =>
+			[title, kind, id].some((field) => field?.toLowerCase().includes(query)),
 		);
 	}, [searchText]);
 

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -132,10 +132,7 @@ interface FeedItemProps {
 	shouldObscureFeed?: boolean;
 	byline?: string;
 	showPinboard?: boolean;
-	/**
-	 * Some feed items -- event graphics, for example -- don't correspond to a
-	 * page on the site, so there is nothing to link to.
-	 */
+	/** Some feed items, such as event graphics, have no page to link to. */
 	showViewButton?: boolean;
 	intendedAudience?: {
 		source: IntendedAudienceSignifierProps['source'];

--- a/fronts-client/src/components/feed/FeedItem.tsx
+++ b/fronts-client/src/components/feed/FeedItem.tsx
@@ -132,6 +132,11 @@ interface FeedItemProps {
 	shouldObscureFeed?: boolean;
 	byline?: string;
 	showPinboard?: boolean;
+	/**
+	 * Some feed items -- event graphics, for example -- don't correspond to a
+	 * page on the site, so there is nothing to link to.
+	 */
+	showViewButton?: boolean;
 	intendedAudience?: {
 		source: IntendedAudienceSignifierProps['source'];
 		target: IntendedAudienceSignifierProps['target'];
@@ -163,6 +168,7 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 			handleDragStart,
 			byline,
 			showPinboard,
+			showViewButton = true,
 		} = this.props;
 
 		const { preview, live, ophan } = getPaths(id);
@@ -251,7 +257,9 @@ export class FeedItem extends React.Component<FeedItemProps, {}> {
 						showPinboard={showPinboard}
 						renderButtons={(props) => (
 							<>
-								<HoverViewButton hoverText="View" href={href} {...props} />
+								{showViewButton && (
+									<HoverViewButton hoverText="View" href={href} {...props} />
+								)}
 								{displayOphanLink && (
 									<HoverOphanButton {...props} href={ophan} hoverText="Ophan" />
 								)}

--- a/fronts-client/src/components/feed/FeedSection.tsx
+++ b/fronts-client/src/components/feed/FeedSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled, theme } from 'constants/theme';
 
 import { selectors as editionsIssueSelectors } from '../../bundles/editionsIssueBundle';
@@ -10,10 +10,18 @@ import { media } from 'util/mediaQueries';
 import { connect } from 'react-redux';
 import { State } from 'types/State';
 import { RecipeSearchContainer } from './RecipeSearchContainer';
+import { EventGraphicsSearchContainer } from './EventGraphicsSearchContainer';
+import { selectFeatureValue } from 'selectors/featureSwitchesSelectors';
 
 interface Props {
 	isClipboardOpen: boolean;
 	isFeast: boolean;
+	showEventGraphics: boolean;
+}
+
+export enum FeedSource {
+	articles = 'articles',
+	eventGraphics = 'eventGraphics',
 }
 
 const FeedSectionContainer = styled.div`
@@ -34,12 +42,63 @@ const FeedWrapper = styled.div<{ isClipboardOpen: boolean }>`
 		isClipboardOpen ? `solid 1px ${theme.base.colors.borderColor}` : null};
 `;
 
-const FeedSection = ({ isClipboardOpen, isFeast }: Props) => (
+const FeedSourceSelectorContainer = styled.div`
+	margin-bottom: 10px;
+	margin-right: 10px;
+`;
+
+const FeedSourceSelect = styled.select`
+	width: 100%;
+`;
+
+/**
+ * The feed for regular (non-feast) fronts, which can show either CAPI content
+ * or the list of available event graphics.
+ */
+const FrontsFeed = () => {
+	const [source, setSource] = useState(FeedSource.articles);
+
+	return (
+		<>
+			<FeedSourceSelectorContainer>
+				<label htmlFor="feedSourceSelector" hidden>
+					Feed source
+				</label>
+				<FeedSourceSelect
+					id="feedSourceSelector"
+					data-testid="feed-source-selector"
+					value={source}
+					onChange={(event) => setSource(event.target.value as FeedSource)}
+				>
+					<option value={FeedSource.articles}>Articles</option>
+					<option value={FeedSource.eventGraphics}>Event graphics</option>
+				</FeedSourceSelect>
+			</FeedSourceSelectorContainer>
+			{source === FeedSource.eventGraphics ? (
+				<EventGraphicsSearchContainer />
+			) : (
+				<CapiSearchContainer />
+			)}
+		</>
+	);
+};
+
+const FeedSection = ({
+	isClipboardOpen,
+	isFeast,
+	showEventGraphics,
+}: Props) => (
 	<FeedSectionContainer>
 		<FeedSectionHeader />
 		<FeedSectionContent>
 			<FeedWrapper isClipboardOpen={isClipboardOpen}>
-				{isFeast ? <RecipeSearchContainer /> : <CapiSearchContainer />}
+				{isFeast ? (
+					<RecipeSearchContainer />
+				) : showEventGraphics ? (
+					<FrontsFeed />
+				) : (
+					<CapiSearchContainer />
+				)}
 			</FeedWrapper>
 			<Clipboard />
 		</FeedSectionContent>
@@ -48,6 +107,7 @@ const FeedSection = ({ isClipboardOpen, isFeast }: Props) => (
 
 const mapStateToProps = (state: State) => ({
 	isFeast: editionsIssueSelectors.selectAll(state)?.platform === 'feast',
+	showEventGraphics: selectFeatureValue(state, 'event-graphics'),
 });
 
 export default connect(mapStateToProps)(FeedSection);

--- a/fronts-client/src/components/feed/FeedSection.tsx
+++ b/fronts-client/src/components/feed/FeedSection.tsx
@@ -43,12 +43,32 @@ const FeedWrapper = styled.div<{ isClipboardOpen: boolean }>`
 `;
 
 const FeedSourceSelectorContainer = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 8px;
 	margin-bottom: 10px;
 	margin-right: 10px;
 `;
 
+const FeedSourceLabel = styled.label`
+	font-size: 14px;
+	white-space: nowrap;
+`;
+
 const FeedSourceSelect = styled.select`
-	width: 100%;
+	flex: 1;
+	height: 36px;
+	padding: 0 8px;
+	font-size: 16px;
+	color: ${theme.base.colors.text};
+	background-color: ${theme.base.colors.backgroundColorLight};
+	border: 1px solid ${theme.base.colors.borderColor};
+	border-radius: 3px;
+
+	&:focus {
+		outline: none;
+		border-color: ${theme.base.colors.borderColorFocus};
+	}
 `;
 
 /**
@@ -61,9 +81,9 @@ const FrontsFeed = () => {
 	return (
 		<>
 			<FeedSourceSelectorContainer>
-				<label htmlFor="feedSourceSelector" hidden>
-					Feed source
-				</label>
+				<FeedSourceLabel htmlFor="feedSourceSelector">
+					Filter by type:
+				</FeedSourceLabel>
 				<FeedSourceSelect
 					id="feedSourceSelector"
 					data-testid="feed-source-selector"

--- a/fronts-client/src/components/feed/FeedSection.tsx
+++ b/fronts-client/src/components/feed/FeedSection.tsx
@@ -72,8 +72,8 @@ const FeedSourceSelect = styled.select`
 `;
 
 /**
- * The feed for regular (non-feast) fronts, which can show either CAPI content
- * or the list of available event graphics.
+ * The feed for regular (non-feast) fronts: either CAPI content or the list of
+ * available event graphics.
  */
 const FrontsFeed = () => {
 	const [source, setSource] = useState(FeedSource.articles);

--- a/fronts-client/src/constants/__tests__/eventGraphics.spec.ts
+++ b/fronts-client/src/constants/__tests__/eventGraphics.spec.ts
@@ -4,9 +4,7 @@ import {
 	getEventGraphicById,
 	getEventGraphicTitle,
 	isEventGraphicId,
-	isEventGraphicSlot,
 } from 'constants/eventGraphics';
-import { FLEXIBLE_SPECIAL_NAME } from 'constants/flexibleContainers';
 
 describe('event graphics', () => {
 	it('should give every event graphic an id with the shared prefix', () => {
@@ -52,22 +50,6 @@ describe('event graphics', () => {
 	describe('getEventGraphicById', () => {
 		it('should return undefined for an unknown id', () => {
 			expect(getEventGraphicById('event-graphic/unknown')).toBeUndefined();
-		});
-	});
-
-	describe('isEventGraphicSlot', () => {
-		it('should accept group 1 of a flexible/special container', () => {
-			expect(isEventGraphicSlot(FLEXIBLE_SPECIAL_NAME, '1')).toBe(true);
-		});
-
-		it('should reject other groups of a flexible/special container', () => {
-			expect(isEventGraphicSlot(FLEXIBLE_SPECIAL_NAME, '0')).toBe(false);
-			expect(isEventGraphicSlot(FLEXIBLE_SPECIAL_NAME, null)).toBe(false);
-		});
-
-		it('should reject group 1 of other container types', () => {
-			expect(isEventGraphicSlot('flexible/general', '1')).toBe(false);
-			expect(isEventGraphicSlot(undefined, '1')).toBe(false);
 		});
 	});
 });

--- a/fronts-client/src/constants/__tests__/eventGraphics.spec.ts
+++ b/fronts-client/src/constants/__tests__/eventGraphics.spec.ts
@@ -1,0 +1,73 @@
+import {
+	EVENT_GRAPHIC_ID_PREFIX,
+	eventGraphics,
+	getEventGraphicById,
+	getEventGraphicTitle,
+	isEventGraphicId,
+	isEventGraphicSlot,
+} from 'constants/eventGraphics';
+import { FLEXIBLE_SPECIAL_NAME } from 'constants/flexibleContainers';
+
+describe('event graphics', () => {
+	it('should give every event graphic an id with the shared prefix', () => {
+		eventGraphics.forEach(({ id }) => {
+			expect(id.startsWith(EVENT_GRAPHIC_ID_PREFIX)).toBe(true);
+		});
+	});
+
+	it('should give every event graphic a title', () => {
+		eventGraphics.forEach(({ title }) => {
+			expect(title).toBeTruthy();
+		});
+	});
+
+	describe('isEventGraphicId', () => {
+		it('should identify event graphic ids', () => {
+			expect(
+				isEventGraphicId('event-graphic/election-tracker/us-midterm-2026'),
+			).toBe(true);
+		});
+
+		it('should not identify articles or snaps as event graphics', () => {
+			expect(isEventGraphicId('snap/32145544543')).toBe(false);
+			expect(isEventGraphicId('politics/2026/nov/01/some-article')).toBe(false);
+		});
+	});
+
+	describe('getEventGraphicTitle', () => {
+		it('should return the title of a known event graphic', () => {
+			const [firstEventGraphic] = eventGraphics;
+			expect(getEventGraphicTitle(firstEventGraphic.id)).toBe(
+				firstEventGraphic.title,
+			);
+		});
+
+		it('should fall back to the id for an unknown event graphic', () => {
+			expect(getEventGraphicTitle('event-graphic/unknown')).toBe(
+				'event-graphic/unknown',
+			);
+		});
+	});
+
+	describe('getEventGraphicById', () => {
+		it('should return undefined for an unknown id', () => {
+			expect(getEventGraphicById('event-graphic/unknown')).toBeUndefined();
+		});
+	});
+
+	describe('isEventGraphicSlot', () => {
+		it('should accept group 1 of a flexible/special container', () => {
+			expect(isEventGraphicSlot(FLEXIBLE_SPECIAL_NAME, '1')).toBe(true);
+		});
+
+		it('should reject other groups of a flexible/special container', () => {
+			expect(isEventGraphicSlot(FLEXIBLE_SPECIAL_NAME, '0')).toBe(false);
+			expect(isEventGraphicSlot(FLEXIBLE_SPECIAL_NAME, null)).toBe(false);
+		});
+
+		it('should reject group 1 of other container types', () => {
+			expect(isEventGraphicSlot('flexible/general', '1')).toBe(false);
+			expect(isEventGraphicSlot(undefined, '1')).toBe(false);
+		});
+	});
+});

--- a/fronts-client/src/constants/cardTypes.ts
+++ b/fronts-client/src/constants/cardTypes.ts
@@ -4,6 +4,7 @@ export const CardTypesMap = {
 	RECIPE: 'recipe',
 	CHEF: 'chef',
 	FEAST_COLLECTION: 'feast-collection',
+	EVENT_GRAPHIC: 'event-graphic',
 } as const;
 
 export type CardTypes = (typeof CardTypesMap)[keyof typeof CardTypesMap];

--- a/fronts-client/src/constants/eventGraphics.ts
+++ b/fronts-client/src/constants/eventGraphics.ts
@@ -1,0 +1,63 @@
+/**
+ * Event graphics are live, self-updating graphics -- for example an election
+ * results tracker or an olympics medal table -- which editors can place onto a
+ * front.
+ *
+ * They are not content-api content. A card pointing at one is identified purely
+ * by its id, which must start with `EVENT_GRAPHIC_ID_PREFIX`. This mirrors
+ * `Trail.eventGraphicPrefix` in facia-scala-client, which is what the rendering
+ * layer keys off. Because the prefix is the only marker that survives a round
+ * trip to S3 (the card's `cardType` is not part of the stored trail), it must
+ * not be stripped from the id we persist.
+ *
+ * The list below is deliberately hard-coded: there is no service to search
+ * against yet, and we currently only need to support the US midterms.
+ */
+
+import { FLEXIBLE_SPECIAL_NAME } from 'constants/flexibleContainers';
+
+export const EVENT_GRAPHIC_ID_PREFIX = 'event-graphic/';
+
+export interface EventGraphic {
+	/** The full id, including the `event-graphic/` prefix. */
+	id: string;
+	/** Displayed in the feed and on the card. */
+	title: string;
+	description?: string;
+}
+
+export const eventGraphics: EventGraphic[] = [
+	{
+		id: 'event-graphic/election-tracker/us-midterm-2026',
+		title: 'US midterms 2026 — election tracker',
+		description: 'Live results tracker for the 2026 US midterm elections',
+	},
+];
+
+export const isEventGraphicId = (id: string): boolean =>
+	id.startsWith(EVENT_GRAPHIC_ID_PREFIX);
+
+/**
+ * Event graphics can only be placed in the "snap" slot of a flexible/special
+ * container -- group 1 -- which is the same slot facia-scala-client treats as
+ * the snap card when rendering.
+ */
+export const EVENT_GRAPHIC_GROUP_ID = '1';
+
+export const isEventGraphicSlot = (
+	collectionType?: string,
+	groupId?: string | null,
+): boolean =>
+	collectionType === FLEXIBLE_SPECIAL_NAME &&
+	groupId === EVENT_GRAPHIC_GROUP_ID;
+
+export const getEventGraphicById = (id: string): EventGraphic | undefined =>
+	eventGraphics.find((eventGraphic) => eventGraphic.id === id);
+
+/**
+ * The title to show for a given event graphic id. Falls back to the id itself,
+ * so that a card which was added before an entry was removed from the list
+ * above still renders something meaningful.
+ */
+export const getEventGraphicTitle = (id: string): string =>
+	getEventGraphicById(id)?.title ?? id;

--- a/fronts-client/src/constants/eventGraphics.ts
+++ b/fronts-client/src/constants/eventGraphics.ts
@@ -14,8 +14,6 @@
  * against yet, and we currently only need to support the US midterms.
  */
 
-import { FLEXIBLE_SPECIAL_NAME } from 'constants/flexibleContainers';
-
 export const EVENT_GRAPHIC_ID_PREFIX = 'event-graphic/';
 
 export interface EventGraphic {
@@ -36,20 +34,6 @@ export const eventGraphics: EventGraphic[] = [
 
 export const isEventGraphicId = (id: string): boolean =>
 	id.startsWith(EVENT_GRAPHIC_ID_PREFIX);
-
-/**
- * Event graphics can only be placed in the "snap" slot of a flexible/special
- * container -- group 1 -- which is the same slot facia-scala-client treats as
- * the snap card when rendering.
- */
-export const EVENT_GRAPHIC_GROUP_ID = '1';
-
-export const isEventGraphicSlot = (
-	collectionType?: string,
-	groupId?: string | null,
-): boolean =>
-	collectionType === FLEXIBLE_SPECIAL_NAME &&
-	groupId === EVENT_GRAPHIC_GROUP_ID;
 
 export const getEventGraphicById = (id: string): EventGraphic | undefined =>
 	eventGraphics.find((eventGraphic) => eventGraphic.id === id);

--- a/fronts-client/src/constants/eventGraphics.ts
+++ b/fronts-client/src/constants/eventGraphics.ts
@@ -1,17 +1,11 @@
 /**
- * Event graphics are live, self-updating graphics -- for example an election
- * results tracker or an olympics medal table -- which editors can place onto a
- * front.
+ * Event graphics are live, self-updating graphics (e.g. an election tracker)
+ * which editors can place onto a front. They aren't CAPI content: the id
+ * prefix is the only thing identifying them, both to the rendering layer (see
+ * `Trail.eventGraphicPrefix` in facia-scala-client) and to us, since `cardType`
+ * isn't persisted. So it must never be stripped from the id we save.
  *
- * They are not content-api content. A card pointing at one is identified purely
- * by its id, which must start with `EVENT_GRAPHIC_ID_PREFIX`. This mirrors
- * `Trail.eventGraphicPrefix` in facia-scala-client, which is what the rendering
- * layer keys off. Because the prefix is the only marker that survives a round
- * trip to S3 (the card's `cardType` is not part of the stored trail), it must
- * not be stripped from the id we persist.
- *
- * The list below is deliberately hard-coded: there is no service to search
- * against yet, and we currently only need to support the US midterms.
+ * The list is hard-coded because there's no service to search against yet.
  */
 
 export const EVENT_GRAPHIC_ID_PREFIX = 'event-graphic/';
@@ -19,7 +13,6 @@ export const EVENT_GRAPHIC_ID_PREFIX = 'event-graphic/';
 export interface EventGraphic {
 	/** The full id, including the `event-graphic/` prefix. */
 	id: string;
-	/** Displayed in the feed and on the card. */
 	title: string;
 	description?: string;
 }
@@ -38,10 +31,6 @@ export const isEventGraphicId = (id: string): boolean =>
 export const getEventGraphicById = (id: string): EventGraphic | undefined =>
 	eventGraphics.find((eventGraphic) => eventGraphic.id === id);
 
-/**
- * The title to show for a given event graphic id. Falls back to the id itself,
- * so that a card which was added before an entry was removed from the list
- * above still renders something meaningful.
- */
+/** Falls back to the id, so cards for removed entries still render. */
 export const getEventGraphicTitle = (id: string): string =>
 	getEventGraphicById(id)?.title ?? id;

--- a/fronts-client/src/constants/eventGraphics.ts
+++ b/fronts-client/src/constants/eventGraphics.ts
@@ -10,23 +10,29 @@
 
 export const EVENT_GRAPHIC_ID_PREFIX = 'event-graphic/';
 
+export type EventGraphicKind = 'Election Tracker';
+
 export interface EventGraphic {
 	/** The full id, including the `event-graphic/` prefix. */
 	id: string;
 	title: string;
-	description?: string;
+	kind: EventGraphicKind;
 }
 
 export const eventGraphics: EventGraphic[] = [
 	{
 		id: 'event-graphic/election-tracker/us-midterm-2026',
 		title: 'US midterms 2026 — election tracker',
-		description: 'Live results tracker for the 2026 US midterm elections',
+		kind: 'Election Tracker',
 	},
 ];
 
 export const isEventGraphicId = (id: string): boolean =>
 	id.startsWith(EVENT_GRAPHIC_ID_PREFIX);
+
+export const eventGraphicKind = (id: String): EventGraphicKind =>
+	eventGraphics.find((eventGraphic) => eventGraphic.id === id)?.kind ??
+	'Election Tracker';
 
 export const getEventGraphicById = (id: string): EventGraphic | undefined =>
 	eventGraphics.find((eventGraphic) => eventGraphic.id === id);

--- a/fronts-client/src/lib/dnd/CardTypeLevel.tsx
+++ b/fronts-client/src/lib/dnd/CardTypeLevel.tsx
@@ -3,6 +3,7 @@ import { Card } from 'types/Collection';
 import Level, { LevelProps } from './Level';
 import { CardTypes, CardTypesMap } from 'constants/cardTypes';
 import { collectionDropTypeDenylist } from 'constants/fronts';
+import { isEventGraphicId } from 'constants/eventGraphics';
 import { CARD_TYPE } from './constants';
 import ArticleDrag, {
 	dragOffsetX,
@@ -53,6 +54,18 @@ export const denyDragEvent =
 	};
 
 /**
+ * The type advertised when a card already on a front or the clipboard is
+ * dragged. `cardType` is not persisted, so for cards restored from a saved
+ * collection the type has to be derived from the id -- otherwise a saved event
+ * graphic would look like an article and could be dropped as a sublink.
+ */
+export const getCardDropType = (card: Card): CardTypes =>
+	card.cardType ??
+	(isEventGraphicId(card.id)
+		? CardTypesMap.EVENT_GRAPHIC
+		: CardTypesMap.ARTICLE);
+
+/**
  * A Level that only accepts a Card type. Useful for providing common drag and
  * behaviour for Card components.
  */
@@ -63,7 +76,7 @@ export const CardTypeLevel: React.FC<Props> = (props: Props) => (
 			props.cardTypeAllowList,
 			props.cardTypeDenyList,
 		)}
-		getDropType={(card) => card.cardType || CardTypesMap.ARTICLE}
+		getDropType={getCardDropType}
 		dragImageOffsetX={dragOffsetX}
 		dragImageOffsetY={dragOffsetY}
 		renderDrag={(af) => <ArticleDrag id={af.uuid} />}

--- a/fronts-client/src/lib/dnd/CardTypeLevel.tsx
+++ b/fronts-client/src/lib/dnd/CardTypeLevel.tsx
@@ -55,9 +55,9 @@ export const denyDragEvent =
 
 /**
  * The type advertised when a card already on a front or the clipboard is
- * dragged. `cardType` is not persisted, so for cards restored from a saved
- * collection the type has to be derived from the id -- otherwise a saved event
- * graphic would look like an article and could be dropped as a sublink.
+ * dragged. `cardType` isn't persisted, so saved event graphics have to be typed
+ * from their id -- otherwise they'd look like articles and could be dropped as
+ * sublinks.
  */
 export const getCardDropType = (card: Card): CardTypes =>
 	card.cardType ??

--- a/fronts-client/src/lib/dnd/CardTypeLevel.tsx
+++ b/fronts-client/src/lib/dnd/CardTypeLevel.tsx
@@ -20,20 +20,36 @@ type Props = Omit<
 	| 'getId'
 > & {
 	cardTypeAllowList?: CardTypes[];
+	cardTypeDenyList?: CardTypes[];
 };
 
 export const denyDragEvent =
-	(cardTypeAllowList?: string[] | undefined) => (e: React.DragEvent) => {
+	(
+		cardTypeAllowList?: string[] | undefined,
+		cardTypeDenyList?: string[] | undefined,
+	) =>
+	(e: React.DragEvent) => {
 		const dropEventIsNotPermitted = e.dataTransfer.types.some((type) =>
 			collectionDropTypeDenylist.includes(type),
 		);
 
+		const cardTypeBeingDropped = e.dataTransfer.getData(CARD_TYPE);
+
 		const cardTypeBeingDroppedIsNotPermitted =
 			!!cardTypeAllowList &&
-			!!e.dataTransfer.getData(CARD_TYPE) &&
-			!cardTypeAllowList.includes(e.dataTransfer.getData(CARD_TYPE));
+			!!cardTypeBeingDropped &&
+			!cardTypeAllowList.includes(cardTypeBeingDropped);
 
-		return dropEventIsNotPermitted || cardTypeBeingDroppedIsNotPermitted;
+		const cardTypeBeingDroppedIsDenied =
+			!!cardTypeDenyList &&
+			!!cardTypeBeingDropped &&
+			cardTypeDenyList.includes(cardTypeBeingDropped);
+
+		return (
+			dropEventIsNotPermitted ||
+			cardTypeBeingDroppedIsNotPermitted ||
+			cardTypeBeingDroppedIsDenied
+		);
 	};
 
 /**
@@ -43,7 +59,10 @@ export const denyDragEvent =
 export const CardTypeLevel: React.FC<Props> = (props: Props) => (
 	<Level
 		{...props}
-		denyDragEvent={denyDragEvent(props.cardTypeAllowList)}
+		denyDragEvent={denyDragEvent(
+			props.cardTypeAllowList,
+			props.cardTypeDenyList,
+		)}
 		getDropType={(card) => card.cardType || CardTypesMap.ARTICLE}
 		dragImageOffsetX={dragOffsetX}
 		dragImageOffsetY={dragOffsetY}

--- a/fronts-client/src/lib/dnd/__tests__/cardTypeLevel.spec.ts
+++ b/fronts-client/src/lib/dnd/__tests__/cardTypeLevel.spec.ts
@@ -1,0 +1,56 @@
+import { denyDragEvent } from '../CardTypeLevel';
+import { CardTypesMap } from 'constants/cardTypes';
+import { CARD_TYPE } from 'lib/dnd/constants';
+
+const dragEventWithCardType = (cardType: string, types: string[] = []) =>
+	({
+		dataTransfer: {
+			types,
+			getData: (key: string) => (key === CARD_TYPE ? cardType : ''),
+		},
+	}) as unknown as React.DragEvent;
+
+describe('denyDragEvent', () => {
+	it('should allow a drag with no allow or deny list', () => {
+		expect(
+			denyDragEvent()(dragEventWithCardType(CardTypesMap.EVENT_GRAPHIC)),
+		).toBe(false);
+	});
+
+	it('should deny card types on the deny list', () => {
+		expect(
+			denyDragEvent(undefined, [CardTypesMap.EVENT_GRAPHIC])(
+				dragEventWithCardType(CardTypesMap.EVENT_GRAPHIC),
+			),
+		).toBe(true);
+	});
+
+	it('should allow card types absent from the deny list', () => {
+		expect(
+			denyDragEvent(undefined, [CardTypesMap.EVENT_GRAPHIC])(
+				dragEventWithCardType(CardTypesMap.ARTICLE),
+			),
+		).toBe(false);
+	});
+
+	it('should not deny untyped drops, such as plain urls', () => {
+		expect(
+			denyDragEvent(undefined, [CardTypesMap.EVENT_GRAPHIC])(
+				dragEventWithCardType(''),
+			),
+		).toBe(false);
+	});
+
+	it('should still honour the allow list', () => {
+		expect(
+			denyDragEvent([CardTypesMap.RECIPE])(
+				dragEventWithCardType(CardTypesMap.ARTICLE),
+			),
+		).toBe(true);
+		expect(
+			denyDragEvent([CardTypesMap.RECIPE])(
+				dragEventWithCardType(CardTypesMap.RECIPE),
+			),
+		).toBe(false);
+	});
+});

--- a/fronts-client/src/lib/dnd/__tests__/cardTypeLevel.spec.ts
+++ b/fronts-client/src/lib/dnd/__tests__/cardTypeLevel.spec.ts
@@ -1,6 +1,7 @@
-import { denyDragEvent } from '../CardTypeLevel';
+import { denyDragEvent, getCardDropType } from '../CardTypeLevel';
 import { CardTypesMap } from 'constants/cardTypes';
 import { CARD_TYPE } from 'lib/dnd/constants';
+import { Card } from 'types/Collection';
 
 const dragEventWithCardType = (cardType: string, types: string[] = []) =>
 	({
@@ -52,5 +53,32 @@ describe('denyDragEvent', () => {
 				dragEventWithCardType(CardTypesMap.RECIPE),
 			),
 		).toBe(false);
+	});
+});
+
+describe('getCardDropType', () => {
+	it('should use the card type when it is set', () => {
+		expect(
+			getCardDropType({
+				uuid: 'uuid',
+				id: 'some/article',
+				cardType: CardTypesMap.RECIPE,
+			} as Card),
+		).toBe(CardTypesMap.RECIPE);
+	});
+
+	it('should derive the event graphic type from the id when the card type is missing', () => {
+		expect(
+			getCardDropType({
+				uuid: 'uuid',
+				id: 'event-graphic/election-tracker/us-midterm-2026',
+			} as Card),
+		).toBe(CardTypesMap.EVENT_GRAPHIC);
+	});
+
+	it('should default to an article', () => {
+		expect(getCardDropType({ uuid: 'uuid', id: 'some/article' } as Card)).toBe(
+			CardTypesMap.ARTICLE,
+		);
 	});
 });

--- a/fronts-client/src/selectors/__tests__/cardSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/cardSelectors.spec.ts
@@ -7,8 +7,7 @@ const stateWithEventGraphic = {
 	cards: {
 		...stateWithSnaplinksAndArticles.cards,
 		'2f0b1e1c-2f52-4a4a-9a6f-8a1b8b4a6b3d': {
-			// No cardType: this is what a card looks like when it has been read
-			// back from a saved collection, because cardType isn't persisted.
+			// No cardType: cards read back from a saved collection don't have one.
 			id: 'event-graphic/election-tracker/us-midterm-2026',
 			frontPublicationDate: 4,
 			publishedBy: 'Computers',

--- a/fronts-client/src/selectors/__tests__/cardSelectors.spec.ts
+++ b/fronts-client/src/selectors/__tests__/cardSelectors.spec.ts
@@ -2,6 +2,22 @@ import { createSelectCardType } from '../cardSelectors';
 import { stateWithSnaplinksAndArticles } from 'fixtures/shared';
 import { CardTypesMap } from 'constants/cardTypes';
 
+const stateWithEventGraphic = {
+	...stateWithSnaplinksAndArticles,
+	cards: {
+		...stateWithSnaplinksAndArticles.cards,
+		'2f0b1e1c-2f52-4a4a-9a6f-8a1b8b4a6b3d': {
+			// No cardType: this is what a card looks like when it has been read
+			// back from a saved collection, because cardType isn't persisted.
+			id: 'event-graphic/election-tracker/us-midterm-2026',
+			frontPublicationDate: 4,
+			publishedBy: 'Computers',
+			meta: {},
+			uuid: '2f0b1e1c-2f52-4a4a-9a6f-8a1b8b4a6b3d',
+		},
+	},
+};
+
 describe('Card selectors', () => {
 	describe('createCardTypeSelector', () => {
 		it('should identify snap links', () => {
@@ -21,6 +37,15 @@ describe('Card selectors', () => {
 					'134c9d4f-b05c-43f4-be41-a605b6dccab9',
 				),
 			).toEqual(CardTypesMap.ARTICLE);
+		});
+		it('should identify event graphics by their id, without a cardType', () => {
+			const selectCardType = createSelectCardType();
+			expect(
+				selectCardType(
+					stateWithEventGraphic,
+					'2f0b1e1c-2f52-4a4a-9a6f-8a1b8b4a6b3d',
+				),
+			).toEqual(CardTypesMap.EVENT_GRAPHIC);
 		});
 	});
 });

--- a/fronts-client/src/selectors/cardSelectors.ts
+++ b/fronts-client/src/selectors/cardSelectors.ts
@@ -15,9 +15,8 @@ const createSelectCardType = () =>
 			return card.cardType;
 		}
 
-		// `cardType` is not persisted -- it isn't a field on the trail we send to
-		// the backend -- so for cards restored from a saved collection the type
-		// must be derived from the id.
+		// `cardType` isn't persisted, so cards restored from a saved collection
+		// have to be typed from their id. See constants/eventGraphics.
 		if (isEventGraphicId(card.id)) {
 			return CardTypesMap.EVENT_GRAPHIC;
 		}

--- a/fronts-client/src/selectors/cardSelectors.ts
+++ b/fronts-client/src/selectors/cardSelectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import { selectCard, selectExternalArticleFromCard } from './shared';
 import { validateId } from 'util/snap';
 import { CardTypesMap } from 'constants/cardTypes';
+import { isEventGraphicId } from 'constants/eventGraphics';
 import { getContributorImage } from 'util/CAPIUtils';
 
 const createSelectCardType = () =>
@@ -12,6 +13,13 @@ const createSelectCardType = () =>
 
 		if (card.cardType) {
 			return card.cardType;
+		}
+
+		// `cardType` is not persisted -- it isn't a field on the trail we send to
+		// the backend -- so for cards restored from a saved collection the type
+		// must be derived from the id.
+		if (isEventGraphicId(card.id)) {
+			return CardTypesMap.EVENT_GRAPHIC;
 		}
 
 		return validateId(card.id) ? CardTypesMap.SNAP_LINK : CardTypesMap.ARTICLE;

--- a/fronts-client/src/util/__tests__/card.spec.ts
+++ b/fronts-client/src/util/__tests__/card.spec.ts
@@ -1,5 +1,8 @@
-import { cloneActiveImageMeta } from 'util/card';
+import { cloneActiveImageMeta, getCardEntitiesFromDrop } from 'util/card';
 import { CardMeta } from 'types/Collection';
+import { CardTypesMap } from 'constants/cardTypes';
+import { eventGraphics } from 'constants/eventGraphics';
+import { State } from 'types/State';
 
 const createCard = (meta: CardMeta = {}) => ({
 	id: 'id',
@@ -120,6 +123,25 @@ describe('card utils', () => {
 				imageSrcHeight: 'image',
 				imageSrcOrigin: 'image',
 			});
+		});
+	});
+
+	describe('getCardEntitiesFromDrop', () => {
+		it('should create a card from an event graphic drop', async () => {
+			const [eventGraphic] = eventGraphics;
+			const { card } = await getCardEntitiesFromDrop(
+				{ type: 'EVENT_GRAPHIC', data: eventGraphic },
+				false,
+				jest.fn(),
+				{} as State,
+			);
+
+			expect(card).toBeDefined();
+			// The prefixed id is the only marker that survives a round trip to S3,
+			// so it must be persisted verbatim.
+			expect(card?.id).toBe(eventGraphic.id);
+			expect(card?.cardType).toBe(CardTypesMap.EVENT_GRAPHIC);
+			expect(card?.uuid).toBeDefined();
 		});
 	});
 });

--- a/fronts-client/src/util/__tests__/card.spec.ts
+++ b/fronts-client/src/util/__tests__/card.spec.ts
@@ -137,8 +137,7 @@ describe('card utils', () => {
 			);
 
 			expect(card).toBeDefined();
-			// The prefixed id is the only marker that survives a round trip to S3,
-			// so it must be persisted verbatim.
+			// The prefixed id is the only marker that's persisted.
 			expect(card?.id).toBe(eventGraphic.id);
 			expect(card?.cardType).toBe(CardTypesMap.EVENT_GRAPHIC);
 			expect(card?.uuid).toBeDefined();

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -325,10 +325,8 @@ const getRecipeEntityFromFeedDrop = (recipe: Recipe): TArticleEntities => {
 };
 
 /**
- * Event graphics aren't CAPI content and aren't snaps: the card is built
- * entirely from the hard-coded entry, and its id -- including the
- * `event-graphic/` prefix, which is what identifies it downstream -- is stored
- * as-is.
+ * Event graphics aren't CAPI content and aren't snaps, so the card is built
+ * from the hard-coded entry, keeping the id (prefix included) as-is.
  */
 const getEventGraphicEntityFromFeedDrop = (
 	eventGraphic: EventGraphic,

--- a/fronts-client/src/util/card.ts
+++ b/fronts-client/src/util/card.ts
@@ -32,6 +32,7 @@ import {
 } from 'util/url';
 import { Recipe } from '../types/Recipe';
 import { CardTypesMap, type CardTypes } from '../constants/cardTypes';
+import { EventGraphic } from '../constants/eventGraphics';
 import { Chef } from '../types/Chef';
 import { State } from '../types/State';
 import { selectCard } from '../selectors/shared';
@@ -199,6 +200,10 @@ const getCardEntitiesFromDrop = async (
 		return getFeastCollectionFromFeedDrop(drop.data, state);
 	}
 
+	if (drop.type === 'EVENT_GRAPHIC') {
+		return getEventGraphicEntityFromFeedDrop(drop.data);
+	}
+
 	const droppedDataURL = drop.data.trim();
 	const resourceIdOrUrl = isGoogleRedirectUrl(droppedDataURL)
 		? getRelevantURLFromGoogleRedirectURL(droppedDataURL)
@@ -315,6 +320,22 @@ const getChefEntityFromFeedDrop = (chef: Chef): TArticleEntities => {
 
 const getRecipeEntityFromFeedDrop = (recipe: Recipe): TArticleEntities => {
 	const card = createCard(recipe.id, false, { cardType: CardTypesMap.RECIPE });
+
+	return { card };
+};
+
+/**
+ * Event graphics aren't CAPI content and aren't snaps: the card is built
+ * entirely from the hard-coded entry, and its id -- including the
+ * `event-graphic/` prefix, which is what identifies it downstream -- is stored
+ * as-is.
+ */
+const getEventGraphicEntityFromFeedDrop = (
+	eventGraphic: EventGraphic,
+): TArticleEntities => {
+	const card = createCard(eventGraphic.id, false, {
+		cardType: CardTypesMap.EVENT_GRAPHIC,
+	});
 
 	return { card };
 };

--- a/fronts-client/src/util/collectionUtils.ts
+++ b/fronts-client/src/util/collectionUtils.ts
@@ -6,6 +6,7 @@ import { CapiArticle } from 'types/Capi';
 import { Recipe } from '../types/Recipe';
 import { Chef } from '../types/Chef';
 import { CardTypesMap } from 'constants/cardTypes';
+import { EventGraphic } from 'constants/eventGraphics';
 import { Card } from '../types/Collection';
 
 export interface RefDrop {
@@ -32,12 +33,18 @@ export interface FeastCollectionDrop {
 	data: Card;
 }
 
+export interface EventGraphicDrop {
+	type: 'EVENT_GRAPHIC';
+	data: EventGraphic;
+}
+
 export type MappableDropType =
 	| RefDrop
 	| CAPIDrop
 	| RecipeDrop
 	| ChefDrop
-	| FeastCollectionDrop;
+	| FeastCollectionDrop
+	| EventGraphicDrop;
 
 const dropToCardMap = {
 	capi: (data: string): CAPIDrop => ({
@@ -54,6 +61,10 @@ const dropToCardMap = {
 	}),
 	[CardTypesMap.FEAST_COLLECTION]: (data: string): FeastCollectionDrop => ({
 		type: 'FEAST_COLLECTION',
+		data: JSON.parse(data),
+	}),
+	[CardTypesMap.EVENT_GRAPHIC]: (data: string): EventGraphicDrop => ({
+		type: 'EVENT_GRAPHIC',
 		data: JSON.parse(data),
 	}),
 	text: (url: string): RefDrop => ({ type: 'REF', data: url }),


### PR DESCRIPTION
## What's changed?

In this PR, and with the help of Opus 5, we implement the features that enable editors to place event graphics directly into front containers. This capability is hidden behind a feature switch that can be enabled here https://fronts.code.dev-gutools.co.uk/v2/features

At this stage event graphics are hard-coded (a list of 1), no particular restriction is applied with regard to the destination of the event graphic placement, except for sublinks, where it isn't possible to place any event graphics.

<img width="1069" height="699" alt="image" src="https://github.com/user-attachments/assets/a25b781f-168d-49a5-b88a-85d5cd5f060d" />


## Implementation notes
<!-- Include any specific areas you want to highlight for review that you feel might be worthy of discussion (i.e. any non-obvious decisions you've made) -->

## Checklist

### General
- [x] 🤖 Relevant tests added
- [x] ✅ CI checks / tests run locally
- [x] 🔍 Checked on CODE

### Client
- [x] 🚫 No obvious console errors on the client (i.e. React dev mode errors)
- [x] 🎛️ No regressions with existing user interactions (i.e. all existing buttons, inputs etc. work)
- [x] 📷 Screenshots / GIFs of relevant UI changes included
